### PR TITLE
dupefilter should record requests even with dont_filter

### DIFF
--- a/scrapy/core/scheduler.py
+++ b/scrapy/core/scheduler.py
@@ -45,7 +45,7 @@ class Scheduler(object):
         return self.df.close(reason)
 
     def enqueue_request(self, request):
-        if not request.dont_filter and self.df.request_seen(request):
+        if self.df.request_seen(request) and not request.dont_filter:
             self.df.log(request, self.spider)
             return False
         dqok = self._dqpush(request)


### PR DESCRIPTION
dupefilter must see and record all requests even with dont_filter, and
thus a subsequent duplicate request happened to have no dont_filter can
be filtered out.

Example: consider having some start_urls marked as dont_filter, any
self-referencing urls will not be de-duplicated.

Apparently this problem was introduced since Jun 2011 after a refactoring at
https://github.com/scrapy/scrapy/commit/03751749a80526f3d97f60f0f63892501ef5de19
