### PR TITLE
Update settings.rst

### DIFF
--- a/docs/topics/settings.rst
+++ b/docs/topics/settings.rst
@@ -354,10 +354,9 @@ This setting is also impacts the :setting:`RANDOMIZE_DOWNLOAD_DELAY`
 setting (which is enabled by default, but does not yield any delay). By default, 
 Scrapy can use a random interval for requests between 0.5 and 1.5 secs.
 
-:setting:`RANDOMIZE_DOWNLOAD_DELAY` only works if DOWNLOAD_DELAY is and integer > 0 
-as the random interval is a multiple of DOWNLOAD_DELAY * values between 0.5 and 1.5. 
-The default DOWNLOAD_DELAY of 0 yields no delay between requests as any multiple of 0 
-is zero (no delay).
+:setting:`RANDOMIZE_DOWNLOAD_DELAY` only works if DOWNLOAD_DELAY is > 0 as the random 
+interval is a multiple of DOWNLOAD_DELAY * values between 0.5 and 1.5. The default 
+DOWNLOAD_DELAY of 0 yields no delay between requests as any multiple of 0 is zero (no delay).
 
 A DOWNLOAD_DELAY of 1 would enable random request intervals between 0.5 and 1.5.
 A DOWNLOAD_DELAY of 5 would enable random request intervals between 2.5 and 7.5 secs.

--- a/docs/topics/settings.rst
+++ b/docs/topics/settings.rst
@@ -350,9 +350,18 @@ supported.  Example::
 
     DOWNLOAD_DELAY = 0.25    # 250 ms of delay
 
-This setting is also affected by the :setting:`RANDOMIZE_DOWNLOAD_DELAY`
-setting (which is enabled by default). By default, Scrapy doesn't wait a fixed
-amount of time between requests, but uses a random interval between 0.5 and 1.5
+This setting is also impacts the :setting:`RANDOMIZE_DOWNLOAD_DELAY`
+setting (which is enabled by default, but does not yield any delay). By default, 
+Scrapy can use a random interval for requests between 0.5 and 1.5 secs.
+
+:setting:`RANDOMIZE_DOWNLOAD_DELAY` only works if DOWNLOAD_DELAY is and integer > 0 
+as the random interval is a multiple of DOWNLOAD_DELAY * values between 0.5 and 1.5. 
+The default DOWNLOAD_DELAY of 0 yields no delay between requests as any multiple of 0 
+is zero (no delay).
+
+A DOWNLOAD_DELAY of 1 would enable random request intervals between 0.5 and 1.5.
+A DOWNLOAD_DELAY of 5 would enable random request intervals between 2.5 and 7.5 secs.
+
 * :setting:`DOWNLOAD_DELAY`.
 
 When :setting:`CONCURRENT_REQUESTS_PER_IP` is non-zero, delays are enforced

--- a/docs/topics/settings.rst
+++ b/docs/topics/settings.rst
@@ -350,7 +350,7 @@ supported.  Example::
 
     DOWNLOAD_DELAY = 0.25    # 250 ms of delay
 
-This setting is also impacts the :setting:`RANDOMIZE_DOWNLOAD_DELAY`
+This setting also impacts the :setting:`RANDOMIZE_DOWNLOAD_DELAY`
 setting (which is enabled by default, but does not yield any delay). By default, 
 Scrapy can use a random interval for requests between 0.5 and 1.5 secs.
 


### PR DESCRIPTION
Clarified that RANDOMIZE_DOWNLOAD_DELAY, while enabled by default, does not create any delay in requests unless DOWNLOAD_DELAY is an int > 0 as RANDOMIZE_DOWNLOAD_DELAY is a multiple of DOWNLOAD_DELAY and a random float between 0.5 and 1.5. Since any number multiplied by zero is zero, RANDOMIZE_DOWNLOAD_DELAY only actually works if DOWNLOAD_DELAY is > 0 .