### PR TITLE
[MRG] make scrapy.version_info a tuple of integers

### DIFF
--- a/scrapy/__init__.py
+++ b/scrapy/__init__.py
@@ -6,7 +6,7 @@ import pkgutil
 __version__ = pkgutil.get_data(__package__, 'VERSION').strip()
 if not isinstance(__version__, str):
     __version__ = __version__.decode('ascii')
-version_info = tuple(__version__.split('.')[:3])
+version_info = tuple(int(v) for v in __version__.split('.')[:3])
 
 import sys, os, warnings
 


### PR DESCRIPTION
`sys.version_info[:3]` is a tuple of ints, and `sqlite.version_info` is a tuple of ints, but `scrapy.version_info` is a tuple of strings now. It may cause two subtle errors:

1) when comparing with an another tuple of strings values are compared alphabetically, so "3" is greater than "22";
2) when comparing with a tuple of ints in Python 2.x it always returns False.

One nice thing about Python 3 porting is that it exposes this kind of errors :)
Tests in https://github.com/scrapy/scrapy/pull/679 don't run under Python 3.3 partially because of this, see https://travis-ci.org/scrapy/scrapy/jobs/22299093.
