### PR TITLE
added debug log message for filtered URLs

### DIFF
--- a/scrapy/core/scheduler.py
+++ b/scrapy/core/scheduler.py
@@ -46,6 +46,8 @@ class Scheduler(object):
 
     def enqueue_request(self, request):
         if not request.dont_filter and self.df.request_seen(request):
+            log.msg(format="Skip already visited URL: %(url)s",
+                    level=log.DEBUG, url=request.url)
             return
         dqok = self._dqpush(request)
         if dqok:


### PR DESCRIPTION
Sometime it is hard to notice URLs which were skip without any log messages, especially when many items should be scraped and some of them should be duplicated.
