### PR TITLE
[WIP] Run tests with pytest instead of trial

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ env:
 - TOXENV=precise
 - TOXENV=trunk
 - TOXENV=pypy
+- TOXENV=py33
 matrix:
   allow_failures:
   - env: TOXENV=pypy

--- a/tests-requirements.txt
+++ b/tests-requirements.txt
@@ -1,3 +1,4 @@
 # Tests requirements
 mock
 mitmproxy >= 0.10
+pytest-twisted

--- a/tox.ini
+++ b/tox.ini
@@ -5,6 +5,8 @@
 
 [tox]
 envlist = py27, pypy, precise, trunk, py33
+indexserver =
+    HPK = https://devpi.net/hpk/dev/
 
 [testenv]
 deps =
@@ -15,7 +17,7 @@ deps =
     django
     -rtests-requirements.txt
 commands =
-    trial {posargs:scrapy}
+    py.test --twisted {posargs:scrapy}
 
 [testenv:precise]
 basepython = python2.7
@@ -34,7 +36,7 @@ basepython = python2.7
 commands =
     pip install https://github.com/scrapy/w3lib/archive/master.zip#egg=w3lib
     pip install https://github.com/scrapy/queuelib/archive/master.zip#egg=queuelib
-    trial {posargs:scrapy}
+    py.test --twisted {posargs:scrapy}
 
 [testenv:py33]
 basepython = python3.3
@@ -45,8 +47,10 @@ deps =
     cssselect>=0.9
     queuelib>=1.1.1
     w3lib>=1.5
-commands =
-    trial {posargs:scrapy}
+    # tests requirements
+    mock
+    :HPK:pytest>2.5.2
+    pytest-twisted
 
 [testenv:windows]
 commands =


### PR DESCRIPTION
pytest has good support for running twisted trial tests and it works under Python3.

This PR aims to port our testsuite for pytest under Python2 and enable Python3 testing to ease further porting of Scrapy

**This pull request doesn't aim to succeed testcases on Python3**
