### PR TITLE
[WIP] try to restore pypy tests

### DIFF
--- a/.travis-workarounds.sh
+++ b/.travis-workarounds.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -e
+set -x
+
+if [[ "${TOXENV}" == "pypy" ]]; then
+    sudo add-apt-repository -y ppa:pypy/ppa
+    sudo apt-get -qy update
+    sudo apt-get install -y pypy pypy-dev
+    # This is required because we need to get rid of the Travis installed PyPy
+    # or it'll take precedence over the PPA installed one.
+    sudo rm -rf /usr/local/pypy/bin
+fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,8 @@ matrix:
   allow_failures:
   - env: TOXENV=pypy
 install:
-  - pip install -M tox
+- ./.travis-workarounds.sh
+- pip install tox
 script: tox
 notifications:
   irc:


### PR DESCRIPTION
Pillow is install-able if latest pypy is installed from official ppa. 
