### PR TITLE
lxml selectors cannot handle non-unicode or non-ascii xpaths

### DIFF
--- a/scrapy/tests/test_selector.py
+++ b/scrapy/tests/test_selector.py
@@ -49,6 +49,17 @@ class XPathSelectorTestCase(unittest.TestCase):
         xpath = self.hxs_cls(response)
         self.assertEqual(xpath.select(u'//input[@name="\xa9"]/@value').extract(), [u'1'])
 
+    def test_selector_encoded_query(self):
+        body = '''<p><input name="\xa3" value='1'/></p>'''
+        response = TextResponse(url="http://example.com", body=body, encoding='latin1')
+        xpath = self.hxs_cls(response)
+        self.assertEqual(xpath.select(b'//input[@name="\xa3"]/@value').extract(), [u'1'])
+
+        body = '''<p><div class="\xa3"><span id="\xa3">text</span></div></p>'''
+        response = TextResponse(url="http://example.com", body=body, encoding='latin1')
+        xpath = self.hxs_cls(response)
+        self.assertEqual(xpath.select(b'//div[@class="\xa3"]').select('.//span[@id="\xa3"]/text()').extract(), [u'text'])
+
     @libxml2debug
     def test_selector_same_type(self):
         """Test XPathSelector returning the same type in x() method"""


### PR DESCRIPTION
Recently we switched default selectors backend to lxml but happens that lxml is strict and raises errors if non-ascii encoded xpath strings are passed

```

======================================================================
ERROR: test_selector_encoded_query
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/daniel/envs/sh/local/lib/python2.7/site-packages/twisted/internet/defer.py", line 133, in maybeDeferred
    result = f(*args, **kw)
  File "/home/daniel/envs/sh/local/lib/python2.7/site-packages/twisted/internet/utils.py", line 191, in runWithWarningsSuppressed
    result = f(*a, **kw)
  File "/home/daniel/src/scrapy/scrapy/tests/test_selector.py", line 56, in test_selector_encoded_query
    self.assertEqual(xpath.select(b'//input[@name="\xa3"]/@value').extract(), [u'1'])
  File "/home/daniel/src/scrapy/scrapy/selector/lxmlsel.py", line 54, in select
    result = self.xpathev(xpath)
  File "xpath.pxi", line 311, in lxml.etree.XPathElementEvaluator.__call__ (src/lxml/lxml.etree.c:113737)
  File "apihelpers.pxi", line 1366, in lxml.etree._utf8 (src/lxml/lxml.etree.c:22211)
ValueError: All strings must be XML compatible: Unicode or ASCII, no NULL bytes or control characters

----------------------------------------------------------------------
```
