### PR TITLE
Fixes #368: Support functools.partial in scrapy.utils.python.get_func_args()

### DIFF
--- a/scrapy/tests/test_utils_python.py
+++ b/scrapy/tests/test_utils_python.py
@@ -1,3 +1,4 @@
+import functools
 import operator
 import unittest
 from itertools import count
@@ -174,12 +175,14 @@ class UtilsPythonTestCase(unittest.TestCase):
                 pass
 
         a = A(1, 2, 3)
+        partial_f1 = functools.partial(f1, None)
         cal = Callable()
 
         self.assertEqual(get_func_args(f1), ['a', 'b', 'c'])
         self.assertEqual(get_func_args(f2), ['a', 'b', 'c'])
         self.assertEqual(get_func_args(A), ['a', 'b', 'c'])
         self.assertEqual(get_func_args(a.method), ['a', 'b', 'c'])
+        self.assertEqual(get_func_args(partial_f1), ['a', 'b', 'c'])
         self.assertEqual(get_func_args(cal), ['a', 'b', 'c'])
         self.assertEqual(get_func_args(object), [])
 

--- a/scrapy/utils/python.py
+++ b/scrapy/utils/python.py
@@ -10,7 +10,7 @@ import re
 import inspect
 import weakref
 import errno
-from functools import wraps
+from functools import partial, wraps
 from sgmllib import SGMLParser
 
 
@@ -156,6 +156,8 @@ def get_func_args(func, stripself=False):
         return get_func_args(func.__func__, True)
     elif inspect.ismethoddescriptor(func):
         return []
+    elif isinstance(func, partial):
+        return get_func_args(func.func)
     elif hasattr(func, '__call__'):
         if inspect.isroutine(func):
             return []


### PR DESCRIPTION
Return args of underlying function, as in [sage.misc.sageinspect.sage_getargspec](http://trac.sagemath.org/browser/src/sage/misc/sageinspect.py) - simplest solution for scrapy's needs in practice, as pointed to by @kmike in [#368](https://github.com/scrapy/scrapy/issues/368#issuecomment-22816747).
