### PR TITLE
Add a note about reporting security issues

### DIFF
--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -23,6 +23,12 @@ There are many ways to contribute to Scrapy. Here are some of them:
 Reporting bugs
 ==============
 
+.. note::
+
+    Please report security issues **only** to
+    scrapy-security@googlegroups.com. This is a private list only open to
+    trusted Scrapy developers, and its archives are not public.
+
 Well-written bug reports are very helpful, so keep in mind the following
 guidelines when reporting a new bug.
 


### PR DESCRIPTION
Since @kmike created a mailing list for security issues we should direct people there from the documentation.
Wording taken mostly from the Django docs: https://docs.djangoproject.com/en/dev/internals/contributing/bugs-and-features/#reporting-security-issues
