### PR TITLE
Support pre-compiled XPath expressions and CSS selectors

### DIFF
--- a/scrapy/selector/unified.py
+++ b/scrapy/selector/unified.py
@@ -57,9 +57,12 @@ class XPath(object_ref):
             try:
                 self._compiled_xpath = etree.XPath(self.xpath,
                     namespaces=self.namespaces)
-            except etree.XPathError:
-                raise ValueError("Invalid XPath: %s" % self.xpath)
-        return self._compiled_xpath(document)
+            except etree.XPathError as e:
+                raise ValueError("Invalid XPath: %s -- %s" % (self.xpath, str(e)))
+        try:
+            return self._compiled_xpath(document)
+        except etree.XPathEvalError as e:
+            raise ValueError("Invalid XPath: %s -- %s" % (self.xpath, str(e)))
 
 
 class CSS(XPath):
@@ -109,8 +112,8 @@ class Selector(object_ref):
         else:
             try:
                 result = xpathev(query, namespaces=self.namespaces)
-            except etree.XPathError:
-                raise ValueError("Invalid XPath: %s" % query)
+            except etree.XPathError as e:
+                raise ValueError("Invalid XPath: %s -- %s" % (query, str(e)))
 
         if type(result) is not list:
             result = [result]

--- a/scrapy/selector/unified.py
+++ b/scrapy/selector/unified.py
@@ -45,12 +45,20 @@ class XPath(object_ref):
     def __init__(self, xpath, type=None, namespaces=None):
         self.xpath = xpath
         self.namespaces = namespaces
-        try:
-            self._compiled_xpath = etree.XPath(xpath, namespaces=namespaces)
-        except etree.XPathError:
-            raise ValueError("Invalid XPath: %s" % xpath)
+        self._compiled_xpath = None
+
+    def register_namespace(self, prefix, uri):
+        if self.namespaces is None:
+            self.namespaces = {}
+        self.namespaces[prefix] = uri
 
     def __call__(self, document):
+        if self._compiled_xpath is None:
+            try:
+                self._compiled_xpath = etree.XPath(self.xpath,
+                    namespaces=self.namespaces)
+            except etree.XPathError:
+                raise ValueError("Invalid XPath: %s" % self.xpath)
         return self._compiled_xpath(document)
 
 

--- a/scrapy/selector/unified.py
+++ b/scrapy/selector/unified.py
@@ -13,7 +13,7 @@ from .lxmldocument import LxmlDocument
 from .csstranslator import ScrapyHTMLTranslator, ScrapyGenericTranslator
 
 
-__all__ = ['Selector', 'SelectorList']
+__all__ = ['Selector', 'SelectorList', 'XPath', 'CSS']
 
 _ctgroup = {
     'html': {'_parser': etree.HTMLParser,
@@ -38,6 +38,31 @@ def _response_from_text(text, st):
     rt = XmlResponse if st == 'xml' else HtmlResponse
     return rt(url='about:blank', encoding='utf-8',
               body=unicode_to_str(text, 'utf-8'))
+
+
+class XPath(object_ref):
+
+    def __init__(self, xpath, type=None, namespaces=None):
+        self.xpath = xpath
+        self.namespaces = namespaces
+        try:
+            self._compiled_xpath = etree.XPath(xpath, namespaces=namespaces)
+        except etree.XPathError:
+            raise ValueError("Invalid XPath: %s" % xpath)
+
+    def __call__(self, document):
+        return self._compiled_xpath(document)
+
+
+class CSS(XPath):
+
+    _csstranslator_type = 'html'
+
+    def __init__(self, css, *args, **kwargs):
+        self.css = css
+        self._csstranslator = _ctgroup[self._csstranslator_type]['_csstranslator']
+        super(CSS, self).__init__(
+            self._csstranslator.css_to_xpath(css), *args, **kwargs)
 
 
 class Selector(object_ref):
@@ -71,10 +96,13 @@ class Selector(object_ref):
         except AttributeError:
             return SelectorList([])
 
-        try:
-            result = xpathev(query, namespaces=self.namespaces)
-        except etree.XPathError:
-            raise ValueError("Invalid XPath: %s" % query)
+        if isinstance(query, (XPath, CSS)):
+            result = query(self._root)
+        else:
+            try:
+                result = xpathev(query, namespaces=self.namespaces)
+            except etree.XPathError:
+                raise ValueError("Invalid XPath: %s" % query)
 
         if type(result) is not list:
             result = [result]
@@ -86,7 +114,10 @@ class Selector(object_ref):
         return SelectorList(result)
 
     def css(self, query):
-        return self.xpath(self._css2xpath(query))
+        if isinstance(query, CSS):
+            return self.xpath(query)
+        else:
+            return self.xpath(self._css2xpath(query))
 
     def _css2xpath(self, query):
         return self._csstranslator.css_to_xpath(query)

--- a/scrapy/tests/test_selector.py
+++ b/scrapy/tests/test_selector.py
@@ -444,9 +444,15 @@ class CompiledSelectorTestCase(unittest.TestCase):
         """
 
         response = XmlResponse(url="http://example.com", body=body)
+
         xp_somens_a_text = XPath("//somens:a/text()",
             namespaces={"somens":"http://scrapy.org"})
         x = self.sscls(response)
+        self.assertEqual(x.xpath(xp_somens_a_text).extract(),
+                         [u'take this'])
+
+        xp_somens_a_text = XPath("//somens:a/text()")
+        xp_somens_a_text.register_namespace("somens", "http://scrapy.org")
         self.assertEqual(x.xpath(xp_somens_a_text).extract(),
                          [u'take this'])
 
@@ -534,8 +540,9 @@ class CompiledSelectorTestCase(unittest.TestCase):
         response = XmlResponse(url="http://example.com", body="<html></html>")
         x = self.sscls(response)
         xpath = "//test[@foo='bar]"
+        xp = XPath(xpath)
         try:
-            XPath(xpath)
+            x.xpath(xp)
         except ValueError as e:
             assert xpath in str(e), "Exception message does not contain invalid xpath"
         except Exception as e:

--- a/scrapy/tests/test_selector.py
+++ b/scrapy/tests/test_selector.py
@@ -4,7 +4,7 @@ import weakref
 from twisted.trial import unittest
 from scrapy.exceptions import ScrapyDeprecationWarning
 from scrapy.http import TextResponse, HtmlResponse, XmlResponse
-from scrapy.selector import Selector
+from scrapy.selector import Selector, XPath, CSS
 from scrapy.selector.lxmlsel import XmlXPathSelector, HtmlXPathSelector, XPathSelector
 
 
@@ -295,6 +295,365 @@ class SelectorTestCase(unittest.TestCase):
         self.assertEqual(len(sel.xpath("//link/@type")), 0)
         sel.remove_namespaces()
         self.assertEqual(len(sel.xpath("//link/@type")), 2)
+
+
+class CompiledSelectorTestCase(unittest.TestCase):
+
+    sscls = Selector
+
+    def test_simple_selection(self):
+        """Simple selector tests"""
+
+        xp_input = XPath('//input')
+        xp_input_name = XPath("//input[@name='a']/@name")
+        xp_number_concat = XPath(
+            "number(concat(//input[@name='a']/@value, //input[@name='b']/@value))")
+        xp_concat = XPath("concat('xpath', 'rules')")
+        xp_concat_value = XPath("concat(//input[@name='a']/@value, //input[@name='b']/@value)")
+
+        body = "<p><input name='a'value='1'/><input name='b'value='2'/></p>"
+        response = TextResponse(url="http://example.com", body=body)
+        sel = self.sscls(response)
+
+        xl = sel.xpath(xp_input)
+        self.assertEqual(2, len(xl))
+        for x in xl:
+            assert isinstance(x, self.sscls)
+
+        self.assertEqual(sel.xpath(xp_input).extract(),
+                         [x.extract() for x in sel.xpath(xp_input)])
+
+        self.assertEqual([x.extract() for x in sel.xpath(xp_input_name)],
+                         [u'a'])
+        self.assertEqual([x.extract() for x in sel.xpath(xp_number_concat)],
+                         [u'12.0'])
+
+        self.assertEqual(sel.xpath(xp_concat).extract(),
+                         [u'xpathrules'])
+        self.assertEqual([x.extract() for x in sel.xpath(xp_concat_value)],
+                         [u'12'])
+
+    def test_select_unicode_query(self):
+        xp_input_value = XPath(u'//input[@name="\xa9"]/@value')
+        body = u"<p><input name='\xa9' value='1'/></p>"
+        response = TextResponse(url="http://example.com", body=body, encoding='utf8')
+        sel = self.sscls(response)
+        self.assertEqual(sel.xpath(xp_input_value).extract(), [u'1'])
+
+    def test_list_elements_type(self):
+        """Test Selector returning the same type in selection methods"""
+        text = '<p>test<p>'
+        xp_p = XPath("//p")
+        css_p = CSS("p")
+        assert isinstance(self.sscls(text=text).xpath(xp_p)[0], self.sscls)
+        assert isinstance(self.sscls(text=text).css(css_p)[0], self.sscls)
+
+    def test_boolean_result(self):
+        body = "<p><input name='a'value='1'/><input name='b'value='2'/></p>"
+        response = TextResponse(url="http://example.com", body=body)
+        xp_name_a = XPath("//input[@name='a']/@name='a'")
+        xp_name_n = XPath("//input[@name='a']/@name='n'")
+        xs = self.sscls(response)
+        self.assertEquals(xs.xpath(xp_name_a).extract(), [u'1'])
+        self.assertEquals(xs.xpath(xp_name_n).extract(), [u'0'])
+
+    def test_differences_parsing_xml_vs_html(self):
+        """Test that XML and HTML Selector's behave differently"""
+        # some text which is parsed differently by XML and HTML flavors
+        text = '<div><img src="a.jpg"><p>Hello</div>'
+        xp_div = XPath("//div")
+        hs = self.sscls(text=text, type='html')
+        self.assertEqual(hs.xpath(xp_div).extract(),
+                         [u'<div><img src="a.jpg"><p>Hello</p></div>'])
+
+        xs = self.sscls(text=text, type='xml')
+        self.assertEqual(xs.xpath(xp_div).extract(),
+                         [u'<div><img src="a.jpg"><p>Hello</p></img></div>'])
+
+    def test_flavor_detection(self):
+        text = '<div><img src="a.jpg"><p>Hello</div>'
+        xp_div = XPath("//div")
+        sel = self.sscls(XmlResponse('http://example.com', body=text))
+        self.assertEqual(sel.type, 'xml')
+        self.assertEqual(sel.xpath(xp_div).extract(),
+                         [u'<div><img src="a.jpg"><p>Hello</p></img></div>'])
+
+        sel = self.sscls(HtmlResponse('http://example.com', body=text))
+        self.assertEqual(sel.type, 'html')
+        self.assertEqual(sel.xpath(xp_div).extract(),
+                         [u'<div><img src="a.jpg"><p>Hello</p></div>'])
+
+    def test_nested_selectors(self):
+        """Nested selector tests"""
+        body = """<body>
+                    <div class='one'>
+                      <ul>
+                        <li>one</li><li>two</li>
+                      </ul>
+                    </div>
+                    <div class='two'>
+                      <ul>
+                        <li>four</li><li>five</li><li>six</li>
+                      </ul>
+                    </div>
+                  </body>"""
+
+        response = HtmlResponse(url="http://example.com", body=body)
+
+        xp_div_two = XPath('//div[@class="two"]')
+        xp_all_li = XPath("//li")
+        xp_ul_li = XPath("./ul/li")
+        xp_desc_li = XPath(".//li")
+        xp_child_li = XPath("./li")
+
+        x = self.sscls(response)
+        divtwo = x.xpath(xp_div_two)
+        self.assertEqual(divtwo.xpath(xp_all_li).extract(),
+                         ["<li>one</li>", "<li>two</li>", "<li>four</li>", "<li>five</li>", "<li>six</li>"])
+        self.assertEqual(divtwo.xpath(xp_ul_li).extract(),
+                         ["<li>four</li>", "<li>five</li>", "<li>six</li>"])
+        self.assertEqual(divtwo.xpath(xp_desc_li).extract(),
+                         ["<li>four</li>", "<li>five</li>", "<li>six</li>"])
+        self.assertEqual(divtwo.xpath(xp_child_li).extract(), [])
+
+    def test_mixed_nested_selectors(self):
+        body = '''<body>
+                    <div id=1>not<span>me</span></div>
+                    <div class="dos"><p>text</p><a href='#'>foo</a></div>
+               </body>'''
+        xp_div_id1 = XPath('//div[@id="1"]')
+        css_span_text = CSS('span::text')
+        css_id1 = CSS('#1')
+        xp_span_text = XPath('./span/text()')
+
+        sel = self.sscls(text=body)
+        self.assertEqual(sel.xpath(xp_div_id1).css(css_span_text).extract(), [u'me'])
+        self.assertEqual(sel.css(css_id1).xpath(xp_span_text).extract(), [u'me'])
+
+    def test_dont_strip(self):
+        xp_text = XPath("//text()")
+        sel = self.sscls(text='<div>fff: <a href="#">zzz</a></div>')
+        self.assertEqual(sel.xpath(xp_text).extract(), [u'fff: ', u'zzz'])
+
+    def test_namespaces_simple(self):
+        body = """
+        <test xmlns:somens="http://scrapy.org">
+           <somens:a id="foo">take this</a>
+           <a id="bar">found</a>
+        </test>
+        """
+
+        response = XmlResponse(url="http://example.com", body=body)
+        xp_somens_a_text = XPath("//somens:a/text()",
+            namespaces={"somens":"http://scrapy.org"})
+        x = self.sscls(response)
+        self.assertEqual(x.xpath(xp_somens_a_text).extract(),
+                         [u'take this'])
+
+    def test_namespaces_multiple(self):
+        body = """<?xml version="1.0" encoding="UTF-8"?>
+<BrowseNode xmlns="http://webservices.amazon.com/AWSECommerceService/2005-10-05"
+            xmlns:b="http://somens.com"
+            xmlns:p="http://www.scrapy.org/product" >
+    <b:Operation>hello</b:Operation>
+    <TestTag b:att="value"><Other>value</Other></TestTag>
+    <p:SecondTestTag><material>iron</material><price>90</price><p:name>Dried Rose</p:name></p:SecondTestTag>
+</BrowseNode>
+        """
+        response = XmlResponse(url="http://example.com", body=body)
+
+        xp_testtag = XPath("//xmlns:TestTag", namespaces={
+                "xmlns": "http://webservices.amazon.com/AWSECommerceService/2005-10-05"
+            })
+        xp_operation_text = XPath("//b:Operation/text()", namespaces={
+                "b": "http://somens.com"
+            })
+        xp_testtag_att = XPath("//xmlns:TestTag/@b:att", namespaces={
+                "xmlns": "http://webservices.amazon.com/AWSECommerceService/2005-10-05",
+                "b": "http://somens.com"
+            })
+        xp_secondtesttag_price_text = XPath("//p:SecondTestTag/xmlns:price/text()", namespaces={
+                "p": "http://www.scrapy.org/product",
+                "xmlns": "http://webservices.amazon.com/AWSECommerceService/2005-10-05",
+            })
+        xp_secondtesttag = XPath("//p:SecondTestTag", namespaces={
+                "p": "http://www.scrapy.org/product",
+            })
+        xp_secondtesttag_material = XPath("//p:SecondTestTag/xmlns:material/text()", namespaces={
+                "p": "http://www.scrapy.org/product",
+                "xmlns": "http://webservices.amazon.com/AWSECommerceService/2005-10-05",
+            })
+
+        x = self.sscls(response)
+
+        self.assertEqual(len(x.xpath(xp_testtag)), 1)
+        self.assertEqual(x.xpath(xp_operation_text).extract()[0], 'hello')
+        self.assertEqual(x.xpath(xp_testtag_att).extract()[0], 'value')
+        self.assertEqual(x.xpath(xp_secondtesttag_price_text).extract()[0], '90')
+
+        x.register_namespace("xmlns", "http://webservices.amazon.com/AWSECommerceService/2005-10-05")
+        self.assertEqual(x.xpath(xp_secondtesttag).xpath("./xmlns:price/text()")[0].extract(), '90')
+        self.assertEqual(x.xpath(xp_secondtesttag_material).extract()[0], 'iron')
+
+    def test_re(self):
+        body = """<div>Name: Mary
+                    <ul>
+                      <li>Name: John</li>
+                      <li>Age: 10</li>
+                      <li>Name: Paul</li>
+                      <li>Age: 20</li>
+                    </ul>
+                    Age: 20
+                  </div>"""
+        response = HtmlResponse(url="http://example.com", body=body)
+        xp_ul_li = XPath("//ul/li")
+        x = self.sscls(response)
+
+        name_re = re.compile("Name: (\w+)")
+        self.assertEqual(x.xpath(xp_ul_li).re(name_re),
+                         ["John", "Paul"])
+        self.assertEqual(x.xpath(xp_ul_li).re("Age: (\d+)"),
+                         ["10", "20"])
+
+    def test_re_intl(self):
+        body = """<div>Evento: cumplea\xc3\xb1os</div>"""
+        response = HtmlResponse(url="http://example.com", body=body, encoding='utf-8')
+        xp_div = XPath("//div")
+        x = self.sscls(response)
+        self.assertEqual(x.xpath(xp_div).re("Evento: (\w+)"), [u'cumplea\xf1os'])
+
+    def test_selector_over_text(self):
+        hs = self.sscls(text='<root>lala</root>')
+        xp_over_text = XPath('.')
+        self.assertEqual(hs.extract(), u'<html><body><root>lala</root></body></html>')
+        xs = self.sscls(text='<root>lala</root>', type='xml')
+        self.assertEqual(xs.extract(), u'<root>lala</root>')
+        self.assertEqual(xs.xpath(xp_over_text).extract(), [u'<root>lala</root>'])
+
+    def test_invalid_xpath(self):
+        response = XmlResponse(url="http://example.com", body="<html></html>")
+        x = self.sscls(response)
+        xpath = "//test[@foo='bar]"
+        try:
+            XPath(xpath)
+        except ValueError as e:
+            assert xpath in str(e), "Exception message does not contain invalid xpath"
+        except Exception as e:
+            raise AssertionError("A invalid XPath does not raise ValueError; raised %r" % type(e))
+        else:
+            raise AssertionError("A invalid XPath does not raise an exception")
+
+    def test_http_header_encoding_precedence(self):
+        # u'\xa3'     = pound symbol in unicode
+        # u'\xc2\xa3' = pound symbol in utf-8
+        # u'\xa3'     = pound symbol in latin-1 (iso-8859-1)
+
+        meta = u'<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">'
+        head = u'<head>' + meta + u'</head>'
+        body_content = u'<span id="blank">\xa3</span>'
+        body = u'<body>' + body_content + u'</body>'
+        html = u'<html>' + head + body + u'</html>'
+        encoding = 'utf-8'
+        html_utf8 = html.encode(encoding)
+
+        headers = {'Content-Type': ['text/html; charset=utf-8']}
+        xp_span_blank_text = XPath("//span[@id='blank']/text()")
+        response = HtmlResponse(url="http://example.com", headers=headers, body=html_utf8)
+        x = self.sscls(response)
+        self.assertEquals(x.xpath(xp_span_blank_text).extract(),
+                          [u'\xa3'])
+
+    def test_empty_bodies(self):
+        # shouldn't raise errors
+        r1 = TextResponse('http://www.example.com', body='')
+        xp_text = XPath('//text()')
+        self.sscls(r1).xpath(xp_text).extract()
+
+    def test_null_bytes(self):
+        # shouldn't raise errors
+        r1 = TextResponse('http://www.example.com', \
+                          body='<root>pre\x00post</root>', \
+                          encoding='utf-8')
+        xp_text = XPath('//text()')
+        self.sscls(r1).xpath(xp_text).extract()
+
+    def test_badly_encoded_body(self):
+        # \xe9 alone isn't valid utf8 sequence
+        r1 = TextResponse('http://www.example.com', \
+                          body='<html><p>an Jos\xe9 de</p><html>', \
+                          encoding='utf-8')
+        xp_text = XPath('//text()')
+        self.sscls(r1).xpath(xp_text).extract()
+
+    def test_select_on_unevaluable_nodes(self):
+        r = self.sscls(text=u'<span class="big">some text</span>')
+        xp_text = XPath('//text()')
+        xp_b = XPath('.//b')
+        xp_span_class = XPath('//span/@class')
+        xp_desc_text = XPath('.//text()')
+        # Text node
+        x1 = r.xpath(xp_text)
+        self.assertEquals(x1.extract(), [u'some text'])
+        self.assertEquals(x1.xpath(xp_b).extract(), [])
+        # Tag attribute
+        x1 = r.xpath(xp_span_class)
+        self.assertEquals(x1.extract(), [u'big'])
+        self.assertEquals(x1.xpath(xp_desc_text).extract(), [])
+
+    def test_select_on_text_nodes(self):
+        xp1 = XPath("//div/descendant::text()[preceding-sibling::b[contains(text(), 'Options')]]")
+        xp2 = XPath("//div/descendant::text()/preceding-sibling::b[contains(text(), 'Options')]")
+
+        r = self.sscls(text=u'<div><b>Options:</b>opt1</div><div><b>Other</b>opt2</div>')
+
+        x1 = r.xpath(xp1)
+        self.assertEquals(x1.extract(), [u'opt1'])
+
+        x1 = r.xpath(xp2)
+        self.assertEquals(x1.extract(), [u'<b>Options:</b>'])
+
+    def test_nested_select_on_text_nodes(self):
+        xp1 = XPath("//div/descendant::text()")
+        xp2 = XPath("./preceding-sibling::b[contains(text(), 'Options')]")
+        # FIXME: does not work with lxml backend [upstream]
+        r = self.sscls(text=u'<div><b>Options:</b>opt1</div><div><b>Other</b>opt2</div>')
+        x1 = r.xpath(xp1)
+        x2 = x1.xpath(xp2)
+        self.assertEquals(x2.extract(), [u'<b>Options:</b>'])
+    test_nested_select_on_text_nodes.skip = "Text nodes lost parent node reference in lxml"
+
+    def test_weakref_slots(self):
+        """Check that classes are using slots and are weak-referenceable"""
+        x = self.sscls()
+        weakref.ref(x)
+        assert not hasattr(x, '__dict__'), "%s does not use __slots__" % \
+            x.__class__.__name__
+
+    def test_remove_namespaces(self):
+        xml = """<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom" xml:lang="en-US" xmlns:media="http://search.yahoo.com/mrss/">
+  <link type="text/html">
+  <link type="application/atom+xml">
+</feed>
+"""
+        xp_link = XPath("//link")
+        sel = self.sscls(XmlResponse("http://example.com/feed.atom", body=xml))
+        self.assertEqual(len(sel.xpath(xp_link)), 0)
+        sel.remove_namespaces()
+        self.assertEqual(len(sel.xpath(xp_link)), 2)
+
+    def test_remove_attributes_namespaces(self):
+        xml = """<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns:atom="http://www.w3.org/2005/Atom" xml:lang="en-US" xmlns:media="http://search.yahoo.com/mrss/">
+  <link atom:type="text/html">
+  <link atom:type="application/atom+xml">
+</feed>
+"""
+        xp_link_type = XPath("//link/@type")
+        sel = self.sscls(XmlResponse("http://example.com/feed.atom", body=xml))
+        self.assertEqual(len(sel.xpath(xp_link_type)), 0)
+        sel.remove_namespaces()
+        self.assertEqual(len(sel.xpath(xp_link_type)), 2)
 
 
 class DeprecatedXpathSelectorTest(unittest.TestCase):

--- a/scrapy/tests/test_spider.py
+++ b/scrapy/tests/test_spider.py
@@ -9,6 +9,7 @@ from scrapy.spider import BaseSpider
 from scrapy.http import Response, TextResponse, XmlResponse, HtmlResponse
 from scrapy.contrib.spiders.init import InitSpider
 from scrapy.contrib.spiders import CrawlSpider, XMLFeedSpider, CSVFeedSpider, SitemapSpider
+from scrapy.selector import XPath
 
 
 class BaseSpiderTest(unittest.TestCase):
@@ -89,6 +90,229 @@ class XMLFeedSpiderTest(BaseSpiderTest):
                  'updated': [u'2009-08-16'],
                  'other': [u'foo'],
                  'custom': []},
+            ], iterator)
+
+    def test_register_namespace_compiled(self):
+        body = """<?xml version="1.0" encoding="UTF-8"?>
+        <urlset xmlns:x="http://www.google.com/schemas/sitemap/0.84"
+                xmlns:y="http://www.example.com/schemas/extras/1.0">
+        <url><x:loc>http://www.example.com/Special-Offers.html</loc><y:updated>2009-08-16</updated><other value="bar" y:custom="fuu"/></url>
+        <url><loc>http://www.example.com/</loc><y:updated>2009-08-16</updated><other value="foo"/></url>
+        </urlset>"""
+        response = XmlResponse(url='http://example.com/sitemap.xml', body=body)
+
+        class _XMLSpider(self.spider_class):
+            itertag = 'url'
+            namespaces = (
+                ('a', 'http://www.google.com/schemas/sitemap/0.84'),
+                ('b', 'http://www.example.com/schemas/extras/1.0'),
+            )
+            xp_loc_text = XPath('a:loc/text()')
+            xp_loc_text.register_namespace(
+                'a', 'http://www.google.com/schemas/sitemap/0.84')
+
+            xp_updated_text = XPath('b:updated/text()', namespaces={
+                'b':'http://www.example.com/schemas/extras/1.0'
+            })
+            xp_other_value = XPath('other/@value')
+            xp_other_custom = XPath('other/@b:custom')
+            xp_other_custom.register_namespace(
+                'b', 'http://www.example.com/schemas/extras/1.0')
+
+            def parse_node(self, response, selector):
+                yield {
+                    'loc': selector.xpath(self.xp_loc_text).extract(),
+                    'updated': selector.xpath(self.xp_updated_text).extract(),
+                    'other': selector.xpath(self.xp_other_value).extract(),
+                    'custom': selector.xpath(self.xp_other_custom).extract(),
+                }
+
+        for iterator in ('iternodes', 'xml'):
+            spider = _XMLSpider('example', iterator=iterator)
+            output = list(spider.parse(response))
+            self.assertEqual(len(output), 2, iterator)
+            self.assertEqual(output, [
+                {'loc': [u'http://www.example.com/Special-Offers.html'],
+                 'updated': [u'2009-08-16'],
+                 'custom': [u'fuu'],
+                 'other': [u'bar']},
+                {'loc': [],
+                 'updated': [u'2009-08-16'],
+                 'other': [u'foo'],
+                 'custom': []},
+            ], iterator)
+
+    def test_register_defaultnamespace(self):
+        body = """<?xml version="1.0" encoding="utf-8"?>
+<feed xmlns:im="http://itunes.apple.com/rss" xmlns="http://www.w3.org/2005/Atom" xml:lang="en">
+    <id>https://itunes.apple.com/us/rss/topaudiobooks/limit=10/xml</id>
+    <title>iTunes Store: Top Audiobooks</title>
+    <updated>2013-11-24T12:41:07-07:00</updated>
+    <link rel="alternate" type="text/html" href="https://itunes.apple.com/WebObjects/MZStore.woa/wa/viewTop?cc=us&amp;id=38&amp;popId=8"/>
+    <link rel="self" href="https://itunes.apple.com/us/rss/topaudiobooks/limit=10/xml"/>
+    <icon>http://itunes.apple.com/favicon.ico</icon>
+    <author>
+        <name>iTunes Store</name>
+        <uri>http://www.apple.com/itunes/</uri>
+    </author>
+    <rights>Copyright 2008 Apple Inc.</rights>
+    <entry>
+        <updated>2013-11-24T12:41:07-07:00</updated>
+        <id im:id="387391500">https://itunes.apple.com/us/audiobook/mockingjay-final-book-hunger/id387391500?uo=2</id>
+        <title>Mockingjay: The Final Book of the Hunger Games (Unabridged) - Suzanne Collins</title>
+        <im:name>Mockingjay: The Final Book of the Hunger Games (Unabridged)</im:name>
+        <link rel="alternate" type="text/html" href="https://itunes.apple.com/us/audiobook/mockingjay-final-book-hunger/id387391500?uo=2"/>
+        <im:contentType term="Audiobook" label="Audiobook"/>
+        <category im:id="50000044" term="Kids &amp; Young Adults" scheme="https://itunes.apple.com/us/genre/audiobooks-kids-young-adults/id50000044?uo=2" label="Kids &amp; Young Adults"/>
+        <link title="Preview" rel="enclosure" type="audio/x-m4a" href="http://a390.phobos.apple.com/us/r30/Music4/v4/51/99/a7/5199a7b9-db39-e5ab-3438-4a76328eb2d5/mzaf_2857127299462152824.plus.aac.p.m4a" im:assetType="preview"><im:duration>30000</im:duration></link>
+        <im:artist href="https://itunes.apple.com/us/artist/suzanne-collins/id110188933?mt=11&amp;uo=2">Suzanne Collins</im:artist>
+        <im:price amount="17.95000" currency="USD">$17.95</im:price>
+        <im:image height="55">http://a1385.phobos.apple.com/us/r30/Music/ac/3e/30/mzi.ihhqvuls.55x55-70.jpg</im:image>
+        <im:image height="60">http://a107.phobos.apple.com/us/r30/Music/ac/3e/30/mzi.ihhqvuls.60x60-50.jpg</im:image>
+        <im:image height="170">http://a1562.phobos.apple.com/us/r30/Music/ac/3e/30/mzi.ihhqvuls.170x170-75.jpg</im:image>
+        <rights>&#8471; &#169; 2010 Scholastic Audio</rights>
+        <im:releaseDate label="August 24, 2010">2010-08-24T00:00:00-07:00</im:releaseDate>
+    </entry>
+    <entry>
+        <updated>2013-11-24T12:41:07-07:00</updated>
+        <id im:id="329920607">https://itunes.apple.com/us/audiobook/catching-fire-hunger-games/id329920607?uo=2</id>
+        <title>Catching Fire: Hunger Games, Book 2 (Unabridged) - Suzanne Collins</title>
+        <im:name>Catching Fire: Hunger Games, Book 2 (Unabridged)</im:name>
+        <link rel="alternate" type="text/html" href="https://itunes.apple.com/us/audiobook/catching-fire-hunger-games/id329920607?uo=2"/>
+        <im:contentType term="Audiobook" label="Audiobook"/>
+        <category im:id="50000044" term="Kids &amp; Young Adults" scheme="https://itunes.apple.com/us/genre/audiobooks-kids-young-adults/id50000044?uo=2" label="Kids &amp; Young Adults"/>
+        <link title="Preview" rel="enclosure" type="audio/x-m4a" href="http://a109.phobos.apple.com/us/r30/Music4/v4/6b/c6/f9/6bc6f9f9-60a4-b8d5-1227-b96995c74f08/mzaf_1215338369218175103.plus.aac.p.m4a" im:assetType="preview"><im:duration>30000</im:duration></link>
+        <im:artist href="https://itunes.apple.com/us/artist/suzanne-collins/id110188933?mt=11&amp;uo=2">Suzanne Collins</im:artist>
+        <im:price amount="24.95000" currency="USD">$24.95</im:price>
+        <im:image height="55">http://a451.phobos.apple.com/us/r30/Music/d2/83/27/mzi.mywamvuu.55x55-70.jpg</im:image>
+        <im:image height="60">http://a1525.phobos.apple.com/us/r30/Music/d2/83/27/mzi.mywamvuu.60x60-50.jpg</im:image>
+        <im:image height="170">http://a1364.phobos.apple.com/us/r30/Music/d2/83/27/mzi.mywamvuu.170x170-75.jpg</im:image>
+        <rights>&#8471; &#169; 2009 Scholastic Audio</rights>
+        <im:releaseDate label="September 1, 2009">2009-09-01T00:00:00-07:00</im:releaseDate>
+    </entry>
+</feed>"""
+        response = XmlResponse(url='http://example.com/sitemap.xml', body=body)
+
+        class _XMLSpider(self.spider_class):
+            itertag = 'entry'
+            itertag_ns_prefix = 'atom'
+            itertag_ns_name = 'http://www.w3.org/2005/Atom'
+            namespaces = (
+                ('im', "http://itunes.apple.com/rss"),
+                ('atom', 'http://www.w3.org/2005/Atom'),
+            )
+
+            def parse_node(self, response, selector):
+                yield {
+                    'updated': selector.xpath('atom:updated/text()').extract(),
+                    'contentType': selector.xpath('im:contentType/@term').extract(),
+                    'releaseDate': selector.xpath('im:releaseDate/@label').extract(),
+                }
+
+        for iterator in ('iternodes', 'xml'):
+            spider = _XMLSpider('example', iterator=iterator)
+            output = list(spider.parse(response))
+            self.assertEqual(len(output), 2, iterator)
+            self.assertEqual(output, [
+                {'contentType': [u'Audiobook'],
+                'releaseDate': [u'August 24, 2010'],
+                'updated': [u'2013-11-24T12:41:07-07:00']},
+                {'contentType': [u'Audiobook'],
+                'releaseDate': [u'September 1, 2009'],
+                'updated': [u'2013-11-24T12:41:07-07:00']},
+            ], iterator)
+
+
+    def test_register_defaultnamespace_compiled(self):
+        body = """<?xml version="1.0" encoding="utf-8"?>
+<feed xmlns:im="http://itunes.apple.com/rss" xmlns="http://www.w3.org/2005/Atom" xml:lang="en">
+    <id>https://itunes.apple.com/us/rss/topaudiobooks/limit=10/xml</id>
+    <title>iTunes Store: Top Audiobooks</title>
+    <updated>2013-11-24T12:41:07-07:00</updated>
+    <link rel="alternate" type="text/html" href="https://itunes.apple.com/WebObjects/MZStore.woa/wa/viewTop?cc=us&amp;id=38&amp;popId=8"/>
+    <link rel="self" href="https://itunes.apple.com/us/rss/topaudiobooks/limit=10/xml"/>
+    <icon>http://itunes.apple.com/favicon.ico</icon>
+    <author>
+        <name>iTunes Store</name>
+        <uri>http://www.apple.com/itunes/</uri>
+    </author>
+    <rights>Copyright 2008 Apple Inc.</rights>
+    <entry>
+        <updated>2013-11-24T12:41:07-07:00</updated>
+        <id im:id="387391500">https://itunes.apple.com/us/audiobook/mockingjay-final-book-hunger/id387391500?uo=2</id>
+        <title>Mockingjay: The Final Book of the Hunger Games (Unabridged) - Suzanne Collins</title>
+        <im:name>Mockingjay: The Final Book of the Hunger Games (Unabridged)</im:name>
+        <link rel="alternate" type="text/html" href="https://itunes.apple.com/us/audiobook/mockingjay-final-book-hunger/id387391500?uo=2"/>
+        <im:contentType term="Audiobook" label="Audiobook"/>
+        <category im:id="50000044" term="Kids &amp; Young Adults" scheme="https://itunes.apple.com/us/genre/audiobooks-kids-young-adults/id50000044?uo=2" label="Kids &amp; Young Adults"/>
+        <link title="Preview" rel="enclosure" type="audio/x-m4a" href="http://a390.phobos.apple.com/us/r30/Music4/v4/51/99/a7/5199a7b9-db39-e5ab-3438-4a76328eb2d5/mzaf_2857127299462152824.plus.aac.p.m4a" im:assetType="preview"><im:duration>30000</im:duration></link>
+        <im:artist href="https://itunes.apple.com/us/artist/suzanne-collins/id110188933?mt=11&amp;uo=2">Suzanne Collins</im:artist>
+        <im:price amount="17.95000" currency="USD">$17.95</im:price>
+        <im:image height="55">http://a1385.phobos.apple.com/us/r30/Music/ac/3e/30/mzi.ihhqvuls.55x55-70.jpg</im:image>
+        <im:image height="60">http://a107.phobos.apple.com/us/r30/Music/ac/3e/30/mzi.ihhqvuls.60x60-50.jpg</im:image>
+        <im:image height="170">http://a1562.phobos.apple.com/us/r30/Music/ac/3e/30/mzi.ihhqvuls.170x170-75.jpg</im:image>
+        <rights>&#8471; &#169; 2010 Scholastic Audio</rights>
+        <im:releaseDate label="August 24, 2010">2010-08-24T00:00:00-07:00</im:releaseDate>
+    </entry>
+    <entry>
+        <updated>2013-11-24T12:41:07-07:00</updated>
+        <id im:id="329920607">https://itunes.apple.com/us/audiobook/catching-fire-hunger-games/id329920607?uo=2</id>
+        <title>Catching Fire: Hunger Games, Book 2 (Unabridged) - Suzanne Collins</title>
+        <im:name>Catching Fire: Hunger Games, Book 2 (Unabridged)</im:name>
+        <link rel="alternate" type="text/html" href="https://itunes.apple.com/us/audiobook/catching-fire-hunger-games/id329920607?uo=2"/>
+        <im:contentType term="Audiobook" label="Audiobook"/>
+        <category im:id="50000044" term="Kids &amp; Young Adults" scheme="https://itunes.apple.com/us/genre/audiobooks-kids-young-adults/id50000044?uo=2" label="Kids &amp; Young Adults"/>
+        <link title="Preview" rel="enclosure" type="audio/x-m4a" href="http://a109.phobos.apple.com/us/r30/Music4/v4/6b/c6/f9/6bc6f9f9-60a4-b8d5-1227-b96995c74f08/mzaf_1215338369218175103.plus.aac.p.m4a" im:assetType="preview"><im:duration>30000</im:duration></link>
+        <im:artist href="https://itunes.apple.com/us/artist/suzanne-collins/id110188933?mt=11&amp;uo=2">Suzanne Collins</im:artist>
+        <im:price amount="24.95000" currency="USD">$24.95</im:price>
+        <im:image height="55">http://a451.phobos.apple.com/us/r30/Music/d2/83/27/mzi.mywamvuu.55x55-70.jpg</im:image>
+        <im:image height="60">http://a1525.phobos.apple.com/us/r30/Music/d2/83/27/mzi.mywamvuu.60x60-50.jpg</im:image>
+        <im:image height="170">http://a1364.phobos.apple.com/us/r30/Music/d2/83/27/mzi.mywamvuu.170x170-75.jpg</im:image>
+        <rights>&#8471; &#169; 2009 Scholastic Audio</rights>
+        <im:releaseDate label="September 1, 2009">2009-09-01T00:00:00-07:00</im:releaseDate>
+    </entry>
+</feed>"""
+        response = XmlResponse(url='http://example.com/sitemap.xml', body=body)
+
+        class _XMLSpider(self.spider_class):
+            itertag = 'entry'
+            itertag_ns_prefix = 'atom'
+            itertag_ns_name = 'http://www.w3.org/2005/Atom'
+            namespaces = (
+                ('im', "http://itunes.apple.com/rss"),
+                ('atom', 'http://www.w3.org/2005/Atom'),
+            )
+
+            xp_update_text = XPath('atom:updated/text()')
+            xp_update_text.register_namespace(
+                'atom', 'http://www.w3.org/2005/Atom')
+
+            xp_contentype_term = XPath('im:contentType/@term', namespaces={
+                'im': "http://itunes.apple.com/rss"
+            })
+
+            xp_releasedate_label = XPath('im:releaseDate/@label')
+            xp_releasedate_label.register_namespace(
+                'im', "http://itunes.apple.com/rss")
+
+            def parse_node(self, response, selector):
+                yield {
+                    'updated': selector.xpath(self.xp_update_text).extract(),
+                    'contentType': selector.xpath(self.xp_contentype_term).extract(),
+                    'releaseDate': selector.xpath(self.xp_releasedate_label).extract(),
+                }
+
+        for iterator in ('iternodes', 'xml'):
+            spider = _XMLSpider('example', iterator=iterator)
+            output = list(spider.parse(response))
+            self.assertEqual(len(output), 2, iterator)
+            self.assertEqual(output, [
+                {'contentType': [u'Audiobook'],
+                'releaseDate': [u'August 24, 2010'],
+                'updated': [u'2013-11-24T12:41:07-07:00']},
+                {'contentType': [u'Audiobook'],
+                'releaseDate': [u'September 1, 2009'],
+                'updated': [u'2013-11-24T12:41:07-07:00']},
             ], iterator)
 
 


### PR DESCRIPTION
`lxml` supports compiled XPath expressions (http://lxml.de/xpathxslt.html#the-xpath-class)

> The XPath class compiles an XPath expression into a callable function (...)
> The compilation takes as much time as in the xpath() method, but it is done only once per class instantiation. This makes it especially efficient for repeated evaluation of the same XPath expression.

This PR adds support for compiled selectors in `Selector` through new `XPath` and `CSS` classes.

`XPath` and `CSS` instances are therefore also suitable in `ItemLoader`'s `.add/replace/get_xpath()` and `.add/replace/get_css()`

There's also a refactoring of `FormRequest` to using `lxml.etree.XPath` where it makes sense.

I haven't done any performance comparison tests.
Some benchmarking results: http://lxml.de/performance.html#xpath

There are probably other code areas where compiled selectors make sense. Can you spot any?

Documentation for `Selector` and `ItemLoader` still needs updating.