### PR TITLE
Add type conversion and encoding for non-str message for msg() in log.py

### DIFF
--- a/scrapy/log.py
+++ b/scrapy/log.py
@@ -127,6 +127,11 @@ def msg(message=None, _level=INFO, **kw):
     if message is None:
         log.msg(**kw)
     else:
+        # add type conversion for non-str message, e.g. list, dict, etc.
+        if not isinstance(message, basestring):
+            message = str(message)
+        if not isinstance(message, unicode):
+            message = message.decode("unicode_escape").encode("utf-8")
         log.msg(message, **kw)
 
 def err(_stuff=None, _why=None, **kw):


### PR DESCRIPTION
If `message` variable is a non-str variable such as list or dict containing unicode basestring, then `log.msg(message, level=log.INFO)` will print out raw unicode, instead of the unicode basestring.

Example:

If `s = [u'<title>Любовь  константинов Голощапова - Надежда ����������� | LinkedIn</title>']`, then `log.msg(s, level=log.INFO)` or `log.msg(str(s), level=log.INFO)` prints out `[u'<title>\u041b\u044e\u0431\u043e\u0432\u044c...[skipped]...\ufffd\ufffd\ufffd | LinkedIn</title>']`.

Therefore I added two `isinstance` check for `message` variable in `def msg` in `log.py`, and to convert `message` to unicode basestring if it is not. After that, `log.msg()` will print out correct unicode basestring.

The patch passed the original test suite.
