### PR TITLE
Updated settings import in contrib/feedexport.py class S3FeedStorage

### DIFF
--- a/scrapy/contrib/feedexport.py
+++ b/scrapy/contrib/feedexport.py
@@ -19,6 +19,7 @@ from scrapy.utils.ftp import ftp_makedirs_cwd
 from scrapy.exceptions import NotConfigured
 from scrapy.utils.misc import load_object
 from scrapy.utils.python import get_func_args
+from scrapy.utils.project import get_project_settings
 
 
 class IFeedStorage(Interface):
@@ -81,7 +82,7 @@ class FileFeedStorage(object):
 class S3FeedStorage(BlockingFeedStorage):
 
     def __init__(self, uri):
-        from scrapy.conf import settings
+        settings = get_project_settings()
         try:
             import boto
         except ImportError:


### PR DESCRIPTION
This little patch fixes the use of the deprecated scrapy.settings module used in the class S3FeedStorage in contrib/feedexport.py. After applying this commit the warning below will not appear when exporting to S3. 

```
/usr/lib/python2.7/site-packages/Scrapy-0.17.0-py2.7.egg/scrapy/contrib/feedexport.py:84:
ScrapyDeprecationWarning:
Module `scrapy.conf` is deprecated, use `crawler.settings` attribute instead 
```
