### PR TITLE
Enhance scrapy.utils.memory to support Solaris

### DIFF
--- a/scrapy/utils/memory.py
+++ b/scrapy/utils/memory.py
@@ -1,4 +1,5 @@
 import os
+import sys
 
 _vmvalue_scale = {'kB': 1024, 'mB': 1024*1024, 'KB': 1024, 'MB': 1024*1024}
 
@@ -13,15 +14,18 @@ def get_vmvalue_from_procfs(vmkey='VmSize', pid=None):
         t = open('/proc/%d/status' % pid)
     except IOError:
         raise RuntimeError("/proc filesystem not supported")
-    v = t.read()
-    t.close()
-    # get vmkey line e.g. 'VmRSS:  9999  kB\n ...'
-    i = v.index(vmkey + ':')
-    v = v[i:].split(None, 3)  # whitespace
-    if len(v) < 3:
-        return 0  # invalid format?
-    # convert Vm value to bytes
-    return int(v[1]) * _vmvalue_scale[v[2]]
+    if sys.platform == "sunos5": 
+        return _vmvalue_solaris(vmkey, pid)
+    else:
+        v = t.read()
+        t.close()
+        # get vmkey line e.g. 'VmRSS:  9999  kB\n ...'
+        i = v.index(vmkey + ':')
+        v = v[i:].split(None, 3)  # whitespace
+        if len(v) < 3:
+            return 0  # invalid format?
+        # convert Vm value to bytes
+        return int(v[1]) * _vmvalue_scale[v[2]]
 
 def procfs_supported():
     try:
@@ -30,3 +34,37 @@ def procfs_supported():
         return False
     else:
         return True
+
+def _vmvalue_solaris(vmkey, pid):
+    import struct
+
+     # Memory layout for struct psinfo. 
+     # http://docs.sun.com/app/docs/doc/816-5174/proc-4?l=en&a=view
+    _psinfo_struct_format = ( 
+        "10i"   # pr_flag [0] through pr_egid [9] 
+        "5L"    # pr_addr [10] through pr_ttyydev [14] 
+        "2H"    # pr_pctcpu [15] and pr_pctmem [16] 
+        "6l"    # pr_start [17-18] through pr_ctime [21-22] 
+        "16s"   # pr_fname [23] 
+        "80s"   # pr_psargs [24] 
+        "2i"    # pr_wstat[25] and pr_argc [26] 
+        "2L"    # pr_argv [27] and pr_envp [28] 
+        "b3x"   # pr_dmodel[29] and pr_pad2 
+        "7i"    # pr_taskid [30] through pr_filler 
+        "20i6l" # pr_lwp 
+        ) 
+    psinfo_file = os.path.join("/proc", str(pid), "psinfo")
+    with open(psinfo_file) as f:
+        parts = struct.unpack(_psinfo_struct_format, f.read())
+
+    vmkey_index = {
+        'VmSize' : 11, # pr_size
+        'VmRSS'  : 12, # pr_rssize
+    }
+
+    vm_in_kB = parts[vmkey_index[vmkey]]
+
+    def kB_to_Bytes(kB):
+        return kB * 1024
+    
+    return kB_to_Bytes(vm_in_kB)


### PR DESCRIPTION
scrapy.utils.memory.get_vmvalue_from_procfs()
causes test case failure on SunOS 5.10 i86pc. Modified it support SunOS 5.10
