### PR TITLE
Update practices.rst

### DIFF
--- a/docs/topics/practices.rst
+++ b/docs/topics/practices.rst
@@ -29,12 +29,13 @@ project as example.
 
     from twisted.internet import reactor
     from scrapy.crawler import Crawler
-    from scrapy.settings import Settings
     from scrapy import log, signals
     from testspiders.spiders.followall import FollowAllSpider
+    from scrapy.utils.project import get_project_settings
 
     spider = FollowAllSpider(domain='scrapinghub.com')
-    crawler = Crawler(Settings())
+    settings = get_project_settings()
+    crawler = Crawler(settings)
     crawler.signals.connect(reactor.stop, signal=signals.spider_closed)
     crawler.configure()
     crawler.crawl(spider)


### PR DESCRIPTION
With this modification scrapy runs the spider with project settings. The previous example ran only with default settings resulting in ignoring all user settings as pipelines for example.
