### PR TITLE
Skipping cookie retrieval for non http requests

### DIFF
--- a/scrapy/http/cookies.py
+++ b/scrapy/http/cookies.py
@@ -23,6 +23,7 @@ class CookieJar(object):
         # the cookiejar implementation iterates through all domains
         # instead we restrict to potential matches on the domain
         req_host = urlparse_cached(request).hostname
+        if not req_host: return
 
         if not IPV4_RE.search(req_host):
             hosts = potential_domain_matches(req_host)

--- a/scrapy/tests/test_downloadermiddleware_cookies.py
+++ b/scrapy/tests/test_downloadermiddleware_cookies.py
@@ -129,3 +129,8 @@ class CookiesMiddlewareTest(TestCase):
         req5_3 = Request('http://scrapytest.org/some-redirected-path')
         assert self.mw.process_request(req5_3, self.spider) is None
         self.assertEquals(req5_3.headers.get('Cookie'), 'C1=value1')
+
+        #skip cookie retrieval for not http request
+        req6 = Request('file:///scrapy/sometempfile')
+        assert self.mw.process_request(req6, self.spider) is None
+        self.assertEquals(req6.headers.get('Cookie'), None)


### PR DESCRIPTION
Cookie retrieval should be done for http requests only
