### PR TITLE
fix scrapy.version_info when SCRAPY_VERSION_FROM_GIT is set

### DIFF
--- a/scrapy/__init__.py
+++ b/scrapy/__init__.py
@@ -6,7 +6,8 @@ import pkgutil
 __version__ = pkgutil.get_data(__package__, 'VERSION').strip()
 if not isinstance(__version__, str):
     __version__ = __version__.decode('ascii')
-version_info = tuple(int(v) for v in __version__.split('.')[:3])
+version_info = tuple(int(v) if v.isdigit() else v
+                     for v in __version__.split('.'))
 
 import sys, os, warnings
 


### PR DESCRIPTION
Previously it failed with the following exception with SCRAPY_VERSION_FROM_GIT set:

```
version_info = tuple(int(v) for v in __version__.split('.')[:3])
ValueError: invalid literal for int() with base 10: '0-189-g7814cbf' 
```

After this fix `__version__` parts that can't be converted to int will be left as strings, e.g. `(0, 23, '0-189-g7814cbf')`.
