### PR TITLE
make some middlewares not require a crawler

### DIFF
--- a/scrapy/contrib/downloadermiddleware/cookies.py
+++ b/scrapy/contrib/downloadermiddleware/cookies.py
@@ -15,10 +15,14 @@ class CookiesMiddleware(object):
         self.debug = debug
 
     @classmethod
-    def from_crawler(cls, crawler):
-        if not crawler.settings.getbool('COOKIES_ENABLED'):
+    def from_settings(cls, settings):
+        if not settings.getbool('COOKIES_ENABLED'):
             raise NotConfigured
-        return cls(crawler.settings.getbool('COOKIES_DEBUG'))
+        return cls(settings.getbool('COOKIES_DEBUG'))
+
+    @classmethod
+    def from_crawler(cls, crawler):
+        return cls.from_settings(crawler.settings)
 
     def process_request(self, request, spider):
         if 'dont_merge_cookies' in request.meta:

--- a/scrapy/contrib/downloadermiddleware/defaultheaders.py
+++ b/scrapy/contrib/downloadermiddleware/defaultheaders.py
@@ -11,8 +11,12 @@ class DefaultHeadersMiddleware(object):
         self._headers = headers
 
     @classmethod
+    def from_settings(cls, settings):
+        return cls(settings.get('DEFAULT_REQUEST_HEADERS').items())
+
+    @classmethod
     def from_crawler(cls, crawler):
-        return cls(crawler.settings.get('DEFAULT_REQUEST_HEADERS').items())
+        return cls.from_settings(crawler.settings)
 
     def process_request(self, request, spider):
         for k, v in self._headers:

--- a/scrapy/contrib/downloadermiddleware/downloadtimeout.py
+++ b/scrapy/contrib/downloadermiddleware/downloadtimeout.py
@@ -4,8 +4,6 @@ Download timeout middleware
 See documentation in docs/topics/downloader-middleware.rst
 """
 
-from scrapy import signals
-
 
 class DownloadTimeoutMiddleware(object):
 
@@ -13,14 +11,14 @@ class DownloadTimeoutMiddleware(object):
         self._timeout = timeout
 
     @classmethod
-    def from_crawler(cls, crawler):
-        o = cls(crawler.settings['DOWNLOAD_TIMEOUT'])
-        crawler.signals.connect(o.spider_opened, signal=signals.spider_opened)
-        return o
+    def from_settings(cls, settings):
+        return cls(settings['DOWNLOAD_TIMEOUT'])
 
-    def spider_opened(self, spider):
-        self._timeout = getattr(spider, 'download_timeout', self._timeout)
+    @classmethod
+    def from_crawler(cls, crawler):
+        return cls.from_settings(crawler.settings)
 
     def process_request(self, request, spider):
-        if self._timeout:
-            request.meta.setdefault('download_timeout', self._timeout)
+        _timeout = getattr(spider, 'download_timeout', self._timeout)
+        if _timeout:
+            request.meta.setdefault('download_timeout', _timeout)

--- a/scrapy/contrib/downloadermiddleware/httpauth.py
+++ b/scrapy/contrib/downloadermiddleware/httpauth.py
@@ -6,26 +6,13 @@ See documentation in docs/topics/downloader-middleware.rst
 
 from w3lib.http import basic_auth_header
 
-from scrapy import signals
-
 
 class HttpAuthMiddleware(object):
     """Set Basic HTTP Authorization header
     (http_user and http_pass spider class attributes)"""
 
-    @classmethod
-    def from_crawler(cls, crawler):
-        o = cls()
-        crawler.signals.connect(o.spider_opened, signal=signals.spider_opened)
-        return o
-
-    def spider_opened(self, spider):
+    def process_request(self, request, spider):
         usr = getattr(spider, 'http_user', '')
         pwd = getattr(spider, 'http_pass', '')
-        if usr or pwd:
-            self.auth = basic_auth_header(usr, pwd)
-
-    def process_request(self, request, spider):
-        auth = getattr(self, 'auth', None)
-        if auth and 'Authorization' not in request.headers:
-            request.headers['Authorization'] = auth
+        if (usr or pwd) and 'Authorization' not in request.headers:
+            request.headers['Authorization'] = basic_auth_header(usr, pwd)

--- a/scrapy/contrib/downloadermiddleware/httpcompression.py
+++ b/scrapy/contrib/downloadermiddleware/httpcompression.py
@@ -9,13 +9,17 @@ from scrapy.exceptions import NotConfigured
 class HttpCompressionMiddleware(object):
     """This middleware allows compressed (gzip, deflate) traffic to be
     sent/received from web sites"""
-    
+
     @classmethod
-    def from_crawler(cls, crawler):
-        if not crawler.settings.getbool('COMPRESSION_ENABLED'):
+    def from_settings(cls, settings):
+        if not settings.getbool('COMPRESSION_ENABLED'):
             raise NotConfigured
         return cls()
-    
+
+    @classmethod
+    def from_crawler(cls, crawler):
+        return cls.from_settings(crawler.settings)
+
     def process_request(self, request, spider):
         request.headers.setdefault('Accept-Encoding', 'x-gzip,gzip,deflate')
 

--- a/scrapy/contrib/downloadermiddleware/redirect.py
+++ b/scrapy/contrib/downloadermiddleware/redirect.py
@@ -18,8 +18,12 @@ class BaseRedirectMiddleware(object):
         self.priority_adjust = settings.getint('REDIRECT_PRIORITY_ADJUST')
 
     @classmethod
+    def from_settings(cls, settings):
+        return cls(settings)
+
+    @classmethod
     def from_crawler(cls, crawler):
-        return cls(crawler.settings)
+        return cls.from_settings(crawler.settings)
 
     def _redirect(self, redirected, request, spider, reason):
         ttl = request.meta.setdefault('redirect_ttl', self.max_redirect_times)

--- a/scrapy/contrib/downloadermiddleware/retry.py
+++ b/scrapy/contrib/downloadermiddleware/retry.py
@@ -46,8 +46,12 @@ class RetryMiddleware(object):
         self.priority_adjust = settings.getint('RETRY_PRIORITY_ADJUST')
 
     @classmethod
+    def from_settings(cls, settings):
+        return cls(settings)
+
+    @classmethod
     def from_crawler(cls, crawler):
-        return cls(crawler.settings)
+        return cls.from_settings(crawler.settings)
 
     def process_response(self, request, response, spider):
         if 'dont_retry' in request.meta:

--- a/scrapy/contrib/downloadermiddleware/useragent.py
+++ b/scrapy/contrib/downloadermiddleware/useragent.py
@@ -1,7 +1,5 @@
 """Set User-Agent header per spider or use a default value from settings"""
 
-from scrapy import signals
-
 
 class UserAgentMiddleware(object):
     """This middleware allows spiders to override the user_agent"""
@@ -10,14 +8,14 @@ class UserAgentMiddleware(object):
         self.user_agent = user_agent
 
     @classmethod
-    def from_crawler(cls, crawler):
-        o = cls(crawler.settings['USER_AGENT'])
-        crawler.signals.connect(o.spider_opened, signal=signals.spider_opened)
-        return o
+    def from_settings(cls, settings):
+        return cls(settings['USER_AGENT'])
 
-    def spider_opened(self, spider):
-        self.user_agent = getattr(spider, 'user_agent', self.user_agent)
+    @classmethod
+    def from_crawler(cls, crawler):
+        return cls.from_settings(crawler.settings)
 
     def process_request(self, request, spider):
-        if self.user_agent:
-            request.headers.setdefault('User-Agent', self.user_agent)
+        user_agent = getattr(spider, 'user_agent', self.user_agent)
+        if user_agent:
+            request.headers.setdefault('User-Agent', user_agent)

--- a/scrapy/contrib/spidermiddleware/referer.py
+++ b/scrapy/contrib/spidermiddleware/referer.py
@@ -9,10 +9,14 @@ from scrapy.exceptions import NotConfigured
 class RefererMiddleware(object):
 
     @classmethod
-    def from_crawler(cls, crawler):
-        if not crawler.settings.getbool('REFERER_ENABLED'):
+    def from_settings(cls, settings):
+        if not settings.getbool('REFERER_ENABLED'):
             raise NotConfigured
         return cls()
+
+    @classmethod
+    def from_crawler(cls, crawler):
+        return cls.from_settings(crawler.settings)
 
     def process_spider_output(self, response, result, spider):
         def _set_referer(r):

--- a/scrapy/tests/test_downloadermiddleware_downloadtimeout.py
+++ b/scrapy/tests/test_downloadermiddleware_downloadtimeout.py
@@ -17,21 +17,18 @@ class DownloadTimeoutMiddlewareTest(unittest.TestCase):
 
     def test_default_download_timeout(self):
         req, spider, mw = self.get_request_spider_mw()
-        mw.spider_opened(spider)
         assert mw.process_request(req, spider) is None
         self.assertEquals(req.meta.get('download_timeout'), 180)
 
     def test_spider_has_download_timeout(self):
         req, spider, mw = self.get_request_spider_mw()
         spider.download_timeout = 2
-        mw.spider_opened(spider)
         assert mw.process_request(req, spider) is None
         self.assertEquals(req.meta.get('download_timeout'), 2)
 
     def test_request_has_download_timeout(self):
         req, spider, mw = self.get_request_spider_mw()
         spider.download_timeout = 2
-        mw.spider_opened(spider)
         req.meta['download_timeout'] = 1
         assert mw.process_request(req, spider) is None
         self.assertEquals(req.meta.get('download_timeout'), 1)

--- a/scrapy/tests/test_downloadermiddleware_httpauth.py
+++ b/scrapy/tests/test_downloadermiddleware_httpauth.py
@@ -13,7 +13,6 @@ class HttpAuthMiddlewareTest(unittest.TestCase):
     def setUp(self):
         self.mw = HttpAuthMiddleware()
         self.spider = TestSpider('foo')
-        self.mw.spider_opened(self.spider)
 
     def tearDown(self):
         del self.mw

--- a/scrapy/tests/test_downloadermiddleware_useragent.py
+++ b/scrapy/tests/test_downloadermiddleware_useragent.py
@@ -24,7 +24,6 @@ class UserAgentMiddlewareTest(TestCase):
         # settings UESR_AGENT to None should remove the user agent
         spider, mw = self.get_spider_and_mw('default_useragent')
         spider.user_agent = None
-        mw.spider_opened(spider)
         req = Request('http://scrapytest.org/')
         assert mw.process_request(req, spider) is None
         assert req.headers.get('User-Agent') is None
@@ -32,7 +31,6 @@ class UserAgentMiddlewareTest(TestCase):
     def test_spider_agent(self):
         spider, mw = self.get_spider_and_mw('default_useragent')
         spider.user_agent = 'spider_useragent'
-        mw.spider_opened(spider)
         req = Request('http://scrapytest.org/')
         assert mw.process_request(req, spider) is None
         self.assertEquals(req.headers['User-Agent'], 'spider_useragent')
@@ -40,7 +38,6 @@ class UserAgentMiddlewareTest(TestCase):
     def test_header_agent(self):
         spider, mw = self.get_spider_and_mw('default_useragent')
         spider.user_agent = 'spider_useragent'
-        mw.spider_opened(spider)
         req = Request('http://scrapytest.org/', headers={'User-Agent': 'header_useragent'})
         assert mw.process_request(req, spider) is None
         self.assertEquals(req.headers['User-Agent'], 'header_useragent')
@@ -48,7 +45,6 @@ class UserAgentMiddlewareTest(TestCase):
     def test_no_agent(self):
         spider, mw = self.get_spider_and_mw(None)
         spider.user_agent = None
-        mw.spider_opened(spider)
         req = Request('http://scrapytest.org/')
         assert mw.process_request(req, spider) is None
         assert 'User-Agent' not in req.headers


### PR DESCRIPTION
Technically scrapy does not require middlewares require a crawler: https://github.com/scrapy/scrapy/blob/master/scrapy/middleware.py#L32

But all our contrib mws do (and fail on L35 if they are not instantiated from a crawler).
Some mws really require a crawler (for access to stats for example), but others don't. This PR fixes the others.

Offsite middleware can also be converted to not require a crawler, but I wanted some feedback first: do we want such a change?
