### PR TITLE
Implement FEED_STORE_EMPTY for FileFeedStorage

### DIFF
--- a/scrapy/contrib/feedexport.py
+++ b/scrapy/contrib/feedexport.py
@@ -32,7 +32,10 @@ class IFeedStorage(Interface):
         object that will be used for the exporters"""
 
     def store(file):
-        """Store the given file stream"""
+        """Store the given file stream."""
+
+    def cleanup(file):
+        """Do cleanup tasks when no items were stored, e.g. removing the file."""
 
 
 @implementer(IFeedStorage)
@@ -43,6 +46,9 @@ class BlockingFeedStorage(object):
 
     def store(self, file):
         return threads.deferToThread(self._store_in_thread, file)
+
+    def cleanup(self, file):
+        file.close()
 
     def _store_in_thread(self, file):
         raise NotImplementedError
@@ -60,6 +66,9 @@ class StdoutFeedStorage(object):
     def store(self, file):
         pass
 
+    def cleanup(self, file):
+        pass
+
 
 @implementer(IFeedStorage)
 class FileFeedStorage(object):
@@ -75,6 +84,10 @@ class FileFeedStorage(object):
 
     def store(self, file):
         file.close()
+
+    def cleanup(self, file):
+        file.close()
+        os.remove(file.name)
 
 
 class S3FeedStorage(BlockingFeedStorage):
@@ -176,7 +189,8 @@ class FeedExporter(object):
     def close_spider(self, spider):
         slot = self.slot
         if not slot.itemcount and not self.store_empty:
-            return
+            d = defer.maybeDeferred(slot.storage.cleanup, slot.file)
+            return d
         slot.exporter.finish_exporting()
         logfmt = "%%s %s feed (%d items) in: %s" % (self.format, \
             slot.itemcount, slot.uri)


### PR DESCRIPTION
FileFeedStorage left empty files when no items were scraped. This patch
adds a cleanup method to the IFeedStorage interface that will be called
by FeedExporter when no items were scraped.

Fixes scrapy/scrapy#872