### PR TITLE
[MRG] Resolved issue #546. Output format parsing from filename extension.

### DIFF
--- a/scrapy/commands/crawl.py
+++ b/scrapy/commands/crawl.py
@@ -38,7 +38,10 @@ class Command(ScrapyCommand):
             if not opts.output_format:
                 opts.output_format = os.path.splitext(opts.output)[1].replace(".", "")
             if opts.output_format not in valid_output_formats:
-                raise UsageError('Invalid/unrecognized output format: %s, Expected %s' % (opts.output_format, valid_output_formats))
+                raise UsageError("Unrecognized output format '%s', set one"
+                                 " using the '-t' switch or as a file extension"
+                                 " from the supported list %s" % (opts.output_format,
+                                                                  tuple(valid_output_formats)))
             self.settings.overrides['FEED_FORMAT'] = opts.output_format
 
     def run(self, args, opts):

--- a/scrapy/commands/runspider.py
+++ b/scrapy/commands/runspider.py
@@ -7,6 +7,7 @@ from scrapy.command import ScrapyCommand
 from scrapy.exceptions import UsageError
 from scrapy.utils.conf import arglist_to_dict
 
+
 def _import_file(filepath):
     abspath = os.path.abspath(filepath)
     dirname, file = os.path.split(abspath)
@@ -21,6 +22,7 @@ def _import_file(filepath):
         if dirname:
             sys.path.pop(0)
     return module
+
 
 class Command(ScrapyCommand):
 
@@ -59,7 +61,10 @@ class Command(ScrapyCommand):
             if not opts.output_format:
                 opts.output_format = os.path.splitext(opts.output)[1].replace(".", "")
             if opts.output_format not in valid_output_formats:
-                raise UsageError('Invalid/unrecognized output format: %s, Expected %s' % (opts.output_format, valid_output_formats))
+                raise UsageError("Unrecognized output format '%s', set one"
+                                 " using the '-t' switch or as a file extension"
+                                 " from the supported list %s" % (opts.output_format,
+                                                                  tuple(valid_output_formats)))
             self.settings.overrides['FEED_FORMAT'] = opts.output_format
 
     def run(self, args, opts):


### PR DESCRIPTION
Instead of explicitly specify the output format type, we can learn it from the file extension.
