### PR TITLE
Added "request" attribute to Failure objects

### DIFF
--- a/scrapy/core/scraper.py
+++ b/scrapy/core/scraper.py
@@ -95,6 +95,9 @@ class Scraper(object):
             slot.closing.callback(spider)
 
     def enqueue_scrape(self, response, request, spider):
+        if isinstance(response, Failure):
+            response.value.request = request
+
         slot = self.slots[spider]
         dfd = slot.add_response_request(response, request)
         def finish_scraping(_):


### PR DESCRIPTION
When error occurs during downloading, it carries "request" attribute that can be used in spider's errbacks.
