### PR TITLE
[MRG] allow running individual tests via tox

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -17,7 +17,7 @@ deps =
     mock
     mitmproxy
 commands =
-    trial scrapy
+    trial {posargs:scrapy}
 
 [testenv:precise]
 basepython = python2.7
@@ -37,7 +37,7 @@ basepython = python2.7
 commands =
     pip install https://github.com/scrapy/w3lib/archive/master.zip#egg=w3lib
     pip install https://github.com/scrapy/queuelib/archive/master.zip#egg=queuelib
-    trial scrapy
+    trial {posargs:scrapy}
 
 [testenv:py33]
 basepython = python3.3
@@ -52,7 +52,7 @@ deps =
     mock>=1.0.1
     mitmproxy>=0.9.2
 commands =
-    trial scrapy
+    trial {posargs:scrapy}
 
 [testenv:windows]
 commands =


### PR DESCRIPTION
Example: `tox -e trunk -- scrapy.tests.test_spider`
