### PR TITLE
Stripping hrefs extracted by linkextractor of preceding and following spaces

### DIFF
--- a/scrapy/contrib/linkextractors/lxmlhtml.py
+++ b/scrapy/contrib/linkextractors/lxmlhtml.py
@@ -42,6 +42,8 @@ class LxmlParserLinkExtractor(object):
             for attrib in attribs:
                 if not self.scan_attr(attrib):
                     continue
+                if attrib in ['href', 'src']:
+                    attribs[attrib] = attribs[attrib].strip()
                 yield (el, attrib, attribs[attrib])
 
     def _extract_links(self, selector, response_url, response_encoding, base_url):


### PR DESCRIPTION
stripping all extracted `href` and `src` attributes of preceding and following spaces to reduce infite looping as described in issue https://github.com/scrapy/scrapy/issues/838.
