### PR TITLE
Update faq.rst

### DIFF
--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -173,7 +173,7 @@ higher) in your spider::
 
         name = 'myspider'
 
-        DOWNLOAD_DELAY = 2
+        download_delay = 2
 
         # [ ... rest of the spider code ... ]
 


### PR DESCRIPTION
It seems that spider.DOWNLOAD_DELAY is deprecated.
