### PR TITLE
Fixed default value of attrs argument in SgmlLinkExtractor to be tuple

### DIFF
--- a/docs/topics/link-extractors.rst
+++ b/docs/topics/link-extractors.rst
@@ -69,8 +69,9 @@ SgmlLinkExtractor
         domains which won't be considered for extracting the links
     :type deny_domains: str or list
 
-    :param deny_extensions: a list of extensions that should be ignored when
-        extracting links. If not given, it will default to the
+    :param deny_extensions: a single value or list of strings containing
+        extensions that should be ignored when extracting links. 
+        If not given, it will default to the
         ``IGNORED_EXTENSIONS`` list defined in the `scrapy.linkextractor`_
         module.
     :type deny_extensions: list
@@ -85,7 +86,7 @@ SgmlLinkExtractor
         Defaults to ``('a', 'area')``.
     :type tags: str or list
 
-    :param attrs: list of attributes which should be considered when looking
+    :param attrs: an attribute or list of attributes which should be considered when looking
         for links to extract (only for those tags specified in the ``tags``
         parameter). Defaults to ``('href',)``
     :type attrs: list

--- a/scrapy/contrib/linkextractors/sgml.py
+++ b/scrapy/contrib/linkextractors/sgml.py
@@ -95,7 +95,7 @@ _is_valid_url = lambda url: url.split('://', 1)[0] in set(['http', 'https', 'fil
 class SgmlLinkExtractor(BaseSgmlLinkExtractor):
 
     def __init__(self, allow=(), deny=(), allow_domains=(), deny_domains=(), restrict_xpaths=(),
-                 tags=('a', 'area'), attrs=('href'), canonicalize=True, unique=True, process_value=None,
+                 tags=('a', 'area'), attrs=('href',), canonicalize=True, unique=True, process_value=None,
                  deny_extensions=None):
         self.allow_res = [x if isinstance(x, _re_type) else re.compile(x) for x in arg_to_iter(allow)]
         self.deny_res = [x if isinstance(x, _re_type) else re.compile(x) for x in arg_to_iter(deny)]
@@ -105,9 +105,9 @@ class SgmlLinkExtractor(BaseSgmlLinkExtractor):
         self.canonicalize = canonicalize
         if deny_extensions is None:
             deny_extensions = IGNORED_EXTENSIONS
-        self.deny_extensions = set(['.' + e for e in deny_extensions])
-        tag_func = lambda x: x in tags
-        attr_func = lambda x: x in attrs
+        self.deny_extensions = {'.' + e for e in arg_to_iter(deny_extensions)}
+        tag_func = lambda x: x in arg_to_iter(tags)
+        attr_func = lambda x: x in arg_to_iter(attrs)
         BaseSgmlLinkExtractor.__init__(self,
                                        tag=tag_func,
                                        attr=attr_func,


### PR DESCRIPTION
- Fixed bug in issue #652 (default value of `attrs` is now tuple)
- Wrapped `tags` and `attrs` in `arg_to_iter()`, so `tag_func` and `attr_func` would accept both strings and lists. (so this version of the constructor is compatible with the old one)
