### PR TITLE
[MRG] no need to use dict in scrapy.utils.python.unique

### DIFF
--- a/scrapy/utils/python.py
+++ b/scrapy/utils/python.py
@@ -53,13 +53,13 @@ def flatten(x):
 
 def unique(list_, key=lambda x: x):
     """efficient function to uniquify a list preserving item order"""
-    seen = {}
+    seen = set()
     result = []
     for item in list_:
         seenkey = key(item)
-        if seenkey in seen: 
+        if seenkey in seen:
             continue
-        seen[seenkey] = 1
+        seen.add(seenkey)
         result.append(item)
     return result
 
@@ -70,7 +70,7 @@ def str_to_unicode(text, encoding=None, errors='strict'):
     object without the risk of double-decoding problems (which can happen if
     you don't use the default 'ascii' encoding)
     """
-    
+
     if encoding is None:
         encoding = 'utf-8'
     if isinstance(text, str):


### PR DESCRIPTION
We don't support Python 2.2 anymore :)

There are other possible optimizations (like special-casing identity key function), but `scrapy.utils.python.unique` is barely used in scrapy, and all usages in scrapy are with non-default key function.
