### PR TITLE
[WIP] fix xmliter namespace on selected node

### DIFF
--- a/tests/test_utils_iterators.py
+++ b/tests/test_utils_iterators.py
@@ -61,7 +61,6 @@ class XmliterTestCase(unittest.TestCase):
         """
         response = XmlResponse(url='http://mydummycompany.com', body=body)
         my_iter = self.xmliter(response, 'item')
-
         node = next(my_iter)
         node.register_namespace('g', 'http://base.google.com/ns/1.0')
         self.assertEqual(node.xpath('title/text()').extract(), ['Item 1'])
@@ -73,6 +72,11 @@ class XmliterTestCase(unittest.TestCase):
         self.assertEqual(node.xpath('image_link/text()').extract(), [])
         self.assertEqual(node.xpath('id/text()').extract(), [])
         self.assertEqual(node.xpath('price/text()').extract(), [])
+
+        my_iter = self.xmliter(response, 'g:image_link')
+        node = next(my_iter)
+        node.register_namespace('g', 'http://base.google.com/ns/1.0')
+        self.assertEqual(node.xpath('text()').extract(), ['http://www.mydummycompany.com/images/item1.jpg'])
 
     def test_xmliter_exception(self):
         body = u"""<?xml version="1.0" encoding="UTF-8"?><products><product>one</product><product>two</product></products>"""


### PR DESCRIPTION
This PR was triggered by [scrapy-users](https://groups.google.com/forum/#!topic/scrapy-users/VN6409UHexQ)

Actually `xmliter` populates a `Selector` with everything from the position 0 to the tag start, so if we had 100mb before the tag we want to iter it copy those 100mb across all the `Selector` objects. Also it just extract this info for the first tag and embed the rest on that, this can cause info crossing.

In this PR I kept the regex stuff even tho I think we should use something like [`iterparse`](https://docs.python.org/2/library/xml.etree.elementtree.html#xml.etree.ElementTree.iterparse).

Currently `xmliter_lxml` tests are failing due to it has a different API.
