### PR TITLE
Save the lxml link subtree when extracting links.

### DIFF
--- a/scrapy/contrib/linkextractors/lxmlhtml.py
+++ b/scrapy/contrib/linkextractors/lxmlhtml.py
@@ -57,7 +57,7 @@ class LxmlParserLinkExtractor(object):
                 url = url.encode(response_encoding)
             # to fix relative links after process_value
             url = urljoin(response_url, url)
-            link = Link(url, _collect_string_content(el) or u'',
+            link = Link(url, _collect_string_content(el) or u'', element=el,
                 nofollow=True if el.get('rel') == 'nofollow' else False)
             links.append(link)
 

--- a/scrapy/link.py
+++ b/scrapy/link.py
@@ -10,9 +10,9 @@ import six
 class Link(object):
     """Link objects represent an extracted link by the LinkExtractor."""
 
-    __slots__ = ['url', 'text', 'fragment', 'nofollow']
+    __slots__ = ['url', 'text', 'fragment', 'nofollow', 'element']
 
-    def __init__(self, url, text='', fragment='', nofollow=False):
+    def __init__(self, url, text='', fragment='', nofollow=False, element=None):
         if isinstance(url, six.text_type):
             import warnings
             warnings.warn("Do not instantiate Link objects with unicode urls. "
@@ -22,6 +22,7 @@ class Link(object):
         self.text = text
         self.fragment = fragment
         self.nofollow = nofollow
+        self.element = element
 
     def __eq__(self, other):
         return self.url == other.url and self.text == other.text and \


### PR DESCRIPTION
Some crawler tasks require extracting additional information out of the
node subtree that the link URL came from. Recording the text contents of
the subtree isn't always enough.

Only LxmlLinkExtractor saves this context at the moment, because it's
not clear what the other types of link extractors should save.
