### PR TITLE
Don't rely on external urls for tests

### DIFF
--- a/scrapy/utils/testsite.py
+++ b/scrapy/utils/testsite.py
@@ -7,10 +7,12 @@ from twisted.web import server, resource, static, util
 class SiteTest(object):
 
     def setUp(self):
+        super(SiteTest, self).setUp()
         self.site = reactor.listenTCP(0, test_site(), interface="127.0.0.1")
         self.baseurl = "http://localhost:%d/" % self.site.getHost().port
 
     def tearDown(self):
+        super(SiteTest, self).tearDown()
         self.site.stopListening()
 
     def url(self, path):


### PR DESCRIPTION
I changed the parse command test to use a locally-hosted page instead of http://scrapinghub.com. It's the only test that relied on a external url, so, since scrapinghub.com is currently breaking our travis builds because of an issue already reported, after this PR tests should be safer.

 