### PR TITLE
log level specified on command line is not used

### DIFF
--- a/scrapy/command.py
+++ b/scrapy/command.py
@@ -93,7 +93,11 @@ class ScrapyCommand(object):
 
         if opts.loglevel:
             self.settings.overrides['LOG_ENABLED'] = True
-            self.settings.overrides['LOG_LEVEL'] = opts.loglevel
+            try:
+                level = int(opts.loglevel)
+            except:
+                level = opts.loglevel
+            self.settings.overrides['LOG_LEVEL'] = level
 
         if opts.nolog:
             self.settings.overrides['LOG_ENABLED'] = False


### PR DESCRIPTION
An alternative to removing the illusion of supporting random integer log levels (see https://github.com/scrapy/scrapy/pull/138) is to actually support it by using the self.settings.overrides value that get set via a command such as

> scrapy crawl --loglevel=1 --logfile=debug.log my_spider
