### PR TITLE
fix logging error with unicode spider name

### DIFF
--- a/scrapy/log.py
+++ b/scrapy/log.py
@@ -77,7 +77,7 @@ def _adapt_eventdict(eventDict, log_level=INFO, encoding='utf-8', prepend_level=
 
     spider = ev.get('spider')
     if spider:
-        ev['system'] = spider.name
+        ev['system'] = unicode_to_str(spider.name, encoding)
 
     lvlname = level_names.get(level, 'NOLEVEL')
     message = ev.get('message')


### PR DESCRIPTION
Log message fails if spider name is in unicode, because "system" key in eventDict isn't encoded.
