### PR TITLE
[WIP] optparse to argparse

### DIFF
--- a/scrapy/command.py
+++ b/scrapy/command.py
@@ -78,6 +78,27 @@ class ScrapyCommand(object):
         """
         return self.long_desc()
 
+    def add_arguments(self, parser):
+        """
+        Populate ArgumentParser with arguments available for this command
+        """
+        group = parser.add_argument_group(title='global arguments')
+        group.add_argument("--logfile", metavar="FILE",
+            help="log file. if omitted stderr will be used")
+        group.add_argument("-L", "--loglevel", metavar="LEVEL", default=None,
+            help="log level (default: %s)" % self.settings['LOG_LEVEL'])
+        group.add_argument("--nolog", action="store_true",
+            help="disable logging completely")
+        group.add_argument("--profile", metavar="FILE", default=None,
+            help="write python cProfile stats to FILE")
+        group.add_argument("--lsprof", metavar="FILE", default=None,
+            help="write lsprof profiling stats to FILE")
+        group.add_argument("--pidfile", metavar="FILE",
+            help="write process ID to FILE")
+        group.add_argument("-s", "--set", action="append", default=[], metavar="NAME=VALUE",
+            help="set/override setting (may be repeated)")
+        group.add_argument("--pdb", action="store_true", help="enable pdb on failure")
+
     def add_options(self, parser):
         """
         Populate option parse with options available for this command

--- a/scrapy/commands/crawl.py
+++ b/scrapy/commands/crawl.py
@@ -14,6 +14,16 @@ class Command(ScrapyCommand):
     def short_desc(self):
         return "Run a spider"
 
+    def add_arguments(self, parser):
+        super(Command, self).add_arguments(parser)
+        parser.add_argument('spider', help='spider to run')
+        parser.add_argument('-a', dest="spargs", action="append", default=[], metavar="NAME=VALUE",
+                          help="set spider argument (may be repeated)")
+        parser.add_argument("-o", "--output", metavar="FILE",
+                          help="dump scraped items into FILE (use - for stdout)")
+        parser.add_argument("-t", "--output-format", metavar="FORMAT",
+                          help="format to use for dumping items with -o")
+
     def add_options(self, parser):
         ScrapyCommand.add_options(self, parser)
         parser.add_option("-a", dest="spargs", action="append", default=[], metavar="NAME=VALUE",
@@ -48,11 +58,15 @@ class Command(ScrapyCommand):
             self.settings.set('FEED_FORMAT', opts.output_format, priority='cmdline')
 
     def run(self, args, opts):
-        if len(args) < 1:
-            raise UsageError()
-        elif len(args) > 1:
-            raise UsageError("running 'scrapy crawl' with more than one spider is no longer supported")
-        spname = args[0]
+        # --- backwards compatibility for optparse ---
+        if isinstance(args, list):
+            if len(args) < 1:
+                raise UsageError()
+            elif len(args) > 1:
+                raise UsageError("running 'scrapy crawl' with more than one spider is no longer supported")
+            spname = args[0]
+        else:
+            spname = args.spider
 
         crawler = self.crawler_process.create_crawler()
         spider = crawler.spiders.create(spname, **opts.spargs)

--- a/scrapy/commands/deploy.py
+++ b/scrapy/commands/deploy.py
@@ -46,6 +46,25 @@ class Command(ScrapyCommand):
         return "Deploy the current project into the given Scrapyd server " \
             "(known as target)"
 
+    def add_arguments(self, parser):
+        super(Command, self).add_arguments(parser)
+        parser.add_argument('target', nargs='?', default='default',
+            help='target of the deploy')
+        parser.add_argument("-p", "--project",
+            help="the project name in the target")
+        parser.add_argument("-v", "--version",
+            help="the version to deploy. Defaults to current timestamp")
+        parser.add_argument("-l", "--list-targets", action="store_true", \
+            help="list available targets")
+        parser.add_argument("-d", "--debug", action="store_true",
+            help="debug mode (do not remove build dir)")
+        parser.add_argument("-L", "--list-projects", metavar="TARGET", \
+            help="list available projects on TARGET")
+        parser.add_argument("--egg", metavar="FILE",
+            help="use the given egg, instead of building it")
+        parser.add_argument("--build-egg", metavar="FILE",
+            help="only build the egg, don't deploy it")
+
     def add_options(self, parser):
         ScrapyCommand.add_options(self, parser)
         parser.add_option("-p", "--project",
@@ -92,7 +111,12 @@ class Command(ScrapyCommand):
             _log("Writing egg to %s" % opts.build_egg)
             shutil.copyfile(egg, opts.build_egg)
         else: # buld egg and deploy
-            target_name = _get_target_name(args)
+            # --- backwards compatibility for optparse ---
+            if isinstance(args, list):
+                target_name = _get_target_name(args)
+            else:
+                target_name = args.target
+            # --------------------------------------------
             target = _get_target(target_name)
             project = _get_project(target, opts)
             version = _get_version(target, opts)

--- a/scrapy/commands/edit.py
+++ b/scrapy/commands/edit.py
@@ -17,20 +17,29 @@ class Command(ScrapyCommand):
     def long_desc(self):
         return "Edit a spider using the editor defined in EDITOR setting"
 
+    def add_arguments(self, parser):
+        super(Command, self).add_arguments(parser)
+        parser.add_argument('spider', help='spider to edit')
+
     def _err(self, msg):
         sys.stderr.write(msg + os.linesep)
         self.exitcode = 1
 
     def run(self, args, opts):
-        if len(args) != 1:
-            raise UsageError()
+        # --- backwards compatibility for optparse ---
+        if isinstance(args, list):
+            if len(args) != 1:
+                raise UsageError()
+            sname = args[0]
+        else:
+            sname = args.spider
 
         crawler = self.crawler_process.create_crawler()
         editor = crawler.settings['EDITOR']
         try:
-            spider = crawler.spiders.create(args[0])
+            spider = crawler.spiders.create(sname)
         except KeyError:
-            return self._err("Spider not found: %s" % args[0])
+            return self._err("Spider not found: %s" % sname)
 
         sfile = sys.modules[spider.__module__].__file__
         sfile = sfile.replace('.pyc', '.py')

--- a/scrapy/commands/genspider.py
+++ b/scrapy/commands/genspider.py
@@ -32,6 +32,22 @@ class Command(ScrapyCommand):
     def short_desc(self):
         return "Generate new spider using pre-defined templates"
 
+    def add_arguments(self, parser):
+        super(Command, self).add_arguments(parser)
+        group = parser.add_mutually_exclusive_group(required=True)
+        group.add_argument('name', nargs='?', help='name of the new spider')
+        group.add_argument("-l", "--list", dest="list", action="store_true",
+            help="List available templates")
+        group.add_argument("-d", "--dump", dest="dump", metavar="TEMPLATE",
+            help="Dump template to standard output")
+        parser.add_argument('domain', nargs='?', help='allowed domain for the spider')
+        parser.add_argument("-e", "--edit", dest="edit", action="store_true",
+            help="Edit spider after creating it")
+        parser.add_argument("-t", "--template", dest="template", default="basic",
+            help="Uses a custom template.")
+        parser.add_argument("--force", dest="force", action="store_true",
+            help="If the spider already exists, overwrite it with the template")
+
     def add_options(self, parser):
         ScrapyCommand.add_options(self, parser)
         parser.add_option("-l", "--list", dest="list", action="store_true",
@@ -54,10 +70,17 @@ class Command(ScrapyCommand):
             if template_file:
                 print(open(template_file, 'r').read())
             return
-        if len(args) != 2:
-            raise UsageError()
 
-        name, domain = args[0:2]
+        # --- backwards compatibility for optparse ---
+        if isinstance(args, list):
+            if len(args) != 2:
+                raise UsageError()
+            name, domain = args[0:2]
+        else:
+            name, domain = args.name, args.domain
+            if domain is None:
+                raise UsageError
+
         module = sanitize_module_name(name)
 
         if self.settings.get('BOT_NAME') == module:

--- a/scrapy/commands/runspider.py
+++ b/scrapy/commands/runspider.py
@@ -37,6 +37,16 @@ class Command(ScrapyCommand):
     def long_desc(self):
         return "Run the spider defined in the given file"
 
+    def add_arguments(self, parser):
+        super(Command, self).add_arguments(parser)
+        parser.add_argument('spider_file', help='path to the spider file')
+        parser.add_argument("-a", dest="spargs", action="append", default=[], metavar="NAME=VALUE",
+                          help="set spider argument (may be repeated)")
+        parser.add_argument("-o", "--output", metavar="FILE",
+                          help="dump scraped items into FILE (use - for stdout)")
+        parser.add_argument("-t", "--output-format", metavar="FORMAT",
+                          help="format to use for dumping items with -o")
+
     def add_options(self, parser):
         ScrapyCommand.add_options(self, parser)
         parser.add_option("-a", dest="spargs", action="append", default=[], metavar="NAME=VALUE",
@@ -71,9 +81,14 @@ class Command(ScrapyCommand):
             self.settings.set('FEED_FORMAT', opts.output_format, priority='cmdline')
 
     def run(self, args, opts):
-        if len(args) != 1:
-            raise UsageError()
-        filename = args[0]
+        # --- backwards compatibility for optparse ---
+        if isinstance(args, list):
+            if len(args) != 1:
+                raise UsageError()
+            filename = args[0]
+        else:
+            filename = args.spider_file
+
         if not os.path.exists(filename):
             raise UsageError("File not found: %s\n" % filename)
         try:

--- a/scrapy/commands/settings.py
+++ b/scrapy/commands/settings.py
@@ -12,6 +12,19 @@ class Command(ScrapyCommand):
     def short_desc(self):
         return "Get settings values"
 
+    def add_arguments(self, parser):
+        super(Command, self).add_arguments(parser)
+        parser.add_argument("--get", dest="get", metavar="SETTING", \
+            help="print raw setting value")
+        parser.add_argument("--getbool", dest="getbool", metavar="SETTING", \
+            help="print setting value, intepreted as a boolean")
+        parser.add_argument("--getint", dest="getint", metavar="SETTING", \
+            help="print setting value, intepreted as an integer")
+        parser.add_argument("--getfloat", dest="getfloat", metavar="SETTING", \
+            help="print setting value, intepreted as an float")
+        parser.add_argument("--getlist", dest="getlist", metavar="SETTING", \
+            help="print setting value, intepreted as an float")
+
     def add_options(self, parser):
         ScrapyCommand.add_options(self, parser)
         parser.add_option("--get", dest="get", metavar="SETTING", \

--- a/scrapy/commands/shell.py
+++ b/scrapy/commands/shell.py
@@ -24,6 +24,15 @@ class Command(ScrapyCommand):
     def long_desc(self):
         return "Interactive console for scraping the given url"
 
+    def add_arguments(self, parser):
+        super(Command, self).add_arguments(parser)
+        parser.add_argument('url', nargs='?',
+            help='url to fetch before open the shell')
+        parser.add_argument("-c", dest="code",
+            help="evaluate the code in the shell, print the result and exit")
+        parser.add_argument("--spider", dest="spider",
+            help="use this spider")
+
     def add_options(self, parser):
         ScrapyCommand.add_options(self, parser)
         parser.add_option("-c", dest="code",
@@ -40,7 +49,12 @@ class Command(ScrapyCommand):
     def run(self, args, opts):
         crawler = self.crawler_process.create_crawler()
 
-        url = args[0] if args else None
+        # --- backwards compatibility for optparse ---
+        if isinstance(args, list):
+            url = args[0] if args else None
+        else:
+            url = args.url
+
         spider = crawler.spiders.create(opts.spider) if opts.spider else None
 
         self.crawler_process.start_crawling()

--- a/scrapy/commands/startproject.py
+++ b/scrapy/commands/startproject.py
@@ -34,6 +34,10 @@ class Command(ScrapyCommand):
     def short_desc(self):
         return "Create new project"
 
+    def add_arguments(self, parser):
+        super(Command, self).add_arguments(parser)
+        parser.add_argument('project_name', help='project name to retrieve from')
+
     def _is_valid_name(self, project_name):
         def _module_exists(module_name):
             try:
@@ -54,9 +58,13 @@ class Command(ScrapyCommand):
         return False
 
     def run(self, args, opts):
-        if len(args) != 1:
-            raise UsageError()
-        project_name = args[0]
+        # --- backwards compatibility for optparse ---
+        if isinstance(args, list):
+            if len(args) != 1:
+                raise UsageError()
+            project_name = args[0]
+        else:
+            project_name = args.project_name
 
         if not self._is_valid_name(project_name):
             self.exitcode = 1

--- a/scrapy/commands/version.py
+++ b/scrapy/commands/version.py
@@ -16,6 +16,11 @@ class Command(ScrapyCommand):
     def short_desc(self):
         return "Print Scrapy version"
 
+    def add_arguments(self, parser):
+        super(Command, self).add_arguments(parser)
+        parser.add_argument("--verbose", "-v", dest="verbose", action="store_true",
+            help="also display twisted/python/platform info (useful for bug reports)")
+
     def add_options(self, parser):
         ScrapyCommand.add_options(self, parser)
         parser.add_option("--verbose", "-v", dest="verbose", action="store_true",

--- a/scrapy/commands/view.py
+++ b/scrapy/commands/view.py
@@ -11,10 +11,13 @@ class Command(fetch.Command):
         return "Fetch a URL using the Scrapy downloader and show its " \
             "contents in a browser"
 
+    def add_arguments(self, parser):
+        super(Command, self).add_arguments(parser)
+        parser.add_argument('--spider', dest='spider', help='use this spider')
+
     def add_options(self, parser):
         ScrapyCommand.add_options(self, parser)
-        parser.add_option("--spider", dest="spider",
-            help="use this spider")
+        parser.add_option("--spider", dest="spider", help="use this spider")
 
     def _print_response(self, response, opts):
         open_in_browser(response)


### PR DESCRIPTION
It uses argparse whenever it can, based on `any('add_arguments' not in vars(cmd.__class__) and 'add_options' in vars(cmd.__class__) for cmd in cmds.values())`

```
$ scrapy --help
usage: scrapy [-h]  ...

Scrapy 0.25.1 - no active project.

optional arguments:
  -h, --help    show this help message and exit

commands:
  More commands available when run from project directory.


    runspider   Run a self-contained spider (without creating a project)
    shell       Interactive scraping console
    settings    Get settings values
    bench       Run quick benchmark test
    version     Print Scrapy version
    startproject
                Create new project
    fetch       Fetch a URL using the Scrapy downloader
    view        Open URL in browser, as seen by Scrapy
```

```
$ scrapy bench --help
usage: scrapy bench [-h] [--logfile FILE] [-L LEVEL] [--nolog]
                    [--profile FILE] [--lsprof FILE] [--pidfile FILE]
                    [-s NAME=VALUE] [--pdb]

Run quick benchmark test

optional arguments:
  -h, --help            show this help message and exit

global arguments:
  --logfile FILE        log file. if omitted stderr will be used
  -L LEVEL, --loglevel LEVEL
                        log level (default: DEBUG)
  --nolog               disable logging completely
  --profile FILE        write python cProfile stats to FILE
  --lsprof FILE         write lsprof profiling stats to FILE
  --pidfile FILE        write process ID to FILE
  -s NAME=VALUE, --set NAME=VALUE
                        set/override setting (may be repeated)
  --pdb                 enable pdb on failure
```

Closes #1118