### PR TITLE
Allow FEED_EXPORT_DELIMITER setting to change csv.writer delimiter

### DIFF
--- a/scrapy/contrib/feedexport.py
+++ b/scrapy/contrib/feedexport.py
@@ -141,6 +141,7 @@ class FeedExporter(object):
         self.format = settings['FEED_FORMAT'].lower()
         self.storages = self._load_components('FEED_STORAGES')
         self.exporters = self._load_components('FEED_EXPORTERS')
+        self.delimiter = settings.get('FEED_EXPORT_DELIMITER')
         if not self._storage_supported(self.urifmt):
             raise NotConfigured
         if not self._exporter_supported(self.format):
@@ -170,7 +171,8 @@ class FeedExporter(object):
         uri = self.urifmt % self._get_uri_params(spider)
         storage = self._get_storage(uri)
         file = storage.open(spider)
-        exporter = self._get_exporter(file)
+        kwargs = dict(delimiter=self.delimiter) if self.delimiter else {}
+        exporter = self._get_exporter(file, **kwargs)
         exporter.start_exporting()
         self.slots[spider] = SpiderSlot(file, exporter, storage, uri)
 

--- a/scrapy/tests/test_contrib_exporter.py
+++ b/scrapy/tests/test_contrib_exporter.py
@@ -152,6 +152,14 @@ class CsvItemExporterTest(BaseItemExporterTest):
         ie.finish_exporting()
         self.assertEqual(output.getvalue(), '"Mary,Paul",John\r\n')
 
+    def test_delimiter(self):
+        output = StringIO()
+        ie = CsvItemExporter(output, delimiter=';')
+        ie.start_exporting()
+        ie.export_item(self.i)
+        ie.finish_exporting()
+        self.assertEqual(output.getvalue(), 'age;name\r\n22;John\xc2\xa3\r\n')
+
 class XmlItemExporterTest(BaseItemExporterTest):
 
     def _get_exporter(self, **kwargs):


### PR DESCRIPTION
This setting is not needed in the global defaults and can be used in `settings.py`:

```
FEED_EXPORT_DELIMITER = ';'
```

or on the command-line:

```
stav@maia:$ scrapy crawl myspider -s FEED_URI=output.csv -s FEED_FORMAT=csv -s FEED_EXPORT_DELIMITER=';'
```
