### PR TITLE
Add note to item-pipeline documentation explaining order 

### DIFF
--- a/docs/topics/item-pipeline.rst
+++ b/docs/topics/item-pipeline.rst
@@ -140,5 +140,6 @@ To activate an Item Pipeline component you must add its class to the
    }
 
 The integer values you assign to classes in this setting determine the
-order they run in. It's customary to define them in the 0-1000 range.
+order they run in- items go through pipelines from order number low to
+high. It's customary to define these numbers in the 0-1000 range.
 


### PR DESCRIPTION
As a new Scrapy user I had trouble hunting down what the numbers meant in the ITEM_PIPELINES setting. I added a note to the item-pipeline documentation to make it more clear.
