### PR TITLE
Scrapy 0.16 Overview doc issues: class definition name, and bad XPath description

### DIFF
--- a/docs/intro/overview.rst
+++ b/docs/intro/overview.rst
@@ -45,7 +45,7 @@ This would be our Item::
 
     from scrapy.item import Item, Field
 
-    class Torrent(Item):
+    class TorrentItem(Item):
         url = Field()
         name = Field()
         description = Field()


### PR DESCRIPTION
Same issue with XPath query as in master. Query returns torrent size not torrent description. Also, class Torrent() is invoked in spider's parse_torrent() method as TorrentItem(). Changed class name to TorrentItem so NameError doesn't occur.
