### PR TITLE
Fix url_has_any_extension bug

### DIFF
--- a/scrapy/utils/url.py
+++ b/scrapy/utils/url.py
@@ -28,7 +28,7 @@ def url_is_from_spider(url, spider):
         getattr(spider, 'allowed_domains', []))
 
 def url_has_any_extension(url, extensions):
-    return posixpath.splitext(parse_url(url).path)[1].lower() in extensions
+    return posixpath.splitext(parse_url(url).path)[-1].lower() in extensions
 
 def canonicalize_url(url, keep_blank_values=True, keep_fragments=False, \
         encoding=None):


### PR DESCRIPTION
Extension is the last element in the list split around '.',
thus the index should be -1 instead of 1.
