### PR TITLE
Param type should be Respons

### DIFF
--- a/docs/topics/spider-middleware.rst
+++ b/docs/topics/spider-middleware.rst
@@ -97,7 +97,7 @@ single Python class that defines one or more of the following methods:
         :type response: class:`~scrapy.http.Response` object
 
         :param result: the result returned by the spider
-        :type result: an iterable of :class:`~scrapy.http.Request` or
+        :type result: an iterable of :class:`~scrapy.http.Response` or
           :class:`~scrapy.item.Item` objects
 
         :param spider: the spider whose result is being processed


### PR DESCRIPTION
The "result" param type of  process_spider_output should be Response but not Request.
As the process_spider_exception may return an iterable of Response.