### PR TITLE
Fix big in PickleItemExporter that created invalid pickle dumps.

### DIFF
--- a/scrapy/contrib/exporter/__init__.py
+++ b/scrapy/contrib/exporter/__init__.py
@@ -180,10 +180,12 @@ class PickleItemExporter(BaseItemExporter):
 
     def __init__(self, file, protocol=0, **kwargs):
         self._configure(kwargs)
-        self.pickler = Pickler(file, protocol)
+        self.file = file
+        self.protocol = protocol
 
     def export_item(self, item):
-        self.pickler.dump(dict(self._get_serialized_fields(item)))
+        pickle.dump(dict(self._get_serialized_fields(item)), self.file,
+            self.protocol)
 
 
 class MarshalItemExporter(BaseItemExporter):


### PR DESCRIPTION
My attempts to use the PickleItemExporter were resulting in invalid pickle files. It took me awhile to figure out that the cause of the problem was the the Item keys were being exhausted after the first run of export_item. The result was that the first pickled item included both keys and values where subsequent Items had only values. This broke the pickle and made it unloadable.

Unfortunately, I'm not _totally_ sure where the bug was coming from. The call to item.iterkeys() in _get_serialized_fields seems to be what's blowing up, so it's almost certainly a problem with the use of generators. The code that was here is what I would have written, so I'm a bit baffled.

This commit, however, does fix the problem.
