### PR TITLE
Optparse-stype options in Spiders (command line crawl)

### DIFF
--- a/scrapy/cmdline.py
+++ b/scrapy/cmdline.py
@@ -11,6 +11,7 @@ from scrapy.command import ScrapyCommand
 from scrapy.exceptions import UsageError
 from scrapy.utils.misc import walk_modules
 from scrapy.utils.project import inside_project, get_project_settings
+from scrapy.utils.options import ScrapyComandOptionParser
 from scrapy.settings.deprecated import check_deprecated_settings
 
 def _iter_command_classes(module_name):
@@ -81,7 +82,7 @@ def _print_commands(settings, inproject):
 def _print_unknown_command(settings, cmdname, inproject):
     _print_header(settings, inproject)
     print "Unknown command: %s\n" % cmdname
-    print 'Use "scrapy" to see available commands' 
+    print 'Use "scrapy" to see available commands'
 
 def _run_print_help(parser, func, *a, **kw):
     try:
@@ -122,7 +123,7 @@ def execute(argv=None, settings=None):
     inproject = inside_project()
     cmds = _get_commands_dict(settings, inproject)
     cmdname = _pop_command_name(argv)
-    parser = optparse.OptionParser(formatter=optparse.TitledHelpFormatter(), \
+    parser = ScrapyComandOptionParser(formatter=optparse.TitledHelpFormatter(), \
         conflict_handler='resolve')
     if not cmdname:
         _print_commands(settings, inproject)
@@ -136,10 +137,10 @@ def execute(argv=None, settings=None):
     parser.description = cmd.long_desc()
     settings.defaults.update(cmd.default_settings)
     cmd.settings = settings
-    cmd.add_options(parser)
+    cmd.set_crawler(crawler)
+    cmd.add_options(parser, argv[1:])
     opts, args = parser.parse_args(args=argv[1:])
     _run_print_help(parser, cmd.process_options, args, opts)
-    cmd.set_crawler(crawler)
     _run_print_help(parser, _run_command, cmd, args, opts)
     sys.exit(cmd.exitcode)
 

--- a/scrapy/command.py
+++ b/scrapy/command.py
@@ -61,7 +61,7 @@ class ScrapyCommand(object):
         """
         return self.long_desc()
 
-    def add_options(self, parser):
+    def add_options(self, parser, argv=[]):
         """
         Populate option parse with options available for this command
         """
@@ -83,7 +83,7 @@ class ScrapyCommand(object):
             help="set/override setting (may be repeated)")
         group.add_option("--pdb", action="store_true", help="enable pdb on failure")
         parser.add_option_group(group)
-        
+
     def process_options(self, args, opts):
         try:
             self.settings.overrides.update(arglist_to_dict(opts.set))

--- a/scrapy/spidermanager.py
+++ b/scrapy/spidermanager.py
@@ -54,3 +54,10 @@ class SpiderManager(object):
         closed = getattr(spider, 'closed', None)
         if callable(closed):
             return closed(reason)
+
+    def get_option_list(self, spider_name):
+        try:
+            spcls = self._spiders[spider_name]
+        except KeyError:
+            raise KeyError("Spider not found: %s" % spider_name)
+        return getattr(spcls, 'option_list', [])

--- a/scrapy/utils/options.py
+++ b/scrapy/utils/options.py
@@ -1,0 +1,18 @@
+import optparse
+
+class SpiderOption(optparse.Option):
+    _dummy = True
+
+class ScrapyComandOptionParser(optparse.OptionParser):
+    def parse_args(self, args=None, values=None):
+        (options, args) = optparse.OptionParser.parse_args(self, args, values)
+        for option in self._get_all_options():
+            if isinstance(option, SpiderOption):
+                spider_options = getattr(options, 'spideropts', None)
+                if not spider_options:
+                    spider_options = optparse.Values()
+                    setattr(options, 'spideropts', spider_options)
+                setattr(spider_options, option.dest, getattr(options, option.dest))
+        return (options, args)
+
+make_option = SpiderOption


### PR DESCRIPTION
This is a proposition to define options in spiders similar to what Django has for management commands.

It's basically an alternative to the `-a key=val` technique, but add `optparse`'s conversions and boolean support.

**Note: I only tested this for `scrapy crawl`**

Define `option_list` as a list of options in your spider.
Options are then available in spider in `self.cmdopts`.

Example usage:

```python
...
from scrapy.utils.options import make_option

class MyOptionsSpider(scrapy.spider.BaseSpider):
    ...
    option_list = [
        make_option("-I", "--counter", dest="counter", type="int",
                      help="set a cool option", default=None)
    ]

    def parse(self, response):
        ...
        print "counter:", self.cmdopts.counter
```
Then,
```
scrapy crawl MyOptions -I 899
```

**CAUTION: spider name has to be first parameter after `scrapy crawl`**