### PR TITLE
Do not send HTTP header if value for header key is None (fixes #473)

### DIFF
--- a/scrapy/core/downloader/handlers/http11.py
+++ b/scrapy/core/downloader/handlers/http11.py
@@ -67,7 +67,8 @@ class ScrapyAgent(object):
         # request details
         url = urldefrag(request.url)[0]
         method = request.method
-        headers = TxHeaders(request.headers)
+        headers = TxHeaders(dict((k, filter(lambda h: h is not None, v)) for k, v in request.headers.items()
+                            if v is not None and filter(lambda h: h is not None, v)))
         bodyproducer = _RequestBodyProducer(request.body) if request.body else None
 
         start_time = time()


### PR DESCRIPTION
May not be the best place for it, and surely there is a nicer way to achieve the same thing.

If you set `headers={"Referer": None}`, you get `{'Referer': [None]}` at `HTTP11DownloadHandler` level.

Probably should be done also for HTTP/1.0

Implementation of https://github.com/scrapy/scrapy/issues/473
