### PR TITLE
Override Request 'method' in FormRequest

### DIFF
--- a/scrapy/http/request/form.py
+++ b/scrapy/http/request/form.py
@@ -36,7 +36,8 @@ class FormRequest(Request):
         form = _get_form(response, formname, formnumber, formxpath)
         formdata = _get_inputs(form, formdata, dont_click, clickdata, response)
         url = form.action or form.base_url
-        return cls(url, method=form.method, formdata=formdata, **kwargs)
+        method = kwargs.pop('method', form.method)
+        return cls(url, method=method, formdata=formdata, **kwargs)
 
 
 def _urlencode(seq, enc):

--- a/scrapy/tests/test_http_request.py
+++ b/scrapy/tests/test_http_request.py
@@ -268,6 +268,16 @@ class FormRequestTest(RequestTest):
         self.assertEqual(fs['one'], ['1'])
         self.assertEqual(fs['two'], ['2'])
 
+    def test_from_response_override_method(self):
+        response = _buildresponse(
+                '''<html><body>
+                <form action="/app"></form>
+                </body></html>''')
+        request = FormRequest.from_response(response)
+        self.assertEqual(request.method, 'GET')
+        request = FormRequest.from_response(response, method='POST')
+        self.assertEqual(request.method, 'POST')
+
     def test_from_response_submit_first_clickable(self):
         response = _buildresponse(
             """<form action="get.php" method="GET">


### PR DESCRIPTION
Sometimes the method in the form is not valid or we want to override it.
