### PR TITLE
Just a simple refactoring on *MemoryQueue classes that improve the performance

### DIFF
--- a/scrapy/utils/queue.py
+++ b/scrapy/utils/queue.py
@@ -10,13 +10,11 @@ class FifoMemoryQueue(object):
 
     def __init__(self):
         self.q = deque()
-
-    def push(self, obj):
-        self.q.appendleft(obj)
+        self.push = self.q.append
 
     def pop(self):
-        if self.q:
-            return self.q.pop()
+        q = self.q
+        return q.popleft() if q else None
 
     def close(self):
         pass
@@ -28,8 +26,9 @@ class FifoMemoryQueue(object):
 class LifoMemoryQueue(FifoMemoryQueue):
     """Memory LIFO queue."""
 
-    def push(self, obj):
-        self.q.append(obj)
+    def pop(self):
+        q = self.q
+        return q.pop() if q else None
 
 
 class FifoDiskQueue(object):


### PR DESCRIPTION
I was looking at the queues implementation and started to play with them, then I realized this improvement was nice.

Test script to test performance: https://gist.github.com/3310581 (include old and patched queue)

On 1 M items:

```
% python perf_queues.py 1000000
class : FifoMemoryQueue
 push time: 0.26581287384
  pop time: 0.302397012711
  empty pop time: 0.182332992554
class : LifoMemoryQueue
 push time: 0.263482093811
  pop time: 0.325941085815
  empty pop time: 0.188323974609
class : NewFifoMemoryQueue
 push time: 0.0734930038452
  pop time: 0.290125846863
  empty pop time: 0.195247888565
class : NewLifoMemoryQueue
 push time: 0.0740909576416
  pop time: 0.288778066635
  empty pop time: 0.199521064758
```

On 10M items:

```
% python perf_queues.py 10000000
class : FifoMemoryQueue
 push time: 2.70697999001
  pop time: 2.92778491974
  empty pop time: 1.98276090622
class : LifoMemoryQueue
 push time: 2.7147758007
  pop time: 2.98942518234
  empty pop time: 1.80923390388
class : NewFifoMemoryQueue
 push time: 0.750053882599
  pop time: 2.96709609032
  empty pop time: 1.99379086494
class : NewLifoMemoryQueue
 push time: 0.768209934235
  pop time: 2.88156580925
  empty pop time: 1.88952207565
```

Improvement:
- FifoMemoryQueue on push ~4x
- LifoMemoryQueue on push ~4x

_UPDATE:_ @dangra point me to test the case of the empty queue, now include them.
