### PR TITLE
change Scraper API to call internal `_parse` method (fix #781)

### DIFF
--- a/scrapy/core/scraper.py
+++ b/scrapy/core/scraper.py
@@ -143,7 +143,7 @@ class Scraper(object):
     def call_spider(self, result, request, spider):
         result.request = request
         dfd = defer_result(result)
-        dfd.addCallbacks(request.callback or spider.parse, request.errback)
+        dfd.addCallbacks(request.callback or spider._parse, request.errback)
         return dfd.addCallback(iterate_spider_output)
 
     def handle_spider_error(self, _failure, request, response, spider):

--- a/scrapy/spiders/__init__.py
+++ b/scrapy/spiders/__init__.py
@@ -72,6 +72,9 @@ class Spider(object_ref):
     def make_requests_from_url(self, url):
         return Request(url, dont_filter=True)
 
+    def _parse(self, response):
+        return self.parse(response)
+
     def parse(self, response):
         raise NotImplementedError
 

--- a/scrapy/spiders/crawl.py
+++ b/scrapy/spiders/crawl.py
@@ -39,7 +39,7 @@ class CrawlSpider(Spider):
         super(CrawlSpider, self).__init__(*a, **kw)
         self._compile_rules()
 
-    def parse(self, response):
+    def _parse(self, response):
         return self._parse_response(response, self.parse_start_url, cb_kwargs={}, follow=True)
 
     def parse_start_url(self, response):

--- a/scrapy/spiders/feed.py
+++ b/scrapy/spiders/feed.py
@@ -61,7 +61,7 @@ class XMLFeedSpider(Spider):
             for result_item in self.process_results(response, ret):
                 yield result_item
 
-    def parse(self, response):
+    def _parse(self, response):
         if not hasattr(self, 'parse_node'):
             raise NotConfigured('You must define parse_node method in order to scrape this XML feed')
 
@@ -128,7 +128,7 @@ class CSVFeedSpider(Spider):
             for result_item in self.process_results(response, ret):
                 yield result_item
 
-    def parse(self, response):
+    def _parse(self, response):
         if not hasattr(self, 'parse_row'):
             raise NotConfigured('You must define parse_row method in order to scrape this CSV feed')
         response = self.adapt_response(response)

--- a/tests/test_spider.py
+++ b/tests/test_spider.py
@@ -155,7 +155,7 @@ class XMLFeedSpiderTest(SpiderTest):
 
         for iterator in ('iternodes', 'xml'):
             spider = _XMLSpider('example', iterator=iterator)
-            output = list(spider.parse(response))
+            output = list(spider._parse(response))
             self.assertEqual(len(output), 2, iterator)
             self.assertEqual(output, [
                 {'loc': [u'http://www.example.com/Special-Offers.html'],


### PR DESCRIPTION
As a fix to the CrawlSpider-can't-have-parse useability issue (#712 / now #781) ,
I propose having another internal `_parse` method called by the `Scraper` instead of `parse`, and using that in spiders who want internal "pre-processing", then exposing `parse` as the public, documented, no-baggage method to implement/override from a spider.

`Spider` simply calls the public `parse` method from `_parse`, while `CrawlSpider` and cohorts can do their thing in `_parse` and  give the cold shoulder to users trying to break them by re-defining `parse` without calling `super()`.

Since all spiders presently should subclass from `Spider`, this also doesnt't break any existing spider classes who keep using `parse` exclusively.
