### PR TITLE
Support XPathItemLoader selector reassignment

### DIFF
--- a/scrapy/contrib/loader/__init__.py
+++ b/scrapy/contrib/loader/__init__.py
@@ -129,9 +129,15 @@ class ItemLoader(object):
                 "%s must be instantiated with a selector "
                 "or a response" % self.__class__.__name__)
 
-    def set_selector(self, selector):
-        self.selector = selector
-        self.context.update(selector=selector)
+    def reset(self, selector=None, response=None):
+        if response is not None:
+            if selector is None:
+                selector = self.default_selector_class(response)
+            self.selector = selector
+            self.context.update(selector=selector, response=response)
+        elif selector is not None:
+            self.selector = selector
+            self.context.update(selector=selector)
 
     def add_xpath(self, field_name, xpath, *processors, **kw):
         values = self._get_xpathvalues(xpath, **kw)


### PR DESCRIPTION
A major useability problem I have with the XPathItemLoader is that I cannot yield it to subsequent pages via Request.meta because the selector is readonly and can't be reassigned on the subsequent page.

Yielding the item with loader.load_item() and instancing a new loader with this item seems sufficient in a few cases but not always, as adding values to an already 'filled' Item field will then get overwritten instead of appended to (which is good enough, again, in some cases).

The included patch seems to work for me for keeping the loader around in Request.meta and then reassigning the selector, but I would love some feedback if this is indeed a viable approach.
