### PR TITLE
Using CRLF as line marker according to http 1.1 definition

### DIFF
--- a/scrapy/core/downloader/handlers/http11.py
+++ b/scrapy/core/downloader/handlers/http11.py
@@ -66,12 +66,11 @@ class TunnelingTCP4ClientEndpoint(TCP4ClientEndpoint):
 
     def requestTunnel(self, protocol):
         """Asks the proxy to open a tunnel."""
-        tunnelReq = 'CONNECT %s:%s HTTP/1.1\n' % (self._tunneledHost,
+        tunnelReq = 'CONNECT %s:%s HTTP/1.1\r\n' % (self._tunneledHost,
                                                   self._tunneledPort)
         if self._proxyAuthHeader:
-            tunnelReq += 'Proxy-Authorization: %s \n\n' % self._proxyAuthHeader
-        else:
-            tunnelReq += '\n'
+            tunnelReq += 'Proxy-Authorization: %s\r\n' % self._proxyAuthHeader
+        tunnelReq += '\r\n'
         protocol.transport.write(tunnelReq)
         self._protocolDataReceived = protocol.dataReceived
         protocol.dataReceived = self.processProxyResponse


### PR DESCRIPTION
According to http 1.1 definition http://www.w3.org/Protocols/rfc2616/rfc2616-sec2.html we should using CRLF as end-of-line marker. In my case some of my proxies will return 407 if it's not ended with '\r\n'. And we can see it clearly in twisted's [http client](https://github.com/twisted/twisted/blob/trunk/twisted/web/http.py#L410) implementation. 
