### PR TITLE
Allow returning of None in CSVFeedSpider

### DIFF
--- a/scrapy/contrib/spiders/feed.py
+++ b/scrapy/contrib/spiders/feed.py
@@ -126,6 +126,8 @@ class CSVFeedSpider(Spider):
 
         for row in csviter(response, self.delimiter, self.headers, self.quotechar):
             ret = self.parse_row(response, row)
+            if ret is None:
+                continue
             if isinstance(ret, (BaseItem, Request)):
                 ret = [ret]
             if not isinstance(ret, (list, tuple)):


### PR DESCRIPTION
to support ignoring rows (header/footer and such).

Example using CSVFeedSpider:
```py
def parse_row(self, response, row):
    if row['COL1'] == 'FIRST-COLUMN':
        self.log('Ignoring CSV header row')
        return

    [... continue here]
```

At this time, the Spider will barf when returning nothing/`None`.