### PR TITLE
Implementation of inheriting of all parents' fields during multiple inheritance of Item class

### DIFF
--- a/scrapy/item.py
+++ b/scrapy/item.py
@@ -32,6 +32,9 @@ class ItemMeta(type):
 
         cls = type.__new__(mcs, class_name, bases, new_attrs)
         cls.fields = cls.fields.copy()
+        for e in cls.__mro__[::-1]:
+           if hasattr(e, 'fields'):
+               cls.fields.update(e.fields)
         cls.fields.update(fields)
         return cls
 


### PR DESCRIPTION
# SEP-21

---

Items when inherited from multiple item classes do not inherit all of its parents'  fields. It inherits fields only from its first parent. This is because of the way Scrapy handle's the Item class. All fields are stored using a dict attr - 'fields' implemented in the DictItem class. So during multiple inheritance this 'fields' attr is inherited from the first parent.

This proposal aims to inherit all parents' fields during multiple inheritance of a Item class.

Please refer to https://gist.github.com/arijitchakraborty/7868842 for details.
