### PR TITLE
Handling inconsistencies among Twisted releases

### DIFF
--- a/scrapy/webservice.py
+++ b/scrapy/webservice.py
@@ -4,7 +4,7 @@ Scrapy web services extension
 See docs/topics/webservice.rst
 """
 
-from twisted.web import server, error
+from twisted.web import server, resource
 
 from scrapy.exceptions import NotConfigured
 from scrapy import log, signals
@@ -45,7 +45,7 @@ class JsonRpcResource(JsonResource):
             newtarget = getattr(target, name)
             return JsonRpcResource(self.crawler, newtarget)
         except AttributeError:
-            return error.NoResource("No such child resource.")
+            return resource.ErrorPage(404, "No Such Resource", "No such child resource.")
 
     def get_target(self):
         return self._target


### PR DESCRIPTION
Using scrapy with Twisted 13 produce this exception if a user visit a not-defined resource. The patch should solve the issue.

```
    Traceback (most recent call last):
      File "/Users/nopper/.pythonbrew/venvs/Python-2.7.3/frugal/lib/python2.7/site-packages/twisted/protocols/basic.py", line 571, in dataReceived
        why = self.lineReceived(line)
      File "/Users/nopper/.pythonbrew/venvs/Python-2.7.3/frugal/lib/python2.7/site-packages/twisted/web/http.py", line 1619, in lineReceived
        self.allContentReceived()
      File "/Users/nopper/.pythonbrew/venvs/Python-2.7.3/frugal/lib/python2.7/site-packages/twisted/web/http.py", line 1694, in allContentReceived
        req.requestReceived(command, path, version)
      File "/Users/nopper/.pythonbrew/venvs/Python-2.7.3/frugal/lib/python2.7/site-packages/twisted/web/http.py", line 790, in requestReceived
        self.process()
    --- <exception caught here> ---
      File "/Users/nopper/.pythonbrew/venvs/Python-2.7.3/frugal/lib/python2.7/site-packages/twisted/web/server.py", line 184, in process
        resrc = self.site.getResourceFor(self)
      File "/Users/nopper/.pythonbrew/venvs/Python-2.7.3/frugal/lib/python2.7/site-packages/twisted/web/server.py", line 701, in getResourceFor
        return resource.getChildForRequest(self.resource, request)
      File "/Users/nopper/.pythonbrew/venvs/Python-2.7.3/frugal/lib/python2.7/site-packages/twisted/web/resource.py", line 98, in getChildForRequest
        resource = resource.getChildWithDefault(pathElement, request)
      File "/Users/nopper/.pythonbrew/venvs/Python-2.7.3/frugal/lib/python2.7/site-packages/twisted/web/resource.py", line 201, in getChildWithDefault
        return self.getChild(path, request)
      File "/Users/nopper/.pythonbrew/venvs/Python-2.7.3/frugal/lib/python2.7/site-packages/scrapy/webservice.py", line 48, in getChild
        return error.NoResource("No such child resource.")
    exceptions.AttributeError: 'module' object has no attribute 'NoResource'
```
