### PR TITLE
Remove "x-gzip" from Requests' "Accept-Encoding" header

### DIFF
--- a/scrapy/contrib/downloadermiddleware/httpcompression.py
+++ b/scrapy/contrib/downloadermiddleware/httpcompression.py
@@ -17,7 +17,7 @@ class HttpCompressionMiddleware(object):
         return cls()
     
     def process_request(self, request, spider):
-        request.headers.setdefault('Accept-Encoding', 'x-gzip,gzip,deflate')
+        request.headers.setdefault('Accept-Encoding', 'gzip,deflate')
 
     def process_response(self, request, response, spider):
         if isinstance(response, Response):

--- a/scrapy/tests/test_downloadermiddleware_httpcompression.py
+++ b/scrapy/tests/test_downloadermiddleware_httpcompression.py
@@ -50,7 +50,7 @@ class HttpCompressionTest(TestCase):
         request = Request('http://scrapytest.org')
         assert 'Accept-Encoding' not in request.headers
         self.mw.process_request(request, self.spider)
-        self.assertEqual(request.headers.get('Accept-Encoding'), 'x-gzip,gzip,deflate')
+        self.assertEqual(request.headers.get('Accept-Encoding'), 'gzip,deflate')
 
     def test_process_response_gzip(self):
         response = self._getresponse('gzip')


### PR DESCRIPTION
Having "x-gzip" as first encoding in "Accept-Encoding" header seems to cause encoding issues with some (IIS?) web servers (response not compressed, valid but not compressed)

"x-gzip" is not included in "Accept-Encoding" headers sent by latest Chrome or Firefox releases

After discussing with @dangra and @pablohoffman (https://github.com/scrapy/scrapy/commit/81fbe8c9a4b3940cd1cdf27ff0848a7ec5360512#commitcomment-4617865) the consensus is to remove it in requests still accepting it in responses

Moving "x-gzip" to the end of the accepted encoding list also works (with the server exhibiting the issue)
