### PR TITLE
Make sure that the response's meta is not discarded when passed to the SpiderCrawl._requests_to_follow

### DIFF
--- a/scrapy/contrib/spiders/crawl.py
+++ b/scrapy/contrib/spiders/crawl.py
@@ -55,7 +55,7 @@ class CrawlSpider(BaseSpider):
                 links = rule.process_links(links)
             seen = seen.union(links)
             for link in links:
-                r = Request(url=link.url, callback=self._response_downloaded)
+                r = Request(url=link.url, callback=self._response_downloaded, meta=response.meta)
                 r.meta.update(rule=n, link_text=link.text)
                 yield rule.process_request(r)
 
@@ -73,7 +73,7 @@ class CrawlSpider(BaseSpider):
         if follow and settings.getbool('CRAWLSPIDER_FOLLOW_LINKS', True):
             for request_or_item in self._requests_to_follow(response):
                 yield request_or_item
-                
+
 
     def _compile_rules(self):
         def get_method(method):


### PR DESCRIPTION
**Use Case:**

One of my spiders have the the following:

``` python
class MySpider(CrawlSpider):
    ...
    def start_requests(self):
        ...
        for i in ...
             yield FormRequest(url, method='POST',
                   formdata={'page': i},
                   callback=self._requests_to_follow,
                   meta={...}
             )  
```

As you can see, i am creating a new `Response` while passing it some data as meta to be able to retrieve it in my main parse method.

Without the following patch, the `_requests_to_follow` method was creating a new `Response` but this latest didn't have the meta that i passed, which IMHO i consider a bug.

**My fix** was to extend the `_requests_to_follow` method as bellow but i am hopping that this bug can be fixed in scrapy directly:

``` python
def _requests_to_follow(self, response):
        """Extend the parent ``_requests_to_follow`` method to be able to pass
        the original response's meta data that the original method cut off when
        creating response from the rules.

        """
        for new_response in \
                super(MySpider, self)._requests_to_follow(response):
            new_response.meta.update(response.meta)
            yield new_response
```

N.B: I didn't write any unit test for this b/c i didn't find a simple way to test it, FYI i did run all the tests after the change to make sure i didn't break anything :), so if the tests are required please advise me as to the best way to do it.

Thanks,
