### PR TITLE
Prevent hanging on invalid start_requests

### DIFF
--- a/scrapy/core/engine.py
+++ b/scrapy/core/engine.py
@@ -24,7 +24,10 @@ class Slot(object):
     def __init__(self, start_requests, close_if_idle, nextcall, scheduler):
         self.closing = False
         self.inprogress = set() # requests in progress
-        self.start_requests = iter(start_requests)
+        try:
+            self.start_requests = iter(start_requests)
+        except TypeError:
+            self.start_requests = None
         self.close_if_idle = close_if_idle
         self.nextcall = nextcall
         self.scheduler = scheduler

--- a/scrapy/tests/test_crawl.py
+++ b/scrapy/tests/test_crawl.py
@@ -129,6 +129,14 @@ class CrawlTestCase(TestCase):
         self.assertEqual(spider.visited, 3)
 
     @defer.inlineCallbacks
+    def test_start_requests_not_iterable(self):
+        spider = SimpleSpider()
+        spider.start_requests = lambda: None
+        yield docrawl(spider)
+        errors = self.flushLoggedErrors()
+        self.assertEqual(len(errors), 0)
+
+    @defer.inlineCallbacks
     def test_unbounded_response(self):
         # Completeness of responses without Content-Length or Transfer-Encoding
         # can not be determined, we treat them as valid but flagged as "partial"


### PR DESCRIPTION
There are cases where if the start_requests isn't an iterable scrapy hangs.

Some examples:

``` python
def start_requests(self):
    return None
```

``` python
def start_requests(self):
    pass
```

``` python
def start_requests(self):
    return Request(<some_url>)
```
