### PR TITLE
[MRG] DOC document download_timeout 

### DIFF
--- a/docs/topics/downloader-middleware.rst
+++ b/docs/topics/downloader-middleware.rst
@@ -263,7 +263,14 @@ DownloadTimeoutMiddleware
 .. class:: DownloadTimeoutMiddleware
 
     This middleware sets the download timeout for requests specified in the
-    :setting:`DOWNLOAD_TIMEOUT` setting.
+    :setting:`DOWNLOAD_TIMEOUT` setting or :attr:`download_timeout`
+    spider attribute.
+
+.. note::
+
+    You can also set download timeout per-request using
+    :reqmeta:`download_timeout` Request.meta key; this is supported
+    even when DownloadTimeoutMiddleware is disabled.
 
 HttpAuthMiddleware
 ------------------

--- a/docs/topics/request-response.rst
+++ b/docs/topics/request-response.rst
@@ -229,6 +229,7 @@ Those are:
 * :reqmeta:`redirect_urls`
 * :reqmeta:`bindaddress`
 * :reqmeta:`dont_obey_robotstxt`
+* :reqmeta:`download_timeout`
 
 .. reqmeta:: bindaddress
 
@@ -236,6 +237,15 @@ bindaddress
 -----------
 
 The IP of the outgoing IP address to use for the performing the request.
+
+.. reqmeta:: download_timeout
+
+download_timeout
+----------------
+
+The amount of time (in secs) that the downloader will wait before timing out.
+See also: :setting:`DOWNLOAD_TIMEOUT`.
+
 
 .. _topics-request-response-ref-request-subclasses:
 

--- a/docs/topics/settings.rst
+++ b/docs/topics/settings.rst
@@ -416,6 +416,12 @@ Default: ``180``
 
 The amount of time (in secs) that the downloader will wait before timing out.
 
+.. note::
+
+    This timeout can be set per spider using :attr:`download_timeout`
+    spider attribute and per-request using :reqmeta:`download_timeout`
+    Request.meta key.
+
 .. setting:: DUPEFILTER_CLASS
 
 DUPEFILTER_CLASS


### PR DESCRIPTION
Neither Request.meta key nor Spider attribute were documented.
