### PR TITLE
fix IPython shell scope issue by using IPython.embed()

### DIFF
--- a/scrapy/utils/console.py
+++ b/scrapy/utils/console.py
@@ -13,16 +13,16 @@ def start_python_console(namespace=None, noipython=False, banner=''):
                 raise ImportError()
 
             try:
-                try:
-                    from IPython.terminal import embed
-                except ImportError:
-                    from IPython.frontend.terminal import embed
-                sh = embed.InteractiveShellEmbed(banner1=banner)
+                from IPython.terminal.embed import InteractiveShellEmbed
+                from IPython.terminal.ipapp import load_default_config
             except ImportError:
-                from IPython.Shell import IPShellEmbed
-                sh = IPShellEmbed(banner=banner)
+                from IPython.frontend.terminal.embed import InteractiveShellEmbed
+                from IPython.frontend.terminal.ipapp import load_default_config
 
-            sh(global_ns={}, local_ns=namespace)
+            config = load_default_config()
+            shell = InteractiveShellEmbed(
+                banner1=banner, user_ns=namespace, config=config)
+            shell()
         except ImportError:
             import code
             try: # readline module is only available on unix systems


### PR DESCRIPTION
Hey folks,

So, this is my attempt to fix issue #794.
I discovered that using `IPython.embed` function handles the scoping correctly.
Plus, it will also respect the configuration in the IPython's user default profile.

To verify the change of behavior, this was my test:

```
>>> a = 1
>>> (lambda: a)()
1
```

Before the changes:

```
$ scrapy shell
....
In [1]: a = 1

In [2]: (lambda: a)()
---------------------------------------------------------------------------
NameError                                 Traceback (most recent call last)
<ipython-input-2-3ca364159dc4> in <module>()
----> 1 (lambda: a)()

<ipython-input-2-3ca364159dc4> in <lambda>()
----> 1 (lambda: a)()

NameError: global name 'a' is not defined
```

After the changes:

```
scrapy shell
....
>>> a = 1
>>> (lambda: a)()
    1
```

<sub>Note how in this session IPython loads using the ">>> " prompt I've configured in my user profile.<sub>

Relevant IPython documentation: https://github.com/ipython/ipython/wiki/Cookbook%3a-Updating-code-for-use-with-IPython-0.11-and-later#Embedding_API

Does this look OK?
