### PR TITLE
[MRG] update instruction to install using ubuntu packages

### DIFF
--- a/docs/topics/ubuntu.rst
+++ b/docs/topics/ubuntu.rst
@@ -26,9 +26,7 @@ To use the packages:
 
     sudo apt-get update && sudo apt-get install scrapy-VERSION
 
-.. warning:: Please note that these packages are updated frequently, and so if
-   you find you can't download the packages, try updating your apt package
-   lists first, e.g., with ``apt-get update``.
+.. note:: Repeat step 3 if you are trying to upgrade Scrapy.
 
 .. warning:: `python-scrapy` is a different package provided by official debian
    repositories, it's very outdated and it isn't supported by Scrapy team.


### PR DESCRIPTION
Implements option (1) from #509 and address issue commented by https://github.com/scrapy/scrapy/issues/511#issuecomment-32687403

It also uses a new key for signing repository files:

```
pub   2048R/627220E7 2014-01-18 [expires: 2024-01-16]
uid                  Scrapy Team (APT Signing Key) <info@scrapy.org>
```

Previous repositories per codename still work, and they are kept uptodate and signed by old key:

```
pub   2048R/19403F1D 2010-06-10
uid                  Insophia (Scrapy Package Signing Key) <info@insophia.com>
```
