### PR TITLE
[MRG+1] encode unicode selector exception

### DIFF
--- a/scrapy/selector/unified.py
+++ b/scrapy/selector/unified.py
@@ -3,6 +3,7 @@ XPath selectors based on lxml
 """
 
 from lxml import etree
+import six
 
 from scrapy.utils.misc import extract_regex
 from scrapy.utils.trackref import object_ref
@@ -95,7 +96,8 @@ class Selector(object_ref):
             result = xpathev(query, namespaces=self.namespaces,
                              smart_strings=self._lxml_smart_strings)
         except etree.XPathError:
-            raise ValueError("Invalid XPath: %s" % query)
+            msg = u"Invalid XPath: %s" % query
+            raise ValueError(msg if six.PY3 else msg.encode("unicode_escape"))
 
         if type(result) is not list:
             result = [result]


### PR DESCRIPTION
The exception quotes an xpath string
which may be unicode.

When an invalid xpath contains wide characters
eg ```sel.xpath(u'//x[@y="з"/]')``` (this is a Cyrilic "z", not a "3")
they end up verbatim in the exception message (which quotes the xpath).
Unicode strings should be encoded http://bugs.python.org/issue2517
Currently a UnicodeEncodeError (eg ``` UnicodeEncodeError('ascii', u'Invalid XPath: //x[@y="\u0437"/]', 23, 24, 'ordinal not in range(128)')```) hides the original exception.

~~In this PR I encode the exception message to utf8 and update the relevant test.~~
In this PR I encode the exception message to unicode_escape in python2 and update the relevant tests.