### PR TITLE
Singletons removal

### DIFF
--- a/scrapy/contrib/closespider.py
+++ b/scrapy/contrib/closespider.py
@@ -8,7 +8,6 @@ from collections import defaultdict
 
 from twisted.internet import reactor
 from twisted.python import log as txlog
-from scrapy.xlib.pydispatch import dispatcher
 
 from scrapy import signals, log
 
@@ -29,12 +28,12 @@ class CloseSpider(object):
         if self.errorcount:
             txlog.addObserver(self.catch_log)
         if self.pagecount:
-            dispatcher.connect(self.page_count, signal=signals.response_received)
+            crawler.signals.connect(self.page_count, signal=signals.response_received)
         if self.timeout:
-            dispatcher.connect(self.spider_opened, signal=signals.spider_opened)
+            crawler.signals.connect(self.spider_opened, signal=signals.spider_opened)
         if self.itemcount:
-            dispatcher.connect(self.item_scraped, signal=signals.item_scraped)
-        dispatcher.connect(self.spider_closed, signal=signals.spider_closed)
+            crawler.signals.connect(self.item_scraped, signal=signals.item_scraped)
+        crawler.signals.connect(self.spider_closed, signal=signals.spider_closed)
 
     @classmethod
     def from_crawler(cls, crawler):

--- a/scrapy/contrib/downloadermiddleware/robotstxt.py
+++ b/scrapy/contrib/downloadermiddleware/robotstxt.py
@@ -6,8 +6,6 @@ enable this middleware and enable the ROBOTSTXT_OBEY setting.
 
 import robotparser
 
-from scrapy.xlib.pydispatch import dispatcher
-
 from scrapy import signals, log
 from scrapy.exceptions import NotConfigured, IgnoreRequest
 from scrapy.http import Request
@@ -24,8 +22,8 @@ class RobotsTxtMiddleware(object):
         self._parsers = {}
         self._spider_netlocs = {}
         self._useragents = {}
-        dispatcher.connect(self.spider_opened, signals.spider_opened)
-        dispatcher.connect(self.spider_closed, signals.spider_closed)
+        crawler.signals.connect(self.spider_opened, signals.spider_opened)
+        crawler.signals.connect(self.spider_closed, signals.spider_closed)
 
     @classmethod
     def from_crawler(cls, crawler):

--- a/scrapy/contrib/downloadermiddleware/stats.py
+++ b/scrapy/contrib/downloadermiddleware/stats.py
@@ -1,30 +1,32 @@
 from scrapy.exceptions import NotConfigured
 from scrapy.utils.request import request_httprepr
 from scrapy.utils.response import response_httprepr
-from scrapy.stats import stats
 
 class DownloaderStats(object):
+
+    def __init__(self, stats):
+        self.stats = stats
 
     @classmethod
     def from_crawler(cls, crawler):
         if not crawler.settings.getbool('DOWNLOADER_STATS'):
             raise NotConfigured
-        return cls()
+        return cls(crawler.stats)
 
     def process_request(self, request, spider):
-        stats.inc_value('downloader/request_count', spider=spider)
-        stats.inc_value('downloader/request_method_count/%s' % request.method, spider=spider)
+        self.stats.inc_value('downloader/request_count', spider=spider)
+        self.stats.inc_value('downloader/request_method_count/%s' % request.method, spider=spider)
         reqlen = len(request_httprepr(request))
-        stats.inc_value('downloader/request_bytes', reqlen, spider=spider)
+        self.stats.inc_value('downloader/request_bytes', reqlen, spider=spider)
 
     def process_response(self, request, response, spider):
-        stats.inc_value('downloader/response_count', spider=spider)
-        stats.inc_value('downloader/response_status_count/%s' % response.status, spider=spider)
+        self.stats.inc_value('downloader/response_count', spider=spider)
+        self.stats.inc_value('downloader/response_status_count/%s' % response.status, spider=spider)
         reslen = len(response_httprepr(response))
-        stats.inc_value('downloader/response_bytes', reslen, spider=spider)
+        self.stats.inc_value('downloader/response_bytes', reslen, spider=spider)
         return response
 
     def process_exception(self, request, exception, spider):
         ex_class = "%s.%s" % (exception.__class__.__module__, exception.__class__.__name__)
-        stats.inc_value('downloader/exception_count', spider=spider)
-        stats.inc_value('downloader/exception_type_count/%s' % ex_class, spider=spider)
+        self.stats.inc_value('downloader/exception_count', spider=spider)
+        self.stats.inc_value('downloader/exception_type_count/%s' % ex_class, spider=spider)

--- a/scrapy/contrib/feedexport.py
+++ b/scrapy/contrib/feedexport.py
@@ -15,7 +15,6 @@ from twisted.internet import defer, threads
 from w3lib.url import file_uri_to_path
 
 from scrapy import log, signals
-from scrapy.xlib.pydispatch import dispatcher
 from scrapy.utils.ftp import ftp_makedirs_cwd
 from scrapy.exceptions import NotConfigured
 from scrapy.utils.misc import load_object
@@ -149,9 +148,14 @@ class FeedExporter(object):
         uripar = settings['FEED_URI_PARAMS']
         self._uripar = load_object(uripar) if uripar else lambda x, y: None
         self.slots = {}
-        dispatcher.connect(self.open_spider, signals.spider_opened)
-        dispatcher.connect(self.close_spider, signals.spider_closed)
-        dispatcher.connect(self.item_scraped, signals.item_scraped)
+
+    @classmethod
+    def from_crawler(cls, crawler):
+        o = cls()
+        crawler.signals.connect(o.open_spider, signals.spider_opened)
+        crawler.signals.connect(o.close_spider, signals.spider_closed)
+        crawler.signals.connect(o.item_scraped, signals.item_scraped)
+        return o
 
     @classmethod
     def from_crawler(cls, crawler):

--- a/scrapy/contrib/logstats.py
+++ b/scrapy/contrib/logstats.py
@@ -1,6 +1,5 @@
 from twisted.internet import task
 
-from scrapy.xlib.pydispatch import dispatcher
 from scrapy.exceptions import NotConfigured
 from scrapy import log, signals
 
@@ -19,12 +18,20 @@ class LogStats(object):
         self.interval = interval
         self.slots = {}
         self.multiplier = 60.0 / self.interval
-        dispatcher.connect(self.item_scraped, signal=signals.item_scraped)
-        dispatcher.connect(self.response_received, signal=signals.response_received)
-        dispatcher.connect(self.spider_opened, signal=signals.spider_opened)
-        dispatcher.connect(self.spider_closed, signal=signals.spider_closed)
-        dispatcher.connect(self.engine_started, signal=signals.engine_started)
-        dispatcher.connect(self.engine_stopped, signal=signals.engine_stopped)
+
+    @classmethod
+    def from_crawler(cls, crawler):
+        interval = settings.getfloat('LOGSTATS_INTERVAL')
+        if not interval:
+            raise NotConfigured
+        o = cls(interval)
+        crawler.signals.connect(o.item_scraped, signal=signals.item_scraped)
+        crawler.signals.connect(o.response_received, signal=signals.response_received)
+        crawler.signals.connect(o.spider_opened, signal=signals.spider_opened)
+        crawler.signals.connect(o.spider_closed, signal=signals.spider_closed)
+        crawler.signals.connect(o.engine_started, signal=signals.engine_started)
+        crawler.signals.connect(o.engine_stopped, signal=signals.engine_stopped)
+        return o
 
     @classmethod
     def from_crawler(cls, crawler):

--- a/scrapy/contrib/memdebug.py
+++ b/scrapy/contrib/memdebug.py
@@ -6,30 +6,29 @@ See documentation in docs/topics/extensions.rst
 
 import gc
 
-from scrapy.xlib.pydispatch import dispatcher
-
 from scrapy import signals
 from scrapy.exceptions import NotConfigured
-from scrapy.stats import stats
 from scrapy.utils.trackref import live_refs
 
 class MemoryDebugger(object):
 
-    def __init__(self, trackrefs=False):
+    def __init__(self, stats, trackrefs=False):
         try:
             import libxml2
             self.libxml2 = libxml2
         except ImportError:
             self.libxml2 = None
+        self.stats = stats
         self.trackrefs = trackrefs
-        dispatcher.connect(self.engine_started, signals.engine_started)
-        dispatcher.connect(self.engine_stopped, signals.engine_stopped)
 
     @classmethod
     def from_crawler(cls, crawler):
         if not crawler.settings.getbool('MEMDEBUG_ENABLED'):
             raise NotConfigured
-        return cls(crawler.settings.getbool('TRACK_REFS'))
+        o = cls(crawler.stats, crawler.settings.getbool('TRACK_REFS'))
+        crawler.signals.connect(o.engine_started, signals.engine_started)
+        crawler.signals.connect(o.engine_stopped, signals.engine_stopped)
+        return o
 
     def engine_started(self):
         if self.libxml2:
@@ -38,11 +37,11 @@ class MemoryDebugger(object):
     def engine_stopped(self):
         if self.libxml2:
             self.libxml2.cleanupParser()
-            stats.set_value('memdebug/libxml2_leaked_bytes', self.libxml2.debugMemory(1))
+            self.stats.set_value('memdebug/libxml2_leaked_bytes', self.libxml2.debugMemory(1))
         gc.collect()
-        stats.set_value('memdebug/gc_garbage_count', len(gc.garbage))
+        self.stats.set_value('memdebug/gc_garbage_count', len(gc.garbage))
         if self.trackrefs:
             for cls, wdict in live_refs.iteritems():
                 if not wdict:
                     continue
-                stats.set_value('memdebug/live_refs/%s' % cls.__name__, len(wdict))
+                self.stats.set_value('memdebug/live_refs/%s' % cls.__name__, len(wdict))

--- a/scrapy/contrib/spidermiddleware/depth.py
+++ b/scrapy/contrib/spidermiddleware/depth.py
@@ -19,16 +19,13 @@ class DepthMiddleware(object):
         self.prio = prio
 
     @classmethod
-    def from_settings(cls, settings):
+    def from_crawler(cls, crawler):
+        settings = crawler.settings
         maxdepth = settings.getint('DEPTH_LIMIT')
         usestats = settings.getbool('DEPTH_STATS')
         verbose = settings.getbool('DEPTH_STATS_VERBOSE')
         prio = settings.getint('DEPTH_PRIORITY')
-        if usestats:
-            from scrapy.stats import stats
-        else:
-            stats = None
-        return cls(maxdepth, stats, verbose, prio)
+        return cls(maxdepth, crawler.stats, verbose, prio)
 
     def process_spider_output(self, response, result, spider):
         def _filter(request):

--- a/scrapy/contrib/spidermiddleware/offsite.py
+++ b/scrapy/contrib/spidermiddleware/offsite.py
@@ -6,7 +6,6 @@ See documentation in docs/topics/spider-middleware.rst
 
 import re
 
-from scrapy.xlib.pydispatch import dispatcher
 from scrapy import signals
 from scrapy.http import Request
 from scrapy.utils.httpobj import urlparse_cached
@@ -17,8 +16,13 @@ class OffsiteMiddleware(object):
     def __init__(self):
         self.host_regexes = {}
         self.domains_seen = {}
-        dispatcher.connect(self.spider_opened, signal=signals.spider_opened)
-        dispatcher.connect(self.spider_closed, signal=signals.spider_closed)
+
+    @classmethod
+    def from_crawler(cls, crawler):
+        o = cls()
+        crawler.signals.connect(o.spider_opened, signal=signals.spider_opened)
+        crawler.signals.connect(o.spider_closed, signal=signals.spider_closed)
+        return o
 
     def process_spider_output(self, response, result, spider):
         for x in result:

--- a/scrapy/contrib/spiderstate.py
+++ b/scrapy/contrib/spiderstate.py
@@ -1,7 +1,6 @@
 import os, cPickle as pickle
 
 from scrapy import signals
-from scrapy.xlib.pydispatch import dispatcher
 
 class SpiderState(object):
     """Store and load spider state during a scraping job"""
@@ -12,8 +11,8 @@ class SpiderState(object):
     @classmethod
     def from_crawler(cls, crawler):
         obj = cls(crawler.settings.get('JOBDIR'))
-        dispatcher.connect(obj.spider_closed, signal=signals.spider_closed)
-        dispatcher.connect(obj.spider_opened, signal=signals.spider_opened)
+        crawler.signals.connect(obj.spider_closed, signal=signals.spider_closed)
+        crawler.signals.connect(obj.spider_opened, signal=signals.spider_opened)
         return obj
 
     def spider_closed(self, spider):

--- a/scrapy/contrib/statsmailer.py
+++ b/scrapy/contrib/statsmailer.py
@@ -4,30 +4,29 @@ StatsMailer extension sends an email when a spider finishes scraping.
 Use STATSMAILER_RCPTS setting to enable and give the recipient mail address
 """
 
-from scrapy.xlib.pydispatch import dispatcher
-
-from scrapy.stats import stats
 from scrapy import signals
 from scrapy.mail import MailSender
 from scrapy.exceptions import NotConfigured
 
 class StatsMailer(object):
 
-    def __init__(self, recipients):
+    def __init__(self, stats, recipients):
+        self.stats = stats
         self.recipients = recipients
-        if not self.recipients:
-            raise NotConfigured
-        dispatcher.connect(self.stats_spider_closed, signal=signals.stats_spider_closed)
 
     @classmethod
     def from_crawler(cls, crawler):
         recipients = crawler.settings.getlist("STATSMAILER_RCPTS")
-        return cls(recipients)
-
+        if not recipients:
+            raise NotConfigured
+        o = cls(crawler.stats, recipients)
+        crawler.connect(o.stats_spider_closed, signal=signals.stats_spider_closed)
+        return o
+        
     def stats_spider_closed(self, spider, spider_stats):
         mail = MailSender()
         body = "Global stats\n\n"
-        body += "\n".join("%-50s : %s" % i for i in stats.get_stats().items())
+        body += "\n".join("%-50s : %s" % i for i in self.stats.get_stats().items())
         body += "\n\n%s stats\n\n" % spider.name
         body += "\n".join("%-50s : %s" % i for i in spider_stats.items())
         mail.send(self.recipients, "Scrapy stats for: %s" % spider.name, body)

--- a/scrapy/contrib/throttle.py
+++ b/scrapy/contrib/throttle.py
@@ -1,4 +1,3 @@
-from scrapy.xlib.pydispatch import dispatcher
 from scrapy.exceptions import NotConfigured
 from scrapy import signals
 from scrapy.utils.httpobj import urlparse_cached
@@ -63,8 +62,8 @@ class AutoThrottle(object):
         if not settings.getbool('AUTOTHROTTLE_ENABLED'):
             raise NotConfigured
         self.crawler = crawler
-        dispatcher.connect(self.spider_opened, signal=signals.spider_opened)
-        dispatcher.connect(self.response_received, signal=signals.response_received)
+        crawler.signals.connect(self.spider_opened, signal=signals.spider_opened)
+        crawler.signals.connect(self.response_received, signal=signals.response_received)
         self.START_DELAY = settings.getfloat("AUTOTHROTTLE_START_DELAY", 5.0)
         self.CONCURRENCY_CHECK_PERIOD = settings.getint("AUTOTHROTTLE_CONCURRENCY_CHECK_PERIOD", 10)
         self.MAX_CONCURRENCY = settings.getint("AUTOTHROTTLE_MAX_CONCURRENCY", 8)

--- a/scrapy/contrib/webservice/stats.py
+++ b/scrapy/contrib/webservice/stats.py
@@ -1,9 +1,8 @@
 from scrapy.webservice import JsonRpcResource
-from scrapy.stats import stats
 
 class StatsResource(JsonRpcResource):
 
     ws_name = 'stats'
 
     def __init__(self, crawler):
-        JsonRpcResource.__init__(self, crawler, stats)
+        JsonRpcResource.__init__(self, crawler, crawler.stats)

--- a/scrapy/core/downloader/__init__.py
+++ b/scrapy/core/downloader/__init__.py
@@ -8,7 +8,6 @@ from twisted.internet import reactor, defer
 from twisted.python.failure import Failure
 
 from scrapy.utils.defer import mustbe_deferred
-from scrapy.utils.signal import send_catch_log
 from scrapy.utils.httpobj import urlparse_cached
 from scrapy.resolver import dnscache
 from scrapy.exceptions import ScrapyDeprecationWarning
@@ -68,6 +67,7 @@ class Downloader(object):
 
     def __init__(self, crawler):
         self.settings = crawler.settings
+        self.signals = crawler.signals
         self.slots = {}
         self.active = set()
         self.handlers = DownloadHandlers()
@@ -114,7 +114,7 @@ class Downloader(object):
 
     def _enqueue_request(self, request, spider, slot):
         def _downloaded(response):
-            send_catch_log(signal=signals.response_downloaded, \
+            self.signals.send_catch_log(signal=signals.response_downloaded, \
                     response=response, request=request, spider=spider)
             return response
 

--- a/scrapy/core/engine.py
+++ b/scrapy/core/engine.py
@@ -11,13 +11,11 @@ from twisted.internet import defer
 from twisted.python.failure import Failure
 
 from scrapy import log, signals
-from scrapy.stats import stats
 from scrapy.core.downloader import Downloader
 from scrapy.core.scraper import Scraper
 from scrapy.exceptions import DontCloseSpider, ScrapyDeprecationWarning
 from scrapy.http import Response, Request
 from scrapy.utils.misc import load_object
-from scrapy.utils.signal import send_catch_log, send_catch_log_deferred
 from scrapy.utils.reactor import CallLaterOnce
 
 
@@ -53,7 +51,9 @@ class Slot(object):
 class ExecutionEngine(object):
 
     def __init__(self, crawler, spider_closed_callback):
+        self.crawler = crawler
         self.settings = crawler.settings
+        self.signals = crawler.signals
         self.slots = {}
         self.running = False
         self.paused = False
@@ -71,7 +71,7 @@ class ExecutionEngine(object):
         """Start the execution engine"""
         assert not self.running, "Engine already running"
         self.start_time = time()
-        yield send_catch_log_deferred(signal=signals.engine_started)
+        yield self.signals.send_catch_log_deferred(signal=signals.engine_started)
         self.running = True
 
     def stop(self):
@@ -195,7 +195,7 @@ class ExecutionEngine(object):
                 response.request = request # tie request to response received
                 log.msg(log.formatter.crawled(request, response, spider), \
                     level=log.DEBUG, spider=spider)
-                send_catch_log(signal=signals.response_received, \
+                self.signals.send_catch_log(signal=signals.response_received, \
                     response=response, request=request, spider=spider)
             return response
 
@@ -218,13 +218,13 @@ class ExecutionEngine(object):
             spider.name
         log.msg("Spider opened", spider=spider)
         nextcall = CallLaterOnce(self._next_request, spider)
-        scheduler = self.scheduler_cls.from_settings(self.settings)
+        scheduler = self.scheduler_cls.from_crawler(self.crawler)
         slot = Slot(start_requests or (), close_if_idle, nextcall, scheduler)
         self.slots[spider] = slot
         yield scheduler.open(spider)
         yield self.scraper.open_spider(spider)
-        stats.open_spider(spider)
-        yield send_catch_log_deferred(signals.spider_opened, spider=spider)
+        self.crawler.stats.open_spider(spider)
+        yield self.signals.send_catch_log_deferred(signals.spider_opened, spider=spider)
         slot.nextcall.schedule()
 
     def _spider_idle(self, spider):
@@ -235,7 +235,7 @@ class ExecutionEngine(object):
         next loop and this function is guaranteed to be called (at least) once
         again for this spider.
         """
-        res = send_catch_log(signal=signals.spider_idle, \
+        res = self.signals.send_catch_log(signal=signals.spider_idle, \
             spider=spider, dont_log=DontCloseSpider)
         if any(isinstance(x, Failure) and isinstance(x.value, DontCloseSpider) \
                 for _, x in res):
@@ -261,11 +261,11 @@ class ExecutionEngine(object):
         dfd.addBoth(lambda _: slot.scheduler.close(reason))
         dfd.addErrback(log.err, spider=spider)
 
-        dfd.addBoth(lambda _: send_catch_log_deferred(signal=signals.spider_closed, \
+        dfd.addBoth(lambda _: self.signals.send_catch_log_deferred(signal=signals.spider_closed, \
             spider=spider, reason=reason))
         dfd.addErrback(log.err, spider=spider)
 
-        dfd.addBoth(lambda _: stats.close_spider(spider, reason=reason))
+        dfd.addBoth(lambda _: self.crawler.stats.close_spider(spider, reason=reason))
         dfd.addErrback(log.err, spider=spider)
 
         dfd.addBoth(lambda _: log.msg("Spider closed (%s)" % reason, spider=spider))
@@ -284,5 +284,5 @@ class ExecutionEngine(object):
 
     @defer.inlineCallbacks
     def _finish_stopping_engine(self):
-        yield send_catch_log_deferred(signal=signals.engine_stopped)
-        yield stats.engine_stopped()
+        yield self.signals.send_catch_log_deferred(signal=signals.engine_stopped)
+        yield self.crawler.stats.engine_stopped()

--- a/scrapy/crawler.py
+++ b/scrapy/crawler.py
@@ -2,10 +2,10 @@ import signal
 
 from twisted.internet import reactor, defer
 
-from scrapy.xlib.pydispatch import dispatcher
 from scrapy.core.engine import ExecutionEngine
 from scrapy.resolver import CachingThreadedResolver
 from scrapy.extension import ExtensionManager
+from scrapy.signalmanager import SignalManager
 from scrapy.utils.ossignal import install_shutdown_handlers, signal_names
 from scrapy.utils.misc import load_object
 from scrapy import log, signals
@@ -16,6 +16,8 @@ class Crawler(object):
     def __init__(self, settings):
         self.configured = False
         self.settings = settings
+        self.signals = SignalManager(self)
+        self.stats = load_object(settings['STATS_CLASS'])(self)
 
     def install(self):
         import scrapy.project
@@ -65,7 +67,7 @@ class CrawlerProcess(Crawler):
 
     def __init__(self, *a, **kw):
         super(CrawlerProcess, self).__init__(*a, **kw)
-        dispatcher.connect(self.stop, signals.engine_stopped)
+        self.signals.connect(self.stop, signals.engine_stopped)
         install_shutdown_handlers(self._signal_shutdown)
 
     def start(self):

--- a/scrapy/signalmanager.py
+++ b/scrapy/signalmanager.py
@@ -1,0 +1,27 @@
+from scrapy.xlib.pydispatch import dispatcher
+from scrapy.utils import signal
+
+class SignalManager(object):
+
+    def __init__(self, sender=dispatcher.Anonymous):
+        self.sender = sender
+
+    def connect(self, *a, **kw):
+        kw.setdefault('sender', self.sender)
+        return dispatcher.connect(*a, **kw)
+
+    def disconnect(self, *a, **kw):
+        kw.setdefault('sender', self.sender)
+        return dispatcher.disconnect(*a, **kw)
+
+    def send_catch_log(self, *a, **kw):
+        kw.setdefault('sender', self.sender)
+        return signal.send_catch_log(*a, **kw)
+
+    def send_catch_log_deferred(self, *a, **kw):
+        kw.setdefault('sender', self.sender)
+        return signal.send_catch_log_deferred(*a, **kw)
+
+    def disconnect_all(self, *a, **kw):
+        kw.setdefault('sender', self.sender)
+        return signal.disconnect_all(*a, **kw)

--- a/scrapy/spidermanager.py
+++ b/scrapy/spidermanager.py
@@ -9,7 +9,6 @@ from scrapy import signals
 from scrapy.interfaces import ISpiderManager
 from scrapy.utils.misc import walk_modules
 from scrapy.utils.spider import iter_spider_classes
-from scrapy.xlib.pydispatch import dispatcher
 
 
 class SpiderManager(object):
@@ -22,7 +21,6 @@ class SpiderManager(object):
         for name in self.spider_modules:
             for module in walk_modules(name):
                 self._load_spiders(module)
-        dispatcher.connect(self.close_spider, signals.spider_closed)
 
     def _load_spiders(self, module):
         for spcls in iter_spider_classes(module):
@@ -34,7 +32,9 @@ class SpiderManager(object):
 
     @classmethod
     def from_crawler(cls, crawler):
-        return cls.from_settings(crawler.settings)
+        sm = cls.from_settings(crawler.settings)
+        crawler.signals.connect(sm.close_spider, signals.spider_closed)
+        return sm
 
     def create(self, spider_name, **spider_kwargs):
         try:

--- a/scrapy/stats.py
+++ b/scrapy/stats.py
@@ -1,9 +1,7 @@
-from scrapy.statscol import DummyStatsCollector
-from scrapy.conf import settings
-from scrapy.utils.misc import load_object
+from scrapy.project import crawler
+stats = crawler.stats
 
-# if stats are disabled use a DummyStatsCollector to improve performance
-if settings.getbool('STATS_ENABLED'):
-    stats = load_object(settings['STATS_CLASS'])()
-else:
-    stats = DummyStatsCollector()
+import warnings
+from scrapy.exceptions import ScrapyDeprecationWarning
+warnings.warn("Module `scrapy.stats` is deprecated, use `crawler.stats` attribute instead",
+    ScrapyDeprecationWarning, stacklevel=2)

--- a/scrapy/telnet.py
+++ b/scrapy/telnet.py
@@ -10,11 +10,8 @@ from twisted.conch import manhole, telnet
 from twisted.conch.insults import insults
 from twisted.internet import protocol
 
-from scrapy.xlib.pydispatch import dispatcher
 from scrapy.exceptions import NotConfigured
-from scrapy.stats import stats
 from scrapy import log, signals
-from scrapy.utils.signal import send_catch_log
 from scrapy.utils.trackref import print_live_refs
 from scrapy.utils.engine import print_engine_status
 from scrapy.utils.reactor import listen_tcp
@@ -39,8 +36,8 @@ class TelnetConsole(protocol.ServerFactory):
         self.noisy = False
         self.portrange = map(int, crawler.settings.getlist('TELNETCONSOLE_PORT'))
         self.host = crawler.settings['TELNETCONSOLE_HOST']
-        dispatcher.connect(self.start_listening, signals.engine_started)
-        dispatcher.connect(self.stop_listening, signals.engine_stopped)
+        self.crawler.signals.connect(self.start_listening, signals.engine_started)
+        self.crawler.signals.connect(self.stop_listening, signals.engine_stopped)
 
     @classmethod
     def from_crawler(cls, crawler):
@@ -70,7 +67,7 @@ class TelnetConsole(protocol.ServerFactory):
             'slot': slot,
             'manager': self.crawler,
             'extensions': self.crawler.extensions,
-            'stats': stats,
+            'stats': self.crawler.stats,
             'spiders': self.crawler.spiders,
             'settings': self.crawler.settings,
             'est': lambda: print_engine_status(self.crawler.engine),
@@ -80,5 +77,5 @@ class TelnetConsole(protocol.ServerFactory):
             'help': "This is Scrapy telnet console. For more info see: " \
                 "http://doc.scrapy.org/en/latest/topics/telnetconsole.html",
         }
-        send_catch_log(update_telnet_vars, telnet_vars=telnet_vars)
+        self.crawler.signals.send_catch_log(update_telnet_vars, telnet_vars=telnet_vars)
         return telnet_vars

--- a/scrapy/tests/test_downloadermiddleware_stats.py
+++ b/scrapy/tests/test_downloadermiddleware_stats.py
@@ -3,35 +3,36 @@ from unittest import TestCase
 from scrapy.contrib.downloadermiddleware.stats import DownloaderStats
 from scrapy.http import Request, Response
 from scrapy.spider import BaseSpider
-from scrapy.stats import stats
+from scrapy.utils.test import get_crawler
 
 
 class TestDownloaderStats(TestCase):
 
     def setUp(self):
+        self.crawler = get_crawler()
         self.spider = BaseSpider('scrapytest.org')
-        self.mw = DownloaderStats()
+        self.mw = DownloaderStats(self.crawler.stats)
 
-        stats.open_spider(self.spider)
+        self.crawler.stats.open_spider(self.spider)
 
         self.req = Request('http://scrapytest.org')
         self.res = Response('scrapytest.org', status=400)
 
     def test_process_request(self):
         self.mw.process_request(self.req, self.spider)
-        self.assertEqual(stats.get_value('downloader/request_count', \
+        self.assertEqual(self.crawler.stats.get_value('downloader/request_count', \
             spider=self.spider), 1)
         
     def test_process_response(self):
         self.mw.process_response(self.req, self.res, self.spider)
-        self.assertEqual(stats.get_value('downloader/response_count', \
+        self.assertEqual(self.crawler.stats.get_value('downloader/response_count', \
             spider=self.spider), 1)
 
     def test_process_exception(self):
         self.mw.process_exception(self.req, Exception(), self.spider)
-        self.assertEqual(stats.get_value('downloader/exception_count', \
+        self.assertEqual(self.crawler.stats.get_value('downloader/exception_count', \
             spider=self.spider), 1)
 
     def tearDown(self):
-        stats.close_spider(self.spider, '')
+        self.crawler.stats.close_spider(self.spider, '')
 

--- a/scrapy/tests/test_mail.py
+++ b/scrapy/tests/test_mail.py
@@ -1,22 +1,22 @@
 from cStringIO import StringIO
 import unittest
 
-from scrapy.xlib.pydispatch import dispatcher
-
 from scrapy.mail import MailSender, mail_sent
+from scrapy.utils.test import get_crawler
 
 
 class MailSenderTest(unittest.TestCase):
 
     def setUp(self):
         self.catched_msg = None
-        dispatcher.connect(self._catch_mail_sent, signal=mail_sent)
+        self.crawler = get_crawler()
+        self.crawler.signals.connect(self._catch_mail_sent, signal=mail_sent)
 
     def tearDown(self):
-        dispatcher.disconnect(self._catch_mail_sent, signal=mail_sent)
+        self.crawler.signals.disconnect(self._catch_mail_sent, signal=mail_sent)
 
     def test_send(self):
-        mailsender = MailSender(debug=True)
+        mailsender = MailSender(debug=True, crawler=self.crawler)
         mailsender.send(to=['test@scrapy.org'], subject='subject', body='body')
 
         assert self.catched_msg
@@ -36,7 +36,7 @@ class MailSenderTest(unittest.TestCase):
         attach.seek(0)
         attachs = [('attachment', 'text/plain', attach)]
 
-        mailsender = MailSender(debug=True)
+        mailsender = MailSender(debug=True, crawler=self.crawler)
         mailsender.send(to=['test@scrapy.org'], subject='subject', body='body',
                        attachs=attachs)
 

--- a/scrapy/tests/test_spidermiddleware_depth.py
+++ b/scrapy/tests/test_spidermiddleware_depth.py
@@ -4,6 +4,7 @@ from scrapy.contrib.spidermiddleware.depth import DepthMiddleware
 from scrapy.http import Response, Request
 from scrapy.spider import BaseSpider
 from scrapy.statscol import StatsCollector
+from scrapy.utils.test import get_crawler
 
 
 class TestDepthMiddleware(TestCase):
@@ -11,7 +12,7 @@ class TestDepthMiddleware(TestCase):
     def setUp(self):
         self.spider = BaseSpider('scrapytest.org')
 
-        self.stats = StatsCollector()
+        self.stats = StatsCollector(get_crawler())
         self.stats.open_spider(self.spider)
 
         self.mw = DepthMiddleware(1, self.stats, True)

--- a/scrapy/webservice.py
+++ b/scrapy/webservice.py
@@ -6,7 +6,6 @@ See docs/topics/webservice.rst
 
 from twisted.web import server, error
 
-from scrapy.xlib.pydispatch import dispatcher
 from scrapy.exceptions import NotConfigured
 from scrapy import log, signals
 from scrapy.utils.jsonrpc import jsonrpc_server_call
@@ -80,8 +79,8 @@ class WebService(server.Site):
             root.putChild(res.ws_name, res)
         server.Site.__init__(self, root, logPath=logfile)
         self.noisy = False
-        dispatcher.connect(self.start_listening, signals.engine_started)
-        dispatcher.connect(self.stop_listening, signals.engine_stopped)
+        crawler.signals.connect(self.start_listening, signals.engine_started)
+        crawler.signals.connect(self.stop_listening, signals.engine_stopped)
 
     @classmethod
     def from_crawler(cls, crawler):


### PR DESCRIPTION
This pull request is to review and discuss the singletons removal branch, that is expected to land for the next major release (Scrapy 0.16).

The code passes all tests and is (quite) backwards compatible but there's a couple of things missing yet:
- remove logging singleton (`crawler.log.msg()` I suppose)
- update the documentation with the changes
