### PR TITLE
RAII for Exporters

### DIFF
--- a/docs/topics/exporters.rst
+++ b/docs/topics/exporters.rst
@@ -69,6 +69,22 @@ Exporter to export scraped items to different files, one per spider::
            self.exporter.export_item(item)
            return item
 
+Alternatively, you can also use `with` statement instead of calling
+:meth:`~BaseItemExporter.start_exporting` and
+:meth:`~BaseItemExporter.finish_exporting` directly.
+
+::
+
+    with SomeExporter() as exporter:
+        exporter.export_item(item)
+
+is equivalent to::
+
+    exporter = SomeExporter()
+    exporter.start_exporting()
+    exporter.export_item(item)
+    exporter.finish_exporting()
+
 
 .. _topics-exporters-field-serialization:
 

--- a/scrapy/contrib/exporter/__init__.py
+++ b/scrapy/contrib/exporter/__init__.py
@@ -39,6 +39,13 @@ class BaseItemExporter(object):
         serializer = field.get('serializer', self._to_str_if_unicode)
         return serializer(value)
 
+    def __enter__(self):
+        self.start_exporting()
+        return self
+
+    def __exit__(self, *exc_info):
+        self.finish_exporting()
+
     def start_exporting(self):
         pass
 

--- a/scrapy/tests/test_contrib_exporter.py
+++ b/scrapy/tests/test_contrib_exporter.py
@@ -2,6 +2,7 @@ import unittest, json, cPickle as pickle
 from cStringIO import StringIO
 import lxml.etree
 import re
+import types
 
 from scrapy.item import Item, Field
 from scrapy.utils.python import str_to_unicode
@@ -41,6 +42,34 @@ class BaseItemExporterTest(unittest.TestCase):
                 raise
         self.ie.finish_exporting()
         self._check_output()
+
+    def test_raii(self):
+        self._patch_exporter_for_raii_test()
+
+        with self.ie as exporter:
+            try:
+                exporter.export_item(self.i)
+            except NotImplementedError:
+                if self.ie.__class__ is not BaseItemExporter:
+                    raise
+
+        self.assertTrue(getattr(self.ie, '_started_exporting'))
+        self.assertTrue(getattr(self.ie, '_finished_exporting'))
+        self._check_output()
+
+    def _patch_exporter_for_raii_test(self):
+        def _new_start_exporting(self):
+            self._old_start_exporting()
+            self._started_exporting = True
+
+        def _new_finish_exporting(self):
+            self._old_finish_exporting()
+            self._finished_exporting = True
+
+        self.ie._old_start_exporting = self.ie.start_exporting
+        self.ie._old_finish_exporting = self.ie.finish_exporting
+        self.ie.start_exporting = types.MethodType(_new_start_exporting, self.ie)
+        self.ie.finish_exporting = types.MethodType(_new_finish_exporting, self.ie)
 
     def test_serialize_field(self):
         self.assertEqual(self.ie.serialize_field( \


### PR DESCRIPTION
It would be handful to provide [RAII](http://en.wikipedia.org/wiki/Resource_Acquisition_Is_Initialization) for exporters, especially when there is just one item to export.

```
with SomeExporter() as exporter:
    exporter.export_item(item)
```

would be simple and less error-prone than

```
exporter = SomeExporter()
exporter.start_exporting()
exporter.export_item(item)
exporter.finish_exporting()
```
