### PR TITLE
Register EXSLT namespaces by default (resolves #470)

### DIFF
--- a/docs/topics/selectors.rst
+++ b/docs/topics/selectors.rst
@@ -250,7 +250,7 @@ and come with these pre-registered namespaces to use in XPath expressions:
 ======  ====================================    =======================
 prefix  namespace                               usage
 ======  ====================================    =======================
-regexp  http://exslt.org/regular-expressions    `regular expressions`_
+re      http://exslt.org/regular-expressions    `regular expressions`_
 set     http://exslt.org/sets                   `set manipulation`_
 ======  ====================================    =======================
 
@@ -276,7 +276,7 @@ Example selecting links in list item with a "class" attribute ending with a digi
     >>> sel = Selector(text=doc, type="html")
     >>> sel.xpath('//li//@href').extract()
     [u'link1.html', u'link2.html', u'link3.html', u'link4.html', u'link5.html']
-    >>> sel.xpath('//li[regexp:test(@class, "item-\d$")]//@href').extract()
+    >>> sel.xpath('//li[re:test(@class, "item-\d$")]//@href').extract()
     [u'link1.html', u'link2.html', u'link4.html', u'link5.html']
     >>>
 

--- a/scrapy/selector/unified.py
+++ b/scrapy/selector/unified.py
@@ -47,7 +47,7 @@ class Selector(object_ref):
 
     _default_type = None
     _default_namespaces = {
-        "regexp": "http://exslt.org/regular-expressions",
+        "re": "http://exslt.org/regular-expressions",
 
         # supported in libxslt:
         # set:difference

--- a/scrapy/tests/test_selector.py
+++ b/scrapy/tests/test_selector.py
@@ -352,36 +352,36 @@ class ExsltTestCase(unittest.TestCase):
         response = TextResponse(url="http://example.com", body=body)
         sel = self.sscls(response)
 
-        # regexp:test()
+        # re:test()
         self.assertEqual(
             sel.xpath(
-                '//input[regexp:test(@name, "[A-Z]+", "i")]').extract(),
-            [x.extract() for x in sel.xpath('//input[regexp:test(@name, "[A-Z]+", "i")]')])
+                '//input[re:test(@name, "[A-Z]+", "i")]').extract(),
+            [x.extract() for x in sel.xpath('//input[re:test(@name, "[A-Z]+", "i")]')])
         self.assertEqual(
             [x.extract()
              for x in sel.xpath(
-                 '//a[regexp:test(@href, "\.html$")]/text()')],
+                 '//a[re:test(@href, "\.html$")]/text()')],
             [u'first link', u'second link'])
         self.assertEqual(
             [x.extract()
              for x in sel.xpath(
-                 '//a[regexp:test(@href, "first")]/text()')],
+                 '//a[re:test(@href, "first")]/text()')],
             [u'first link'])
         self.assertEqual(
             [x.extract()
              for x in sel.xpath(
-                 '//a[regexp:test(@href, "second")]/text()')],
+                 '//a[re:test(@href, "second")]/text()')],
             [u'second link'])
 
 
-        # regexp:match() is rather special: it returns a node-set of <match> nodes
+        # re:match() is rather special: it returns a node-set of <match> nodes
         #[u'<match>http://www.bayes.co.uk/xml/index.xml?/xml/utils/rechecker.xml</match>',
         #u'<match>http</match>',
         #u'<match>www.bayes.co.uk</match>',
         #u'<match></match>',
         #u'<match>/xml/index.xml?/xml/utils/rechecker.xml</match>']
         self.assertEqual(
-            sel.xpath('regexp:match(//a[regexp:test(@href, "\.xml$")]/@href,'
+            sel.xpath('re:match(//a[re:test(@href, "\.xml$")]/@href,'
                       '"(\w+):\/\/([^/:]+)(:\d*)?([^# ]*)")/text()').extract(),
             [u'http://www.bayes.co.uk/xml/index.xml?/xml/utils/rechecker.xml',
              u'http',
@@ -391,9 +391,9 @@ class ExsltTestCase(unittest.TestCase):
 
 
 
-        # regexp:replace()
+        # re:replace()
         self.assertEqual(
-            sel.xpath('regexp:replace(//a[regexp:test(@href, "\.xml$")]/@href,'
+            sel.xpath('re:replace(//a[re:test(@href, "\.xml$")]/@href,'
                       '"(\w+)://(.+)(\.xml)", "","https://\\2.html")').extract(),
             [u'https://www.bayes.co.uk/xml/index.xml?/xml/utils/rechecker.html'])
 


### PR DESCRIPTION
`lxml` supports interesting [EXSLT](http://www.exslt.org/) extensions to XPath 1.0 (via `libxslt`).
This PR register some of the corresponding namespaces by default in the `Selector` class.

The most useful IMO are:
- [set manipulation](http://www.exslt.org/set/index.html), using prefix `set:` (namespace `http://exslt.org/sets`)
- [regular expressions](http://www.exslt.org/regexp/index.html), and especially `regexp:test()` when one needs to use regex inside a XPath; using prefix `regexp:` (namespace `http://exslt.org/regular-expressions`)

One could add `re:` as an alias prefix for regular expressions.
(Regex support is in fact NOT in `libxslt` but is implemented in `lxml` using XPath extensions in Python)

Only regex tests added for now.
