### PR TITLE
Removed the link 'scrapy-developers' from Docs/Contributing to Scrapy - scrapy-developers google group is now depracated

### DIFF
--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -17,9 +17,6 @@ There are many ways to contribute to Scrapy. Here are some of them:
   `Writing patches`_ and `Submitting patches`_ below for details on how to
   write and submit a patch.
 
-* Join the `scrapy-developers`_ mailing list and share your ideas on how to
-  improve Scrapy. We're always open to suggestions.
-
 Reporting bugs
 ==============
 


### PR DESCRIPTION
Maybe you people want to add a bullet saying that anybody could have development discussions here in Github.
