### PR TITLE
SgmlLinkExtractor - fix for parsing <area> tag with Unicode present

### DIFF
--- a/scrapy/contrib/linkextractors/sgml.py
+++ b/scrapy/contrib/linkextractors/sgml.py
@@ -67,6 +67,7 @@ class BaseSgmlLinkExtractor(SGMLParser):
         SGMLParser.reset(self)
         self.links = []
         self.base_url = None
+        self.current_link = None
 
     def unknown_starttag(self, tag, attrs):
         if tag == 'base':

--- a/tests/test_contrib_linkextractors.py
+++ b/tests/test_contrib_linkextractors.py
@@ -284,6 +284,17 @@ class SgmlLinkExtractorTestCase(unittest.TestCase):
                          [Link(url='http://example.org/foo', text=u'>\u4eac<\u4e1c',
                                fragment='', nofollow=False)])
 
+    def test_area_tag_with_unicode_present(self):
+        body = """<html><body>\xbe\xa9<map><area href="http://example.org/foo" /></map></body></html>"""
+        response = HtmlResponse("http://example.org", body=body, encoding='utf-8')
+        lx = self.extractor_cls()
+        lx.extract_links(response)
+        lx.extract_links(response)
+        lx.extract_links(response)
+        self.assertEqual(lx.extract_links(response),
+                         [Link(url='http://example.org/foo', text=u'',
+                               fragment='', nofollow=False)])
+
     def test_encoded_url(self):
         body = """<html><body><div><a href="?page=2">BinB</a></body></html>"""
         response = HtmlResponse("http://known.fm/AC%2FDC/", body=body, encoding='utf8')


### PR DESCRIPTION
`current_link` wasn't cleaned during reset and might have been reused for next pass of `extract_links`. Easiest way to see it is to try to 'extract_links' from response containing `<area>` tag or un-closed `<a>` tag two times in a row.

Additionally text field of link was converted to Unicode so when it was reused `handle_data` tried to concatenate Unicode and string and if string contained any characters not from ascii range it died with exception `UnicodeError`.
