### PR TITLE
Add the overwrite parameter to the FormRequest constructor

### DIFF
--- a/docs/topics/request-response.rst
+++ b/docs/topics/request-response.rst
@@ -260,6 +260,11 @@ fields with form data from :class:`Response` objects.
        body of the request.
     :type formdata: dict or iterable of tuples
 
+    :param overwrite: default to ``True``. If a parameter is in both url and 
+    formdata and this parameter is set to True, the function will overwrite the
+    url parameter instead of doing simple concatenation
+    :type overwrite: boolean
+
     The :class:`FormRequest` objects support the following class method in
     addition to the standard :class:`Request` methods:
 

--- a/scrapy/http/request/form.py
+++ b/scrapy/http/request/form.py
@@ -17,11 +17,16 @@ class FormRequest(Request):
         formdata = kwargs.pop('formdata', None)
         if formdata and kwargs.get('method') is None:
             kwargs['method'] = 'POST'
+        if kwargs.get('overwrite') is None:
+            kwargs['overwrite'] = True
 
         super(FormRequest, self).__init__(*args, **kwargs)
 
         if formdata:
             items = formdata.iteritems() if isinstance(formdata, dict) else formdata
+            if self.method == 'GET' and self.overwrite:
+                self.url, items = _get_baseurl_and_parameters(self.url, items)
+
             querystr = _urlencode(items, self.encoding)
             if self.method == 'POST':
                 self.headers.setdefault('Content-Type', 'application/x-www-form-urlencoded')
@@ -45,6 +50,25 @@ def _urlencode(seq, enc):
               for k, vs in seq
               for v in (vs if hasattr(vs, '__iter__') else [vs])]
     return urllib.urlencode(values, doseq=1)
+
+def _get_baseurl_and_parameters(url, parameters):
+    if not '?' in url:
+        baseUrl = url
+
+    elif url.count('?') > 1:
+        raise ValueError('Invalid URL %s' % url)
+
+    else:
+        baseUrl, paramsURL = url.split('?')
+        for keyValue in paramsURL.split('&'):
+            key, value = keyValue.split('=')
+            if value is None and key in parameters:
+                del parameters[key]
+            elif not key in parameters:
+                parameters[key] = value
+
+    return baseUrl, parameters
+
 
 def _get_form(response, formname, formnumber, formxpath):
     """Find the form element """


### PR DESCRIPTION
I find myself using a lot this pattern inside a callback function (I've fetched the first page of the search, all the search parameters are in the url, and I want to fetch the other pages):

```py
for page in xrange(2, NB_PAGES):
    yield FormRequest(
        url = response.url,
        method = "GET", 
        callback = self.parse_page, 
        data = {'page': page})
```

The problem is that if the `page` parameter is already present in the url, I'd like to overwrite it. This is what this PR allows us to do:

```py
FormRequest("http://website.com?a=1&b=1", method = "GET", formdata = {"b":"2", "c":"3"})
>>> "http://website.com?a=1&b=2&c=3"

FormRequest("http://website.com?a=1&b=1", method = "GET", formdata = {"b":"2", "c":"3"}, overwrite = False)
>>> "http://website.com?a=1&b=1&b=2&c=3"
```

It also allows to destroy parameters in url with the `None` value.

```py
FormRequest("http://website.com?a=1&b=1", method = "GET", formdata = {"a":None, "c":"3"})
>>> "http://website.com?b=1&c=3"
```

Please tell me what you think of this proposition.