### PR TITLE
In downloader_middleware docs, remove reference to process_request returning a Request object

### DIFF
--- a/docs/topics/downloader-middleware.rst
+++ b/docs/topics/downloader-middleware.rst
@@ -63,9 +63,9 @@ single Python class that defines one or more of the following methods:
       This method is called for each request that goes through the download
       middleware.
 
-      :meth:`process_request` should return either ``None``, a
-      :class:`~scrapy.http.Response` object, or a :class:`~scrapy.http.Request`
-      object.
+      :meth:`process_request` should either return ``None``, return a
+      :class:`~scrapy.http.Response` object, or raise an
+      :exc:`~scrapy.exceptions.IgnoreRequest` exception
 
       If it returns ``None``, Scrapy will continue processing this request, executing all
       other middlewares until, finally, the appropriate downloader handler is called


### PR DESCRIPTION
Based on experimentation, it does not seem like the download middleware process_request() method can actually return a Request object with any effect. Furthermore, the documentation below the changed lines outlines the effect of raising an IgnoreRequest exception.

With that in mind, this is a very minor change that simply updates the docs so that it is not stated that process_request() can return a Request object.
