### PR TITLE
ImagesPipeline should not fail if Item['images'] is not defined.

### DIFF
--- a/scrapy/contrib/pipeline/images.py
+++ b/scrapy/contrib/pipeline/images.py
@@ -309,5 +309,6 @@ class ImagesPipeline(MediaPipeline):
         return [Request(x) for x in item.get('image_urls', [])]
 
     def item_completed(self, results, item, info):
-        item['images'] = [x for ok, x in results if ok]
+        if 'images' in item.fields:
+            item['images'] = [x for ok, x in results if ok]
         return item


### PR DESCRIPTION
In my project I am using several Items and only one of them I want to use with ImagesPipeline to download images. Currently the method item_completed does not check if the images attribute is defined and it fails it not. It would be better just to continue gracefully - same like with image_urls attribute.
