### PR TITLE
Selector. __str__()  method

### DIFF
--- a/scrapy/selector/unified.py
+++ b/scrapy/selector/unified.py
@@ -146,10 +146,12 @@ class Selector(object_ref):
     def __nonzero__(self):
         return bool(self.extract())
 
-    def __str__(self):
+    def __repr__(self):
         data = repr(self.extract()[:40])
         return "<%s xpath=%r data=%s>" % (type(self).__name__, self._expr, data)
-    __repr__ = __str__
+
+    def __str__(self):
+        return self.extract()
 
     # Deprecated api
     @deprecated(use_instead='.xpath()')

--- a/tests/test_selector.py
+++ b/tests/test_selector.py
@@ -55,6 +55,19 @@ class SelectorTestCase(unittest.TestCase):
             ["<Selector xpath=u'//input[@value=\"\\xa9\"]/@value' data=u'\\xa9'>"]
         )
 
+    def test_str_method(self):
+        body = u"<p>par1</p><p>par2</p>"
+        response = TextResponse(url="http://example.com/", body=body, encoding='utf8')
+        sel = self.sscls(response)
+        self.assertEqual(
+            u'par1, par2',
+            u', '.join(map(unicode, sel.xpath('//p/text()')))
+        )
+        self.assertEqual(
+            [u'[par1]', u'[par2]'],
+            map('[{}]'.format, sel.xpath('//p/text()'))
+        )
+
     def test_select_unicode_query(self):
         body = u"<p><input name='\xa9' value='1'/></p>"
         response = TextResponse(url="http://example.com", body=body, encoding='utf8')


### PR DESCRIPTION
I often use functions that implicitly call ```str()``` upon their arguments
and having to prepend an extract() in the composition seems too noisy to
me. I would expect ```__str__()``` to return the extracted text of the selected
node all along. This doesn't and shouldn't concern SelectorList at all.
I don't see a reason for a __collection__ to have such a method.

I saw many PRs discussing methods for single node extraction,
joined string results etc. I do not mean to replace the functionality
suggested by them.

A note on unicode: I don't understand why this works with unicode text,
I thought ```__str__``` can only return an encoded bytearray. Please comment.
