### PR TITLE
Allow None as item_element for XmlItemExporter

### DIFF
--- a/scrapy/contrib/exporter/__init__.py
+++ b/scrapy/contrib/exporter/__init__.py
@@ -123,10 +123,12 @@ class XmlItemExporter(BaseItemExporter):
         self.xg.startElement(self.root_element, {})
 
     def export_item(self, item):
-        self.xg.startElement(self.item_element, {})
+        if self.item_element is not None:
+            self.xg.startElement(self.item_element, {})
         for name, value in self._get_serialized_fields(item, default_value=''):
             self._export_xml_field(name, value)
-        self.xg.endElement(self.item_element)
+        if self.item_element is not None:
+            self.xg.endElement(self.item_element)
 
     def finish_exporting(self):
         self.xg.endElement(self.root_element)


### PR DESCRIPTION
XmlItemExporter can now accept 'None' as its item_element, which will cause it to only do a root_element. This makes single-item XML exports a bit easier.
