### PR TITLE
[WIP] Support :nth(n), :first, :last pseudo selectors (fixes #842)

### DIFF
--- a/docs/topics/selectors.rst
+++ b/docs/topics/selectors.rst
@@ -206,14 +206,14 @@ extensions as pseudo-elements:
 
 Scrapy also extends CSS3 selectors with the following `structural pseudo-classes`_,
 similar to the standard ``:first-child``, ``:last-child`` and ``:nth-child()``:
- * ``::first`` and ``::last`` select first and last elements
+ * ``:first`` and ``:last`` select first and last elements
    satisfying the current selectors. For example, if you wanted to
    select the last row with class "green" from a table, you could use
    ``table tr.green::last``
- * ``::nth(N)`` is similar to the previous ``::first`` except that you can
+ * ``:nth(N)`` is similar to the previous ``:first`` except that you can
    specify the position of the element you want.
    For example, for the 3rd row with class "green" from a table
-   you would use ``table tr.green::nth(3)``
+   you would use ``table tr.green:nth(3)``
 
 .. _structural pseudo-classes: http://www.w3.org/TR/selectors/#structural-pseudos
 

--- a/docs/topics/selectors.rst
+++ b/docs/topics/selectors.rst
@@ -145,6 +145,11 @@ pseudo-elements::
     >>> response.css('title::text').extract()
     [u'Example website']
 
+.. note::
+
+    These pseudo-elements are **not standard CSS3 syntax**.
+    See :ref:`topics-selectors-css3-extensions` for details.
+
 Now we're going to get the base URL and some image links::
 
     >>> response.xpath('//base/@href').extract()
@@ -180,6 +185,37 @@ Now we're going to get the base URL and some image links::
      u'image3_thumb.jpg',
      u'image4_thumb.jpg',
      u'image5_thumb.jpg']
+
+
+.. _topics-selectors-css3-extensions:
+
+Scrapy extensions to CSS selectors
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+XPath is very powerful but can be hard to read (and maintain) at times.
+CSS selectors' syntax is much simpler and provides helpful shortcuts
+to common selection patterns, but has less features for extracting data
+from HTML documents.
+
+To bridge the gap between the two (a little) Scrapy has added the following
+extensions as pseudo-elements:
+
+ * ``::text`` selects text nodes that are children of the current element
+ * ``::attr(attribute_name)`` selects the value of the attribute passed
+   as argument for the current element
+
+Scrapy also extends CSS3 selectors with the following `structural pseudo-classes`_,
+similar to the standard ``:first-child``, ``:last-child`` and ``:nth-child()``:
+ * ``::first`` and ``::last`` select first and last elements
+   satisfying the current selectors. For example, if you wanted to
+   select the last row with class "green" from a table, you could use
+   ``table tr.green::last``
+ * ``::nth(N)`` is similar to the previous ``::first`` except that you can
+   specify the position of the element you want.
+   For example, for the 3rd row with class "green" from a table
+   you would use ``table tr.green::nth(3)``
+
+.. _structural pseudo-classes: http://www.w3.org/TR/selectors/#structural-pseudos
 
 .. _topics-selectors-nesting-selectors:
 

--- a/docs/topics/selectors.rst
+++ b/docs/topics/selectors.rst
@@ -209,9 +209,10 @@ similar to the standard ``:first-child``, ``:last-child`` and ``:nth-child()``:
  * ``:first`` and ``:last`` select first and last elements
    satisfying the current selectors. For example, if you wanted to
    select the last row with class "green" from a table, you could use
-   ``table tr.green::last``
- * ``:nth(N)`` is similar to the previous ``:first`` except that you can
-   specify the position of the element you want.
+   ``table tr.green:last``
+ * ``:nth(an+b)`` is similar to the previous ``:first`` except that you can
+   specify the position of the element you want, using the same *an+b*
+   notation as the other standard `structural pseudo-classes`_.
    For example, for the 3rd row with class "green" from a table
    you would use ``table tr.green:nth(3)``
 

--- a/scrapy/selector/csstranslator.py
+++ b/scrapy/selector/csstranslator.py
@@ -108,23 +108,24 @@ class TranslatorMixin(object):
         return self.xpath_sibling_predicate(xp, "preceding-sibling", count-1)
 
     def xpath_first_simple_pseudo_element(self, xpath):
-        """Support selecting first child nodes using ::first pseudo-element"""
+        """Support selecting first child nodes using ::first pseudo-class"""
         xpexpr = ScrapyXPathExpr.from_xpath(xpath)
         predicate = self.xpath_first_sibling_predicate(xpexpr)
         xpexpr.append_predicate(predicate)
         return xpexpr
 
     def xpath_last_simple_pseudo_element(self, xpath):
-        """Support selecting last child nodes using ::last pseudo-element"""
+        """Support selecting last child nodes using ::last pseudo-class"""
         xpexpr = ScrapyXPathExpr.from_xpath(xpath)
         predicate = self.xpath_last_sibling_predicate(xpexpr)
         xpexpr.append_predicate(predicate)
         return xpexpr
 
     def xpath_nth_functional_pseudo_element(self, xpath, function):
+        """Support selecting n-th child nodes using ::nth(N) pseudo-class"""
         if function.argument_types() not in (['NUMBER'],):
             raise ExpressionError(
-                "Expected a single string or ident for ::nth(), got %r"
+                "Expected a single number for ::nth(), got %r"
                 % function.arguments)
         xpexpr = ScrapyXPathExpr.from_xpath(xpath)
         predicate = self.xpath_nth_sibling_predicate(xpexpr, int(function.arguments[0].value))

--- a/scrapy/selector/csstranslator.py
+++ b/scrapy/selector/csstranslator.py
@@ -146,12 +146,14 @@ class TranslatorMixin(object):
         if a != 1:
             # last() - position() - b +1 = an
             if last:
-                left = '(last() - position())'
+                left = 'last() - position()'
             # position() - b = an
             else:
                 left = 'position()'
             if b != 0:
-                left = '(%s %s)' % (left, b_neg)
+                left = '%s %s' % (left, b_neg)
+            if last or b != 0:
+                left = '(%s)' % left
             expr = ['%s mod %s = 0' % (left, a)]
         else:
             expr = []

--- a/scrapy/selector/csstranslator.py
+++ b/scrapy/selector/csstranslator.py
@@ -92,17 +92,32 @@ class TranslatorMixin(object):
             predicate += "[%s]" % xpexpr.condition
         return "count(%s)=%d" % (predicate, count)
 
+    def xpath_first_sibling_predicate(self, xp):
+        if xp.path:
+            return "0"
+        return self.xpath_sibling_predicate(xp, "preceding-sibling", 0)
+
+    def xpath_last_sibling_predicate(self, xp):
+        if xp.path:
+            return "last()"
+        return self.xpath_sibling_predicate(xp, "following-sibling", 0)
+
+    def xpath_nth_sibling_predicate(self, xp, count):
+        if xp.path:
+            return count
+        return self.xpath_sibling_predicate(xp, "preceding-sibling", count-1)
+
     def xpath_first_simple_pseudo_element(self, xpath):
         """Support selecting first child nodes using ::first pseudo-element"""
         xpexpr = ScrapyXPathExpr.from_xpath(xpath)
-        predicate = self.xpath_sibling_predicate(xpexpr, "preceding-sibling", 0)
+        predicate = self.xpath_first_sibling_predicate(xpexpr)
         xpexpr.append_predicate(predicate)
         return xpexpr
 
     def xpath_last_simple_pseudo_element(self, xpath):
         """Support selecting last child nodes using ::last pseudo-element"""
         xpexpr = ScrapyXPathExpr.from_xpath(xpath)
-        predicate = self.xpath_sibling_predicate(xpexpr, "following-sibling", 0)
+        predicate = self.xpath_last_sibling_predicate(xpexpr)
         xpexpr.append_predicate(predicate)
         return xpexpr
 
@@ -112,8 +127,7 @@ class TranslatorMixin(object):
                 "Expected a single string or ident for ::nth(), got %r"
                 % function.arguments)
         xpexpr = ScrapyXPathExpr.from_xpath(xpath)
-        predicate = self.xpath_sibling_predicate(xpexpr, "preceding-sibling",
-            int(function.arguments[0].value)-1)
+        predicate = self.xpath_nth_sibling_predicate(xpexpr, int(function.arguments[0].value))
         xpexpr.append_predicate(predicate)
         return xpexpr
 

--- a/scrapy/selector/csstranslator.py
+++ b/scrapy/selector/csstranslator.py
@@ -1,6 +1,6 @@
 from cssselect import GenericTranslator, HTMLTranslator
 from cssselect.xpath import _unicode, _unicode_safe_getattr, XPathExpr, ExpressionError
-from cssselect.parser import FunctionalPseudoElement
+from cssselect.parser import FunctionalPseudoElement, parse_series
 
 
 class ScrapyXPathExpr(XPathExpr):
@@ -13,10 +13,21 @@ class ScrapyXPathExpr(XPathExpr):
         x = cls(path=xpath.path, element=xpath.element, condition=xpath.condition)
         x.textnode = textnode
         x.attribute = attribute
+        x.post_condition = None
         return x
+
+    def add_post_condition(self, post_condition):
+        if self.post_condition:
+            self.post_condition = '%s and (%s)' % (self.post_condition,
+                                                   post_condition)
+        else:
+            self.post_condition = post_condition
+        return self
 
     def __str__(self):
         path = super(ScrapyXPathExpr, self).__str__()
+        if self.post_condition:
+            path = '%s[%s]' % (path, self.post_condition)
         if self.textnode:
             if path == '*':
                 path = 'text()'
@@ -35,6 +46,7 @@ class ScrapyXPathExpr(XPathExpr):
         super(ScrapyXPathExpr, self).join(combiner, other)
         self.textnode = other.textnode
         self.attribute = other.attribute
+        self.post_condition = other.post_condition
         return self
 
 
@@ -77,37 +89,111 @@ class TranslatorMixin(object):
         """Support selecting text nodes using ::text pseudo-element"""
         return ScrapyXPathExpr.from_xpath(xpath, textnode=True)
 
-    def xpath_sibling_predicate(self, xpexpr, axis, count):
-        predicate = "%s::%s" % (axis, _unicode(xpexpr.element))
-        if xpexpr.condition:
-            predicate += "[%s]" % xpexpr.condition
-        return "count(%s)=%d" % (predicate, count)
-
     def xpath_first_pseudo(self, xpath):
         """Support selecting first child nodes using :first pseudo-class"""
-        xpexpr = ScrapyXPathExpr.from_xpath(xpath)
-        predicate = self.xpath_sibling_predicate(xpexpr, "preceding-sibling", 0)
-        xpexpr.add_condition(predicate)
-        return xpexpr
+        xpath.add_star_prefix()
+        return xpath.add_post_condition("position() = 1")
 
     def xpath_last_pseudo(self, xpath):
         """Support selecting last child nodes using :last pseudo-class"""
-        xpexpr = ScrapyXPathExpr.from_xpath(xpath)
-        predicate = self.xpath_sibling_predicate(xpexpr, "following-sibling", 0)
-        xpexpr.add_condition(predicate)
-        return xpexpr
+        xpath.add_star_prefix()
+        return xpath.add_post_condition("position() = last()")
+
+    def xpath_anb_condition(self, function, last=False):
+        try:
+            a, b = parse_series(function.arguments)
+        except ValueError:
+            raise ExpressionError("Invalid series: '%r'" % function.arguments)
+        # non-last
+        # --------
+        #    position() = an+b
+        # -> position() - b = an
+        #
+        # if a < 0:
+        #    position() - b <= 0
+        # -> position() <= b
+        #
+        # last
+        # ----
+        #    last() - position() = an+b -1
+        # -> last() - position() - b +1 = an
+        #
+        # if a < 0:
+        #    last() - position() - b +1 <= 0
+        # -> position() >= last() - b +1
+        #
+        # -b +1 = -(b-1)
+        if last:
+            b = b - 1
+        if b > 0:
+            b_neg = str(-b)
+        else:
+            b_neg = '+%s' % (-b)
+        if a == 0:
+            if last:
+                # http://www.w3.org/TR/selectors/#nth-last-child-pseudo
+                # The :nth-last-child(an+b) pseudo-class notation represents
+                # an element that has an+b-1 siblings after it in the document tree
+                #
+                #    last() - position() = an+b-1
+                # -> position() = last() -b +1 (for a==0)
+                #
+                if b == 0:
+                    b = 'last()'
+                else:
+                    b = 'last() %s' % b_neg
+            return 'position() = %s' % b
+        if a != 1:
+            # last() - position() - b +1 = an
+            if last:
+                left = '(last() - position())'
+            # position() - b = an
+            else:
+                left = 'position()'
+            if b != 0:
+                left = '(%s %s)' % (left, b_neg)
+            expr = ['%s mod %s = 0' % (left, a)]
+        else:
+            expr = []
+        if last:
+            if b == 0:
+                right = 'last()'
+            else:
+                right = 'last() %s' % b_neg
+            if a > 0:
+                expr.append('(position() <= %s)' % right)
+            else:
+                expr.append('(position() >= %s)' % right)
+        else:
+            # position() > 0 so if b < 0, then position() > b
+            # also, position() >= 1 always
+            if b > 1:
+                if a > 0:
+                    expr.append('position() >= %s' % b)
+                else:
+                    expr.append('position() <= %s' % b)
+
+        expr = ' and '.join(expr)
+        if expr:
+            return expr
 
     def xpath_nth_function(self, xpath, function):
-        """Support selecting n-th child nodes using ::nth(N) pseudo-class"""
-        if function.argument_types() not in (['NUMBER'],):
-            raise ExpressionError(
-                "Expected a single number for ::nth(), got %r"
-                % function.arguments)
-        xpexpr = ScrapyXPathExpr.from_xpath(xpath)
-        predicate = self.xpath_sibling_predicate(xpexpr, "preceding-sibling",
-            int(function.arguments[0].value)-1)
-        xpexpr.add_condition(predicate)
-        return xpexpr
+        """Support selecting n-th child nodes using :nth(an+b) pseudo-class"""
+        xpath.add_star_prefix()
+        cond = self.xpath_anb_condition(function, last=False)
+        if cond:
+            return xpath.add_post_condition(cond)
+        else:
+            return xpath
+
+    def xpath_nth_last_function(self, xpath, function):
+        """Support selecting n-th child nodes using :nth-last(an+b) pseudo-class"""
+        xpath.add_star_prefix()
+        cond = self.xpath_anb_condition(function, last=True)
+        if cond:
+            return xpath.add_post_condition(cond)
+        else:
+            return xpath
 
 
 class ScrapyGenericTranslator(TranslatorMixin, GenericTranslator):

--- a/tests/test_selector_csstranslator.py
+++ b/tests/test_selector_csstranslator.py
@@ -85,12 +85,22 @@ class TranslatorMixinTest(unittest.TestCase):
             ('a[href]::text', u'descendant-or-self::a[@href]/text()'),
             ('a[href] ::text', u'descendant-or-self::a[@href]/descendant-or-self::text()'),
             ('p::text, a::text', u"descendant-or-self::p/text() | descendant-or-self::a/text()"),
+        ]
+        for css, xpath in cases:
+            self.assertEqual(self.c2x(css), xpath, css)
+
+    def test_nth_pseudo_element(self):
+        cases = [
             ('p.red::last', u"descendant-or-self::p[@class and contains(concat(' ', normalize-space(@class), ' '), ' red ')]"
                              "[count(following-sibling::p[@class and contains(concat(' ', normalize-space(@class), ' '), ' red ')])=0]"),
             ('input[type=checkbox]::first', u"descendant-or-self::input[@type = 'checkbox']"
                                              "[count(preceding-sibling::input[@type = 'checkbox'])=0]"),
             ('input[type=checkbox]::nth(3)', u"descendant-or-self::input[@type = 'checkbox']"
                                               "[count(preceding-sibling::input[@type = 'checkbox'])=2]"),
+            ('p > input[type=checkbox]::nth(3)', u"descendant-or-self::p/input[@type = 'checkbox'][3]"),
+            ('div > p.last > ul::nth(3)', u"descendant-or-self::div"
+                                           "/p[@class and contains(concat(' ', normalize-space(@class), ' '), ' last ')]"
+                                           "/ul[3]"),
         ]
         for css, xpath in cases:
             self.assertEqual(self.c2x(css), xpath, css)

--- a/tests/test_selector_csstranslator.py
+++ b/tests/test_selector_csstranslator.py
@@ -89,18 +89,27 @@ class TranslatorMixinTest(unittest.TestCase):
         for css, xpath in cases:
             self.assertEqual(self.c2x(css), xpath, css)
 
-    def test_nth_pseudo_element(self):
+    def test_nth_pseudo_class(self):
         cases = [
-            ('p.red::last', u"descendant-or-self::p[@class and contains(concat(' ', normalize-space(@class), ' '), ' red ')]"
-                             "[count(following-sibling::p[@class and contains(concat(' ', normalize-space(@class), ' '), ' red ')])=0]"),
-            ('input[type=checkbox]::first', u"descendant-or-self::input[@type = 'checkbox']"
-                                             "[count(preceding-sibling::input[@type = 'checkbox'])=0]"),
-            ('input[type=checkbox]::nth(3)', u"descendant-or-self::input[@type = 'checkbox']"
-                                              "[count(preceding-sibling::input[@type = 'checkbox'])=2]"),
-            ('p > input[type=checkbox]::nth(3)', u"descendant-or-self::p/input[@type = 'checkbox'][3]"),
-            ('div > p.last > ul::nth(3)', u"descendant-or-self::div"
-                                           "/p[@class and contains(concat(' ', normalize-space(@class), ' '), ' last ')]"
-                                           "/ul[3]"),
+            ('p.red:last', u"descendant-or-self::p"
+                            "[@class and contains(concat(' ', normalize-space(@class), ' '), ' red ')"
+                            " and (count(following-sibling::p[@class and contains(concat(' ', normalize-space(@class), ' '), ' red ')])=0)]"),
+            ('input[type=checkbox]:first', u"descendant-or-self::input"
+                                            "[@type = 'checkbox'"
+                                            " and (count(preceding-sibling::input[@type = 'checkbox'])=0)]"),
+            ('input[type=checkbox]:nth(3)', u"descendant-or-self::input"
+                                             "[@type = 'checkbox'"
+                                             " and (count(preceding-sibling::input[@type = 'checkbox'])=2)]"),
+            ('p input[type=checkbox]:nth(3)', u"descendant-or-self::p"
+                                               "/descendant-or-self::*/input"
+                                               "[@type = 'checkbox'"
+                                               " and (count(preceding-sibling::input[@type = 'checkbox'])=2)]"),
+            ('p > input[type=checkbox]:nth(3)', u"descendant-or-self::p/input"
+                                                 "[@type = 'checkbox'"
+                                                 " and (count(preceding-sibling::input[@type = 'checkbox'])=2)]"),
+            ('div > p.last > ul:nth(3)', u"descendant-or-self::div"
+                                         "/p[@class and contains(concat(' ', normalize-space(@class), ' '), ' last ')]"
+                                         "/ul[count(preceding-sibling::ul)=2]"),
         ]
         for css, xpath in cases:
             self.assertEqual(self.c2x(css), xpath, css)
@@ -168,10 +177,16 @@ class CSSSelectorTest(unittest.TestCase):
         self.assertEqual(self.sel.css('div').css('area:last-child').extract(),
                          [u'<area shape="default" id="area-nohref">'])
 
-    def test_nth_pseudo_element(self):
-        self.assertEqual(self.x('b::nth(2)'), [u'<b id="p-b2">guy</b>'])
+    def test_nth_pseudo_class(self):
+        self.assertEqual(self.x('b:nth(2)'), [u'<b id="p-b2">guy</b>'])
 
-    def test_last_pseudo_element(self):
-        self.assertEqual(self.x('input[type=checkbox]::last'),
+    def test_first_pseudo_class(self):
+        self.assertEqual(self.x('p#paragraph b:first'), [u'<b id="p-b">hi</b>'])
+        self.assertEqual(self.x('map[name=dummymap] > area:first'),
+            [u'<area shape="circle" coords="200,250,25" href="foo.html" id="area-href">'])
+        self.assertEqual(self.x('div:first p:first b:first'), [u'<b id="p-b">hi</b>'])
+
+    def test_last_pseudo_class(self):
+        self.assertEqual(self.x('input[type=checkbox]:last'),
                          [u'<input type="checkbox" id="checkbox-disabled-checked" disabled checked>',
                           u'<input type="checkbox" id="checkbox-fieldset-disabled">'])

--- a/tests/test_selector_csstranslator.py
+++ b/tests/test_selector_csstranslator.py
@@ -105,7 +105,7 @@ class TranslatorMixinTest(unittest.TestCase):
             ('div > a[id*=anchor]:nth-last(2n+1)', u"descendant-or-self::div/a[@id and contains(@id, 'anchor')][(last() - position()) mod 2 = 0 and (position() <= last())]"),
             ('p#paragraph > input[type=checkbox]:nth-last(-n+2)', u"descendant-or-self::p[@id = 'paragraph']"
                                                                    "/input[@type = 'checkbox']"
-                                                                         "[((last() - position()) -1) mod -1 = 0 and (position() >= last() -1)]"),
+                                                                         "[(last() - position() -1) mod -1 = 0 and (position() >= last() -1)]"),
         ]
         for css, xpath in cases:
             self.assertEqual(self.c2x(css), xpath, css)

--- a/tests/test_selector_csstranslator.py
+++ b/tests/test_selector_csstranslator.py
@@ -85,6 +85,12 @@ class TranslatorMixinTest(unittest.TestCase):
             ('a[href]::text', u'descendant-or-self::a[@href]/text()'),
             ('a[href] ::text', u'descendant-or-self::a[@href]/descendant-or-self::text()'),
             ('p::text, a::text', u"descendant-or-self::p/text() | descendant-or-self::a/text()"),
+            ('p.red::last', u"descendant-or-self::p[@class and contains(concat(' ', normalize-space(@class), ' '), ' red ')]"
+                             "[count(following-sibling::p[@class and contains(concat(' ', normalize-space(@class), ' '), ' red ')])=0]"),
+            ('input[type=checkbox]::first', u"descendant-or-self::input[@type = 'checkbox']"
+                                             "[count(preceding-sibling::input[@type = 'checkbox'])=0]"),
+            ('input[type=checkbox]::nth(3)', u"descendant-or-self::input[@type = 'checkbox']"
+                                              "[count(preceding-sibling::input[@type = 'checkbox'])=2]"),
         ]
         for css, xpath in cases:
             self.assertEqual(self.c2x(css), xpath, css)
@@ -151,3 +157,11 @@ class CSSSelectorTest(unittest.TestCase):
                          [u'hi', u'guy'])
         self.assertEqual(self.sel.css('div').css('area:last-child').extract(),
                          [u'<area shape="default" id="area-nohref">'])
+
+    def test_nth_pseudo_element(self):
+        self.assertEqual(self.x('b::nth(2)'), [u'<b id="p-b2">guy</b>'])
+
+    def test_last_pseudo_element(self):
+        self.assertEqual(self.x('input[type=checkbox]::last'),
+                         [u'<input type="checkbox" id="checkbox-disabled-checked" disabled checked>',
+                          u'<input type="checkbox" id="checkbox-fieldset-disabled">'])


### PR DESCRIPTION
~~Known limitation: you cannot write something like `div > p::last > ul::first` because cssselect doesn't support non-terminating pseudo elements~~ This is not true anymore: the latest iteration uses pseudo-classes so you can chain `:first`, `:last` and `:nth()`

