### PR TITLE
Changed name of directory to save file to

### DIFF
--- a/docs/intro/tutorial.rst
+++ b/docs/intro/tutorial.rst
@@ -121,7 +121,7 @@ define the three main, mandatory, attributes:
   objects) and more URLs to follow (as :class:`~scrapy.http.Request` objects).
 
 This is the code for our first Spider; save it in a file named
-``dmoz_spider.py`` under the ``dmoz/spiders`` directory::
+``dmoz_spider.py`` under the ``tutorial/spiders`` directory::
 
    from scrapy.spider import BaseSpider
 


### PR DESCRIPTION
The tutorial says to save to `dmoz/spiders` but this folder is non-existent. I have changed it to `tutorial/spiders` which makes sense in the tutorial.
