### PR TITLE
Using next() for Python 3 compatibility; ordereddict.py converted from DOS to Unix

### DIFF
--- a/scrapy/core/engine.py
+++ b/scrapy/core/engine.py
@@ -108,7 +108,7 @@ class ExecutionEngine(object):
 
         if slot.start_requests and not self._needs_backout(spider):
             try:
-                request = slot.start_requests.next()
+                request = next(slot.start_requests)
             except StopIteration:
                 slot.start_requests = None
             except Exception, exc:

--- a/scrapy/tests/test_utils_iterators.py
+++ b/scrapy/tests/test_utils_iterators.py
@@ -61,7 +61,7 @@ class XmliterTestCase(unittest.TestCase):
         response = XmlResponse(url='http://mydummycompany.com', body=body)
         my_iter = self.xmliter(response, 'item')
 
-        node = my_iter.next()
+        node = next(my_iter)
         node.register_namespace('g', 'http://base.google.com/ns/1.0')
         self.assertEqual(node.xpath('title/text()').extract(), ['Item 1'])
         self.assertEqual(node.xpath('description/text()').extract(), ['This is item 1'])
@@ -77,10 +77,10 @@ class XmliterTestCase(unittest.TestCase):
         body = u"""<?xml version="1.0" encoding="UTF-8"?><products><product>one</product><product>two</product></products>"""
 
         iter = self.xmliter(body, 'product')
-        iter.next()
-        iter.next()
+        next(iter)
+        next(iter)
 
-        self.assertRaises(StopIteration, iter.next)
+        self.assertRaises(StopIteration, next, iter)
 
     def test_xmliter_encoding(self):
         body = '<?xml version="1.0" encoding="ISO-8859-9"?>\n<xml>\n    <item>Some Turkish Characters \xd6\xc7\xde\xdd\xd0\xdc \xfc\xf0\xfd\xfe\xe7\xf6</item>\n</xml>\n\n'
@@ -122,9 +122,9 @@ class LxmlXmliterTestCase(XmliterTestCase):
         self.assertEqual(len(list(no_namespace_iter)), 0)
 
         namespace_iter = self.xmliter(response, 'image_link', 'http://base.google.com/ns/1.0')
-        node = namespace_iter.next()
+        node = next(namespace_iter)
         self.assertEqual(node.xpath('text()').extract(), ['http://www.mydummycompany.com/images/item1.jpg'])
-        node = namespace_iter.next()
+        node = next(namespace_iter)
         self.assertEqual(node.xpath('text()').extract(), ['http://www.mydummycompany.com/images/item2.jpg'])
 
 
@@ -205,12 +205,12 @@ class UtilsCsvTestCase(unittest.TestCase):
 
         response = TextResponse(url="http://example.com/", body=body)
         iter = csviter(response)
-        iter.next()
-        iter.next()
-        iter.next()
-        iter.next()
+        next(iter)
+        next(iter)
+        next(iter)
+        next(iter)
 
-        self.assertRaises(StopIteration, iter.next)
+        self.assertRaises(StopIteration, next, iter)
 
     def test_csviter_encoding(self):
         body1 = get_testdata('feeds', 'feed-sample4.csv')

--- a/scrapy/tests/test_utils_python.py
+++ b/scrapy/tests/test_utils_python.py
@@ -121,7 +121,7 @@ class UtilsPythonTestCase(unittest.TestCase):
     def test_weakkeycache(self):
         class _Weakme(object): pass
         _values = count()
-        wk = WeakKeyCache(lambda k: _values.next())
+        wk = WeakKeyCache(lambda k: next(_values))
         k = _Weakme()
         v = wk[k]
         self.assertEqual(v, wk[k])

--- a/scrapy/utils/defer.py
+++ b/scrapy/utils/defer.py
@@ -93,7 +93,7 @@ def iter_errback(iterable, errback, *a, **kw):
     it = iter(iterable)
     while 1:
         try:
-            yield it.next()
+            yield next(it)
         except StopIteration:
             break
         except:

--- a/scrapy/utils/iterators.py
+++ b/scrapy/utils/iterators.py
@@ -47,7 +47,7 @@ def csviter(obj, delimiter=None, headers=None, encoding=None):
     """
     encoding = obj.encoding if isinstance(obj, TextResponse) else encoding or 'utf-8'
     def _getrow(csv_r):
-        return [str_to_unicode(field, encoding) for field in csv_r.next()]
+        return [str_to_unicode(field, encoding) for field in next(csv_r)]
 
     lines = StringIO(body_or_str(obj, unicode=False))
     if delimiter:

--- a/scrapy/xlib/ordereddict.py
+++ b/scrapy/xlib/ordereddict.py
@@ -70,9 +70,9 @@ class OrderedDict(dict, DictMixin):
         if not self:
             raise KeyError('dictionary is empty')
         if last:
-            key = reversed(self).next()
+            key = next(reversed(self))
         else:
-            key = iter(self).next()
+            key = next(iter(self))
         value = self.pop(key)
         return key, value
 

--- a/scrapy/xlib/tx/endpoints.py
+++ b/scrapy/xlib/tx/endpoints.py
@@ -810,7 +810,7 @@ def _tokenize(description):
             current = ''
             ops = nextOps[n]
         elif n == '\\':
-            current += description.next()
+            current += next(description)
         else:
             current += n
     yield _STRING, current


### PR DESCRIPTION
Converted with `2to3 -w -f next scrapy`, then two places fixed by hand (`assertRaises` in tests)

`xlib/ordereddict.py` was converted by `2to3` from DOS to Unix format. It was the _only_ file in DOS format in project, so I decided to leave it converted (sorry for huge diff). Besides EOL, there is only one trivial change in lines 73-75:

```
if last:
    key = next(reversed(self))
else:
    key = next(iter(self))
```
