### PR TITLE
Fix HtmlParserLinkExtractor and tests after #485 merge

### DIFF
--- a/scrapy/contrib/linkextractors/htmlparser.py
+++ b/scrapy/contrib/linkextractors/htmlparser.py
@@ -62,11 +62,12 @@ class HtmlParserLinkExtractor(HTMLParser):
                     self.current_link = link
 
     def handle_endtag(self, tag):
-        self.current_link = None
+        if self.scan_tag(tag):
+            self.current_link = None
 
     def handle_data(self, data):
-        if self.current_link and not self.current_link.text:
-            self.current_link.text = data.strip()
+        if self.current_link:
+            self.current_link.text = self.current_link.text + data
 
     def matches(self, url):
         """This extractor matches with any url, since

--- a/scrapy/tests/test_contrib_linkextractors.py
+++ b/scrapy/tests/test_contrib_linkextractors.py
@@ -317,7 +317,8 @@ class HtmlParserLinkExtractorTestCase(unittest.TestCase):
                          [Link(url='http://example.com/sample2.html', text=u'sample 2'),
                           Link(url='http://example.com/sample3.html', text=u'sample 3 text'),
                           Link(url='http://example.com/sample3.html', text=u'sample 3 repetition'),
-                          Link(url='http://www.google.com/something', text=u''),])
+                          Link(url='http://www.google.com/something', text=u''),
+                          Link(url='http://example.com/innertag.html', text=u'inner tag'),])
 
 
 class RegexLinkExtractorTestCase(unittest.TestCase):
@@ -332,7 +333,8 @@ class RegexLinkExtractorTestCase(unittest.TestCase):
         self.assertEqual(lx.extract_links(self.response),
                          [Link(url='http://example.com/sample2.html', text=u'sample 2'),
                           Link(url='http://example.com/sample3.html', text=u'sample 3 text'),
-                          Link(url='http://www.google.com/something', text=u''),])
+                          Link(url='http://www.google.com/something', text=u''),
+                          Link(url='http://example.com/innertag.html', text=u'inner tag'),])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Applying the same trick for `HtmlParserLinkExtractor` as done for `SgmlLinkExtractor` in https://github.com/scrapy/scrapy/pull/485
