### PR TITLE
Argument to enable/disable start_requests from Crawler

### DIFF
--- a/docs/topics/api.rst
+++ b/docs/topics/api.rst
@@ -28,11 +28,13 @@ contains a dictionary of all available extensions and their order similar to
 how you :ref:`configure the downloader middlewares
 <topics-downloader-middleware-setting>`.
 
-.. class:: Crawler(spidercls, settings)
+.. class:: Crawler(spidercls, settings, start_requests=True)
 
     The Crawler object must be instantiated with a
     :class:`scrapy.spider.Spider` subclass and a
-    :class:`scrapy.settings.Settings` object.
+    :class:`scrapy.settings.Settings` object. Also there's optional argument
+    `start_requests` which enables/disables
+    :meth:`scrapy.spider.Spider.start_requests` for given spider.
 
     .. attribute:: settings
 
@@ -55,6 +57,13 @@ how you :ref:`configure the downloader middlewares
         For an introduction on signals see :ref:`topics-signals`.
 
         For the API see :class:`~scrapy.signalmanager.SignalManager` class.
+
+    .. attribute:: start_requests
+
+        Boolean, indicates if Crawler must use
+        :meth:`scrapy.spider.Spider.start_requests` when :meth:`crawl`
+        is called.
+
 
     .. attribute:: stats
 
@@ -486,7 +495,7 @@ class (which they all inherit from).
 
         Set the given value for the given key only if current value for the
         same key is lower than value. If there is no current value for the
-        given key, the value is always set. 
+        given key, the value is always set.
 
     .. method:: min_value(key, value)
 

--- a/scrapy/crawler.py
+++ b/scrapy/crawler.py
@@ -16,7 +16,7 @@ from scrapy import log, signals
 
 class Crawler(object):
 
-    def __init__(self, spidercls, settings):
+    def __init__(self, spidercls, settings, start_requests=True):
         self.spidercls = spidercls
         self.settings = settings
         self.signals = SignalManager(self)
@@ -28,6 +28,7 @@ class Crawler(object):
         self.crawling = False
         self.spider = None
         self.engine = None
+        self.start_requests = start_requests
 
     @property
     def spiders(self):
@@ -49,8 +50,11 @@ class Crawler(object):
         try:
             self.spider = self._create_spider(*args, **kwargs)
             self.engine = self._create_engine()
-            start_requests = iter(self.spider.start_requests())
-            yield self.engine.open_spider(self.spider, start_requests)
+            if self.start_requests:
+                start_requests = self.spider.start_requests()
+            else:
+                start_requests = []
+            yield self.engine.open_spider(self.spider, iter(start_requests))
             yield defer.maybeDeferred(self.engine.start)
         except Exception:
             self.crawling = False

--- a/tests/test_crawler.py
+++ b/tests/test_crawler.py
@@ -2,11 +2,17 @@ import warnings
 import unittest
 
 from twisted.internet import defer
+from twisted.trial.unittest import TestCase
 
 from scrapy.crawler import Crawler, CrawlerRunner
 from scrapy.settings import Settings
+from scrapy.utils.engine import get_engine_status
 from scrapy.utils.spider import DefaultSpider
 from scrapy.utils.misc import load_object
+from scrapy.utils.test import get_crawler
+
+from tests.mockserver import MockServer
+from tests.spiders import SingleRequestSpider
 
 
 class CrawlerTestCase(unittest.TestCase):
@@ -24,6 +30,55 @@ class CrawlerTestCase(unittest.TestCase):
 
             self.crawler.spiders
             self.assertEqual(len(w), 1, "Warn deprecated access only once")
+
+
+class CrawlerStartRequestsTestCase(TestCase):
+
+    def setUp(self):
+        self.crawler = get_crawler(SingleRequestSpider)
+        self.engine_status = []
+        self.url = "http://localhost:8998/"
+        self.mockserver = MockServer()
+        self.mockserver.__enter__()
+
+    def tearDown(self):
+        self.mockserver.__exit__(None, None, None)
+
+    def _cb(self, response):
+        self.engine_status.append(get_engine_status(self.crawler.engine))
+
+    def _assert_engine_worked(self):
+        stats = self.crawler.stats.get_stats()
+        self.assertIn('start_time', stats)
+        self.assertIn('finish_time', stats)
+        self.assertEquals(stats['finish_reason'], 'finished')
+
+    @defer.inlineCallbacks
+    def test_start_requests_enabled(self):
+        yield self.crawler.crawl(seed=self.url, callback_func=self._cb)
+        self._assert_engine_worked()
+        self.assertEqual(len(self.engine_status), 1, self.engine_status)
+        est = dict(self.engine_status[0])
+        self.assertEqual(est['engine.spider.name'],
+                         self.crawler.spider.name)
+        self.assertEqual(est['len(engine.scraper.slot.active)'], 1)
+        stats = self.crawler.stats.get_stats()
+        self.assertEqual(stats['scheduler/enqueued'], 1)
+        self.assertEqual(stats['scheduler/dequeued'], 1)
+        self.assertEqual(stats['downloader/request_count'], 1)
+        self.assertEqual(stats['downloader/response_count'], 1)
+
+    @defer.inlineCallbacks
+    def test_start_requests_disabled(self):
+        self.crawler.start_requests = False
+        yield self.crawler.crawl(seed=self.url, callback_func=self._cb)
+        self._assert_engine_worked()
+        self.assertEqual(len(self.engine_status), 0, self.engine_status)
+        stats = self.crawler.stats.get_stats()
+        self.assertNotIn('scheduler/enqueued', stats)
+        self.assertNotIn('scheduler/dequeued', stats)
+        self.assertNotIn('downloader/request_count', stats)
+        self.assertNotIn('downloader/response_count', stats)
 
 
 class CrawlerRunnerTest(unittest.TestCase):


### PR DESCRIPTION
For some projects we need a way to disable `start_requests` for spider based on some condition and it should work for any possible/existing spider. Now it's only possible with overriding `Crawler.crawl` method. This PR aims to provide a simple way to disable `start_requests` for all spider started from given crawler.
