### PR TITLE
document spider.closed() shortcut

### DIFF
--- a/docs/topics/spiders.rst
+++ b/docs/topics/spiders.rst
@@ -195,6 +195,11 @@ Spider
        populating the spider argument with the :attr:`name` of this
        spider. For more information see :ref:`topics-logging`.
 
+   .. method:: closed(reason)
+
+       Called when the spider closes. This method provides a shortcut to
+       signals.connect() for the :signal:`spider_closed` signal.
+
 
 Spider example
 ~~~~~~~~~~~~~~


### PR DESCRIPTION
See: https://github.com/scrapy/scrapy/blob/c70f050bdaeec6d2c32039c005511a32d3b21cc5/scrapy/spidermanager.py#L57-L60
