### PR TITLE
Fixed directory location for dmoz_spider.py file

### DIFF
--- a/docs/intro/tutorial.rst
+++ b/docs/intro/tutorial.rst
@@ -121,7 +121,7 @@ define the three main, mandatory, attributes:
   objects) and more URLs to follow (as :class:`~scrapy.http.Request` objects).
 
 This is the code for our first Spider; save it in a file named
-``dmoz_spider.py`` under the ``dmoz/spiders`` directory::
+``dmoz_spider.py`` under the ``tutorial/spiders`` directory::
 
    from scrapy.spider import BaseSpider
 


### PR DESCRIPTION
It should be under 'tutorial/spiders' not 'dmoz/spiders'
