### PR TITLE
updated deprecated cgi.parse_qsl to use six's parse_qsl

### DIFF
--- a/scrapy/utils/url.py
+++ b/scrapy/utils/url.py
@@ -6,9 +6,9 @@ Some of the functions that used to be imported from this module have been moved
 to the w3lib.url module. Always import those from there instead.
 """
 import posixpath
-from six.moves.urllib.parse import ParseResult, urlunparse, urldefrag, urlparse
+from six.moves.urllib.parse import (ParseResult, urlunparse, urldefrag,
+                                    urlparse, parse_qsl)
 import urllib
-import cgi
 
 # scrapy.utils.url was moved to w3lib.url and import * ensures this move doesn't break old code
 from w3lib.url import *
@@ -54,7 +54,7 @@ def canonicalize_url(url, keep_blank_values=True, keep_fragments=False,
     """
 
     scheme, netloc, path, params, query, fragment = parse_url(url)
-    keyvals = cgi.parse_qsl(query, keep_blank_values)
+    keyvals = parse_qsl(query, keep_blank_values)
     keyvals.sort()
     query = urllib.urlencode(keyvals)
     path = safe_url_string(_unquotepath(path)) or '/'


### PR DESCRIPTION
According to Python 2 documentation: https://docs.python.org/2/library/cgi.html#cgi.parse_qsl

> "This function is deprecated in this module. Use urlparse.parse_qsl() instead. It is maintained here only for backward compatiblity."

For future compatibility with Python 3, the `scrapy.utils.url` module is updated to use `six` library's `urllib.parse.parse_qsl` instead.
https://pythonhosted.org/six/#module-six.moves.urllib.parse
