### PR TITLE
DOC Use pipelines module name instead of pipieline following default project files.

### DIFF
--- a/docs/topics/item-pipeline.rst
+++ b/docs/topics/item-pipeline.rst
@@ -134,8 +134,8 @@ To activate an Item Pipeline component you must add its class to the
 :setting:`ITEM_PIPELINES` setting, like in the following example::
 
    ITEM_PIPELINES = {
-       'myproject.pipeline.PricePipeline': 300,
-       'myproject.pipeline.JsonWriterPipeline': 800,
+       'myproject.pipelines.PricePipeline': 300,
+       'myproject.pipelines.JsonWriterPipeline': 800,
    }
 
 The integer values you assign to classes in this setting determine the

--- a/docs/topics/settings.rst
+++ b/docs/topics/settings.rst
@@ -474,8 +474,8 @@ but they are deprecated.
 Example::
 
    ITEM_PIPELINES = {
-       'mybot.pipeline.validate.ValidateMyItem': 300,
-       'mybot.pipeline.validate.StoreMyItem': 800,
+       'mybot.pipelines.validate.ValidateMyItem': 300,
+       'mybot.pipelines.validate.StoreMyItem': 800,
    }
 
 .. setting:: ITEM_PIPELINES_BASE


### PR DESCRIPTION
The command `startproject` creates, among other files, the file `pipelines.py` where new users create their pipelines. Currently there are two examples of pielines wich refers to the module `pipeline` instead of `pipelines` and this might confuse new python/scrapy users.

This pull request change the module name `pipeline` to `pipelines` in the user examples.
