### PR TITLE
Update tutorial.rst

### DIFF
--- a/docs/intro/tutorial.rst
+++ b/docs/intro/tutorial.rst
@@ -218,9 +218,6 @@ node, or the entire document.
 Selectors have four basic methods (click on the method to see the complete API
 documentation).
 
-* :meth:`~scrapy.selector.Selector.xpath`: returns a list of selectors, each of
-  them representing the nodes selected by the xpath expression given as
-  argument.
 
 * :meth:`~scrapy.selector.Selector.xpath`: returns a list of selectors, each of
   them representing the nodes selected by the CSS expression given as argument. 


### PR DESCRIPTION
Deleted one explanation for the xpath() method that was duplicated.
