### PR TITLE
Spider not found - confusion

### DIFF
--- a/scrapy/utils/project.py
+++ b/scrapy/utils/project.py
@@ -13,8 +13,8 @@ def inside_project():
     if scrapy_module is not None:
         try:
             __import__(scrapy_module)
-        except ImportError:
-            warnings.warn("Cannot import scrapy settings module %s" % scrapy_module)
+        except ImportError as exc:
+            warnings.warn("Cannot import scrapy settings module %s: %s" % (scrapy_module, exc))
         else:
             return True
     return bool(closest_scrapy_cfg())


### PR DESCRIPTION
If you put in settings.py something like import local_settings and local_settings doesn't exist or contains errors you get:

``` bash
/usr/local/lib/python2.7/dist-packages/Scrapy-0.15.1-py2.7.egg/scrapy/utils/project.py:17: UserWarning: Cannot import scrapy settings module settings
warnings.warn("Cannot import scrapy settings module %s" % scrapy_module)
...
File "/usr/local/lib/python2.7/dist-packages/Scrapy-0.15.1-py2.7.egg/scrapy/cmdline.py", line 117, in _run_command
cmd.run(args, opts)
File "/usr/local/lib/python2.7/dist-packages/Scrapy-0.15.1-py2.7.egg/scrapy/commands/crawl.py", line 43, in run
spider = self.crawler.spiders.create(spname, **opts.spargs)
File "/usr/local/lib/python2.7/dist-packages/Scrapy-0.15.1-py2.7.egg/scrapy/spidermanager.py", line 43, in create
raise KeyError("Spider not found: %s" % spider_name)
KeyError: 'Spider not found: fb_spider'
```

Which is not very descriptive.

Now showing details about the exception when ImportError was raises
