### PR TITLE
Add support for bpython.

### DIFF
--- a/scrapy/utils/console.py
+++ b/scrapy/utils/console.py
@@ -1,21 +1,26 @@
 
 def start_python_console(namespace=None, noipython=False):
-    """Start Python console binded to the given namespace. If IPython is
-    available, an IPython console will be started instead, unless `noipython`
-    is True. Also, tab completion will be used on Unix systems.
+    """Start Python console binded to the given namespace. If bpython is
+    available, a bpython console will be started instead, with an IPython
+    console as a fallback unless `noipython` is True. Also, tab completion
+    will be used on Unix systems.
     """
     if namespace is None:
         namespace = {}
     try:
-        try: # use IPython if available
+        try:
             if noipython:
                 raise ImportError
-            import IPython
-            try:
-                IPython.embed(user_ns=namespace)
-            except AttributeError:
-                shell = IPython.Shell.IPShellEmbed(argv=[], user_ns=namespace)
-                shell()
+            try: # use bpython if available
+                import bpython
+                bpython.embed(locals_=namespace)
+            except ImportError: # use IPython if available
+                import IPython
+                try:
+                    IPython.embed(user_ns=namespace)
+                except AttributeError:
+                    shell = IPython.Shell.IPShellEmbed(argv=[], user_ns=namespace)
+                    shell()
         except ImportError:
             import code
             try: # readline module is only available on unix systems


### PR DESCRIPTION
bpython is a fancy interface to the Python interpreter, with lots of features like syntax highlight (using pygments), autocomplete and pastebin support.

This is a trivial patch, we might rethink the `start_python_console` arguments in order to let the user choose which console the user wants. This code defaults to bpython if it is available, falls back to IPython and, finally, python if no fancier interpreter is around.