### PR TITLE
Fixed buildbot tests, after 242c085

### DIFF
--- a/Makefile.buildbot
+++ b/Makefile.buildbot
@@ -6,7 +6,7 @@ endif
 export PYTHONPATH=$(PWD)
 
 test:
-	coverage run --branch $(TRIAL) --reporter=text scrapy.tests
+	coverage run --branch $(TRIAL) --reporter=text tests
 	rm -rf htmlcov && coverage html
 	-s3cmd sync -P htmlcov/ s3://static.scrapy.org/coverage-scrapy-$(BRANCH)/
 


### PR DESCRIPTION
After commit 242c085 buildbot builds started failing because 'scrapy.tests' no longer exists.

This commit updates it to just 'tests'.
