### PR TITLE
rename "sflo" local variables to less cryptic "log_observer"

### DIFF
--- a/scrapy/crawler.py
+++ b/scrapy/crawler.py
@@ -135,12 +135,12 @@ class CrawlerProcess(object):
 
         name, crawler = self.crawlers.popitem()
         self._active_crawler = crawler
-        sflo = log.start_from_crawler(crawler)
+        log_observer = log.start_from_crawler(crawler)
         crawler.configure()
         crawler.install()
         crawler.signals.connect(crawler.uninstall, signals.engine_stopped)
-        if sflo:
-            crawler.signals.connect(sflo.stop, signals.engine_stopped)
+        if log_observer:
+            crawler.signals.connect(log_observer.stop, signals.engine_stopped)
         crawler.signals.connect(self._check_done, signals.engine_stopped)
         crawler.start()
         return name, crawler

--- a/scrapy/log.py
+++ b/scrapy/log.py
@@ -114,12 +114,12 @@ def _get_log_level(level_name_or_id):
 def start(logfile=None, loglevel='INFO', logstdout=True, logencoding='utf-8', crawler=None):
     loglevel = _get_log_level(loglevel)
     file = open(logfile, 'a') if logfile else sys.stderr
-    sflo = ScrapyFileLogObserver(file, loglevel, logencoding, crawler)
+    log_observer = ScrapyFileLogObserver(file, loglevel, logencoding, crawler)
     _oldshowwarning = warnings.showwarning
-    log.startLoggingWithObserver(sflo.emit, setStdout=logstdout)
+    log.startLoggingWithObserver(log_observer.emit, setStdout=logstdout)
     # restore warnings, wrongly silenced by Twisted
     warnings.showwarning = _oldshowwarning
-    return sflo
+    return log_observer
 
 def msg(message=None, _level=INFO, **kw):
     kw['logLevel'] = kw.pop('level', _level)
@@ -140,9 +140,9 @@ def start_from_settings(settings, crawler=None):
             settings['LOG_ENCODING'], crawler)
 
 def scrapy_info(settings):
-    sflo = start_from_settings(settings)
-    if sflo:
-        msg("Scrapy %s started (bot: %s)" % (scrapy.__version__, \
+    log_observer = start_from_settings(settings)
+    if log_observer:
+        msg("Scrapy %s started (bot: %s)" % (scrapy.__version__,
             settings['BOT_NAME']))
 
         msg("Optional features available: %s" % ", ".join(scrapy.optional_features),
@@ -151,7 +151,7 @@ def scrapy_info(settings):
         d = dict(overridden_settings(settings))
         msg(format="Overridden settings: %(settings)r", settings=d, level=INFO)
 
-        sflo.stop()
+        log_observer.stop()
 
 def start_from_crawler(crawler):
     return start_from_settings(crawler.settings, crawler)

--- a/scrapy/tests/test_log.py
+++ b/scrapy/tests/test_log.py
@@ -22,12 +22,12 @@ class ScrapyFileLogObserverTest(unittest.TestCase):
 
     def setUp(self):
         self.f = StringIO()
-        self.sflo = log.ScrapyFileLogObserver(self.f, self.level, self.encoding)
-        self.sflo.start()
+        self.log_observer = log.ScrapyFileLogObserver(self.f, self.level, self.encoding)
+        self.log_observer.start()
 
     def tearDown(self):
         self.flushLoggedErrors()
-        self.sflo.stop()
+        self.log_observer.stop()
 
     def logged(self):
         return self.f.getvalue().strip()[25:]


### PR DESCRIPTION
Hey,

I was reading Crawler source code, encountered "sflo" local variable and had no idea what is it. What do you think about renaming it to "log_observer"?
