### PR TITLE
scrapy genspider allows you to create a spider module with the same name as the project

### DIFF
--- a/scrapy/commands/genspider.py
+++ b/scrapy/commands/genspider.py
@@ -56,6 +56,11 @@ class Command(ScrapyCommand):
 
         name, domain = args[0:2]
         module = sanitize_module_name(name)
+
+        if self.settings.get('BOT_NAME') == module:
+            print "Cannot create a spider with the same name as your project"
+            return
+
         try:
             spider = self.crawler.spiders.create(name)
         except KeyError:

--- a/scrapy/tests/test_commands.py
+++ b/scrapy/tests/test_commands.py
@@ -112,6 +112,10 @@ class GenspiderCommandTest(CommandTest):
         self.assertEqual(0, self.call('genspider', '--dump=basic'))
         self.assertEqual(0, self.call('genspider', '-d', 'basic'))
 
+    def test_same_name_as_project(self):
+        self.assertEqual(2, self.call('genspider', self.project_name))
+        assert not exists(join(self.proj_mod_path, 'spiders', '%s.py' % self.project_name))
+
 
 class MiscCommandsTest(CommandTest):
 


### PR DESCRIPTION
scrapy genspider allows you to create a spider module with the same name as the project leading to import error when you try to use it. This patch checks when creating a spider and prints an error message if the spider name is the same as the project.

``` bash
# cd /tmp/
# scrapy startproject testing
# cd testing/
# scrapy genspider testing example.com
Created spider 'testing' using template 'crawl' in module:
  testing.spiders.testing
# scrapy crawl testing
2013-02-12 12:33:17+0000 [scrapy] INFO: Scrapy 0.12.0.2546 started (bot: testing)
2013-02-12 12:33:17+0000 [scrapy] DEBUG: Enabled extensions: TelnetConsole, SpiderContext, WebService, CoreStats, MemoryUsage, CloseSpider
Traceback (most recent call last):
  File "/usr/bin/scrapy", line 4, in <module>
    execute()
  File "/usr/lib/python2.7/dist-packages/scrapy/cmdline.py", line 131, in execute
    _run_print_help(parser, _run_command, cmd, args, opts)
  File "/usr/lib/python2.7/dist-packages/scrapy/cmdline.py", line 97, in _run_print_help
    func(*a, **kw)
  File "/usr/lib/python2.7/dist-packages/scrapy/cmdline.py", line 138, in _run_command
    cmd.run(args, opts)
  File "/usr/lib/python2.7/dist-packages/scrapy/commands/crawl.py", line 42, in run
    q = self.crawler.queue
  File "/usr/lib/python2.7/dist-packages/scrapy/command.py", line 33, in crawler
    self._crawler.configure()
  File "/usr/lib/python2.7/dist-packages/scrapy/crawler.py", line 36, in configure
    self.spiders = spman_cls.from_settings(self.settings)
  File "/usr/lib/python2.7/dist-packages/scrapy/spidermanager.py", line 33, in from_settings
    return cls(settings.getlist('SPIDER_MODULES'))
  File "/usr/lib/python2.7/dist-packages/scrapy/spidermanager.py", line 23, in __init__
    for module in walk_modules(name):
  File "/usr/lib/python2.7/dist-packages/scrapy/utils/misc.py", line 65, in walk_modules
    submod = __import__(fullpath, {}, {}, [''])
  File "/tmp/testing/testing/spiders/testing.py", line 6, in <module>
    from testing.items import TestingItem
ImportError: No module named items
```
