### PR TITLE
PY3: fix has_key and use six.moves.configparser

### DIFF
--- a/scrapy/tests/test_utils_datatypes.py
+++ b/scrapy/tests/test_utils_datatypes.py
@@ -75,7 +75,6 @@ class CaselessDictTest(unittest.TestCase):
         d = CaselessDict()
         d['a'] = 1
         assert 'a' in d
-        assert d.has_key('a')
 
     def test_pop(self):
         d = CaselessDict()

--- a/scrapy/utils/conf.py
+++ b/scrapy/utils/conf.py
@@ -1,6 +1,6 @@
 import sys
 import os
-from ConfigParser import SafeConfigParser
+from six.moves.configparser import SafeConfigParser
 from operator import itemgetter
 
 def build_component_list(base, custom):

--- a/scrapy/xlib/pydispatch/dispatcher.py
+++ b/scrapy/xlib/pydispatch/dispatcher.py
@@ -134,7 +134,7 @@ def connect(receiver, signal=Any, sender=Any, weak=True):
 	if weak:
 		receiver = saferef.safeRef(receiver, onDelete=_removeReceiver)
 	senderkey = id(sender)
-	if connections.has_key(senderkey):
+	if senderkey in connections:
 		signals = connections[senderkey]
 	else:
 		connections[senderkey] = signals = {}
@@ -154,7 +154,7 @@ def connect(receiver, signal=Any, sender=Any, weak=True):
 	receiverID = id(receiver)
 	# get current set, remove any current references to
 	# this receiver in the set, including back-references
-	if signals.has_key(signal):
+	if signal in signals:
 		receivers = signals[signal]
 		_removeOldBackRefs(senderkey, signal, receiver, receivers)
 	else:
@@ -290,7 +290,7 @@ def getAllReceivers( sender = Any, signal = Any ):
 		for receiver in set:
 			if receiver: # filter out dead instance-method weakrefs
 				try:
-					if not receivers.has_key( receiver ):
+					if receiver not in receivers:
 						receivers[receiver] = 1
 						yield receiver
 				except TypeError:

--- a/scrapy/xlib/pydispatch/robustapply.py
+++ b/scrapy/xlib/pydispatch/robustapply.py
@@ -37,7 +37,7 @@ def robustApply(receiver, *arguments, **named):
     receiver, codeObject, startIndex = function(receiver)
     acceptable = codeObject.co_varnames[startIndex+len(arguments):codeObject.co_argcount]
     for name in codeObject.co_varnames[startIndex:startIndex+len(arguments)]:
-        if named.has_key(name):
+        if name in named:
             raise TypeError(
                 """Argument %r specified both positionally and as a keyword for calling %r"""% (
                     name, receiver,


### PR DESCRIPTION
Yet another small change for py3k support.
