### PR TITLE
Allow to set SSL method to use when connecting to https sites

### DIFF
--- a/scrapy/core/downloader/handlers/http.py
+++ b/scrapy/core/downloader/handlers/http.py
@@ -8,6 +8,7 @@ from scrapy import optional_features
 
 ssl_supported = 'ssl' in optional_features
 
+
 class HttpDownloadHandler(object):
 
     def __init__(self, settings):
@@ -17,15 +18,14 @@ class HttpDownloadHandler(object):
     def download_request(self, request, spider):
         """Return a deferred for the HTTP download"""
         factory = self.HTTPClientFactory(request)
-        self._connect(factory)
-        return factory.deferred
-
-    def _connect(self, factory):
         host, port = factory.host, factory.port
         if factory.scheme == 'https':
             if ssl_supported:
-                return reactor.connectSSL(host, port, factory, \
-                        self.ClientContextFactory())
-            raise NotSupported("HTTPS not supported: install pyopenssl library")
+                ccf = self.ClientContextFactory(request)
+                reactor.connectSSL(host, port, factory, ccf)
+            else:
+                raise NotSupported("HTTPS not supported: install pyopenssl library")
         else:
-            return reactor.connectTCP(host, port, factory)
+            reactor.connectTCP(host, port, factory)
+
+        return factory.deferred

--- a/scrapy/core/downloader/webclient.py
+++ b/scrapy/core/downloader/webclient.py
@@ -151,6 +151,9 @@ class ScrapyClientContextFactory(ClientContextFactory):
     # see https://github.com/scrapy/scrapy/issues/82
     # and https://github.com/scrapy/scrapy/issues/26
 
+    def __init__(self, request):
+        self.method = request.meta.get('ssl_method', SSL.SSLv23_METHOD)
+
     def getContext(self):
         ctx = ClientContextFactory.getContext(self)
         # Enable all workarounds to SSL bugs as documented by


### PR DESCRIPTION
some broken sites fails to scrape if we let SSL method to be negotiated between scrapy client and site server, but they work if method can be explicitly set to TLSv1

```
$ scrapy fetch https://208.86.169.96/
...
2012-11-07 17:05:57-0200 [default] ERROR: Error downloading <GET https://208.86.169.96/>: [('SSL routines', 'SSL23_READ', 'ssl handshake failure')]
...
```

This patch allows to override the ssl method by passing the special meta key `ssl_method`
