### PR TITLE
PY3 make it possible to run some tests in Python3

### DIFF
--- a/scrapy/__init__.py
+++ b/scrapy/__init__.py
@@ -17,7 +17,6 @@ import sys
 if sys.version_info < (2, 7):
     print("Scrapy %s requires Python 2.7" % __version__)
     sys.exit(1)
-del sys
 
 # Ignore noisy twisted deprecation warnings
 import warnings
@@ -25,7 +24,7 @@ warnings.filterwarnings('ignore', category=DeprecationWarning, module='twisted')
 del warnings
 
 # Apply monkey patches to fix issues in external libraries
-import _monkeypatches
+from . import _monkeypatches
 del _monkeypatches
 
 # WARNING: optional_features set is deprecated and will be removed soon. Do not use.
@@ -53,7 +52,13 @@ if twisted_version >= (11, 1, 0):
     optional_features.add('http11')
 
 # Declare top-level shortcuts
-from scrapy.spider import Spider
-from scrapy.http import Request, FormRequest
-from scrapy.selector import Selector
-from scrapy.item import Item, Field
+if sys.version_info[0] == 2:
+    # Top-level shortcuts are not ready for Python 3 (like most of Scrapy);
+    # skip them here to make at least some parts of Scrapy
+    # importable in Python 3.
+    from scrapy.spider import Spider
+    from scrapy.http import Request, FormRequest
+    from scrapy.selector import Selector
+    from scrapy.item import Item, Field
+
+del sys

--- a/tox.ini
+++ b/tox.ini
@@ -42,7 +42,8 @@ commands =
 [testenv:py33]
 basepython = python3.3
 deps =
-    svn+svn://svn.twistedmatrix.com/svn/Twisted/trunk#egg=Twisted
+;    svn+svn://svn.twistedmatrix.com/svn/Twisted/trunk#egg=Twisted
+    twisted >= 14.0.0
     lxml>=3.2.4
     pyOpenSSL>=0.13.1
     cssselect>=0.9


### PR DESCRIPTION
- switch to Twisted 14.0.0 because SVN version broke twisted.log in Python 3;
- skip top-level shortcuts to make at least some tests pass;
- use PY3 compatible import of _monkeypatches.
