### PR TITLE
Fix handling of empty clickables in FormRequest.from_respone()

### DIFF
--- a/scrapy/http/request/form.py
+++ b/scrapy/http/request/form.py
@@ -144,7 +144,7 @@ def _get_clickable(clickdata, form):
     # If we don't have clickdata, we just use the first clickable element
     if clickdata is None:
         el = clickables[0]
-        return (el.name, u'' if el.value is None else el.value)
+        return (el.name, el.value)
 
     # If clickdata is given, we compare it to the clickable elements to find a
     # match. We first look to see if the number is specified in clickdata,
@@ -156,7 +156,7 @@ def _get_clickable(clickdata, form):
         except IndexError:
             pass
         else:
-            return (el.name, u'' if el.value is None else el.value)
+            return (el.name, el.value)
 
     # We didn't find it, so now we build an XPath expression out of the other
     # arguments, because they can be used as such
@@ -164,7 +164,7 @@ def _get_clickable(clickdata, form):
             u''.join(u'[@%s="%s"]' % c for c in clickdata.iteritems())
     el = form.xpath(xpath)
     if len(el) == 1:
-        return (el[0].name, u'' if el[0].value is None else el[0].value)
+        return (el[0].name, el[0].value)
     elif len(el) > 1:
         raise ValueError("Multiple elements found (%r) matching the criteria "
                          "in clickdata: %r" % (el, clickdata))

--- a/scrapy/http/request/form.py
+++ b/scrapy/http/request/form.py
@@ -144,7 +144,7 @@ def _get_clickable(clickdata, form):
     # If we don't have clickdata, we just use the first clickable element
     if clickdata is None:
         el = clickables[0]
-        return (el.name, el.value)
+        return (el.name, u'' if el.value is None else el.value)
 
     # If clickdata is given, we compare it to the clickable elements to find a
     # match. We first look to see if the number is specified in clickdata,
@@ -156,7 +156,7 @@ def _get_clickable(clickdata, form):
         except IndexError:
             pass
         else:
-            return (el.name, el.value)
+            return (el.name, u'' if el.value is None else el.value)
 
     # We didn't find it, so now we build an XPath expression out of the other
     # arguments, because they can be used as such
@@ -164,7 +164,7 @@ def _get_clickable(clickdata, form):
             u''.join(u'[@%s="%s"]' % c for c in clickdata.iteritems())
     el = form.xpath(xpath)
     if len(el) == 1:
-        return (el[0].name, el[0].value)
+        return (el[0].name, u'' if el[0].value is None else el[0].value)
     elif len(el) > 1:
         raise ValueError("Multiple elements found (%r) matching the criteria "
                          "in clickdata: %r" % (el, clickdata))

--- a/scrapy/http/request/form.py
+++ b/scrapy/http/request/form.py
@@ -45,7 +45,7 @@ def _get_form_url(form, url):
     return urlparse.urljoin(form.base_url, url)
 
 def _urlencode(seq, enc):
-    values = [(unicode_to_str(k, enc), unicode_to_str(v, enc))
+    values = [(unicode_to_str(u'' if k is None else k, enc), unicode_to_str(u'' if v is None else v, enc))
               for k, vs in seq
               for v in (vs if hasattr(vs, '__iter__') else [vs])]
     return urllib.urlencode(values, doseq=1)

--- a/scrapy/tests/test_http_request.py
+++ b/scrapy/tests/test_http_request.py
@@ -314,6 +314,21 @@ class FormRequestTest(RequestTest):
         self.assertEqual(fs['one'], ['1'])
         self.assertEqual(fs['two'], ['2'])
 
+    def test_from_response_submit_first_clickable_novalue(self):
+        response = _buildresponse(
+            """<form action="get.php" method="GET">
+            <input type="submit" name="clickable1">
+            <input type="hidden" name="one" value="1">
+            <input type="hidden" name="two" value="3">
+            <input type="submit" name="clickable2">
+            </form>""")
+        req = self.request_class.from_response(response, formdata={'two': '2'})
+        fs = _qs(req)
+        self.assertEqual(fs['clickable1'], [''])
+        self.assertFalse('clickable2' in fs, fs)
+        self.assertEqual(fs['one'], ['1'])
+        self.assertEqual(fs['two'], ['2'])
+
     def test_from_response_submit_not_first_clickable(self):
         response = _buildresponse(
             """<form action="get.php" method="GET">
@@ -326,6 +341,22 @@ class FormRequestTest(RequestTest):
                                               clickdata={'name': 'clickable2'})
         fs = _qs(req)
         self.assertEqual(fs['clickable2'], ['clicked2'])
+        self.assertFalse('clickable1' in fs, fs)
+        self.assertEqual(fs['one'], ['1'])
+        self.assertEqual(fs['two'], ['2'])
+
+    def test_from_response_submit_not_first_clickable_novalue(self):
+        response = _buildresponse(
+            """<form action="get.php" method="GET">
+            <input type="submit" name="clickable1">
+            <input type="hidden" name="one" value="1">
+            <input type="hidden" name="two" value="3">
+            <input type="submit" name="clickable2">
+            </form>""")
+        req = self.request_class.from_response(response, formdata={'two': '2'}, \
+                                              clickdata={'name': 'clickable2'})
+        fs = _qs(req)
+        self.assertEqual(fs['clickable2'], [''])
         self.assertFalse('clickable1' in fs, fs)
         self.assertEqual(fs['one'], ['1'])
         self.assertEqual(fs['two'], ['2'])


### PR DESCRIPTION
Empty Clickables lead to an exception, because unicode_to_str is called with an argument of None, which should be of type unicode.
This is fixed by checking for None values and setting them to u''
