### PR TITLE
"import scrapy" does not import spider

### DIFF
--- a/docs/intro/tutorial.rst
+++ b/docs/intro/tutorial.rst
@@ -123,9 +123,9 @@ define the three main mandatory attributes:
 This is the code for our first Spider; save it in a file named
 ``dmoz_spider.py`` under the ``tutorial/spiders`` directory::
 
-    import scrapy
+    import scrapy.spider
 
-    class DmozSpider(scrapy.Spider):
+    class DmozSpider(scrapy.spider):
         name = "dmoz"
         allowed_domains = ["dmoz.org"]
         start_urls = [


### PR DESCRIPTION
Running Scrapy 0.16.4 in Python 2.7.8 on Mac OSX 10.9.4. The function "import scrapy" does not import spiders - this seems to require "import scrapy.spider".
