### PR TITLE
httpcache: keep stats of cache hit/miss/store and don't store already cached response

### DIFF
--- a/scrapy/contrib/downloadermiddleware/httpcache.py
+++ b/scrapy/contrib/downloadermiddleware/httpcache.py
@@ -52,7 +52,9 @@ class HttpCacheMiddleware(object):
             raise IgnoreRequest("Ignored request not in cache: %s" % request)
 
     def process_response(self, request, response, spider):
-        if self.is_cacheable(request) and self.is_cacheable_response(response):
+        if (self.is_cacheable(request)
+            and self.is_cacheable_response(response)
+            and 'cached' not in response.flags):
             self.storage.store_response(spider, request, response)
             stats.inc_value('httpcache/store', spider=spider)
         return response


### PR DESCRIPTION
Example final stats with httpcache/\* counters:

``` javascript
    {'downloader/request_bytes': 2595,
     'downloader/request_count': 7,
     'downloader/request_method_count/GET': 7,
     'downloader/response_bytes': 1203485,
     'downloader/response_count': 7,
     'downloader/response_status_count/200': 5,
     'downloader/response_status_count/301': 2,
     'finish_reason': 'shutdown',
     'finish_time': datetime.datetime(2011, 12, 30, 18, 3, 43, 953507),
     'httpcache/hit': 6,
     'httpcache/miss': 1,
     'httpcache/store': 7,
     'request_depth_max': 3,
     'scheduler/memory_enqueued': 656,
     'start_time': datetime.datetime(2011, 12, 30, 18, 3, 15, 145445)}
```
