### PR TITLE
change dicts to defaultdicts

### DIFF
--- a/scrapy/cmdline.py
+++ b/scrapy/cmdline.py
@@ -4,6 +4,7 @@ import optparse
 import cProfile
 import inspect
 import pkg_resources
+from collections import defaultdict
 
 import scrapy
 from scrapy.crawler import CrawlerProcess
@@ -25,7 +26,7 @@ def _iter_command_classes(module_name):
                 yield obj
 
 def _get_commands_from_module(module, inproject):
-    d = {}
+    d = defaultdict(object)
     for cmd in _iter_command_classes(module):
         if inproject or not cmd.requires_project:
             cmdname = cmd.__module__.split('.')[-1]
@@ -33,7 +34,7 @@ def _get_commands_from_module(module, inproject):
     return d
 
 def _get_commands_from_entry_points(inproject, group='scrapy.commands'):
-    cmds = {}
+    cmds = defaultdict(object)
     for entry_point in pkg_resources.iter_entry_points(group):
         obj = entry_point.load()
         if inspect.isclass(obj):

--- a/scrapy/contrib/downloadermiddleware/httpproxy.py
+++ b/scrapy/contrib/downloadermiddleware/httpproxy.py
@@ -2,6 +2,7 @@ import base64
 from urllib import getproxies, unquote, proxy_bypass
 from urllib2 import _parse_proxy
 from urlparse import urlunparse
+from collections import defaultdict
 
 from scrapy.utils.httpobj import urlparse_cached
 from scrapy.exceptions import NotConfigured
@@ -10,7 +11,7 @@ from scrapy.exceptions import NotConfigured
 class HttpProxyMiddleware(object):
 
     def __init__(self):
-        self.proxies = {}
+        self.proxies = defaultdict(tuple)
         for type, url in getproxies().items():
             self.proxies[type] = self._get_proxy(url, type)
 


### PR DESCRIPTION
If a dictionary stores only one type of value (e.g. tuple), we can use defaultdict data type to speed up the code and it also helps self-documentation.
I've tried to find dictionaries with single type values and changed those to appropriate defaultdict types.
Let me know if there is an error.
