### PR TITLE
idna-encode netloc for international domains

### DIFF
--- a/scrapy/utils/url.py
+++ b/scrapy/utils/url.py
@@ -12,7 +12,7 @@ import cgi
 
 # scrapy.utils.url was moved to w3lib.url and import * ensures this move doesn't break old code
 from w3lib.url import *
-from scrapy.utils.python import unicode_to_str
+from scrapy.utils.python import unicode_to_str, str_to_unicode
 
 
 def url_is_from_any_domain(url, domains):
@@ -54,6 +54,8 @@ def canonicalize_url(url, keep_blank_values=True, keep_fragments=False,
     """
 
     scheme, netloc, path, params, query, fragment = parse_url(url)
+    netloc = str_to_unicode(netloc, encoding=encoding)
+    netloc = unicode_to_str(netloc.encode('idna'),encoding=encoding)
     keyvals = cgi.parse_qsl(query, keep_blank_values)
     keyvals.sort()
     query = urllib.urlencode(keyvals)

--- a/tests/test_utils_url.py
+++ b/tests/test_utils_url.py
@@ -1,3 +1,4 @@
+# coding:utf-8
 import unittest
 
 from scrapy.spider import Spider
@@ -75,8 +76,12 @@ class UrlUtilsTest(unittest.TestCase):
         self.assertEqual(canonicalize_url("http://www.example.com/"),
                                           "http://www.example.com/")
 
+        self.assertEqual(canonicalize_url(u"http://www.➡.com"),
+                                          "http://www.xn--hgi.com/")
+
         # always return a str
-        assert isinstance(canonicalize_url(u"http://www.example.com"), str)
+        assert isinstance(canonicalize_url(u"http://example.com"), str)
+        assert isinstance(canonicalize_url(u"http://www.➡.com/"), str)
 
         # append missing path
         self.assertEqual(canonicalize_url("http://www.example.com"),


### PR DESCRIPTION
IDNA-encode netloc for international domains when doing url canocalization. Proposed fix for #855