### PR TITLE
[MRG] contracts support for multiple requests and batches

### DIFF
--- a/docs/topics/contracts.rst
+++ b/docs/topics/contracts.rst
@@ -24,10 +24,19 @@ following example::
         with this docstring.
 
         @url http://www.amazon.com/s?field-keywords=selfish+gene
-        @returns items 1 16
+        @url http://www.amazon.com/s?field-keywords=hitchhikers+guide
+        @returns items 16 16
         @returns requests 0 0
         @scrapes Title Author Year Price
+
+        @url http://www.amazon.com/s?field-keywords=scrapy+python
+        @returns items 1 6
         """
+
+Here, we have two batches of contracts (separated by a blank line). In the
+first batch, each of the two urls must return 16 items with Title, Author,
+Year and Price fields. In the second, the url must return between 1 and 6
+items.
 
 This callback is tested using three built-in contracts:
 
@@ -35,9 +44,10 @@ This callback is tested using three built-in contracts:
 
 .. class:: UrlContract
 
-    This contract (``@url``) sets the sample url used when checking other
-    contract conditions for this spider. This contract is mandatory. All
-    callbacks lacking this contract are ignored when running the checks::
+    This contract (``@url``) generates a request with callback the current
+    method, on top of each other contracts will do checks. At least one of the
+    contracts in each batch must create a request, otherwise the whole batch
+    is ignored::
 
     @url url
 
@@ -74,20 +84,24 @@ override three methods:
 
 .. module:: scrapy.contracts
 
-.. class:: Contract(method, \*args)
+.. class:: Contract(method, input_string)
 
     :param method: callback function to which the contract is associated
     :type method: function
 
-    :param args: list of arguments passed into the docstring (whitespace
-        separated)
-    :type args: list
+    :param input_string: string passed in after contract name
+    :type input_string: string
 
-    .. method:: Contract.adjust_request_args(args)
 
-        This receives a ``dict`` as an argument containing default arguments
-        for :class:`~scrapy.http.Request` object. Must return the same or a
-        modified version of it.
+    .. method:: Contract.create_request()
+
+        Creates a :class:`~scrapy.http.Request` object. This can then be
+        subjected to tests using processors below.
+
+    .. method:: Contract.adjust_request(request)
+
+        This receives a :class:`~scrapy.http.Request` object. Must return the
+        same or a modified version of it.
 
     .. method:: Contract.pre_process(response)
 

--- a/scrapy/commands/check.py
+++ b/scrapy/commands/check.py
@@ -104,9 +104,7 @@ class Command(ScrapyCommand):
         for key, value in vars(type(spider)).items():
             if callable(value) and value.__doc__:
                 bound_method = value.__get__(spider, type(spider))
-                request = conman.from_method(bound_method, result)
-
-                if request:
-                    requests.append(request)
+                reqs = conman.from_method(bound_method, result)
+                requests.extend(reqs)
 
         return requests

--- a/scrapy/tests/test_contracts.py
+++ b/scrapy/tests/test_contracts.py
@@ -88,49 +88,51 @@ class ContractsManagerTest(unittest.TestCase):
         spider = TestSpider()
 
         # extract contracts correctly
-        contracts = self.conman.extract_contracts(spider.returns_request)
+        contract_batches = list(self.conman.extract_contracts(spider.returns_request))
+        self.assertEqual(len(contract_batches), 1)
+
+        contracts = contract_batches[0]
         self.assertEqual(len(contracts), 2)
         self.assertEqual(frozenset(type(x) for x in contracts),
-            frozenset([UrlContract, ReturnsContract]))
+                         frozenset([UrlContract, ReturnsContract]))
 
         # returns request for valid method
-        request = self.conman.from_method(spider.returns_request, self.results)
-        self.assertNotEqual(request, None)
+        for req in self.conman.from_method(spider.returns_request, self.results):
+            self.assertNotEqual(req, None)
 
         # no request for missing url
-        request = self.conman.from_method(spider.parse_no_url, self.results)
-        self.assertEqual(request, None)
+        for req in self.conman.from_method(spider.parse_no_url, self.results):
+            self.assertEqual(req, None)
 
     def test_returns(self):
         spider = TestSpider()
-        response = ResponseMock()
+        resp = ResponseMock()
 
         # returns_item
-        request = self.conman.from_method(spider.returns_item, self.results)
-        request.callback(response)
-        self.should_succeed()
+        for req in self.conman.from_method(spider.returns_item, self.results):
+            req.callback(resp)
+            self.should_succeed()
 
         # returns_request
-        request = self.conman.from_method(spider.returns_request, self.results)
-        request.callback(response)
-        self.should_succeed()
+        for req in self.conman.from_method(spider.returns_request, self.results):
+            req.callback(resp)
+            self.should_succeed()
 
         # returns_fail
-        request = self.conman.from_method(spider.returns_fail, self.results)
-        request.callback(response)
-        self.should_fail()
+        for req in self.conman.from_method(spider.returns_fail, self.results):
+            req.callback(resp)
+            self.should_fail()
 
     def test_scrapes(self):
         spider = TestSpider()
-        response = ResponseMock()
+        resp = ResponseMock()
 
         # scrapes_item_ok
-        request = self.conman.from_method(spider.scrapes_item_ok, self.results)
-        request.callback(response)
-        self.should_succeed()
+        for req in self.conman.from_method(spider.scrapes_item_ok, self.results):
+            req.callback(resp)
+            self.should_succeed()
 
         # scrapes_item_fail
-        request = self.conman.from_method(spider.scrapes_item_fail,
-                self.results)
-        request.callback(response)
-        self.should_fail()
+        for req in self.conman.from_method(spider.scrapes_item_fail, self.results):
+            req.callback(resp)
+            self.should_fail()


### PR DESCRIPTION
This allows to:
- have multiple batches of contracts for each method (run separately)
- have multiple requests in each batch of contracts (i.e. multiple @url contracts)

Changes:
- create_request and adjust_request replace adjust_request_args (all custom contracts using adjust_request_args will stop working)
- Contract.args deprecated in favour of Contract.input_string
