### PR TITLE
[MRG] item loader let in empty values different to none

### DIFF
--- a/scrapy/contrib/loader/__init__.py
+++ b/scrapy/contrib/loader/__init__.py
@@ -58,7 +58,7 @@ class ItemLoader(object):
     def _add_value(self, field_name, value):
         value = arg_to_iter(value)
         processed_value = self._process_input_value(field_name, value)
-        if processed_value:
+        if processed_value is not None:
             self._values[field_name] += arg_to_iter(processed_value)
 
     def _replace_value(self, field_name, value):

--- a/tests/test_contrib_loader.py
+++ b/tests/test_contrib_loader.py
@@ -385,6 +385,15 @@ class BasicItemLoaderTest(unittest.TestCase):
         self.assertEqual(item['url'], u'rabbit.hole')
         self.assertEqual(item['summary'], u'rabbithole')
 
+    def test_empty_values_different_to_None(self):
+        il = ItemLoader(item={})
+        il.empty_float_in = TakeFirst()
+        il.empty_str_in = lambda x: x[0]
+        il.default_output_processor = lambda x: x[0]
+        il.add_value('empty_float', 0.0)
+        il.add_value('empty_str', '')
+        self.assertEqual(il.load_item(), {'empty_float': 0.0, 'empty_str': ''})
+
 
 class ProcessorsTest(unittest.TestCase):
 


### PR DESCRIPTION
Right now we cant insert values that evaluate `False`.

``` python
>>> from scrapy.contrib.loader import ItemLoader
>>> from scrapy.contrib.loader.processor import TakeFirst, Identity
>>> il = ItemLoader(item={})
>>> il.price_in = TakeFirst()
>>> il.add_value('price', 0.0)
>>> il.load_item()
{}
>>> il.price_in = Identity()
>>> il.price_out = TakeFirst()
>>> il.add_value('price', 0.0)
>>> il.load_item()
{'price': 0.0} 
```
