### PR TITLE
Shell doesn't handle non-XML/HTML responses

### DIFF
--- a/scrapy/shell.py
+++ b/scrapy/shell.py
@@ -13,7 +13,7 @@ from w3lib.url import any_to_uri
 
 from scrapy.crawler import Crawler
 from scrapy.exceptions import IgnoreRequest
-from scrapy.http import Request, Response
+from scrapy.http import Request, Response, TextResponse
 from scrapy.item import BaseItem
 from scrapy.selector import Selector
 from scrapy.settings import Settings
@@ -99,7 +99,9 @@ class Shell(object):
         self.vars['spider'] = spider
         self.vars['request'] = request
         self.vars['response'] = response
-        self.vars['sel'] = Selector(response)
+        
+        if isinstance(response, TextResponse):
+            self.vars['sel'] = Selector(response)
         if self.inthread:
             self.vars['fetch'] = self.fetch
         self.vars['view'] = open_in_browser

--- a/scrapy/shell.py
+++ b/scrapy/shell.py
@@ -13,7 +13,7 @@ from w3lib.url import any_to_uri
 
 from scrapy.crawler import Crawler
 from scrapy.exceptions import IgnoreRequest
-from scrapy.http import Request, Response, TextResponse
+from scrapy.http import Request, Response, XmlResponse, HtmlResponse
 from scrapy.item import BaseItem
 from scrapy.selector import Selector
 from scrapy.settings import Settings
@@ -100,7 +100,7 @@ class Shell(object):
         self.vars['request'] = request
         self.vars['response'] = response
         
-        if isinstance(response, TextResponse):
+        if isinstance(response, (XmlResponse, HtmlResponse)):
             self.vars['sel'] = Selector(response)
         if self.inthread:
             self.vars['fetch'] = self.fetch

--- a/scrapy/shell.py
+++ b/scrapy/shell.py
@@ -99,7 +99,6 @@ class Shell(object):
         self.vars['spider'] = spider
         self.vars['request'] = request
         self.vars['response'] = response
-        
         if isinstance(response, (XmlResponse, HtmlResponse)):
             self.vars['sel'] = Selector(response)
         if self.inthread:

--- a/scrapy/tests/test_shell.py
+++ b/scrapy/tests/test_shell.py
@@ -1,0 +1,57 @@
+from twisted.trial import unittest
+
+from scrapy.spider import Spider
+from scrapy.shell import Shell
+from scrapy.http import Response, TextResponse, XmlResponse, HtmlResponse
+from scrapy.utils.test import get_crawler
+
+class ShellTest(unittest.TestCase):
+
+    def setUp(self):
+        self.crawler = get_crawler()
+        self.spider = Spider('foo')
+
+    def test_inspect_response_html(self):
+        response = HtmlResponse(url='http://example.com/', body='''
+            <!doctype html>
+            <html>
+                <p>Testing</p>
+            </html>
+        ''')
+        shell = Shell(self.crawler, code='None')
+        shell.start(response=response, spider=self.spider)
+
+        self.assertIn('sel', shell.vars)
+
+    def test_inspect_response_xml(self):
+        response = XmlResponse(url='http://example.com/', body='''
+            <?xml version="1.0" encoding="UTF-8"?>
+            <foo>Testing</foo>
+        ''')
+        shell = Shell(self.crawler, code='None')
+        shell.start(response=response, spider=self.spider)
+
+        self.assertIn('sel', shell.vars)
+
+    def test_inspect_response_text(self):
+        response = TextResponse(url='http://example.com/', body='''
+            {"hello": "world"}
+        ''')
+        shell = Shell(self.crawler, code='None')
+        shell.start(response=response, spider=self.spider)
+
+        self.assertNotIn('sel', shell.vars)
+
+    def test_inspect_response_binary(self):
+        response = Response(url='http://example.com/', body='''
+            '{\xcc\xe8\x92\xe6\xb8\xa21\xb2\xe5O6\xc9\x84\xba8
+            \xa3\x877\xa8v\xee9p.UJ\xa1m\x8a"H\xb3\xcc\x08\xff
+            \x87d\x00i\xce\xb7a\xff\x8c\xd8NX\xae\xc2'
+        ''')
+        shell = Shell(self.crawler, code='None')
+        shell.start(response=response, spider=self.spider)
+
+        self.assertNotIn('sel', shell.vars)
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
The shell doesn't handle non-XML/HTML responses, as it attempts to create a `Selector` object for _every_ response:

```
Traceback (most recent call last):
  File "/home/blender/Projects/python/scrapy/scrapy/tests/test_shell.py", line 52, in test_inspect_response_binary
    shell.start(response=response, spider=self.spider)
  File "/home/blender/Projects/python/scrapy/scrapy/shell.py", line 50, in start
    self.populate_vars(response, request, spider)
  File "/home/blender/Projects/python/scrapy/scrapy/shell.py", line 102, in populate_vars
    self.vars['sel'] = Selector(response)
  File "/home/blender/Projects/python/scrapy/scrapy/selector/unified.py", line 73, in __init__
    _root = LxmlDocument(response, self._parser)
  File "/home/blender/Projects/python/scrapy/scrapy/selector/lxmldocument.py", line 27, in __new__
    cache[parser] = _factory(response, parser)
  File "/home/blender/Projects/python/scrapy/scrapy/selector/lxmldocument.py", line 13, in _factory
    body = response.body_as_unicode().strip().encode('utf8') or '<html/>'
exceptions.AttributeError: 'Response' object has no attribute 'body_as_unicode'
```

Adding some code to test that the response is actually an `XmlResponse` or a `HtmlResponse` fixes this.
