### PR TITLE
Reset items_scraped instead of item_count

### DIFF
--- a/docs/topics/extensions.rst
+++ b/docs/topics/extensions.rst
@@ -140,9 +140,9 @@ Here is the code of such extension::
 
         def item_scraped(self, item, spider):
             self.items_scraped += 1
-            if self.items_scraped == self.item_count:
-                spider.log("scraped %d items, resetting counter" % self.items_scraped)
-                self.item_count = 0
+            if self.items_scraped % self.item_count == 0:
+                spider.log("scraped %d items" % self.items_scraped)
+                
 
 .. _topics-extensions-ref:
 


### PR DESCRIPTION
items_scraped is the counter that needs to be reset each time we have scraped a specific number of items in the code instead of item_count (which represents the specific number of items needed before a message is logged). Updating the source code to reflect this.

Signed-off-by: Sudhanshu Shekhar <sudshekhar02@gmail.com>