### PR TITLE
delete empty file created when no items scraped #872

### DIFF
--- a/tests/test_contrib_feedexport.py
+++ b/tests/test_contrib_feedexport.py
@@ -46,7 +46,8 @@ class FileFeedStorageTest(unittest.TestCase):
         self.assertTrue(os.path.exists(path))
         with open(path, 'rb') as fp:
             self.assertEqual(fp.read(), b"content")
-
+        yield storage.clean()
+        self.assertFalse(os.path.exists(path))
 
 class FTPFeedStorageTest(unittest.TestCase):
 


### PR DESCRIPTION
When no items are scraped, scrapy create empty file in the disk. this pull request will delete the empty file created. #872 

