### PR TITLE
set the exit code to non-zero when contracts fails

### DIFF
--- a/scrapy/commands/check.py
+++ b/scrapy/commands/check.py
@@ -71,6 +71,7 @@ class Command(ScrapyCommand):
         else:
             self.crawler_process.start()
             self.results.printErrors()
+            self.exitcode = 0 if self.results.wasSuccessful() else 1
 
     def get_requests(self, spider):
         requests = []


### PR DESCRIPTION
it's can be handy to to tell the CI that the scrapy contract test failed. 
