### PR TITLE
Add "method" and "with_tail" parameters to XPathSelector(List).extract()

### DIFF
--- a/scrapy/selector/libxml2sel.py
+++ b/scrapy/selector/libxml2sel.py
@@ -55,14 +55,14 @@ class XPathSelector(object_ref):
     def re(self, regex):
         return extract_regex(regex, self.extract())
 
-    def extract(self):
+    def extract(self, method=None, with_tail=False):
         if isinstance(self.xmlNode, basestring):
             text = unicode(self.xmlNode, 'utf-8', errors='ignore')
         elif hasattr(self.xmlNode, 'serialize'):
             if isinstance(self.xmlNode, libxml2.xmlDoc):
                 data = self.xmlNode.getRootElement().serialize('utf-8')
                 text = unicode(data, 'utf-8', errors='ignore') if data else u''
-            elif isinstance(self.xmlNode, libxml2.xmlAttr): 
+            elif isinstance(self.xmlNode, libxml2.xmlAttr):
                 # serialization doesn't work sometimes for xmlAttr types
                 text = unicode(self.xmlNode.content, 'utf-8', errors='ignore')
             else:

--- a/scrapy/selector/list.py
+++ b/scrapy/selector/list.py
@@ -12,8 +12,8 @@ class XPathSelectorList(list):
     def re(self, regex):
         return flatten([x.re(regex) for x in self])
 
-    def extract(self):
-        return [x.extract() for x in self]
+    def extract(self, method=None, with_tail=False):
+        return [x.extract(method=method, with_tail=with_tail) for x in self]
 
     def extract_unquoted(self):
         return [x.extract_unquoted() for x in self]

--- a/scrapy/selector/lxmlsel.py
+++ b/scrapy/selector/lxmlsel.py
@@ -56,10 +56,11 @@ class XPathSelector(object_ref):
     def re(self, regex):
         return extract_regex(regex, self.extract())
 
-    def extract(self):
+    def extract(self, method=None, with_tail=False):
         try:
-            return etree.tostring(self._root, method=self._tostring_method, \
-                encoding=unicode, with_tail=False)
+            method = method or self._tostring_method
+            return etree.tostring(self._root, method=method, \
+                encoding=unicode, with_tail=with_tail)
         except (AttributeError, TypeError):
             if self._root is True:
                 return u'1'

--- a/scrapy/tests/test_selector.py
+++ b/scrapy/tests/test_selector.py
@@ -56,7 +56,7 @@ class XPathSelectorTestCase(unittest.TestCase):
         text = '<p>test<p>'
         assert isinstance(self.xxs_cls(text=text).select("//p")[0],
                           self.xxs_cls)
-        assert isinstance(self.hxs_cls(text=text).select("//p")[0], 
+        assert isinstance(self.hxs_cls(text=text).select("//p")[0],
                           self.hxs_cls)
 
     @libxml2debug
@@ -155,6 +155,8 @@ class XPathSelectorTestCase(unittest.TestCase):
         self.assertEqual(x.select("//p:SecondTestTag").select("./xmlns:price/text()")[0].extract(), '90')
         self.assertEqual(x.select("//p:SecondTestTag/xmlns:material/text()").extract()[0], 'iron')
 
+        self.assertEqual(x.select("//b:Operation").extract(method="text")[0], 'hello')
+
     @libxml2debug
     def test_selector_re(self):
         body = """<div>Name: Mary
@@ -198,6 +200,49 @@ class XPathSelectorTestCase(unittest.TestCase):
         self.assertEqual(xxs.select('.').extract(),
                          [u'<root>lala</root>'])
 
+    @libxml2debug
+    def test_selector_extract_text_method(self):
+        body = """<html>
+<body>
+<h1>A title</h1>
+Includes the following:
+<p>
+This is a paragraph.
+</p>
+<div>
+This includes <a href="page.html">a nested link</a>.
+</div>
+</body>
+</html>
+               """
+        response = HtmlResponse(url="http://example.com", body=body)
+        hxs = self.hxs_cls(response)
+
+        self.assertEqual(hxs.select('//p/text()').extract(),
+                         [u'\nThis is a paragraph.\n'])
+        self.assertEqual(hxs.select('//p').extract(method="text"),
+                         [u'\nThis is a paragraph.\n'])
+        self.assertEqual(hxs.select('//p/text()').extract(method="text"),
+                         [u'\nThis is a paragraph.\n'])
+
+        self.assertEqual(hxs.select('//h1').extract(method="text", with_tail=True),
+                         [u'A title\nIncludes the following:\n'])
+
+        self.assertEqual(hxs.select('//a').extract(),
+                         [u'<a href="page.html">a nested link</a>'])
+        self.assertEqual(hxs.select('//a/text()').extract(),
+                         [u'a nested link'])
+        self.assertEqual(hxs.select('//a').extract(method="text"),
+                         [u'a nested link'])
+        self.assertEqual(hxs.select('//a').extract(method="text", with_tail=True),
+                         [u'a nested link.\n'])
+
+        self.assertEqual(hxs.select('//div/text()').extract(),
+                         [u'\nThis includes ', u'.\n'])
+        self.assertEqual(hxs.select('//div').extract(method="text"),
+                         [u'\nThis includes a nested link.\n'])
+        self.assertEqual(hxs.select('string(//div)').extract(),
+                         [u'\nThis includes a nested link.\n'])
 
     @libxml2debug
     def test_selector_invalid_xpath(self):


### PR DESCRIPTION
When extacting text content, `hxs.select("//element/text()").extract()` usually works,
but I find myself preferring using something like `lxml.etree.tostring(element, method="text", encoding=unicode)`, especially when the text is nested in various `<b>...</b>` or `<span>...</span>` HTML elements.

I also think the `.../text()` step in XPath expressions (and in Scrapy doc examples) misleads users in thinking it will extract the flattened text content of a node, and not only the direct text child nodes (therefore omitting nested text() nodes)

Here I'm adding the `method` and `with_tail` parameters from `lxml.etree.tostring()` to `.extract()`

Note: I haven't handled them in `libxml2sel.py`
