### PR TITLE
Update unified.py

### DIFF
--- a/scrapy/selector/unified.py
+++ b/scrapy/selector/unified.py
@@ -119,7 +119,7 @@ class Selector(object_ref):
         try:
             return etree.tostring(self._root,
                                   method=self._tostring_method,
-                                  encoding=unicode,
+                                  encoding='utf8',
                                   with_tail=False)
         except (AttributeError, TypeError):
             if self._root is True:
@@ -127,7 +127,10 @@ class Selector(object_ref):
             elif self._root is False:
                 return u'0'
             else:
-                return unicode(self._root)
+                if isinstance(self._root, unicode):
+                    return self._root.encode('utf8')
+                else:
+                    return self._root
 
     def register_namespace(self, prefix, uri):
         if self.namespaces is None:


### PR DESCRIPTION
Fixed a bug that Scrapy work with HappyBase, which always returns the matched nodes as a list of unicode strings. In my case, the Java program does not work well with HBase. especially, Chinese character in HBase filter.
Sorry for my poor english.
