### PR TITLE
python3: scrapy.__version__, NoneType, urlparse_monkeypatches

### DIFF
--- a/scrapy/__init__.py
+++ b/scrapy/__init__.py
@@ -4,6 +4,8 @@ Scrapy - a screen scraping framework written in Python
 from __future__ import print_function
 import pkgutil
 __version__ = pkgutil.get_data(__package__, 'VERSION').strip()
+if not isinstance(__version__, str):
+    __version__ = __version__.decode('ascii')
 version_info = tuple(__version__.split('.')[:3])
 
 import sys, os, warnings

--- a/scrapy/utils/trackref.py
+++ b/scrapy/utils/trackref.py
@@ -14,7 +14,8 @@ import weakref, os
 from collections import defaultdict
 from time import time
 from operator import itemgetter
-from types import NoneType
+
+NoneType = type(None)
 
 live_refs = defaultdict(weakref.WeakKeyDictionary)
 

--- a/scrapy/xlib/urlparse_monkeypatches.py
+++ b/scrapy/xlib/urlparse_monkeypatches.py
@@ -1,11 +1,14 @@
-from urlparse import urlparse
+import sys
 
-# workaround for http://bugs.python.org/issue7904 - Python < 2.7
-if urlparse('s3://bucket/key').netloc != 'bucket':
-    from urlparse import uses_netloc
-    uses_netloc.append('s3')
+if sys.version_info[0] == 2:
+    from urlparse import urlparse
 
-# workaround for http://bugs.python.org/issue9374 - Python < 2.7.4
-if urlparse('s3://bucket/key?key=value').query != 'key=value':
-    from urlparse import uses_query
-    uses_query.append('s3')
+    # workaround for http://bugs.python.org/issue7904 - Python < 2.7
+    if urlparse('s3://bucket/key').netloc != 'bucket':
+        from urlparse import uses_netloc
+        uses_netloc.append('s3')
+
+    # workaround for http://bugs.python.org/issue9374 - Python < 2.7.4
+    if urlparse('s3://bucket/key?key=value').query != 'key=value':
+        from urlparse import uses_query
+        uses_query.append('s3')


### PR DESCRIPTION
Python 3 compatibility changes:
1. `__version__` will be `str` in both 2 and 3. Necessary because pkgutil.get_data returns `bytes` in 3.
2. `NoneType` is not available in 3
3. Apply `urlparse_monkeypatches` in Python 2 only. Patches are not needed in 3 (tested in 3.2-3.4).
