### PR TITLE
domain and path support for request cookies

### DIFF
--- a/docs/topics/request-response.rst
+++ b/docs/topics/request-response.rst
@@ -51,10 +51,21 @@ Request objects
        (for single valued headers) or lists (for multi-valued headers).
     :type headers: dict
 
-    :param cookies: the request cookies. Example::
+    :param cookies: the request cookies. These can be sent in two forms::
 
             request_with_cookies = Request(url="http://www.example.com",
                                            cookies={'currency': 'USD', 'country': 'UY'})
+        ::
+
+            request_with_cookies = Request(url="http://www.example.com",
+                                           cookies=[{'name': 'currency',
+                                                    'value': 'USD',
+                                                    'domain': 'example.com',
+                                                    'path': '/currency'}])
+
+        The latter form allows for customizing the ``domain`` and ``path``
+        attributes of the cookie. These is only useful if the cookies are saved
+        for later requests.
 
         When some site returns cookies (in a response) those are stored in the
         cookies for that domain and will be sent again in future requests. That's
@@ -70,7 +81,7 @@ Request objects
                                            meta={'dont_merge_cookies': True})
 
         For more info see :ref:`cookies-mw`.
-    :type cookies: dict
+    :type cookies: dict or list
 
     :param encoding: the encoding of this request (defaults to ``'utf-8'``).
        This encoding will be used to percent-encode the URL and to convert the


### PR DESCRIPTION
Currently you cannot add cookies with a path or a domain to a request ([docs](http://doc.scrapy.org/en/latest/topics/request-response.html#scrapy.http.Request)), since these are passed in the form `{'c1': 'value1', 'c2': 'value2'}`

This allows sending cookies either in the form above or
`[{'name': 'c1', 'value': 'value1', 'path': '/', 'domain': 'example.org'}, ...]`

Name and value are mandatory, path and domain optional. Other possible attributes like 'Expires' or 'Max-age' could also be added. Docs also need to be updated.

Please review.
