### PR TITLE
Image pipeline error improvement

### DIFF
--- a/scrapy/contrib/pipeline/images.py
+++ b/scrapy/contrib/pipeline/images.py
@@ -198,7 +198,7 @@ class ImagesPipeline(MediaPipeline):
             key = self.image_key(request.url)
             checksum = self.image_downloaded(response, request, info)
         except ImageException, ex:
-            log.err('image_downloaded hook failed',
+            log.err('image_downloaded hook failed: %s' % ex,
                     level=log.WARNING, spider=info.spider)
             raise
         except Exception:


### PR DESCRIPTION
When I run the pipeline, it just fails with message WARNING: 'image_downloaded hook failed' which is not very informative.

After the change it reports WARNING: 'image_downloaded hook failed: Cannot process image. Error: decoder jpeg not available' which is a bit better. ;-)
