### PR TITLE
Why not be the spider in the process of change max concurrent requests ?

### DIFF
--- a/scrapy/core/downloader/__init__.py
+++ b/scrapy/core/downloader/__init__.py
@@ -100,13 +100,16 @@ class Downloader(object):
         key = urlparse_cached(request).hostname or ''
         if self.ip_concurrency:
             key = dnscache.get(key, key)
+            concurrency = self.ip_concurrency
+        else:
+            concurrency = self.domain_concurrency
+        concurrency, delay = _get_concurrency_delay(concurrency, spider, self.settings)
+
         if key not in self.slots:
-            if self.ip_concurrency:
-                concurrency = self.ip_concurrency
-            else:
-                concurrency = self.domain_concurrency
-            concurrency, delay = _get_concurrency_delay(concurrency, spider, self.settings)
             self.slots[key] = Slot(concurrency, delay, self.settings)
+        else:
+            self.slots[key].concurrency = concurrency
+            self.slots[key].delay = delay
         return key, self.slots[key]
 
     def _enqueue_request(self, request, spider, slot):


### PR DESCRIPTION
I, as an active user, really miss this feature.
Thank you for your work.
