### PR TITLE
Change version number of dev version from 0.18 to 0.17 in release notes

### DIFF
--- a/docs/news.rst
+++ b/docs/news.rst
@@ -3,7 +3,7 @@
 Release notes
 =============
 
-0.18 (unreleased)
+0.17 (unreleased)
 -----------------
 
 - :ref:`benchmarking`


### PR DESCRIPTION
When browsing the docs I stumbled over this small inconsistency in the release notes: in the release notes, the version number of the next (unreleased) version is 0.18, but 0.17 is missing. I think it should be 0.17?

Sorry for this really minor pull request, I don't mean to be annoying!
