### PR TITLE
Update overview.rst, Torrent referenced as TorrentItem in spider

### DIFF
--- a/docs/intro/overview.rst
+++ b/docs/intro/overview.rst
@@ -45,7 +45,7 @@ This would be our Item::
 
     from scrapy.item import Item, Field
 
-    class Torrent(Item):
+    class TorrentItem(Item):
         url = Field()
         name = Field()
         description = Field()


### PR DESCRIPTION
Torrent referenced as TorrentItem in the spider, thus changing the `Torrent` to the more descriptive `TorrentItem`.
