### PR TITLE
Elaborated Request priority value in Scrapy docs

### DIFF
--- a/docs/topics/request-response.rst
+++ b/docs/topics/request-response.rst
@@ -102,7 +102,8 @@ Request objects
 
     :param priority: the priority of this request (defaults to ``0``).
        The priority is used by the scheduler to define the order used to process
-       requests.
+       requests.  Requests with a higher priority value will execute earlier.  
+       Negative values are allowed in order to indicate relatively low-priority.
     :type priority: int
 
     :param dont_filter: indicates that this request should not be filtered by


### PR DESCRIPTION
I confirmed in the code: it looks like -priority is used to add the requests to a queuelib PriorityQueue

I tested with this code (n=2 mostly occurred first, followed by n=1 and then n=0):

```
from scrapy.spider import Spider
from random import shuffle
from scrapy.http import Request

class TestSpider(Spider):
    name = "test"
    start_urls = [
        'http://www.linkedin.com/company/scrapinghub?n=8',
        'http://www.linkedin.com/company/scrapinghub?n=9'
    ]

    def parse(self, response):
        reqs = [Request(
            'http://www.linkedin.com/company/scrapinghub?n=0',
            dont_filter=True,
            priority = -50,
            callback=self.parse2
        ) for i in range(10)] + [Request(
            'http://www.linkedin.com/company/scrapinghub?n=1',
            dont_filter=True,
            priority = 0,
            callback=self.parse2
        ) for i in range(10)] + [Request(
            'http://www.linkedin.com/company/scrapinghub?n=2',
            dont_filter=True,
            priority = 50,
            callback=self.parse2
        ) for i in range(10)]
        shuffle(reqs)
        return reqs

    def parse2(self, response):
        pass
```
