### PR TITLE
HTTPS over a proxy with Proxy-Connection and CONNECT

### DIFF
--- a/scrapy/core/downloader/webclient.py
+++ b/scrapy/core/downloader/webclient.py
@@ -10,6 +10,8 @@ from scrapy.utils.httpobj import urlparse_cached
 from scrapy.responsetypes import responsetypes
 from scrapy import optional_features
 
+from scrapy import log
+
 
 def _parsed_url_args(parsed):
     path = urlunparse(('', '', parsed.path or '/', parsed.params, parsed.query, ''))
@@ -35,25 +37,83 @@ class ScrapyHTTPPageGetter(HTTPClient):
     def connectionMade(self):
         self.headers = Headers() # bucket for response headers
 
+        if self.factory.use_tunnel:
+            log.msg("Sending CONNECT", log.DEBUG)
+            self.tunnel_started = False
+            self.sendCommand("CONNECT", "%s:%s"
+                % (self.factory.tunnel_to_host, self.factory.tunnel_to_port))
+            self.sendHeaders(only=['Host','Proxy-Connection', 'User-Agent'])
+            del self.factory.headers['Proxy-Connection']
+        else:
+            self.sendEverything()
+
+
+    def sendCommand(self, command, path):
+        if self.factory.use_tunnel and not self.tunnel_started:
+            http_version = "1.1"
+        else:
+            http_version = "1.0"
+        self.transport.write('%s %s HTTP/%s\r\n' % (command, path, http_version))
+
+    def sendEverything(self):
+        self.sendMethod()
+        self.sendHeaders()
+        self.sendBody()
+
+    def sendMethod(self):
         # Method command
         self.sendCommand(self.factory.method, self.factory.path)
-        # Headers
-        for key, values in self.factory.headers.items():
-            for value in values:
+
+    def sendHeaders(self, only=None):
+        # Note: it's a Headers object, not a dict
+        keys = only if only is not None else self.factory.headers.keys()
+        for key in keys:
+            for value in self.factory.headers.getlist(key):
                 self.sendHeader(key, value)
         self.endHeaders()
+
+    def sendBody(self):
         # Body
         if self.factory.body is not None:
             self.transport.write(self.factory.body)
 
     def lineReceived(self, line):
-        return HTTPClient.lineReceived(self, line.rstrip())
+        if self.factory.use_tunnel and not self.tunnel_started: log.msg("LINE: %s" % line)
+        if self.factory.use_tunnel and not self.tunnel_started and not line.rstrip():
+            # End of headers from the proxy in response to our CONNECT request
+            # Skip the call to HTTPClient.lienReceived for now, since otherwise
+            # it would switch to row mode.
+            self.startTunnel()
+        else:
+            return HTTPClient.lineReceived(self, line.rstrip())
+
+    def startTunnel(self):
+        log.msg("starting Tunnel")
+
+        # We'll get a new batch of headers through the tunnel. This sets us
+        # up to capture them.
+        self.firstLine = True
+        self.tunnel_started = True
+
+        # Switch to SSL
+        ctx = ClientContextFactory()
+        self.transport.startTLS(ctx, self.factory)
+
+        # And send the normal request:
+        self.sendEverything()
+
 
     def handleHeader(self, key, value):
-        self.headers.appendlist(key, value)
+        if self.factory.use_tunnel and not self.tunnel_started:
+             pass # maybe log headers for CONNECT request?
+        else:
+             self.headers.appendlist(key, value)
 
     def handleStatus(self, version, status, message):
-        self.factory.gotStatus(version, status, message)
+        if self.factory.use_tunnel and not self.tunnel_started:
+             self.tunnel_status = status
+        else:
+             self.factory.gotStatus(version, status, message)
 
     def handleEndHeaders(self):
         self.factory.gotHeaders(self.headers)
@@ -78,7 +138,7 @@ class ScrapyHTTPPageGetter(HTTPClient):
 
 class ScrapyHTTPClientFactory(HTTPClientFactory):
     """Scrapy implementation of the HTTPClientFactory overwriting the
-    serUrl method to make use of our Url object that cache the parse 
+    serUrl method to make use of our Url object that cache the parse
     result.
     """
 
@@ -127,10 +187,17 @@ class ScrapyHTTPClientFactory(HTTPClientFactory):
     def _set_connection_attributes(self, request):
         parsed = urlparse_cached(request)
         self.scheme, self.netloc, self.host, self.port, self.path = _parsed_url_args(parsed)
+        self.use_tunnel = False
         proxy = request.meta.get('proxy')
         if proxy:
+            old_scheme, old_host, old_port = self.scheme, self.host, self.port
             self.scheme, _, self.host, self.port, _ = _parse(proxy)
-            self.path = self.url
+            if old_scheme=="https" and 'ssl' in optional_features:
+                 self.headers['Proxy-Connection'] = 'keep-alive'
+                 self.use_tunnel = True
+                 self.tunnel_to_host = old_host
+                 self.tunnel_to_port = old_port
+            if not self.use_tunnel: self.path = self.url
 
     def gotHeaders(self, headers):
         self.headers_time = time()


### PR DESCRIPTION
Adds proxy CONNECT support based on sabren's #45 pull request incorporating fix mentioned by scottyallen and subsequent changes to webclient. 

If you are crawling https urls with e.g., proxymesh (a provider [referenced on scrapy.org](http://doc.scrapy.org/en/latest/topics/practices.html)) this is required functionality.
