### PR TITLE
[MRG+1] Support 'True' and 'False' strings as boolean settings values

### DIFF
--- a/scrapy/settings/__init__.py
+++ b/scrapy/settings/__init__.py
@@ -19,14 +19,20 @@ class Settings(object):
 
     def getbool(self, name, default=False):
         """
-        True is: 1, '1', True
-        False is: 0, '0', False, None
+        True is: 1, '1', True, 'True' and 'true'
+        False is: 0, '0', False, None, 'False' and 'false'
         """
         got = self.get(name, default)
         try:
             return bool(int(got))
         except ValueError:
-            return ast.literal_eval(got) == True
+            if got in ["True", "true"]:
+                return True
+            if got in ["False", "false"]:
+                return False
+            raise ValueError("Supported values for boolean settings "
+                             "are 0/1, True/False, '0'/'1', "
+                             "'True'/'False' and 'true'/'false'")
 
     def getint(self, name, default=0):
         return int(self.get(name, default))

--- a/scrapy/settings/__init__.py
+++ b/scrapy/settings/__init__.py
@@ -1,3 +1,4 @@
+import ast
 import json
 from . import default_settings
 
@@ -21,7 +22,11 @@ class Settings(object):
         True is: 1, '1', True
         False is: 0, '0', False, None
         """
-        return bool(int(self.get(name, default)))
+        got = self.get(name, default)
+        try:
+            return bool(int(got))
+        except ValueError:
+            return ast.literal_eval(got) == True
 
     def getint(self, name, default=0):
         return int(self.get(name, default))

--- a/scrapy/tests/test_settings.py
+++ b/scrapy/tests/test_settings.py
@@ -11,9 +11,11 @@ class SettingsTest(unittest.TestCase):
             'TEST_ENABLED1': '1',
             'TEST_ENABLED2': True,
             'TEST_ENABLED3': 1,
+            'TEST_ENABLED4': 'True',
             'TEST_DISABLED1': '0',
             'TEST_DISABLED2': False,
             'TEST_DISABLED3': 0,
+            'TEST_DISABLED4': 'False',
             'TEST_INT1': 123,
             'TEST_INT2': '123',
             'TEST_FLOAT1': 123.45,
@@ -27,11 +29,13 @@ class SettingsTest(unittest.TestCase):
         assert settings.getbool('TEST_ENABLED1') is True
         assert settings.getbool('TEST_ENABLED2') is True
         assert settings.getbool('TEST_ENABLED3') is True
+        assert settings.getbool('TEST_ENABLED4') is True
         assert settings.getbool('TEST_ENABLEDx') is False
         assert settings.getbool('TEST_ENABLEDx', True) is True
         assert settings.getbool('TEST_DISABLED1') is False
         assert settings.getbool('TEST_DISABLED2') is False
         assert settings.getbool('TEST_DISABLED3') is False
+        assert settings.getbool('TEST_DISABLED4') is False
         self.assertEqual(settings.getint('TEST_INT1'), 123)
         self.assertEqual(settings.getint('TEST_INT2'), 123)
         self.assertEqual(settings.getint('TEST_INTx'), 0)

--- a/scrapy/tests/test_settings.py
+++ b/scrapy/tests/test_settings.py
@@ -12,10 +12,14 @@ class SettingsTest(unittest.TestCase):
             'TEST_ENABLED2': True,
             'TEST_ENABLED3': 1,
             'TEST_ENABLED4': 'True',
+            'TEST_ENABLED5': 'true',
+            'TEST_ENABLED_WRONG': 'on',
             'TEST_DISABLED1': '0',
             'TEST_DISABLED2': False,
             'TEST_DISABLED3': 0,
             'TEST_DISABLED4': 'False',
+            'TEST_DISABLED5': 'false',
+            'TEST_DISABLED_WRONG': 'off',
             'TEST_INT1': 123,
             'TEST_INT2': '123',
             'TEST_FLOAT1': 123.45,
@@ -30,12 +34,14 @@ class SettingsTest(unittest.TestCase):
         assert settings.getbool('TEST_ENABLED2') is True
         assert settings.getbool('TEST_ENABLED3') is True
         assert settings.getbool('TEST_ENABLED4') is True
+        assert settings.getbool('TEST_ENABLED5') is True
         assert settings.getbool('TEST_ENABLEDx') is False
         assert settings.getbool('TEST_ENABLEDx', True) is True
         assert settings.getbool('TEST_DISABLED1') is False
         assert settings.getbool('TEST_DISABLED2') is False
         assert settings.getbool('TEST_DISABLED3') is False
         assert settings.getbool('TEST_DISABLED4') is False
+        assert settings.getbool('TEST_DISABLED5') is False
         self.assertEqual(settings.getint('TEST_INT1'), 123)
         self.assertEqual(settings.getint('TEST_INT2'), 123)
         self.assertEqual(settings.getint('TEST_INTx'), 0)
@@ -58,6 +64,8 @@ class SettingsTest(unittest.TestCase):
         self.assertEqual(settings.getdict('TEST_DICT3'), {})
         self.assertEqual(settings.getdict('TEST_DICT3', {'key1': 5}), {'key1': 5})
         self.assertRaises(ValueError, settings.getdict, 'TEST_LIST1')
+        self.assertRaises(ValueError, settings.getbool, 'TEST_ENABLED_WRONG')
+        self.assertRaises(ValueError, settings.getbool, 'TEST_DISABLED_WRONG')
 
 
 class CrawlerSettingsTest(unittest.TestCase):


### PR DESCRIPTION
'1' and '0' are supported.
I think we can support "True" and "False".
