### PR TITLE
changed "import Image" to "from PIL import Image" to support Pillow

### DIFF
--- a/scrapy/contrib/pipeline/images.py
+++ b/scrapy/contrib/pipeline/images.py
@@ -10,7 +10,7 @@ import time
 import hashlib
 import urlparse
 import rfc822
-import Image
+from PIL import Image
 from cStringIO import StringIO
 from collections import defaultdict
 


### PR DESCRIPTION
Pillow ( http://pypi.python.org/pypi/Pillow ) is a pip/virtualenv/easy_install compatible branch of PIL.

To make it work, it needs a tiny change in the import code.
