### PR TITLE
parse command: fix crash in case of bad callback

### DIFF
--- a/scrapy/commands/parse.py
+++ b/scrapy/commands/parse.py
@@ -152,9 +152,14 @@ class Command(ScrapyCommand):
                 else:
                     cb = 'parse'
 
-            cb = cb if callable(cb) else getattr(self.spider, cb, None)
-            if not cb:
-                log.msg('Cannot find callback %r in spider: %s' % (callback, self.spider.name))
+            if not callable(cb):
+                cb_method = getattr(self.spider, cb, None)
+                if callable(cb_method):
+                    cb = cb_method
+                else:
+                    log.msg('Cannot find callback %r in spider: %s' % \
+                            (cb, self.spider.name), level=log.ERROR)
+                    return
 
             # parse items and requests
             depth = response.meta['_depth']


### PR DESCRIPTION
There is an error in the parse command giving a misleading traceback in case the callback cannot be found.
The command should not run in case of a missing callback.
