### PR TITLE
Expanding default list of processors

### DIFF
--- a/scrapy/contrib/loader/common.py
+++ b/scrapy/contrib/loader/common.py
@@ -1,7 +1,9 @@
 """Common functions used in Item Loaders code"""
 
 from functools import partial
+import string
 from scrapy.utils.python import get_func_args
+
 
 def wrap_loader_context(function, context):
     """Wrap functions that receive loader_context to contain the context
@@ -11,3 +13,12 @@ def wrap_loader_context(function, context):
         return partial(function, loader_context=context)
     else:
         return function
+
+
+def clean_punctuation(text):
+    """Strips text of punctuation and whitespaces"""
+    chars = string.punctuation + string.whitespace
+    for c in chars:
+        if c in text:
+            text = text.replace(c, '')
+    return text

--- a/scrapy/contrib/loader/common.py
+++ b/scrapy/contrib/loader/common.py
@@ -1,7 +1,6 @@
 """Common functions used in Item Loaders code"""
 
 from functools import partial
-import string
 from scrapy.utils.python import get_func_args
 
 
@@ -15,9 +14,8 @@ def wrap_loader_context(function, context):
         return function
 
 
-def clean_punctuation(text):
+def purge_chars(text, chars):
     """Strips text of punctuation and whitespaces"""
-    chars = string.punctuation + string.whitespace
     for c in chars:
         if c in text:
             text = text.replace(c, '')

--- a/scrapy/contrib/loader/processor.py
+++ b/scrapy/contrib/loader/processor.py
@@ -3,10 +3,12 @@ This module provides some commonly used processors for Item Loaders.
 
 See documentation in docs/topics/loaders.rst
 """
+import re
 
 from scrapy.utils.misc import arg_to_iter
 from scrapy.utils.datatypes import MergeDict
 from .common import wrap_loader_context
+
 
 class MapCompose(object):
 
@@ -70,3 +72,128 @@ class Join(object):
 
     def __call__(self, values):
         return self.separator.join(values)
+
+
+class Strip(object):
+    def __init__(self, chars=None):
+        self.chars = chars
+
+    def __call__(self, values):
+        if isinstance(values, list):
+            filtered = []
+            for value in values:
+                value = value.strip(self.chars)
+                if value != '' and value is not None:
+                    filtered.append(value)
+            return filtered
+        return values.strip(self.chars)
+
+
+class TakeNth(object):
+
+    def __init__(self, pos):
+        self.pos = pos
+
+    def __call__(self, values):
+        values = [v for v in values if v != '' and v is not None]
+        return values[self.pos]
+
+
+class OnlyEnglish(object):
+    def __call__(self, values):
+        if isinstance(values, list):
+            filtered = []
+            for value in values:
+                try:
+                    value.decode('ascii')
+                except (UnicodeDecodeError, UnicodeEncodeError):
+                    pass
+                else:
+                    filtered.append(value)
+            return filtered
+        else:
+            try:
+                values.decode('ascii')
+            except (UnicodeDecodeError, UnicodeEncodeError):
+                pass
+            else:
+                return values
+
+
+class OnlyChars(object):
+
+    def __call__(self, values):
+        if isinstance(values, list):
+            filtered = []
+            for value in values:
+                value = filter(type(value).isalpha, value)
+                if value != '' and value is not None:
+                    filtered.append(value)
+            return filtered
+        return filter(type(values).isalpha, values)
+
+
+class Filter(object):
+
+    def __init__(self, filter_func):
+        self.filter_func = filter_func
+
+    def __call__(self, values):
+        if isinstance(values, list):
+            filtered = []
+            for value in values:
+                value = filter(self.filter_func, value)
+                if value != '' and value is not None:
+                    filtered.append(value)
+            return filtered
+        return filter(self.filter_func, values)
+
+
+class Replace(object):
+
+    def __init__(self, find, replace, count=-1):
+        self.find = find
+        self.replace = replace
+        self.count = count
+
+    def __call__(self, values):
+        if isinstance(values, list):
+            filtered = []
+            for value in values:
+                value = value.replace(self.find, self.replace, self.count)
+                if value != '' and value is not None:
+                    filtered.append(value)
+            return filtered
+        return values.replace(self.find, self.replace)
+
+
+class ReSub(object):
+
+    def __init__(self, find, replace, count=0, flags=0):
+        self.find = find
+        self.replace = replace
+        self.count = count
+        self.flags = flags
+
+    def __call__(self, values):
+        if isinstance(values, list):
+            filtered = []
+            for value in values:
+                value = re.sub(self.find, self.replace, value, self.count, self.flags)
+                if value != '' and value is not None:
+                    filtered.append(value)
+            return filtered
+        return re.sub(self.find, self.replace, values, self.count, self.flags)
+
+
+class OnlyDigits(object):
+
+    def __call__(self, values):
+        if isinstance(values, list):
+            filtered = []
+            for value in values:
+                value = filter(type(value).isdigit, value)
+                if value != '' and value is not None:
+                    filtered.append(value)
+            return filtered
+        return filter(type(values).isdigit, values)


### PR DESCRIPTION
implementation of suggestion https://github.com/scrapy/scrapy/issues/1010.
Extending default processors: 

`Strip(chars)` - strips every list item of provided `chars`
`TakeNth(position)` - like `TakeFirst()` but for supplied position.
`OnlyAscii(except_chars)` - strips every item of non-ascii characters
`OnlyAsciiItems(except_chars)` - strips away list items that contain non-ascii characters
`OnlyChars(except_chars)` - strips every item of non-alpha characters
`OnlyCharsItems(except_chars)` - strips away list items that contain non-alpha characters
`OnlyDigits(except_chars)` - strips every item of non-digit characters
`OnlyDigitsItems(except_chars)` - strips every item of non-digit characters
`Filter(filter_func)` - only items that pass provided filter_func
`Replace(find, replace, count)` - like builtin `replace`
`ReSub(find, replcae, count, flags)` - like `re.sub`
`ParseNum(return_type, string_locale='en_US.UTF-8')` -  parses string like '10,000' to proper `int` or `float` value (it is determined by return_type argument). string_locale is used by `locale` package to parse the number string.

common arguments:
`except_chars` - for Only<...> processors, provided characters will be ignored in the function. E.g. OnlyDigits(excepte_chars='+')('1+2=3') will return '1+23'

Most of these can be done replaced with simple lambda func but these implementations are more approachable and faster.
