### PR TITLE
Correct init bag for load FilesystemCacheStorage from old location

### DIFF
--- a/scrapy/contrib/downloadermiddleware/httpcache.py
+++ b/scrapy/contrib/downloadermiddleware/httpcache.py
@@ -100,4 +100,4 @@ class FilesystemCacheStorage(_FilesystemCacheStorage):
                       'scrapy.contrib.downloadermiddlware.httpcache is '
                       'deprecated, use scrapy.contrib.httpcache instead.',
                       category=ScrapyDeprecationWarning, stacklevel=1)
-        super(_FilesystemCacheStorage, self).__init__(*args, **kwargs)
+        super(FilesystemCacheStorage, self).__init__(*args, **kwargs)


### PR DESCRIPTION
Correct init bag for load old scrapy.contrib.httpcache.FilesystemCacheStorage
