### PR TITLE
Add dropped items stats to LogStats

### DIFF
--- a/scrapy/contrib/logstats.py
+++ b/scrapy/contrib/logstats.py
@@ -10,8 +10,11 @@ class Slot(object):
     def __init__(self):
         self.items = 0
         self.itemsprev = 0
+        self.dropped_items = 0
+        self.dropped_itemsprev = 0
         self.pages = 0
         self.pagesprev = 0
+
 
 class LogStats(object):
     """Log basic scraping stats periodically"""
@@ -23,6 +26,7 @@ class LogStats(object):
         self.slots = {}
         self.multiplier = 60.0 / self.interval
         dispatcher.connect(self.item_scraped, signal=signals.item_scraped)
+        dispatcher.connect(self.item_dropped, signal=signals.item_dropped)
         dispatcher.connect(self.response_received, signal=signals.response_received)
         dispatcher.connect(self.spider_opened, signal=signals.spider_opened)
         dispatcher.connect(self.spider_closed, signal=signals.spider_closed)
@@ -31,6 +35,9 @@ class LogStats(object):
 
     def item_scraped(self, spider):
         self.slots[spider].items += 1
+
+    def item_dropped(self, spider):
+        self.slots[spider].dropped_items += 1
 
     def response_received(self, spider):
         self.slots[spider].pages += 1
@@ -49,9 +56,10 @@ class LogStats(object):
         for spider, slot in self.slots.items():
             irate = (slot.items - slot.itemsprev) * self.multiplier
             prate = (slot.pages - slot.pagesprev) * self.multiplier
-            slot.pagesprev, slot.itemsprev = slot.pages, slot.items
-            msg = "Crawled %d pages (at %d pages/min), scraped %d items (at %d items/min)" \
-                % (slot.pages, prate, slot.items, irate)
+            irate_dropped = (slot.dropped_items - slot.dropped_itemsprev) * self.multiplier
+            slot.pagesprev, slot.itemsprev, slot.dropped_itemsprev = slot.pages, slot.items, slot.dropped_items
+            msg = "Crawled %d pages (at %d pages/min), scraped %d items (at %d items/min), dropped %d items (at %d items/min)"\
+            % (slot.pages, prate, slot.items, irate, slot.dropped_items, irate_dropped)
             log.msg(msg, spider=spider)
 
     def engine_stopped(self):


### PR DESCRIPTION
I wrote a few spiders, what crawling a very big sites with many items on many pages. I dropped already inserted items in pipelines. So, I want to have info about that. New log looks like this: 
INFO: Crawled 230 pages (at 60 pages/min), scraped 698 items (at 330 items/min), dropped 48698 items (at 30220 items/min)
INFO: Crawled 338 pages (at 31 pages/min), scraped 5141 items (at 1566 items/min), dropped 193327 items (at 26394 items/min)
This is the first my pull request, sorry if I made any mistake.
Part of code of process_item in Pipelines:

session.add(k)
        try:
            session.flush()
        except exc.IntegrityError:
            session.rollback()
            raise DropItem('duplicate "%s"' % item.get('some_part_or_item'))
        else:
            return item
