### PR TITLE
Fixed error message formatting.

### DIFF
--- a/scrapy/core/scraper.py
+++ b/scrapy/core/scraper.py
@@ -205,7 +205,7 @@ class Scraper(object):
                 return self.signals.send_catch_log_deferred(signal=signals.item_dropped, \
                     item=item, spider=spider, exception=output.value)
             else:
-                log.err(output, 'Error processing %(item)s', item=item, spider=spider)
+                log.err(output, 'Error processing %s' % item, spider=spider)
         else:
             logkws = self.logformatter.scraped(output, response, spider)
             log.msg(spider=spider, **logkws)


### PR DESCRIPTION
log.err() doesn't support cool formatting and when error occurred, the message was literally:
    "ERROR: Error processing %(item)s"
