### PR TITLE
Crawlspider rule enhancements

### DIFF
--- a/docs/topics/spiders.rst
+++ b/docs/topics/spiders.rst
@@ -386,7 +386,7 @@ Let's now take a look at an example CrawlSpider with rules::
 
             # Extract links matching 'item.php' only from 'category' pages and parse
             # them with the spider's method parse_item
-            Rule(LinkExtractor(allow=('item\.php', ), in_='category'), callback='parse_item'),
+            Rule(LinkExtractor(allow=('item\.php', )), in_='category', callback='parse_item'),
         )
 
         def parse_item(self, response):

--- a/scrapy/contrib/spiders/crawl.py
+++ b/scrapy/contrib/spiders/crawl.py
@@ -16,10 +16,13 @@ def identity(x):
 
 class Rule(object):
 
-    def __init__(self, link_extractor, callback=None, cb_kwargs=None, follow=None, process_links=None, process_request=identity):
+    def __init__(self, link_extractor, callback=None, cb_kwargs=None, to=None, in_=None,
+                 follow=None, process_links=None, process_request=identity):
         self.link_extractor = link_extractor
         self.callback = callback
         self.cb_kwargs = cb_kwargs or {}
+        self.to = to
+        self.in_ = in_
         self.process_links = process_links
         self.process_request = process_request
         if follow is None:
@@ -49,6 +52,13 @@ class CrawlSpider(Spider):
             return
         seen = set()
         for n, rule in enumerate(self._rules):
+            if rule.in_ is not None:
+                try:
+                    response_rule_to = self._rules[response.meta['rule']].to
+                except (IndexError, KeyError, TypeError):
+                    response_rule_to = None
+                if response_rule_to != rule.in_:
+                    continue
             links = [l for l in rule.link_extractor.extract_links(response) if l not in seen]
             if links and rule.process_links:
                 links = rule.process_links(links)

--- a/tests/test_spider.py
+++ b/tests/test_spider.py
@@ -247,6 +247,45 @@ class CrawlSpiderTest(SpiderTest):
                            'http://example.org/about.html',
                            'http://example.org/nofollow.html'])
 
+    def test_rule_to(self):
+
+        response = HtmlResponse("http://example.org/somepage/index.html",
+            body=self.test_body)
+
+        class _CrawlSpider(self.spider_class):
+            name="test"
+            allowed_domains=['example.org']
+            rules = (
+                Rule(LinkExtractor(), to="linked_from_main_page"),
+            )
+
+        spider = _CrawlSpider()
+        output = list(spider._requests_to_follow(response))
+        self.assertEquals(set([spider._rules[r.meta['rule']].to for r in output]),
+                          set(['linked_from_main_page']))
+
+    def test_rule_in_(self):
+
+        response = HtmlResponse("http://example.org/somepage/index.html",
+            body=self.test_body)
+        response.request = Request("http://example.org/anotherpage/index.html",
+                                   meta={'rule': 1})
+
+        class _CrawlSpider(self.spider_class):
+            name="test"
+            allowed_domains=['example.org']
+            rules = (
+                Rule(LinkExtractor(allow=(r'12\.html$',)), in_="about_page"),
+                Rule(LinkExtractor(allow=(r'about\.html$',)), in_="main_page", to="about_page"),
+                Rule(LinkExtractor(allow=(r'nofollow\.html$',)))
+            )
+
+        spider = _CrawlSpider()
+        output = list(spider._requests_to_follow(response))
+        self.assertEquals([r.url for r in output],
+                          ['http://example.org/somepage/item/12.html',
+                           'http://example.org/nofollow.html'])
+
     def test_follow_links_attribute_population(self):
         crawler = get_crawler()
         spider = self.spider_class.from_crawler(crawler, 'example.com')


### PR DESCRIPTION
This adds a new feature to CrawlSpider Rules.

"to" and "in_" values can be set in rules. Rules with an "in_" value will only be applied to responses that resulted from a rule with a "to" value equal to the "in_" value.

This can be used to only apply certain rules to the results of other specific rules. For example, in documentation I have also updated to describe the new feature, the item rule is only applied in results of the category rule.
