### PR TITLE
Allow settings to take direct references to objects as well as module paths

### DIFF
--- a/scrapy/tests/test_utils_misc/__init__.py
+++ b/scrapy/tests/test_utils_misc/__init__.py
@@ -12,6 +12,8 @@ class UtilsMiscTestCase(unittest.TestCase):
     def test_load_object(self):
         obj = load_object('scrapy.utils.misc.load_object')
         assert obj is load_object
+        obj = load_object(load_object)
+        assert obj is load_object
         self.assertRaises(ImportError, load_object, 'nomodule999.mod.function')
         self.assertRaises(NameError, load_object, 'scrapy.utils.misc.load_object999')
 

--- a/scrapy/utils/misc.py
+++ b/scrapy/utils/misc.py
@@ -22,10 +22,14 @@ def arg_to_iter(arg):
 
 def load_object(path):
     """Load an object given its absolute object path, and return it.
+    If given a non-string object directly, return it.
 
-    object can be a class, function, variable o instance.
+    object can be a class, function, variable or instance.
     path ie: 'scrapy.contrib.downloadermiddelware.redirect.RedirectMiddleware'
     """
+    
+    if not isinstance(path, basestring):
+        return path
 
     try:
         dot = path.rindex('.')


### PR DESCRIPTION
Simple change to allow objects to be passed to settings directly, as well as being able to specify paths.

Fixes issue #64
