### PR TITLE
[MRG] process robots.txt once

### DIFF
--- a/docs/topics/downloader-middleware.rst
+++ b/docs/topics/downloader-middleware.rst
@@ -785,10 +785,18 @@ RobotsTxtMiddleware
     and the :setting:`ROBOTSTXT_OBEY` setting is enabled.
 
     .. warning:: Keep in mind that, if you crawl using multiple concurrent
-       requests per domain, Scrapy could still  download some forbidden pages
+       requests per domain, Scrapy could still download some forbidden pages
        if they were requested before the robots.txt file was downloaded. This
        is a known limitation of the current robots.txt middleware and will
        be fixed in the future.
+
+.. reqmeta:: dont_obey_robotstxt
+
+If :attr:`Request.meta <scrapy.http.Request.meta>` has
+``dont_obey_robotstxt`` key set to True
+the request will be ignored by this middleware even if
+:setting:`ROBOTSTXT_OBEY` is enabled.
+
 
 DownloaderStats
 ---------------

--- a/docs/topics/request-response.rst
+++ b/docs/topics/request-response.rst
@@ -228,6 +228,7 @@ Those are:
 * :reqmeta:`cookiejar`
 * :reqmeta:`redirect_urls`
 * :reqmeta:`bindaddress`
+* :reqmeta:`dont_obey_robotstxt`
 
 .. reqmeta:: bindaddress
 


### PR DESCRIPTION
Currently RobotsTxtMiddleware processes requests to robots.txt it is sending. If an initial request was a redirect then 2 requests to robots.txt are sent. To fix that I've added `dont_obey_robotstxt` Request.meta flag; initially it was private, but as it can be useful for users it is made public. Also, an unused `self._spider_netlocs` set is deleted.
