### PR TITLE
[Moved] extended HtmlXPathSelector adding extract_links method

### DIFF
--- a/scrapy/contrib/selector/html.py
+++ b/scrapy/contrib/selector/html.py
@@ -1,0 +1,40 @@
+from urlparse import urlsplit, urlunsplit, urljoin
+
+from scrapy.selector import HtmlXPathSelector as ScrapyHtmlXPathSelector
+from scrapy.selector.list import XPathSelectorList as ScrapyXPathSelectorList
+
+
+class XPathSelectorList(ScrapyXPathSelectorList):
+
+    def extract_links(self, absolute=False):
+        return [x.extract_links() for x in self]
+
+
+class HtmlXPathSelector(ScrapyHtmlXPathSelector):
+
+    _list_cls = XPathSelectorList
+
+    def _get_base_url(self):
+        if hasattr(self, '_base_url'):
+            return self._base_url
+        html_base = ''.join(self.select('//base/@href').extract())
+        self._base_url = urljoin(self._root.base, html_base)
+        return self._base_url
+
+    def extract_links(self, absolute=False):
+        """This finds any link in an action, archive, background, cite,
+        classid, codebase, data, href, longdesc, profile, src, usemap, dynsrc,
+        or lowsrc attribute.
+        """
+        xpath = '//@*['
+        attrs = ('action', 'archive', 'background', 'cite', 'classid',
+                'codebase', 'data', 'href', 'longdesc', 'profile', 'src',
+                'usemap', 'dynsrc', 'lowsrc')
+        xpath += ' or '.join('name()="{}"'.format(attr) for attr in attrs)
+        xpath += ']'
+        links = self.select(xpath).extract()
+        if absolute:
+            base = self._get_base_url()
+            links = [urljoin(base, link)
+                    for link in links]
+        return [link.encode('utf-8') for link in links]

--- a/scrapy/selector/lxmlsel.py
+++ b/scrapy/selector/lxmlsel.py
@@ -9,8 +9,8 @@ from scrapy.utils.trackref import object_ref
 from scrapy.utils.python import unicode_to_str
 from scrapy.utils.decorator import deprecated
 from scrapy.http import TextResponse
-from .lxmldocument import LxmlDocument
-from .list import XPathSelectorList
+from scrapy.selector.lxmldocument import LxmlDocument
+from scrapy.selector.list import XPathSelectorList
 
 
 __all__ = ['HtmlXPathSelector', 'XmlXPathSelector', 'XPathSelector', \
@@ -22,6 +22,7 @@ class XPathSelector(object_ref):
     __slots__ = ['response', 'text', 'namespaces', '_expr', '_root', '__weakref__']
     _parser = etree.HTMLParser
     _tostring_method = 'html'
+    _list_cls = XPathSelectorList
 
     def __init__(self, response=None, text=None, namespaces=None, _root=None, _expr=None):
         if text is not None:
@@ -39,7 +40,7 @@ class XPathSelector(object_ref):
         try:
             xpathev = self._root.xpath
         except AttributeError:
-            return XPathSelectorList([])
+            return self._list_cls([])
 
         try:
             result = xpathev(xpath, namespaces=self.namespaces)
@@ -51,7 +52,7 @@ class XPathSelector(object_ref):
 
         result = [self.__class__(_root=x, _expr=xpath, namespaces=self.namespaces)
                   for x in result]
-        return XPathSelectorList(result)
+        return self._list_cls(result)
 
     def re(self, regex):
         return extract_regex(regex, self.extract())
@@ -86,7 +87,6 @@ class XPathSelector(object_ref):
         return "<%s xpath=%r data=%s>" % (type(self).__name__, self._expr, data)
 
     __repr__ = __str__
-
 
     @deprecated(use_instead='XPathSelector.extract')
     def extract_unquoted(self):

--- a/scrapy/tests/test_html_selector.py
+++ b/scrapy/tests/test_html_selector.py
@@ -1,0 +1,19 @@
+import unittest
+
+from scrapy.http import HtmlResponse
+from scrapy.contrib.selector.html import HtmlXPathSelector
+
+
+class HtmlXPathSelectorTest(unittest.TestCase):
+
+    def test_extract_links(self):
+        text = '<a href="somelink">Some Text</a>'
+        hxs = HtmlXPathSelector(text=text)
+        self.assertEqual(['somelink'], hxs.extract_links())
+        self.assertEqual(['somelink'], hxs.extract_links(absolute=True))
+        response = HtmlResponse('http://scrapinghub.com/services.html',
+                body=text)
+        hxs = HtmlXPathSelector(response=response)
+        self.assertEqual(['somelink'], hxs.extract_links())
+        self.assertEqual(['http://scrapinghub.com/somelink'],
+                hxs.extract_links(absolute=True))


### PR DESCRIPTION
It imitates the ```iterlinks``` method from ```lxml.html```, except for the style link extraction. Maybe we can extend it a little more and add the common case if ```onclick``` with ```window.location```.

```python
>>> from scrapy.contrib.selector.html import HtmlXPathSelector
>>> hxs = HtmlXPathSelector(text='<a href="alink">LOLOLOLO</a>')
>>> hxs.extract_links()
[u'alink']
```

Useful link http://www.w3.org/TR/REC-html40/index/attributes.html