### PR TITLE
mock is required for running tests

### DIFF
--- a/.travis/requirements-latest.txt
+++ b/.travis/requirements-latest.txt
@@ -4,3 +4,6 @@ twisted
 boto
 Pillow
 django
+
+# testing requirements
+mock

--- a/.travis/requirements-lucid.txt
+++ b/.travis/requirements-lucid.txt
@@ -4,3 +4,6 @@ lxml==2.2.4
 twisted==10.0.0
 boto==1.9b
 Pillow<2.0
+
+# testing requirements
+mock==1.0.1

--- a/.travis/requirements-precise.txt
+++ b/.travis/requirements-precise.txt
@@ -5,3 +5,6 @@ twisted==11.1.0
 boto==2.2.2
 Pillow<2.0
 django==1.3.1
+
+# testing requirements
+mock==1.0.1


### PR DESCRIPTION
Mock is required since https://github.com/scrapy/scrapy/commit/45ff6ec28ac44114b1c8b98e151ff3c21cd9b994.
This fixes tox test running. Mock is available at Travis, but there is no harm in listing it explicitly.
