### PR TITLE
Proposed Changes to DjangoItem documentation

### DIFF
--- a/docs/topics/djangoitem.rst
+++ b/docs/topics/djangoitem.rst
@@ -24,14 +24,16 @@ override fields that are present in the model defining them in the item.
 
 Let's see some examples:
 
-Django model for the examples::
-
+Creating a Django model for the examples::
+   
+   from django.db import models
    class Person(models.Model):
        name = models.CharField(max_length=255)
        age = models.IntegerField()
 
 Defining a basic :class:`DjangoItem`::
-    
+
+   from scrapy.contrib.djangoitem import DjangoItem 
    class PersonItem(DjangoItem):
        django_model = Person
        
@@ -52,7 +54,7 @@ To obtain the Django model from the item, we call the extra method
    >>> person.id
    1
 
-As you see the model is already saved when we call :meth:`~DjangoItem.save`, we
+The model is already saved when we call :meth:`~DjangoItem.save`, we
 can prevent this by calling it with ``commit=False``. We can use
 ``commit=False`` in :meth:`~DjangoItem.save` method to obtain an unsaved model::
 


### PR DESCRIPTION
I was very confused as to how you actually import DjangoItem.
I searched extensively on the internet looking for actual code so I could see how it worked.
I finally found http://blog.just2us.com/2012/07/setting-up-django-with-scrapy/. It is much easier to understand with full files instead of code fragments.
I also edited where it says "we can see that the model is already saved" as I don't see how it's already saved.
