### PR TITLE
Fix downloader leaks

### DIFF
--- a/scrapy/core/engine.py
+++ b/scrapy/core/engine.py
@@ -254,6 +254,9 @@ class ExecutionEngine(object):
 
         dfd = slot.close()
 
+        dfd.addBoth(lambda _: self.downloader.close())
+        dfd.addErrback(log.err, spider=spider)
+
         dfd.addBoth(lambda _: self.scraper.close_spider(spider))
         dfd.addErrback(log.err, spider=spider)
 

--- a/scrapy/tests/test_crawl.py
+++ b/scrapy/tests/test_crawl.py
@@ -1,6 +1,6 @@
 import sys, time
 from twisted.internet import defer
-from twisted.trial.unittest import TestCase, SkipTest
+from twisted.trial.unittest import TestCase
 from subprocess import Popen, PIPE
 from scrapy.spider import BaseSpider
 from scrapy.http import Request
@@ -10,12 +10,13 @@ from scrapy.utils.test import get_crawler
 class FollowAllSpider(BaseSpider):
 
     name = 'follow'
-    start_urls = ["http://localhost:8998/follow?total=10&show=5&order=rand"]
     link_extractor = SgmlLinkExtractor()
 
-    def __init__(self):
+    def __init__(self, total=10, show=20, order="rand"):
         self.urls_visited = []
         self.times = []
+        url = "http://localhost:8998/follow?total=%d&show=%d&order=%s" % (total, show, order)
+        self.start_urls = [url]
 
     def parse(self, response):
         self.urls_visited.append(response.url)
@@ -48,13 +49,9 @@ class CrawlTestCase(TestCase):
 
     @defer.inlineCallbacks
     def test_delay(self):
-        # FIXME: this test fails because Scrapy leaves the reactor dirty with
-        # callLater calls when download delays are used. This test should be
-        # enabled after this bug is fixed.
-        raise SkipTest("disabled due to a reactor leak in the scrapy downloader")
-
         spider = FollowAllSpider()
-        yield docrawl(spider)
+        yield docrawl(spider, {"DOWNLOAD_DELAY": 0.3})
         t = spider.times[0]
-        for y in spider.times[1:]:
-            self.assertTrue(y-t > 0.5, "download delay too small: %s" % (y-t))
+        for t2 in spider.times[1:]:
+            self.assertTrue(t2-t > 0.15, "download delay too small: %s" % (t2-t))
+            t = t2


### PR DESCRIPTION
- fixed reactor callLater leaks when using download delay
- enabled test for dealys (which was disabled due to the reactor leaks)
- fixed downloader slot leaks (slots were created but never removed)
