### PR TITLE
Update item-pipeline.rst

### DIFF
--- a/docs/topics/item-pipeline.rst
+++ b/docs/topics/item-pipeline.rst
@@ -46,7 +46,6 @@ imports, and lines to your __init__ procedure::
    
    class GenericPipeline(object):
       def __init__(self):
-           """setup a unique directory for this scraper run to export to"""
            # boiler pipe required to make spider_opened & spider_closed work
            dispatcher.connect(self.spider_opened, signals.spider_opened)
            dispatcher.connect(self.spider_closed, signals.spider_closed)


### PR DESCRIPTION
Modifying DOCs to mention the undocumented boiler pipe required to make item pipeline methods work correctly (see: http://stackoverflow.com/questions/4113275/scrapy-pipeline-spider-opened-and-spider-closed-not-being-called). Perhaps a better long term solution could be creating a generic pipeline base class?
