### PR TITLE
[WIP] make scrapy command line utility faster

### DIFF
--- a/scrapy/cmdline.py
+++ b/scrapy/cmdline.py
@@ -6,7 +6,6 @@ import inspect
 import pkg_resources
 
 import scrapy
-from scrapy.crawler import CrawlerProcess
 from scrapy.xlib import lsprofcalltree
 from scrapy.command import ScrapyCommand
 from scrapy.exceptions import UsageError
@@ -139,6 +138,7 @@ def execute(argv=None, settings=None):
     opts, args = parser.parse_args(args=argv[1:])
     _run_print_help(parser, cmd.process_options, args, opts)
 
+    from scrapy.crawler import CrawlerProcess
     cmd.crawler_process = CrawlerProcess(settings)
     _run_print_help(parser, _run_command, cmd, args, opts)
     sys.exit(cmd.exitcode)

--- a/scrapy/commands/bench.py
+++ b/scrapy/commands/bench.py
@@ -1,6 +1,4 @@
 from scrapy.command import ScrapyCommand
-from scrapy.tests.spiders import FollowAllSpider
-from scrapy.tests.mockserver import MockServer
 
 class Command(ScrapyCommand):
 
@@ -14,6 +12,9 @@ class Command(ScrapyCommand):
         return "Run quick benchmark test"
 
     def run(self, args, opts):
+        from scrapy.tests.spiders import FollowAllSpider
+        from scrapy.tests.mockserver import MockServer
+
         with MockServer():
             spider = FollowAllSpider(total=100000)
             crawler = self.crawler_process.create_crawler()

--- a/scrapy/commands/shell.py
+++ b/scrapy/commands/shell.py
@@ -7,7 +7,6 @@ See documentation in docs/topics/shell.rst
 from threading import Thread
 
 from scrapy.command import ScrapyCommand
-from scrapy.shell import Shell
 
 
 class Command(ScrapyCommand):
@@ -38,6 +37,7 @@ class Command(ScrapyCommand):
         pass
 
     def run(self, args, opts):
+        from scrapy.shell import Shell
         crawler = self.crawler_process.create_crawler()
 
         url = args[0] if args else None

--- a/scrapy/utils/response.py
+++ b/scrapy/utils/response.py
@@ -9,8 +9,6 @@ import weakref
 import webbrowser
 import tempfile
 
-from twisted.web import http
-from twisted.web.http import RESPONSES
 from w3lib import html
 
 from scrapy.http import HtmlResponse, TextResponse
@@ -54,6 +52,7 @@ def response_status_message(status):
     >>> response_status_message(404)
     '404 Not Found'
     """
+    from twisted.web import http
     return '%s %s' % (status, http.responses.get(int(status)))
 
 def response_httprepr(response):
@@ -61,6 +60,7 @@ def response_httprepr(response):
     is provided only for reference, since it's not the exact stream of bytes
     that was received (that's not exposed by Twisted).
     """
+    from twisted.web.http import RESPONSES
 
     s = "HTTP/1.1 %d %s\r\n" % (response.status, RESPONSES.get(response.status, ''))
     if response.headers:


### PR DESCRIPTION
I noticed that `scrapy` command-line utility became much slower during last half year or so. This is an attempt (unsuccessful so far) to fix that by deferring imports that cause the slowdown (see https://github.com/pyca/pyopenssl/issues/137). On my machine this fix makes `scrapy` without arguments to run in 0.3s instead of 0.8s, but all other commands (e.g. `scrapy list`) still take > 0.8s because they indirectly import OpenSSL (through twisted).
