### PR TITLE
Document CrawlSpider.parse_start_urls method

### DIFF
--- a/docs/topics/spiders.rst
+++ b/docs/topics/spiders.rst
@@ -261,6 +261,14 @@ CrawlSpider
        described below. If multiple rules match the same link, the first one
        will be used, according to the order they're defined in this attribute.
 
+   This spider also exposes an overrideable method:
+
+   .. method:: parse_start_url(response)
+
+      This method is called for the start_urls responses. It allows to parse
+      the initial responses and must return either a 
+      :class:`~scrapy.item.Item` object, a :class:`~scrapy.http.Request` 
+      object, or an iterable containing any of them.
        
 Crawling rules
 ~~~~~~~~~~~~~~


### PR DESCRIPTION
The parse_start_urls method is very useful when you want to scrape paged lists, since you'd need to parse the first page as well as the next ones (which usually get a callback from the Rules). It should make it easier for people asking this very question: http://stackoverflow.com/questions/15836062/scrapy-crawlspider-doesnt-crawl-the-first-landing-page
