### PR TITLE
refactor _iter_command_classes and iter_spider_classes

### DIFF
--- a/scrapy/cmdline.py
+++ b/scrapy/cmdline.py
@@ -8,25 +8,14 @@ import pkg_resources
 import scrapy
 from scrapy.crawler import CrawlerProcess
 from scrapy.xlib import lsprofcalltree
-from scrapy.command import ScrapyCommand
 from scrapy.exceptions import UsageError
-from scrapy.utils.misc import walk_modules
+from scrapy.utils.iterators import iter_classes
 from scrapy.utils.project import inside_project, get_project_settings
 from scrapy.settings.deprecated import check_deprecated_settings
 
-def _iter_command_classes(module_name):
-    # TODO: add `name` attribute to commands and and merge this function with
-    # scrapy.utils.spider.iter_spider_classes
-    for module in walk_modules(module_name):
-        for obj in vars(module).itervalues():
-            if inspect.isclass(obj) and \
-               issubclass(obj, ScrapyCommand) and \
-               obj.__module__ == module.__name__:
-                yield obj
-
 def _get_commands_from_module(module, inproject):
     d = {}
-    for cmd in _iter_command_classes(module):
+    for cmd in iter_classes(module, "scrapy.command", "ScrapyCommand"):
         if inproject or not cmd.requires_project:
             cmdname = cmd.__module__.split('.')[-1]
             d[cmdname] = cmd()

--- a/scrapy/command.py
+++ b/scrapy/command.py
@@ -15,6 +15,8 @@ class ScrapyCommand(object):
     requires_project = False
     crawler_process = None
 
+    name = 'None'
+
     # default settings to be used for this command instead of global defaults
     default_settings = {}
 

--- a/scrapy/commands/runspider.py
+++ b/scrapy/commands/runspider.py
@@ -1,26 +1,7 @@
-import sys
-import os
-from importlib import import_module
-
-from scrapy.utils.spider import iter_spider_classes
 from scrapy.command import ScrapyCommand
 from scrapy.exceptions import UsageError
 from scrapy.utils.conf import arglist_to_dict
-
-def _import_file(filepath):
-    abspath = os.path.abspath(filepath)
-    dirname, file = os.path.split(abspath)
-    fname, fext = os.path.splitext(file)
-    if fext != '.py':
-        raise ValueError("Not a Python source file: %s" % abspath)
-    if dirname:
-        sys.path = [dirname] + sys.path
-    try:
-        module = import_module(fname)
-    finally:
-        if dirname:
-            sys.path.pop(0)
-    return module
+from scrapy.utils.iterators import iter_classes
 
 class Command(ScrapyCommand):
 
@@ -64,13 +45,7 @@ class Command(ScrapyCommand):
         if len(args) != 1:
             raise UsageError()
         filename = args[0]
-        if not os.path.exists(filename):
-            raise UsageError("File not found: %s\n" % filename)
-        try:
-            module = _import_file(filename)
-        except (ImportError, ValueError) as e:
-            raise UsageError("Unable to load %r: %s\n" % (filename, e))
-        spclasses = list(iter_spider_classes(module))
+        spclasses = list(iter_classes(filename, "scrapy.spider", "Spider", is_file=True))
         if not spclasses:
             raise UsageError("No spider found in file: %s\n" % filename)
         spider = spclasses.pop()(**opts.spargs)

--- a/scrapy/spidermanager.py
+++ b/scrapy/spidermanager.py
@@ -8,7 +8,7 @@ from zope.interface import implements
 from scrapy import signals
 from scrapy.interfaces import ISpiderManager
 from scrapy.utils.misc import walk_modules
-from scrapy.utils.spider import iter_spider_classes
+from scrapy.utils.iterators import iter_classes
 
 
 class SpiderManager(object):
@@ -18,12 +18,11 @@ class SpiderManager(object):
     def __init__(self, spider_modules):
         self.spider_modules = spider_modules
         self._spiders = {}
-        for name in self.spider_modules:
-            for module in walk_modules(name):
-                self._load_spiders(module)
+        for module_name in self.spider_modules:
+            self._load_spiders(module_name)
 
-    def _load_spiders(self, module):
-        for spcls in iter_spider_classes(module):
+    def _load_spiders(self, module_name):
+        for spcls in iter_classes(module_name, "scrapy.spider", "Spider"):
             self._spiders[spcls.name] = spcls
 
     @classmethod

--- a/scrapy/tests/test_utils_spider.py
+++ b/scrapy/tests/test_utils_spider.py
@@ -1,7 +1,8 @@
 import unittest
 from scrapy.http import Request
 from scrapy.item import BaseItem
-from scrapy.utils.spider import iterate_spider_output, iter_spider_classes
+from scrapy.utils.spider import iterate_spider_output
+from scrapy.utils.iterators import iter_classes
 
 from scrapy.contrib.spiders import CrawlSpider
 
@@ -29,7 +30,10 @@ class UtilsSpidersTestCase(unittest.TestCase):
 
     def test_iter_spider_classes(self):
         import scrapy.tests.test_utils_spider
-        it = iter_spider_classes(scrapy.tests.test_utils_spider)
+        it = iter_classes("scrapy.tests.test_utils_spider",
+                          "scrapy.spider",
+                          "Spider"
+                          )
         self.assertEqual(set(it), set([MySpider1, MySpider2]))
 
 if __name__ == "__main__":

--- a/scrapy/utils/spider.py
+++ b/scrapy/utils/spider.py
@@ -1,5 +1,3 @@
-import inspect
-
 from scrapy import log
 from scrapy.item import BaseItem
 from scrapy.utils.misc import  arg_to_iter
@@ -7,21 +5,6 @@ from scrapy.utils.misc import  arg_to_iter
 
 def iterate_spider_output(result):
     return [result] if isinstance(result, BaseItem) else arg_to_iter(result)
-
-def iter_spider_classes(module):
-    """Return an iterator over all spider classes defined in the given module
-    that can be instantiated (ie. which have name)
-    """
-    # this needs to be imported here until get rid of the spider manager
-    # singleton in scrapy.spider.spiders
-    from scrapy.spider import Spider
-
-    for obj in vars(module).itervalues():
-        if inspect.isclass(obj) and \
-           issubclass(obj, Spider) and \
-           obj.__module__ == module.__name__ and \
-           getattr(obj, 'name', None):
-            yield obj
 
 def create_spider_for_request(spidermanager, request, default_spider=None, \
         log_none=False, log_multiple=False, **spider_kwargs):


### PR DESCRIPTION
 In ```scrapy.utils.cmdline``` and ```scrapy.utils.spider``` there were 2 almost duplicate functions (```iter_command_classes```, ```iter_spider_classes```) that returns an iterator over the given module.

 I refactored it into ```iter_classes``` iterator that resides in ```scrapy.utils.iterators``` and changed the uses of the former 2 functions throughout the source code to the new ```iter_classes``` iterator. 

If the iterator is supplied with a valid filepath of a ```.py``` module and ```is_path=True``` argument, it loads the source file and returns the instantiable modules if there are problems with loading the source file it throws ```UsageError``` if it encounters an ```ImportError``` or ```ValueError```. 

I've ran the tests and examined the code carefully. But, I might have missed something. So, please let me know  if there are any problems and then I can make the necessary changes