### PR TITLE
For consistency, use `job_dir` helper in `SpiderState` extension.

### DIFF
--- a/scrapy/contrib/spiderstate.py
+++ b/scrapy/contrib/spiderstate.py
@@ -2,6 +2,7 @@ import os
 from six.moves import cPickle as pickle
 
 from scrapy import signals
+from scrapy.utils.job import job_dir
 
 class SpiderState(object):
     """Store and load spider state during a scraping job"""
@@ -11,7 +12,7 @@ class SpiderState(object):
 
     @classmethod
     def from_crawler(cls, crawler):
-        obj = cls(crawler.settings.get('JOBDIR'))
+        obj = cls(job_dir(crawler.settings))
         crawler.signals.connect(obj.spider_closed, signal=signals.spider_closed)
         crawler.signals.connect(obj.spider_opened, signal=signals.spider_opened)
         return obj


### PR DESCRIPTION
The `SpiderState` extension is the only place not using the `job_dir`
helper.

This might cause an error in case JOBDIR is a nested path which does not
exists, although this is least likely by default given the job dir being
set up earlier.
