### PR TITLE
Updated CAMELCASE_EXCLUDE_CHARS to also exclude digits

### DIFF
--- a/scrapy/utils/template.py
+++ b/scrapy/utils/template.py
@@ -16,7 +16,7 @@ def render_templatefile(path, **kwargs):
     if path.endswith('.tmpl'):
         os.remove(path)
 
-CAMELCASE_INVALID_CHARS = re.compile('[^a-zA-Z]')
+CAMELCASE_INVALID_CHARS = re.compile('[^a-zA-Z\d]')
 def string_camelcase(string):
     """ Convert a word  to its CamelCase version and remove invalid chars
 


### PR DESCRIPTION
I ran into this with a project that has digits in its name.
