### PR TITLE
Added periodic stats. Allows periodical stats generation and processing.

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -100,6 +100,7 @@ Built-in services
 
    topics/logging
    topics/stats
+   topics/periodic-stats
    topics/email
    topics/telnetconsole
    topics/webservice
@@ -109,6 +110,9 @@ Built-in services
    
 :doc:`topics/stats`
     Collect statistics about your scraping crawler.
+
+:doc:`topics/periodic-stats`
+    Export selected statistics periodically.
 
 :doc:`topics/email`
     Send email notifications when certain events occur.

--- a/docs/topics/periodic-stats.rst
+++ b/docs/topics/periodic-stats.rst
@@ -1,0 +1,298 @@
+.. _topics-periodic-stats:
+
+==============
+Periodic Stats
+==============
+
+Sometimes you want to monitor statistics or be notified about certain events that occur in your crawling process.
+Scrapy provides the tools for periodically generate and process data from a :ref:`topics-stats`.
+
+Some use cases can be:
+
+- Monitor and graph scraping data over time (memory usage, http codes, errors, scraped items, etc).
+- Get notified when a crawl job has finished or alerted when something happens.
+- Use your own stat values to monitor custom data or events.
+
+You can for instance generate and export your stats and create some time-based graphs using a 3rd party
+tool like `Kibana`_.
+
+
+To achieve this is you must configure a :ref:`topics-stats-periodicstatscollector` with a list of:
+
+- :ref:`topics-stats-valueobservers`: To select and configure the filtered periodic stats.
+- :ref:`topics-stats-statspipelines` To process the generated stats.
+
+.. _topics-stats-periodicstatscollector:
+
+Periodic Stats Collector
+========================
+
+:class:`PeriodicStatsCollector` is a special :class:`MemoryStatsCollector` class, it has exactly the same funcionality
+but can be configured to periodically generate and process stats.
+
+All configuration is done via settings. To use it, simply change the :setting:`STATS_CLASS` setting like this::
+
+    STATS_CLASS = 'scrapy.contrib.periodicstats.PeriodicStatsCollector'
+
+
+Stat values can be filtered defining :ref:`topics-stats-valueobservers`, but sometimes you want all the available
+stats. You can get this with the :setting:`PERIODIC_STATS_EXPORT_ALL` setting::
+
+    PERIODIC_STATS_EXPORT_ALL = True
+
+And to define the interval for generating all the stats you must use
+the :setting:`PERIODIC_STATS_EXPORT_ALL_INTERVAL` setting::
+
+    PERIODIC_STATS_EXPORT_ALL_INTERVAL = 30  # time in seconds
+
+
+You can always deactivate the periodic stats generation with the :setting:`PERIODIC_STATS_ENABLED` setting
+(:class:`MemoryStatsCollector` functionality will still remain the same)::
+
+    PERIODIC_STATS_ENABLED = False
+
+
+
+.. _topics-stats-valueobservers:
+
+Value Observers
+===============
+
+:class:`PeriodicStatsObserver` class allows to select data from the available :ref:`topics-stats` and define when it
+should be generated.
+
+They can be defined using the :setting:`PERIODIC_STATS_OBSERVERS` setting::
+
+    from scrapy.contrib import periodicstats as stats
+
+    PERIODIC_STATS_OBSERVERS = [
+        stats.Observer(key='downloader/response_count'),
+    ]
+
+The previous example will generate the number of responses every second::
+
+    {'downloader/response_count': 5}   # for t=1
+    {'downloader/response_count': 34}  # for t=2
+    {'downloader/response_count': 45}  # for t=3
+    ...
+
+More examples of use below.
+
+
+PeriodicStatsObserver
+---------------------
+
+.. module:: scrapy.contrib.periodicstats
+.. class:: PeriodicStatsObserver(key[, use_re_key=False, use_partial_values=False, export_key=None, export_interval=1, only_export_on_change=False, only_export_on_close=False])
+
+    Class that monitors a stats value and decides to show it or not across intervals.
+
+    :param key: the stats key to use
+    :type key: string
+
+    :param use_re_key: whether key parameter is a regular expression or not
+    :type use_re_key: bool
+
+    :param use_partial_values: defines how numeric values are calculated. If active only variations during the interval will be shown, if disabled (default) the total cumulated value will be used.
+    :type use_partial_values: bool
+
+    :param export_key: the key to use for this value, if not defined ``key`` parameter will be used.
+    :type export_key: string
+
+    :param export_interval: the interval in seconds that will be used to generate this value.
+    :type export_interval: int
+
+    :param only_export_on_change: If active, value will be only generated if has changed since the last interval.
+    :type only_export_on_change: bool
+
+    :param only_export_on_close: If active, value will be only generated when the spider is closed.
+    :type only_export_on_close: bool
+
+You can define many observers::
+
+    PERIODIC_STATS_OBSERVERS = [
+        stats.Observer(key='downloader/request_count'),
+        stats.Observer(key='downloader/response_count'),
+        stats.Observer(key='httpcache/hit'),
+    ]
+
+    """
+    Generated stats:
+    {'downloader/request_count': 10, 'downloader/request_count': 10, 'httpcache/hit': 0}  # for t=1
+    {'downloader/request_count': 23, 'downloader/request_count': 20, 'httpcache/hit': 3}  # for t=2
+    {'downloader/request_count': 23, 'downloader/request_count': 20, 'httpcache/hit': 3}  # for t=3
+    {'downloader/request_count': 34, 'downloader/request_count': 28, 'httpcache/hit': 7}  # for t=4
+    ...
+    """
+
+To use a different name for the stats value use the ``export_key`` parameter::
+
+    PERIODIC_STATS_OBSERVERS = [
+        stats.Observer(key='downloader/request_count', export_key='requests'),
+        stats.Observer(key='downloader/response_count', export_key='responses'),
+        stats.Observer(key='httpcache/hit', export_key='from_cache'),
+    ]
+
+    """
+    Generated stats:
+    {'requests': 10, 'responses': 10, 'from_cache': 0}   # for t=1
+    {'requests': 23, 'responses': 20, 'from_cache': 3}   # for t=2
+    {'requests': 23, 'responses': 20, 'from_cache': 3}   # for t=3
+    {'requests': 34, 'responses': 28, 'from_cache': 7}   # for t=4
+    ...
+    """
+
+You can use several observers at the same key, but then ``export_key`` can't be repeated::
+
+    PERIODIC_STATS_OBSERVERS = [
+        stats.Observer(key='downloader/request_count', export_key='requests_counter'),
+        stats.Observer(key='downloader/request_count', export_key='another_request_counter'),
+    ]
+
+    """
+    Generated stats:
+    {'requests_counter': 10, 'another_request_counter': 10}  # for t=1
+    {'requests_counter': 23, 'another_request_counter': 23}  # for t=2
+    {'requests_counter': 23, 'another_request_counter': 23}  # for t=3
+    {'requests_counter': 34, 'another_request_counter': 34}  # for t=4
+    ...
+    """
+
+By default values are accumulated, but we can also use just differences between intervals with the
+``use_partial_values`` parameter::
+
+    PERIODIC_STATS_OBSERVERS = [
+        stats.Observer(key='downloader/request_count', export_key='requests', use_partial_values=True),
+    ]
+
+    """
+    Generated stats:
+    {'requests': 10}  # for t=1
+    {'requests': 13}  # for t=2
+    {'requests': 0}   # for t=3
+    {'requests': 11}  # for t=4
+    ...
+    """
+
+To minimize generated data we can choose to export data only when it changes with the
+``only_export_on_change`` parameter::
+
+    PERIODIC_STATS_OBSERVERS = [
+        stats.Observer(key='downloader/request_count', export_key='requests', only_export_on_change=True),
+    ]
+
+    """
+    Generated stats:
+    {'requests': 10}  # for t=1
+    {'requests': 13}  # for t=2
+    {}                # for t=3
+    {'requests': 11}  # for t=4
+    ...
+    """
+
+We can define export intervals per key with the ``export_interval`` parameter::
+
+    PERIODIC_STATS_OBSERVERS = [
+        stats.Observer(key='downloader/request_count', export_key='requests', export_interval=1),
+        stats.Observer(key='downloader/response_count', export_key='responses', export_interval=2),
+    ]
+
+    """
+    Generated stats:
+    {'requests': 10, 'responses': 10}  # for t=1
+    {'requests': 23}                   # for t=2
+    {'requests': 23, 'responses': 20}  # for t=3
+    {'requests': 34}                   # for t=4
+    ...
+    """
+
+To export only stats when a spider is finished use the ``only_export_on_close`` parameter::
+
+    PERIODIC_STATS_OBSERVERS = [
+        stats.Observer(key='downloader/request_count', export_key='requests', only_export_on_close=True),
+    ]
+
+    """
+    Generated stats:
+    {}                  # for t=1
+    {}                  # for t=2
+    {}                  # for t=3
+    {}                  # for t=4
+    ...
+    {'requests': 2759}  # on spider_close
+    """
+
+Regular expressions can be used to group/filter data with the ``use_re_key`` parameter:::
+
+    PERIODIC_STATS_OBSERVERS = [
+        stats.Observer(key='downloader/response_status_count/2..', use_re_key=True, export_key='2xx'),
+        stats.Observer(key='downloader/response_status_count/3..', use_re_key=True, export_key='3xx'),
+        stats.Observer(key='downloader/response_status_count/4..', use_re_key=True, export_key='4xx'),
+        stats.Observer(key='downloader/response_status_count/5..', use_re_key=True, export_key='5xx'),
+    ]
+
+    """
+    Generated stats:
+    {'2xx': 10}                               # for t=1
+    {'2xx': 34, '3xx': 1, '4xx':1}            # for t=2
+    {'2xx': 67, '3xx': 4, '4xx':2, '5xx': 1}  # for t=3
+    {'2xx': 90, '3xx': 8, '4xx':2, '5xx': 1}  # for t=4
+    ...
+    """
+
+.. _topics-stats-statspipelines:
+
+Stats Pipelines
+===============
+
+:class:`PeriodicStatsPipeline` objects receive and process the stats generated by the :class:`PeriodicStatsObserver`
+objects for every :ref:`topics-stats-periodicstatscollector` iteration.
+
+You can define the pipeline objects to use with the :setting:`PERIODIC_STATS_PIPELINES` setting::
+
+    PERIODIC_STATS_PIPELINES = [
+        'scrapy.contrib.periodicstats.PeriodicStatsLogger',
+    ]
+
+
+PeriodicStatsPipeline
+---------------------
+
+.. module:: scrapy.contrib.periodicstats
+.. class:: PeriodicStatsPipeline
+
+    .. method:: open_spider(spider)
+
+        Called when the spider is opened.
+
+        :param spider: the spider for which the stats are processed.
+        :type spider: :class:`~scrapy.spider.Spider` object
+
+    .. method:: close_spider(spider)
+
+        Called when the spider is closed.
+
+        :param spider: the spider for which the stats are processed.
+        :type spider: :class:`~scrapy.spider.Spider` object
+
+    .. method:: process_stats(spider, interval, stats)
+
+        Called for every :class:`PeriodicStatsCollector` iteration with the stats to be processed.
+
+        :meth:`process_stats` should return the passed stats or ``None``.
+
+        If it returns the passed stats, they will be passed to the next middleware.
+
+        If it returns ``None``, no further middlewares will be called.
+
+        :param spider: the spider for which the stats are processed.
+        :type spider: :class:`~scrapy.spider.Spider` object
+
+
+You can define your own :class:`PeriodicStatsPipeline` objects to periodically export stats.
+
+
+.. _Kibana: http://www.elasticsearch.org/overview/kibana/
+
+
+

--- a/docs/topics/settings.rst
+++ b/docs/topics/settings.rst
@@ -719,6 +719,67 @@ Example::
 
     NEWSPIDER_MODULE = 'mybot.spiders_dev'
 
+.. setting:: PERIODIC_STATS_ENABLED
+
+PERIODIC_STATS_ENABLED
+----------------------
+
+Default: ``True``
+
+Whether to use or not :ref:`topics-periodic-stats`.
+
+
+.. setting:: PERIODIC_STATS_EXPORT_ALL
+
+PERIODIC_STATS_EXPORT_ALL
+-------------------------
+
+Default: ``False``
+
+Whether to export or not all available stats using :ref:`topics-periodic-stats`.
+
+.. setting:: PERIODIC_STATS_EXPORT_ALL_INTERVAL
+
+PERIODIC_STATS_EXPORT_ALL_INTERVAL
+----------------------------------
+
+Default: ``60``
+
+Time in seconds to export all available stats using :ref:`topics-periodic-stats`.
+
+.. setting:: PERIODIC_STATS_OBSERVERS
+
+PERIODIC_STATS_OBSERVERS
+------------------------
+
+Default: ``[]``
+
+A list containing the :ref:`topics-stats-valueobservers` used in :ref:`topics-periodic-stats`.
+
+Example::
+
+    from scrapy.contrib import periodicstats as stats
+
+    PERIODIC_STATS_OBSERVERS = [
+        stats.Observer(key='downloader/response_count', export_interval=30),
+        stats.Observer(key='httpcache/hit', export_interval=30),
+    ]
+
+.. setting:: PERIODIC_STATS_PIPELINES
+
+PERIODIC_STATS_PIPELINES
+------------------------
+
+Default: ``[]``
+
+A list containing the :ref:`topics-stats-statspipelines` used in :ref:`topics-periodic-stats`.
+
+Example::
+
+    PERIODIC_STATS_PIPELINES = [
+        'scrapy.contrib.periodicstats.PeriodicStatsLogger',
+    ]
+
 .. setting:: RANDOMIZE_DOWNLOAD_DELAY
 
 RANDOMIZE_DOWNLOAD_DELAY

--- a/scrapy/contrib/periodicstats/__init__.py
+++ b/scrapy/contrib/periodicstats/__init__.py
@@ -1,0 +1,3 @@
+from collectors import PeriodicStatsCollector as Collector
+from observers import PeriodicStatsObserver as Observer
+from pipelines import PeriodicStatsPipeline as Pipeline

--- a/scrapy/contrib/periodicstats/__init__.py
+++ b/scrapy/contrib/periodicstats/__init__.py
@@ -1,3 +1,3 @@
-from collectors import PeriodicStatsCollector as Collector
-from observers import PeriodicStatsObserver as Observer
-from pipelines import PeriodicStatsPipeline as Pipeline
+from .collectors import PeriodicStatsCollector as Collector
+from .observers import PeriodicStatsObserver as Observer
+from .pipelines import PeriodicStatsPipeline as Pipeline

--- a/scrapy/contrib/periodicstats/collectors.py
+++ b/scrapy/contrib/periodicstats/collectors.py
@@ -44,6 +44,7 @@ class PeriodicStatsCollector(MemoryStatsCollector):
     def close_spider(self, spider, reason):
         super(PeriodicStatsCollector, self).close_spider(spider, reason)
         if self._enabled:
+            self._task.stop()
             self._process_interval_stats(spider=spider, is_close=True)
             for pipeline in self._pipelines:
                 pipeline.close_spider(spider, reason)

--- a/scrapy/contrib/periodicstats/collectors.py
+++ b/scrapy/contrib/periodicstats/collectors.py
@@ -1,0 +1,151 @@
+from collections import defaultdict
+import re
+
+from twisted.internet import task
+
+from scrapy.statscol import MemoryStatsCollector
+from scrapy.exceptions import NotConfigured
+from scrapy.utils.misc import load_object
+from scrapy.contrib.periodicstats.observers import PeriodicStatsObserver
+from scrapy.contrib.periodicstats.pipelines import PeriodicStatsPipeline
+
+
+DEFAULT_PERIODIC_STATS_ENABLED = True
+DEFAULT_PERIODIC_STATS_EXPORT_ALL = False
+DEFAULT_PERIODIC_STATS_EXPORT_ALL_INTERVAL = 60
+
+
+class PeriodicStatsCollector(MemoryStatsCollector):
+    """
+    Stats collector class that periodically generates stats and pass them to pipelines for processing
+    """
+
+    def __init__(self, crawler):
+        super(PeriodicStatsCollector, self).__init__(crawler=crawler)
+        self._enabled = crawler.settings.get('PERIODIC_STATS_ENABLED',
+                                             DEFAULT_PERIODIC_STATS_ENABLED)
+        if self._enabled:
+            self._export_all = crawler.settings.get('PERIODIC_STATS_EXPORT_ALL',
+                                                    DEFAULT_PERIODIC_STATS_EXPORT_ALL)
+            self._export_all_interval = crawler.settings.get('PERIODIC_STATS_EXPORT_ALL_INTERVAL',
+                                                             DEFAULT_PERIODIC_STATS_EXPORT_ALL_INTERVAL)
+            self._load_observers(crawler)
+            self._load_pipelines(crawler)
+            self._interval = 0
+
+    def open_spider(self, spider):
+        super(PeriodicStatsCollector, self).open_spider(spider)
+        if self._enabled:
+            for pipeline in self._pipelines:
+                pipeline.open_spider(spider)
+            self._task = task.LoopingCall(self._process_interval_stats, spider)
+            self._task.start(1)
+
+    def close_spider(self, spider, reason):
+        super(PeriodicStatsCollector, self).close_spider(spider, reason)
+        if self._enabled:
+            self._process_interval_stats(spider=spider, is_close=True)
+            for pipeline in self._pipelines:
+                pipeline.close_spider(spider, reason)
+
+    def set_value(self, key, value, spider=None):
+        super(PeriodicStatsCollector, self).set_value(key=key, value=value, spider=spider)
+        if self._enabled:
+            for observer in self._get_key_observers(key):
+                observer.set_value(value=value)
+
+    def inc_value(self, key, count=1, start=0, spider=None):
+        super(PeriodicStatsCollector, self).inc_value(key=key, count=count, start=start, spider=spider)
+        if self._enabled:
+            for observer in self._get_key_observers(key):
+                observer.inc_value(count=count, start=start)
+
+    def max_value(self, key, value, spider=None):
+        super(PeriodicStatsCollector, self).max_value(key=key, value=value, spider=spider)
+        if self._enabled:
+            self.set_value(key=key, value=self.get_value(key), spider=spider)
+
+    def min_value(self, key, value, spider=None):
+        super(PeriodicStatsCollector, self).min_value(key=key, value=value, spider=spider)
+        if self._enabled:
+            self.set_value(key=key, value=self.get_value(key), spider=spider)
+
+    def _load_observers(self, crawler):
+        """
+        Loads the stats value observers
+        """
+        export_keys = set()
+        self._observers = defaultdict(list)
+        self._re_observers = defaultdict(list)
+        for observer in crawler.settings.get('PERIODIC_STATS_OBSERVERS', {}):
+            if not isinstance(observer, PeriodicStatsObserver):
+                raise NotConfigured('Stats observers must subclass PeriodicStatsObserver')
+            observer_export_key = observer.export_key
+            if observer_export_key in export_keys:
+                raise NotConfigured('Duplicate export key "%s"' % observer_export_key)
+            export_keys.add(observer_export_key)
+            if not observer.use_re_key:
+                self._observers[observer.key].append(observer)
+            else:
+                self._re_observers[observer.key].append(observer)
+
+    def _load_pipelines(self, crawler):
+        """
+        Loads the stats processor pipelines
+        """
+        self._pipelines = []
+        for pipeline in crawler.settings.get('PERIODIC_STATS_PIPELINES', []):
+            if not isinstance(pipeline, basestring):
+                raise NotConfigured('Stats pipelines must be defined as an object string path in settings')
+            pipeline_class = load_object(pipeline)
+            if not issubclass(pipeline_class, PeriodicStatsPipeline):
+                raise NotConfigured('Stats pipelines must subclass PeriodicStatsPipeline')
+            pipeline = pipeline_class.from_crawler(crawler)
+            self._pipelines.append(pipeline)
+
+    def _process_interval_stats(self, spider, is_close=False):
+        """
+        Returns the interval stats for the current interval
+        """
+        stats = self._get_interval_base_stats(spider=spider, is_close=is_close)
+        stats.update(self._get_interval_observers_stats(self._observers, force=is_close))
+        stats.update(self._get_interval_observers_stats(self._re_observers, force=is_close))
+        for pipeline in self._pipelines:
+            stats = pipeline.process_stats(spider=spider,
+                                           interval=self._interval+1,
+                                           stats=stats)
+            if not stats:
+                break
+        self._interval += 1
+        return stats
+
+    def _get_key_observers(self, key):
+        """
+        Returns a list of observers for the passed key
+        """
+        observers = []
+        for re_key, re_observers in self._re_observers.iteritems():
+            if re.match(re_key, key):
+                observers += re_observers
+        observers += self._observers.get(key, [])
+        return observers
+
+    def _get_interval_observers_stats(self, observers_dict, force):
+        """
+        Returns the interval stats for the passed observers dict
+        """
+        interval_stats = {}
+        for key, observers in observers_dict.iteritems():
+            for observer in observers:
+                export_name, value_stats = observer.get_interval_stats(force=force)
+                if value_stats is not None:
+                    interval_stats[export_name] = value_stats
+        return interval_stats
+
+    def _get_interval_base_stats(self, spider, is_close):
+        """
+        Returns the base stats if export_all parameter is active
+        """
+        if self._export_all and (not self._interval % self._export_all_interval or is_close):
+            return self.get_stats(spider)
+        return {}

--- a/scrapy/contrib/periodicstats/observers.py
+++ b/scrapy/contrib/periodicstats/observers.py
@@ -1,0 +1,69 @@
+class PeriodicStatsObserver(object):
+    """
+    Class that monitors a stats value and decides to show it or not across intervals
+    """
+    def __init__(self, key, use_re_key=False, use_partial_values=False,
+                 export_key=None, export_interval=1,
+                 only_export_on_change=False, only_export_on_close=False):
+        self.key = key
+        self.use_re_key = use_re_key
+        self._export_interval = export_interval
+        self._use_partial_values = use_partial_values
+        self._export_key = export_key
+        self._only_export_on_change = only_export_on_change
+        self._only_export_on_close = only_export_on_close
+        self._value = None
+        self._last_value = None
+        self._interval_counter = 0
+
+    @property
+    def export_key(self):
+        return self._export_key or self.key
+
+    def get_interval_stats(self, force=False):
+        """
+        Returns the stats for the current interval
+        """
+        interval_value, reason = self._get_interval_value(force)
+        #print '%s[%d] value: %s reason: %s' % \
+        #      (self.export_key, self._interval_counter, interval_value, reason)
+        if interval_value is not None:
+            if self._use_partial_values:
+                self._value = 0
+            self._last_value = interval_value
+
+        self._interval_counter += 1
+        return self.export_key, interval_value
+
+    def set_value(self, value, spider=None):
+        self._value = value
+
+    def inc_value(self, count=1, start=0):
+        if self._value is None:
+            self._value = start
+        self._value += count
+
+    def _get_interval_value(self, force):
+        """
+        Returns the stat value for the current interval
+        """
+        if force:
+            return self._value, 'forced'
+        if self._only_export_on_close:
+            return None, 'not close'
+        if self._is_in_interval():
+            self._interval_counter = 0
+            if not self._only_export_on_change:
+                return self._value, 'always'
+            elif self._value_changed():
+                return self._value, 'changed'
+            else:
+                return None, 'not changed'
+        return None, 'not in interval'
+
+    def _value_changed(self):
+        return self._last_value != self._value
+
+    def _is_in_interval(self):
+        return self._interval_counter == 0 or \
+               self._interval_counter >= self._export_interval

--- a/scrapy/contrib/periodicstats/pipelines.py
+++ b/scrapy/contrib/periodicstats/pipelines.py
@@ -1,0 +1,37 @@
+import pprint
+
+from scrapy import log
+
+
+class PeriodicStatsPipeline(object):
+    """
+    Base class for periodic stats pipeline
+    """
+    def __init__(self, crawler):
+        pass
+
+    @classmethod
+    def from_crawler(cls, crawler):
+        return cls(crawler)
+
+    def open_spider(self, spider):
+        pass
+
+    def close_spider(self, spider, reason):
+        pass
+
+    def process_stats(self, spider, period, stats):
+        raise NotImplementedError
+
+
+class PeriodicStatsLogger(PeriodicStatsPipeline):
+    """
+    Stats processor that print stats debug info
+    """
+    def process_stats(self, spider, interval, stats):
+        log.msg('Dumping Scrapy periodic stats:\n' + pprint.pformat({
+            'spider': spider.name,
+            'interval': interval,
+            'stats': stats,
+        }))
+        return stats

--- a/tests/py3-ignores.txt
+++ b/tests/py3-ignores.txt
@@ -35,6 +35,7 @@ tests/test_logformatter.py
 tests/test_log.py
 tests/test_mail.py
 tests/test_middleware.py
+tests/test_periodicstats.py
 tests/test_pipeline_files.py
 tests/test_pipeline_images.py
 tests/test_pipeline_media.py
@@ -68,7 +69,7 @@ tests/test_utils_serialize.py
 tests/test_utils_signal.py
 tests/test_utils_template.py
 tests/test_utils_url.py
-tests/test_webclient.py
+tests/test_webclient.pyx
 
 scrapy/xlib/tx/iweb.py
 scrapy/xlib/tx/interfaces.py

--- a/tests/py3-ignores.txt
+++ b/tests/py3-ignores.txt
@@ -69,7 +69,7 @@ tests/test_utils_serialize.py
 tests/test_utils_signal.py
 tests/test_utils_template.py
 tests/test_utils_url.py
-tests/test_webclient.pyx
+tests/test_webclient.py
 
 scrapy/xlib/tx/iweb.py
 scrapy/xlib/tx/interfaces.py

--- a/tests/test_periodicstats.py
+++ b/tests/test_periodicstats.py
@@ -1,0 +1,548 @@
+import unittest
+
+from scrapy.spider import Spider
+from scrapy.contrib import periodicstats
+from scrapy.utils.test import get_crawler
+from scrapy.exceptions import NotConfigured
+
+
+class CollectorTestManager(object):
+    def __init__(self, settings_dict=None):
+        self.crawler = get_crawler(Spider, settings_dict=settings_dict)
+        self.spider = self.crawler._create_spider('foo')
+        self.collector = periodicstats.Collector(self.crawler)
+
+    def run_interval(self, is_close=False):
+        return self.collector._process_interval_stats(self.spider, is_close=is_close)
+
+    def run_sequence(self, operations_sequence, expected_stats_sequence):
+        operations_list = self._sequence_as_values_list(operations_sequence)
+        expected_stats_list = self._sequence_as_values_list(expected_stats_sequence)
+        for i, (operations, expected_stats) in enumerate(zip(operations_list, expected_stats_list)):
+            self._add_interval_operations(operations)
+            iteration_stats = self.run_interval(is_close=(i == len(operations_list)-1))
+            yield i+1, iteration_stats, expected_stats
+
+    def _add_interval_operations(self, operations):
+        for key, value in operations.iteritems():
+            if isinstance(value, bool):
+                if value is not None:
+                    self.collector.set_value(key, value)
+            elif isinstance(value, int):
+                if value:
+                    self.collector.inc_value(key, value)
+            elif value is not None:
+                self.collector.set_value(key, value)
+
+    def _sequence_as_values_list(self, sequence):
+        values_list = []
+        n_iterations = max([len(l) for l in sequence.values()])
+        for i in range(n_iterations):
+            values = {}
+            for key, data in sequence.iteritems():
+                value = data[i]
+                if value is not None:
+                    values[key] = value
+            values_list.append(values)
+        return values_list
+
+
+OPERATIONS_SEQUENCE = {
+    #    ------------------------------------------------------------------------------------------
+    #        1        2        3        4        5        6        7        8        9       10
+    #    ------------------------------------------------------------------------------------------
+    "A": [  None ,     10 ,      3 ,   None ,      5 ,     10 ,      4 ,   None ,   None ,      8 ],
+    "B": [     5 ,      5 ,     10 ,     10 ,    -20 ,    -20 ,     10 ,     10 ,     50 ,     50 ],
+    "C": [  None ,      1 ,      2 ,   None ,      1 ,     -1 ,      0 ,      1 ,      2 ,      0 ],
+    "D": [  None ,   True ,  False ,   True ,   True ,   True ,  False ,  False ,  False ,   True ],
+    "E": ['black', 'white', 'black', 'white', 'white',   None ,   None , 'white', 'black', 'white'],
+    "F": [  None ,   None ,   'abc',   None ,   'def',   None ,   None ,   None ,   None ,   None ],
+    #    -----------------------------------------------------------------------------------------
+}
+
+
+def extract_subsequence(keys, sequence):
+    return dict([(key, sequence[key]) for key in keys])
+
+OPERATIONS_SEQUENCE_A = extract_subsequence('A', OPERATIONS_SEQUENCE)
+OPERATIONS_SEQUENCE_B = extract_subsequence('B', OPERATIONS_SEQUENCE)
+OPERATIONS_SEQUENCE_C = extract_subsequence('C', OPERATIONS_SEQUENCE)
+OPERATIONS_SEQUENCE_D = extract_subsequence('D', OPERATIONS_SEQUENCE)
+OPERATIONS_SEQUENCE_E = extract_subsequence('E', OPERATIONS_SEQUENCE)
+OPERATIONS_SEQUENCE_F = extract_subsequence('F', OPERATIONS_SEQUENCE)
+
+
+class PeriodicStatsCollectorTest(unittest.TestCase):
+
+    def assert_sequence(self, manager, operations_sequence, expected_stats_sequence):
+        """
+        Runs an operations sequence and asserts that returned stats are the expected ones for each interval
+        """
+        for i, iteration_stats, expected_stats in manager.run_sequence(operations_sequence, expected_stats_sequence):
+            self.assertEqual(iteration_stats, expected_stats,
+                             msg='wrong sequence in iteration #%d:\n'
+                                 '     got: %s\n'
+                                 'expected: %s' %
+                                 (i, iteration_stats, expected_stats))
+
+    def test_basic_collector(self):
+        """
+        Tests base scrapy stats collector
+        """
+        manager = CollectorTestManager()
+        stats = manager.collector
+        self.assertEqual(stats.get_stats(), {})
+        self.assertEqual(stats.get_value('anything'), None)
+        self.assertEqual(stats.get_value('anything', 'default'), 'default')
+        stats.set_value('test', 'value')
+        self.assertEqual(stats.get_stats(), {'test': 'value'})
+        stats.set_value('test2', 23)
+        self.assertEqual(stats.get_stats(), {'test': 'value', 'test2': 23})
+        self.assertEqual(stats.get_value('test2'), 23)
+        stats.inc_value('test2')
+        self.assertEqual(stats.get_value('test2'), 24)
+        stats.inc_value('test2', 6)
+        self.assertEqual(stats.get_value('test2'), 30)
+        stats.max_value('test2', 6)
+        self.assertEqual(stats.get_value('test2'), 30)
+        stats.max_value('test2', 40)
+        self.assertEqual(stats.get_value('test2'), 40)
+        stats.max_value('test3', 1)
+        self.assertEqual(stats.get_value('test3'), 1)
+        stats.min_value('test2', 60)
+        self.assertEqual(stats.get_value('test2'), 40)
+        stats.min_value('test2', 35)
+        self.assertEqual(stats.get_value('test2'), 35)
+        stats.min_value('test4', 7)
+        self.assertEqual(stats.get_value('test4'), 7)
+
+    def test_default(self):
+        """
+        Tests default collector
+        """
+        manager = CollectorTestManager()
+        manager.collector.set_value('test', 'value')
+        self.assertEqual(manager.run_interval(), {})
+        self.assertEqual(manager.run_interval(is_close=True), {})
+
+    def test_sequence_default(self):
+        """
+        Tests sequence with default collector
+        """
+        manager = CollectorTestManager({
+            'PERIODIC_STATS_OBSERVERS': [
+                periodicstats.Observer(key='A'),
+                periodicstats.Observer(key='B'),
+                periodicstats.Observer(key='C'),
+                periodicstats.Observer(key='D'),
+                periodicstats.Observer(key='E'),
+                periodicstats.Observer(key='F'),
+            ]
+        })
+        expected_stats_sequence = {
+            #    ------------------------------------------------------------------------------------------
+            #        1        2        3        4        5        6        7        8        9       10
+            #    ------------------------------------------------------------------------------------------
+            "A": [  None ,     10 ,     13 ,     13 ,     18 ,     28 ,     32 ,     32 ,     32 ,     40 ],
+            "B": [     5 ,     10 ,     20 ,     30 ,     10 ,    -10 ,      0 ,     10 ,     60 ,    110 ],
+            "C": [  None ,      1 ,      3 ,      3 ,      4 ,      3 ,      3 ,      4 ,      6 ,      6 ],
+            "D": [  None ,   True ,  False ,   True ,   True ,   True ,  False ,  False ,  False ,   True ],
+            "E": ['black', 'white', 'black', 'white', 'white', 'white', 'white', 'white', 'black', 'white'],
+            "F": [  None ,   None ,   'abc',  'abc' ,   'def',   'def',   'def',   'def',   'def',   'def'],
+            #    ------------------------------------------------------------------------------------------
+        }
+        self.assert_sequence(
+            manager=manager,
+            operations_sequence=OPERATIONS_SEQUENCE,
+            expected_stats_sequence=expected_stats_sequence
+        )
+
+    def test_sequence_filtering(self):
+        """
+        Tests observer key filtering
+        """
+        manager = CollectorTestManager({
+            'PERIODIC_STATS_OBSERVERS': [
+                periodicstats.Observer(key='A'),
+                periodicstats.Observer(key='C'),
+                periodicstats.Observer(key='F'),
+            ]
+        })
+        expected_stats_sequence = {
+            #    ------------------------------------------------------------------------------------------
+            #        1        2        3        4        5        6        7        8        9       10
+            #    ------------------------------------------------------------------------------------------
+            "A": [  None ,     10 ,     13 ,     13 ,     18 ,     28 ,     32 ,     32 ,     32 ,     40 ],
+            "C": [  None ,      1 ,      3 ,      3 ,      4 ,      3 ,      3 ,      4 ,      6 ,      6 ],
+            "F": [  None ,   None ,   'abc',  'abc' ,   'def',   'def',   'def',   'def',   'def',   'def'],
+            #    ------------------------------------------------------------------------------------------
+        }
+        self.assert_sequence(
+            manager=manager,
+            operations_sequence=OPERATIONS_SEQUENCE,
+            expected_stats_sequence=expected_stats_sequence
+        )
+
+    def test_sequence_export_key(self):
+        """
+        Tests sequence + export keys
+        """
+        manager = CollectorTestManager({
+            'PERIODIC_STATS_OBSERVERS': [
+                periodicstats.Observer(key='A', export_key='a'),
+                periodicstats.Observer(key='B', export_key='b'),
+                periodicstats.Observer(key='C', export_key='c'),
+                periodicstats.Observer(key='D', export_key='d'),
+                periodicstats.Observer(key='E', export_key='e'),
+                periodicstats.Observer(key='F', export_key='f'),
+            ]
+        })
+        expected_stats_sequence = {
+            #    ------------------------------------------------------------------------------------------
+            #        1        2        3        4        5        6        7        8        9       10
+            #    ------------------------------------------------------------------------------------------
+            "a": [  None ,     10 ,     13 ,     13 ,     18 ,     28 ,     32 ,     32 ,     32 ,     40 ],
+            "b": [     5 ,     10 ,     20 ,     30 ,     10 ,    -10 ,      0 ,     10 ,     60 ,    110 ],
+            "c": [  None ,      1 ,      3 ,      3 ,      4 ,      3 ,      3 ,      4 ,      6 ,      6 ],
+            "d": [  None ,   True ,  False ,   True ,   True ,   True ,  False ,  False ,  False ,   True ],
+            "e": ['black', 'white', 'black', 'white', 'white', 'white', 'white', 'white', 'black', 'white'],
+            "f": [  None ,   None ,   'abc',  'abc' ,   'def',   'def',   'def',   'def',   'def',   'def'],
+            #    ------------------------------------------------------------------------------------------
+        }
+        self.assert_sequence(
+            manager=manager,
+            operations_sequence=OPERATIONS_SEQUENCE,
+            expected_stats_sequence=expected_stats_sequence
+        )
+
+    def test_sequence_partial_values(self):
+        """
+        Tests sequence + use_partial_values
+        """
+        manager = CollectorTestManager({
+            'PERIODIC_STATS_OBSERVERS': [
+                periodicstats.Observer(key='A', use_partial_values=True),
+                periodicstats.Observer(key='B', use_partial_values=True),
+                periodicstats.Observer(key='C', use_partial_values=True),
+                periodicstats.Observer(key='D'),
+                periodicstats.Observer(key='E'),
+                periodicstats.Observer(key='F'),
+            ]
+        })
+        expected_stats_sequence = {
+            #    ------------------------------------------------------------------------------------------
+            #        1        2        3        4        5        6        7        8        9       10
+            #    ------------------------------------------------------------------------------------------
+            "A": [  None ,     10 ,      3 ,      0 ,      5 ,     10 ,      4 ,      0 ,     0 ,       8 ],
+            "B": [     5 ,      5 ,     10 ,     10 ,    -20 ,    -20 ,     10 ,     10 ,     50 ,     50 ],
+            "C": [  None ,      1 ,      2 ,      0 ,      1 ,     -1 ,      0 ,      1 ,      2 ,      0 ],
+            "D": [  None ,   True ,  False ,   True ,   True ,   True ,  False ,  False ,  False ,   True ],
+            "E": ['black', 'white', 'black', 'white', 'white', 'white', 'white', 'white', 'black', 'white'],
+            "F": [  None ,   None ,   'abc',  'abc' ,   'def',   'def',   'def',   'def',   'def',   'def'],
+            #    ------------------------------------------------------------------------------------------
+        }
+        self.assert_sequence(
+            manager=manager,
+            operations_sequence=OPERATIONS_SEQUENCE,
+            expected_stats_sequence=expected_stats_sequence
+        )
+
+    def test_sequence_only_export_on_change(self):
+        """
+        Tests sequence + only_export_on_change
+        """
+        manager = CollectorTestManager({
+            'PERIODIC_STATS_OBSERVERS': [
+                periodicstats.Observer(key='A', only_export_on_change=True),
+                periodicstats.Observer(key='B', only_export_on_change=True),
+                periodicstats.Observer(key='C', only_export_on_change=True),
+                periodicstats.Observer(key='D', only_export_on_change=True),
+                periodicstats.Observer(key='E', only_export_on_change=True),
+                periodicstats.Observer(key='F', only_export_on_change=True),
+            ]
+        })
+        expected_stats_sequence = {
+            #    ------------------------------------------------------------------------------------------
+            #        1        2        3        4        5        6        7        8        9       10
+            #    ------------------------------------------------------------------------------------------
+            "A": [  None ,     10 ,     13 ,   None ,     18 ,     28 ,     32 ,   None ,   None ,     40 ],
+            "B": [     5 ,     10 ,     20 ,     30 ,     10 ,    -10 ,      0 ,     10 ,     60 ,    110 ],
+            "C": [  None ,      1 ,      3 ,   None ,      4 ,      3 ,   None ,      4 ,      6 ,      6 ],
+            "D": [  None ,   True ,  False ,   True ,   None ,   None ,  False ,   None ,   None ,   True ],
+            "E": ['black', 'white', 'black', 'white',   None ,   None ,   None ,   None , 'black', 'white'],
+            "F": [  None ,   None ,   'abc',   None ,   'def',   None ,   None ,   None ,   None ,   'def'],
+            #    ------------------------------------------------------------------------------------------
+        }
+        self.assert_sequence(
+            manager=manager,
+            operations_sequence=OPERATIONS_SEQUENCE,
+            expected_stats_sequence=expected_stats_sequence
+        )
+
+    def test_sequence_only_export_on_close(self):
+        """
+        Tests sequence + only_export_on_close
+        """
+        manager = CollectorTestManager({
+            'PERIODIC_STATS_OBSERVERS': [
+                periodicstats.Observer(key='A', only_export_on_close=True),
+                periodicstats.Observer(key='B', only_export_on_close=True),
+                periodicstats.Observer(key='C', only_export_on_close=True),
+                periodicstats.Observer(key='D', only_export_on_close=True),
+                periodicstats.Observer(key='E', only_export_on_close=True),
+                periodicstats.Observer(key='F', only_export_on_close=True),
+            ]
+        })
+        expected_stats_sequence = {
+            #    ------------------------------------------------------------------------------------------
+            #        1        2        3        4        5        6        7        8        9       10
+            #    ------------------------------------------------------------------------------------------
+            "A": [  None ,   None ,   None ,   None ,   None ,   None ,   None ,   None ,   None ,     40 ],
+            "B": [  None ,   None ,   None ,   None ,   None ,   None ,   None ,   None ,   None ,    110 ],
+            "C": [  None ,   None ,   None ,   None ,   None ,   None ,   None ,   None ,   None ,      6 ],
+            "D": [  None ,   None ,   None ,   None ,   None ,   None ,   None ,   None ,   None ,   True ],
+            "E": [  None ,   None ,   None ,   None ,   None ,   None ,   None ,   None ,   None , 'white'],
+            "F": [  None ,   None ,   None ,   None ,   None ,   None ,   None ,   None ,   None ,   'def'],
+            #    ------------------------------------------------------------------------------------------
+        }
+        self.assert_sequence(
+            manager=manager,
+            operations_sequence=OPERATIONS_SEQUENCE,
+            expected_stats_sequence=expected_stats_sequence
+        )
+
+    def test_sequence_export_interval(self):
+        """
+        Tests sequence + export_interval
+        """
+        manager = CollectorTestManager({
+            'PERIODIC_STATS_OBSERVERS': [
+                periodicstats.Observer(key='A', export_interval=1),
+                periodicstats.Observer(key='B', export_interval=2),
+                periodicstats.Observer(key='C', export_interval=3),
+                periodicstats.Observer(key='D', export_interval=4),
+                periodicstats.Observer(key='E', export_interval=5),
+                periodicstats.Observer(key='F', export_interval=6),
+            ]
+        })
+        expected_stats_sequence = {
+            #    ------------------------------------------------------------------------------------------
+            #        1        2        3        4        5        6        7        8        9       10
+            #    ------------------------------------------------------------------------------------------
+            "A": [  None ,     10 ,     13 ,     13 ,     18 ,     28 ,     32 ,     32 ,     32 ,     40 ],
+            "B": [     5 ,   None ,     20 ,   None ,     10 ,   None ,      0 ,   None ,     60 ,    110 ],
+            "C": [  None ,   None ,   None ,      3 ,   None ,   None ,      3 ,   None ,   None ,      6 ],
+            "D": [  None ,   None ,   None ,   None ,   True ,   None ,   None ,   None ,  False ,   True ],
+            "E": ['black',   None ,   None ,   None ,   None , 'white',   None ,   None ,   None , 'white'],
+            "F": [  None ,   None ,   None ,   None ,   None ,   None ,   'def',   None ,   None ,   'def'],
+            #    ------------------------------------------------------------------------------------------
+        }
+        self.assert_sequence(
+            manager=manager,
+            operations_sequence=OPERATIONS_SEQUENCE,
+            expected_stats_sequence=expected_stats_sequence
+        )
+
+    def test_sequence_export_interval_only_export_on_change(self):
+        """
+        Tests sequence + export_interval + only_export_on_change
+        """
+        manager = CollectorTestManager({
+            'PERIODIC_STATS_OBSERVERS': [
+                periodicstats.Observer(key='A', export_interval=1, only_export_on_change=True),
+                periodicstats.Observer(key='B', export_interval=2, only_export_on_change=True),
+                periodicstats.Observer(key='C', export_interval=3, only_export_on_change=True),
+                periodicstats.Observer(key='D', export_interval=4, only_export_on_change=True),
+                periodicstats.Observer(key='E', export_interval=5, only_export_on_change=True),
+                periodicstats.Observer(key='F', export_interval=6, only_export_on_change=True),
+            ]
+        })
+        expected_stats_sequence = {
+            #    ------------------------------------------------------------------------------------------
+            #        1        2        3        4        5        6        7        8        9       10
+            #    ------------------------------------------------------------------------------------------
+            "A": [  None ,     10 ,     13 ,   None ,     18 ,     28 ,     32 ,   None ,   None ,     40 ],
+            "B": [     5 ,   None ,     20 ,   None ,     10 ,   None ,      0 ,   None ,     60 ,    110 ],
+            "C": [  None ,   None ,   None ,      3 ,   None ,   None ,   None ,   None ,   None ,      6 ],
+            "D": [  None ,   None ,   None ,   None ,   True ,   None ,   None ,   None ,  False ,   True ],
+            "E": ['black',   None ,   None ,   None ,   None , 'white',   None ,   None ,   None , 'white'],
+            "F": [  None ,   None ,   None ,   None ,   None ,   None ,   'def',   None ,   None ,   'def'],
+            #    ------------------------------------------------------------------------------------------
+        }
+        self.assert_sequence(
+            manager=manager,
+            operations_sequence=OPERATIONS_SEQUENCE,
+            expected_stats_sequence=expected_stats_sequence
+        )
+
+    def test_sequence_same_key(self):
+        """
+        Tests sequence with several observers for same key
+        """
+        manager = CollectorTestManager({
+            'PERIODIC_STATS_OBSERVERS': [
+                periodicstats.Observer(key='A', export_key='A1'),
+                periodicstats.Observer(key='A', export_key='A2'),
+                periodicstats.Observer(key='A', export_key='A3', use_partial_values=True),
+                periodicstats.Observer(key='A', export_key='A4', only_export_on_change=True),
+                periodicstats.Observer(key='A', export_key='A5', only_export_on_close=True),
+                periodicstats.Observer(key='A', export_key='A6', export_interval=3),
+                periodicstats.Observer(key='A', export_key='A7', export_interval=3, only_export_on_change=True),
+            ]
+        })
+        expected_stats_sequence = {
+            #     ------------------------------------------------------------------------------------------
+            #         1        2        3        4        5        6        7        8        9       10
+            #     ------------------------------------------------------------------------------------------
+            "A1": [  None ,     10 ,     13 ,     13 ,     18 ,     28 ,     32 ,     32 ,     32 ,     40 ],
+            "A2": [  None ,     10 ,     13 ,     13 ,     18 ,     28 ,     32 ,     32 ,     32 ,     40 ],
+            "A3": [  None ,     10 ,      3 ,      0 ,      5 ,     10 ,      4 ,      0 ,     0 ,       8 ],
+            "A4": [  None ,     10 ,     13 ,   None ,     18 ,     28 ,     32 ,   None ,   None ,     40 ],
+            "A5": [  None ,   None ,   None ,   None ,   None ,   None ,   None ,   None ,   None ,     40 ],
+            "A6": [  None ,   None ,   None ,     13 ,   None ,   None ,     32 ,   None ,   None ,     40 ],
+            "A7": [  None ,   None ,   None ,     13 ,   None ,   None ,     32 ,   None ,   None ,     40 ],
+            #     -----------------------------------------------------------------------------------------
+        }
+        self.assert_sequence(
+            manager=manager,
+            operations_sequence=OPERATIONS_SEQUENCE,
+            expected_stats_sequence=expected_stats_sequence
+        )
+
+    def test_sequence_regex(self):
+        """
+        Tests sequence with regular expression keys
+        """
+        manager = CollectorTestManager({
+            'PERIODIC_STATS_OBSERVERS': [
+                periodicstats.Observer(key='[A-C]', use_re_key=True, export_key='ABC'),
+                periodicstats.Observer(key='[A-B]', use_re_key=True, export_key='AB'),
+                periodicstats.Observer(key='[A-B]', use_re_key=True, export_key='AB2', export_interval=3),
+                periodicstats.Observer(key='[AC]',  use_re_key=True, export_key='AC'),
+                periodicstats.Observer(key='[AC]',  use_re_key=True, export_key='AC2', only_export_on_change=True),
+                periodicstats.Observer(key='[B-C]', use_re_key=True, export_key='BC'),
+                periodicstats.Observer(key='[B-C]', use_re_key=True, export_key='BC2', only_export_on_close=True),
+            ]
+        })
+        expected_stats_sequence = {
+            #      ------------------------------------------------------------------------------------------
+            #          1        2        3        4        5        6        7        8        9       10
+            #      ------------------------------------------------------------------------------------------
+            "ABC": [     5 ,     21 ,     36 ,     46 ,     32 ,     21 ,     35 ,     46 ,     98 ,    156 ],
+            "AB":  [     5 ,     20 ,     33 ,     43 ,     28 ,     18 ,     32 ,     42 ,     92 ,    150 ],
+            "AB2": [     5 ,   None ,   None ,     43 ,   None ,   None ,     32 ,   None ,   None ,    150 ],
+            "AC":  [  None ,     11 ,     16 ,     16 ,     22 ,     31 ,     35 ,     36 ,     38 ,     46 ],
+            "AC2": [  None ,     11 ,     16 ,   None ,     22 ,     31 ,     35 ,     36 ,     38 ,     46 ],
+            "BC":  [     5 ,     11 ,     23 ,     33 ,     14 ,     -7 ,      3 ,     14 ,     66 ,    116 ],
+            "BC2": [  None ,   None ,   None ,   None ,   None ,   None ,   None ,   None ,   None ,    116 ],
+            #      ------------------------------------------------------------------------------------------
+        }
+        self.assert_sequence(
+            manager=manager,
+            operations_sequence=OPERATIONS_SEQUENCE,
+            expected_stats_sequence=expected_stats_sequence
+        )
+
+    def test_config_errors(self):
+        """
+        Tests configuration errors
+        """
+        def bad_config_not_an_observer():
+            CollectorTestManager({'PERIODIC_STATS_OBSERVERS': [
+                'Not an observer'
+            ]})
+
+        def bad_config_duplicate_key():
+            CollectorTestManager({'PERIODIC_STATS_OBSERVERS': [
+                periodicstats.Observer(key='A'),
+                periodicstats.Observer(key='A'),
+            ]})
+
+        def bad_config_not_string_pipeline():
+            CollectorTestManager({'PERIODIC_STATS_PIPELINES': [
+                69
+            ]})
+
+        def bad_config_bad_pipeline():
+            CollectorTestManager({'PERIODIC_STATS_PIPELINES': [
+                'tests.test_periodicstats.CollectorTestManager'
+            ]})
+
+        self.assertRaises(NotConfigured, bad_config_not_an_observer)
+        self.assertRaises(NotConfigured, bad_config_duplicate_key)
+        self.assertRaises(NotConfigured, bad_config_not_string_pipeline)
+        self.assertRaises(NotConfigured, bad_config_bad_pipeline)
+
+    def _test_config_disabled(self):
+        """
+        Tests PERIODIC_STATS_ENABLED parameter
+        """
+        manager = CollectorTestManager({'PERIODIC_STATS_ENABLED': False})
+        manager.collector.inc_value('test', 1)
+        self.assertEqual(manager.collector.get_stats(), {'test': 1})
+        self.assertEqual(manager.run_interval(), {})
+
+    def test_sequence_config_export_all(self):
+        """
+        Tests PERIODIC_STATS_EXPORT_ALL parameter
+        """
+        manager = CollectorTestManager({
+            'PERIODIC_STATS_EXPORT_ALL': True,
+            'PERIODIC_STATS_EXPORT_ALL_INTERVAL': 1,
+            'PERIODIC_STATS_OBSERVERS': [
+                periodicstats.Observer(key='A'),
+            ]
+
+        })
+        expected_stats_sequence = {
+            #    ------------------------------------------------------------------------------------------
+            #        1        2        3        4        5        6        7        8        9       10
+            #    ------------------------------------------------------------------------------------------
+            "A": [  None ,     10 ,     13 ,     13 ,     18 ,     28 ,     32 ,     32 ,     32 ,     40 ],
+            "B": [     5 ,     10 ,     20 ,     30 ,     10 ,    -10 ,      0 ,     10 ,     60 ,    110 ],
+            "C": [  None ,      1 ,      3 ,      3 ,      4 ,      3 ,      3 ,      4 ,      6 ,      6 ],
+            "D": [  None ,   True ,  False ,   True ,   True ,   True ,  False ,  False ,  False ,   True ],
+            "E": ['black', 'white', 'black', 'white', 'white', 'white', 'white', 'white', 'black', 'white'],
+            "F": [  None ,   None ,   'abc',  'abc' ,   'def',   'def',   'def',   'def',   'def',   'def'],
+            #    ------------------------------------------------------------------------------------------
+        }
+        self.assert_sequence(
+            manager=manager,
+            operations_sequence=OPERATIONS_SEQUENCE,
+            expected_stats_sequence=expected_stats_sequence
+        )
+
+    def test_sequence_config_export_all_interval(self):
+        """
+        Tests PERIODIC_STATS_EXPORT_ALL_INTERVAL parameter
+        """
+        manager = CollectorTestManager({
+            'PERIODIC_STATS_EXPORT_ALL': True,
+            'PERIODIC_STATS_EXPORT_ALL_INTERVAL': 4,
+            'PERIODIC_STATS_OBSERVERS': [
+                periodicstats.Observer(key='A'),
+                periodicstats.Observer(key='B', export_interval=2),
+            ]
+        })
+        expected_stats_sequence = {
+            #    ------------------------------------------------------------------------------------------
+            #        1        2        3        4        5        6        7        8        9       10
+            #    ------------------------------------------------------------------------------------------
+            "A": [  None ,     10 ,     13 ,     13 ,     18 ,     28 ,     32 ,     32 ,     32 ,     40 ],
+            "B": [     5 ,   None ,     20 ,   None ,     10 ,   None ,      0 ,   None ,     60 ,    110 ],
+            "C": [  None ,   None ,   None ,   None ,      4 ,   None ,   None ,   None ,      6 ,      6 ],
+            "D": [  None ,   None ,   None ,   None ,   True ,   None ,   None ,   None ,  False ,   True ],
+            "E": ['black',   None ,   None ,   None , 'white',   None ,   None ,   None , 'black', 'white'],
+            "F": [  None ,   None ,   None ,   None ,   'def',   None ,   None ,   None ,   'def',   'def'],
+            #    ------------------------------------------------------------------------------------------
+        }
+        self.assert_sequence(
+            manager=manager,
+            operations_sequence=OPERATIONS_SEQUENCE,
+            expected_stats_sequence=expected_stats_sequence
+        )
+
+if __name__ == "__main__":
+    unittest.main()
+
+


### PR DESCRIPTION
Added support to periodically selecting, exporting/processing scrapy stats.

Some use cases can be:
- Monitor and graph scraping data over time (memory usage, http codes, errors, scraped items, etc).
- Get notified when a crawl job has finished or alerted when something happens.
- Use your own stat values to monitor custom data or events.

Time-based graphs can be generated using a 3rd party tool like [Kibana](http://www.elasticsearch.org/overview/kibana/).

Job is done by a `StatCollector` class called `PeriodicStatsCollector`. It can be configurated with:
- `Value Observers`: To select and configure the filtered periodic stats.
- `Stats Pipelines`: To process the generated stats.

All configuration is done via settings, an example that will log responses count every 30 seconds:

``` python
from scrapy.contrib import periodicstats as stats

STATS_CLASS = 'scrapy.contrib.periodicstats.PeriodicStatsCollector'
PERIODIC_STATS_OBSERVERS = [
    stats.Observer(key='downloader/response_count', export_interval=30),
]
PERIODIC_STATS_PIPELINES = [
    'scrapy.contrib.periodicstats.PeriodicStatsLogger',
]
```

That will produce the following output:

```
2015-01-16 11:29:10+0100 [scrapy] INFO: Dumping Scrapy periodic stats:
    {'interval': 1,
     'spider': 'example',
     'stats': {'downloader/response_count': 51}}
2015-01-16 11:29:40+0100 [scrapy] INFO: Dumping Scrapy periodic stats:
    {'interval': 2,
     'spider': 'example',
     'stats': {'downloader/response_count': 489}}
...
```
## Value Observers

They allow to select data from the available Stats Collection and define when it should be generated. 

Some examples...

You can define many observers:

``` python
PERIODIC_STATS_OBSERVERS = [
    stats.Observer(key='downloader/request_count'),
    stats.Observer(key='downloader/response_count'),
    stats.Observer(key='httpcache/hit'),
]

"""
Generated stats:
{'downloader/request_count': 10, 'downloader/request_count': 10, 'httpcache/hit': 0}  # for t=1
{'downloader/request_count': 23, 'downloader/request_count': 20, 'httpcache/hit': 3}  # for t=2
{'downloader/request_count': 23, 'downloader/request_count': 20, 'httpcache/hit': 3}  # for t=3
{'downloader/request_count': 34, 'downloader/request_count': 28, 'httpcache/hit': 7}  # for t=4
...
"""
```

To use a different name for the stats value use the `export_key` parameter:

``` python
PERIODIC_STATS_OBSERVERS = [
    stats.Observer(key='downloader/request_count', export_key='requests'),
    stats.Observer(key='downloader/response_count', export_key='responses'),
    stats.Observer(key='httpcache/hit', export_key='from_cache'),
]

"""
Generated stats:
{'requests': 10, 'responses': 10, 'from_cache': 0}   # for t=1
{'requests': 23, 'responses': 20, 'from_cache': 3}   # for t=2
{'requests': 23, 'responses': 20, 'from_cache': 3}   # for t=3
{'requests': 34, 'responses': 28, 'from_cache': 7}   # for t=4
...
"""
```

You can use several observers at the same key, but then `export_key` can’t be repeated:

``` python
PERIODIC_STATS_OBSERVERS = [
    stats.Observer(key='downloader/request_count', export_key='requests_counter'),
    stats.Observer(key='downloader/request_count', export_key='another_request_counter'),
]

"""
Generated stats:
{'requests_counter': 10, 'another_request_counter': 10}  # for t=1
{'requests_counter': 23, 'another_request_counter': 23}  # for t=2
{'requests_counter': 23, 'another_request_counter': 23}  # for t=3
{'requests_counter': 34, 'another_request_counter': 34}  # for t=4
...
"""
```

By default values are accumulated, but we can also use just differences between intervals with the `use_partial_values` parameter:

``` python
PERIODIC_STATS_OBSERVERS = [
    stats.Observer(key='downloader/request_count', export_key='requests', use_partial_values=True),
]

"""
Generated stats:
{'requests': 10}  # for t=1
{'requests': 13}  # for t=2
{'requests': 0}   # for t=3
{'requests': 11}  # for t=4
...
"""
```

To minimize generated data we can choose to export data only when it changes with the `only_export_on_change` parameter:

``` python
PERIODIC_STATS_OBSERVERS = [
    stats.Observer(key='downloader/request_count', export_key='requests', only_export_on_change=True),
]

"""
Generated stats:
{'requests': 10}  # for t=1
{'requests': 13}  # for t=2
{}                # for t=3
{'requests': 11}  # for t=4
...
"""
```

We can define export intervals per key with the `export_interval` parameter:

``` python
PERIODIC_STATS_OBSERVERS = [
    stats.Observer(key='downloader/request_count', export_key='requests', export_interval=1),
    stats.Observer(key='downloader/response_count', export_key='responses', export_interval=2),
]

"""
Generated stats:
{'requests': 10, 'responses': 10}  # for t=1
{'requests': 23}                   # for t=2
{'requests': 23, 'responses': 20}  # for t=3
{'requests': 34}                   # for t=4
...
"""
```

To export only stats when a spider is finished use the `only_export_on_close` parameter:

``` python
PERIODIC_STATS_OBSERVERS = [
    stats.Observer(key='downloader/request_count', export_key='requests', only_export_on_close=True),
]

"""
Generated stats:
{}                  # for t=1
{}                  # for t=2
{}                  # for t=3
{}                  # for t=4
...
{'requests': 2759}  # on spider_close
"""
```

Regular expressions can be used to group/filter data with the `use_re_key` parameter::

``` python
PERIODIC_STATS_OBSERVERS = [
    stats.Observer(key='downloader/response_status_count/2..', use_re_key=True, export_key='2xx'),
    stats.Observer(key='downloader/response_status_count/3..', use_re_key=True, export_key='3xx'),
    stats.Observer(key='downloader/response_status_count/4..', use_re_key=True, export_key='4xx'),
    stats.Observer(key='downloader/response_status_count/5..', use_re_key=True, export_key='5xx'),
]

"""
Generated stats:
{'2xx': 10}                               # for t=1
{'2xx': 34, '3xx': 1, '4xx':1}            # for t=2
{'2xx': 67, '3xx': 4, '4xx':2, '5xx': 1}  # for t=3
{'2xx': 90, '3xx': 8, '4xx':2, '5xx': 1}  # for t=4
...
"""
```
## Stats Pipelines

Basically work like item pipelines, they have a `process_stats` method where they will receive the generated stats from the observers for every interval.

``` python
class PeriodicStatsPipeline(object):
    """
    Base class for periodic stats pipeline
    """
    def __init__(self, crawler):
        pass

    @classmethod
    def from_crawler(cls, crawler):
        return cls(crawler)

    def open_spider(self, spider):
        pass

    def close_spider(self, spider, reason):
        pass

    def process_stats(self, spider, period, stats):
        raise NotImplementedError


class PeriodicStatsLogger(PeriodicStatsPipeline):
    """
    Stats processor that print stats debug info
    """
    def process_stats(self, spider, interval, stats):
        log.msg('Dumping Scrapy periodic stats:\n' + pprint.pformat({
            'spider': spider.name,
            'interval': interval,
            'stats': stats,
        }))
        return stats
```

Not implemented yet, but some uses may be exporting to ELK through [redis](http://redis.io/)>[logstash](http://logstash.net/) or exporting stats to [hubstorage](https://github.com/scrapinghub/hubstorage) using its API.
