### PR TITLE
OffsiteMiddleware: add 2 stats counters

### DIFF
--- a/scrapy/contrib/spidermiddleware/offsite.py
+++ b/scrapy/contrib/spidermiddleware/offsite.py
@@ -13,12 +13,12 @@ from scrapy import log
 
 class OffsiteMiddleware(object):
 
-    def __init__(self, stats=False):
-        self.stats_enabled = stats
+    def __init__(self, stats):
+        self.stats = stats
 
     @classmethod
     def from_crawler(cls, crawler):
-        o = cls(stats=True)
+        o = cls(crawler.stats)
         crawler.signals.connect(o.spider_opened, signal=signals.spider_opened)
         return o
 
@@ -33,15 +33,8 @@ class OffsiteMiddleware(object):
                         self.domains_seen.add(domain)
                         log.msg(format="Filtered offsite request to %(domain)r: %(request)s",
                                 level=log.DEBUG, spider=spider, domain=domain, request=x)
-
-                        if self.stats_enabled:
-                            spider.crawler.stats.inc_value('offsite/domains',
-                                spider=spider)
-
-                    if self.stats_enabled:
-                        spider.crawler.stats.inc_value('offsite/filtered',
-                            spider=spider)
-
+                        self.stats.inc_value('offsite/domains', spider=spider)
+                    self.stats.inc_value('offsite/filtered', spider=spider)
             else:
                 yield x
 

--- a/scrapy/tests/test_spidermiddleware_offsite.py
+++ b/scrapy/tests/test_spidermiddleware_offsite.py
@@ -3,13 +3,15 @@ from unittest import TestCase
 from scrapy.http import Response, Request
 from scrapy.spider import Spider
 from scrapy.contrib.spidermiddleware.offsite import OffsiteMiddleware
+from scrapy.utils.test import get_crawler
 
 
 class TestOffsiteMiddleware(TestCase):
 
     def setUp(self):
         self.spider = self._get_spider()
-        self.mw = OffsiteMiddleware()
+        crawler = get_crawler()
+        self.mw = OffsiteMiddleware.from_crawler(crawler)
         self.mw.spider_opened(self.spider)
 
     def _get_spider(self):


### PR DESCRIPTION
Similarly to https://github.com/scrapy/scrapy/pull/553, I'm proposing adding 2 counters for `OffsiteMiddleware`:
- number of filtered requests (stats key `offsite/filtered`)
- number of filtered domains (stats key `offsite/domains`)
