### PR TITLE
Add methods to temporarily override the item loader's selector.

### DIFF
--- a/scrapy/loader/__init__.py
+++ b/scrapy/loader/__init__.py
@@ -4,6 +4,7 @@ See documentation in docs/topics/loaders.rst
 
 """
 from collections import defaultdict
+from contextlib import contextmanager
 import six
 
 from scrapy.item import Item
@@ -199,5 +200,19 @@ class ItemLoader(object):
         self._check_selector_method()
         csss = arg_to_iter(csss)
         return flatten(self.selector.css(css).extract() for css in csss)
+
+    @contextmanager
+    def push_selector(self, selector):
+        selector_orig = self.selector
+        self.context['selector'] = self.selector = selector
+        yield
+        self.context['selector'] = self.selector = selector_orig
+
+    def push_xpath(self, xpath):
+        return self.push_selector(self.selector.xpath(xpath))
+
+    def push_css(self, css):
+        return self.push_selector(self.selector.css(css))
+
 
 XPathItemLoader = create_deprecated_class('XPathItemLoader', ItemLoader)

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -612,6 +612,32 @@ class SelectortemLoaderTest(unittest.TestCase):
         l.replace_css('url', 'a::attr(href)', re='http://www\.(.+)')
         self.assertEqual(l.get_output_value('url'), [u'scrapy.org'])
 
+    def test_push_selector(self):
+        l = TestItemLoader(response=self.response)
+        newselector = l.selector.xpath('html')
+        with l.push_selector(newselector):
+            self.assert_(l.selector is newselector)
+        self.assert_(l.selector is not newselector)
+
+    def test_push_xpath(self):
+        l = TestItemLoader(response=self.response)
+        with l.push_xpath('/html/body'):
+            with l.push_xpath('div'):
+                l.add_xpath('name', 'text()')
+            with l.push_xpath('a'):
+                l.add_xpath('url', '@href')
+        self.assertEqual(l.get_output_value('name'), [u'Marta'])
+        self.assertEqual(l.get_output_value('url'), [u'http://www.scrapy.org'])
+
+    def test_push_css(self):
+        l = TestItemLoader(response=self.response)
+        with l.push_css('#id'):
+            l.add_css('name', '::text')
+        with l.push_css('a'):
+            l.add_css('url', '::attr(href)')
+        self.assertEqual(l.get_output_value('name'), [u'Marta'])
+        self.assertEqual(l.get_output_value('url'), [u'http://www.scrapy.org'])
+
 
 class SubselectorLoaderTest(unittest.TestCase):
     response = HtmlResponse(url="", encoding='utf-8', body=b"""


### PR DESCRIPTION
This changes aim to reduce the repeated use of xpath/css prefixes. For
instance, the next piece of code
```python
    il.add_css('name', '#container .foo a::text')
    il.add_css('url', '#container .foo a::attr(url)')
    il.add_css('text', '#container .foo p')
```
can be written as
```python
    with il.push_css('#container .foo'):
        il.add_css('name', 'a::text')
        il.add_css('url', 'a::attr(url)')
        il.add_css('text', 'p')
```
The new ItemLoader methods are:

* `push_selector(selector)` where selector is a instance of `Selector`
class.
* `push_xpath(xpath)` where xpath is a xpath expression.
* `push_css(css)` where css is a css expression.

TODO: docs