### PR TITLE
[WIP] Add .get(index) method to selector results.

### DIFF
--- a/scrapy/selector/unified.py
+++ b/scrapy/selector/unified.py
@@ -155,7 +155,23 @@ class Selector(object_ref):
         return self.extract()
 
 
-class SelectorList(list):
+class GetItemMixin(object):
+
+    def get(self, index):
+        """Returns the element at given index or None."""
+        try:
+            return self[index]
+        except IndexError:
+            pass
+
+
+class ResultList(GetItemMixin, list):
+    """A convenient list class with handy shortcuts."""
+
+
+class SelectorList(GetItemMixin, list):
+
+    result_cls = ResultList
 
     def __getslice__(self, i, j):
         return self.__class__(list.__getslice__(self, i, j))
@@ -167,10 +183,10 @@ class SelectorList(list):
         return self.__class__(flatten([x.css(xpath) for x in self]))
 
     def re(self, regex):
-        return flatten([x.re(regex) for x in self])
+        return self.result_cls(flatten([x.re(regex) for x in self]))
 
     def extract(self):
-        return [x.extract() for x in self]
+        return self.result_cls(x.extract() for x in self)
 
     @deprecated(use_instead='.extract()')
     def extract_unquoted(self):


### PR DESCRIPTION
This is a proposal for #568.

It is very common when not using the item loaders to want to extract just one value using the selector (i.e.: an href value), but the current pattern is either to write a try/except block or checking if the returned result is empty before attempting to access the first element.

This pull requests adds the method `.get(index)` to the class `SelectorList` and adds a new class `ResultList` to provide the same method for the output of `.extract()` and `.re(regex)`. Optionally, it could allow to pass a default value just like `dict.get`.

If the proposal looks good I will add the proper test cases.

Here is an usage example:

``` python
In [1]: text = """
   ...: <span>foo</span>
   ...: <span>1234</span>
   ...: <span>bar</span>
   ...: <span>5678</span>
   ...: """

In [2]: sel = Selector(text=text)

In [3]: sel.css('span').get(0)
Out[3]: <Selector xpath=u'descendant-or-self::span' data=u'<span>foo</span>'>

In [4]: sel.css('h1').get(0)

In [5]: sel.css('span').re('\d+').get(1)
Out[5]: u'5678'

In [6]: sel.css('span').get(3)
Out[6]: <Selector xpath=u'descendant-or-self::span' data=u'<span>5678</span>'>
```
