### PR TITLE
adding option to use html5lib instead of default htmlparser

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 Twisted>=10.0.0
 lxml
+html5lib
 pyOpenSSL
 cssselect>=0.9
 w3lib>=1.8.0

--- a/scrapy/selector/lxmldocument.py
+++ b/scrapy/selector/lxmldocument.py
@@ -5,15 +5,21 @@ garbage collection to lxml element tree documents.
 
 import weakref
 from lxml import etree
+from lxml.html import html5parser
+from lxml.etree import XMLSyntaxError
 from scrapy.utils.trackref import object_ref
-
 
 def _factory(response, parser_cls):
     url = response.url
     body = response.body_as_unicode().strip().encode('utf8') or '<html/>'
-    parser = parser_cls(recover=True, encoding='utf8')
-    return etree.fromstring(body, parser=parser, base_url=url)
 
+    if parser_cls == 'html5parser':
+        result = html5parser.fromstring(body)
+    else:
+        parser = parser_cls(recover=False, encoding='utf8')
+        result = etree.fromstring(body, parser=parser, base_url=url)
+
+    return result
 
 class LxmlDocument(object_ref):
 

--- a/scrapy/selector/lxmldocument.py
+++ b/scrapy/selector/lxmldocument.py
@@ -16,7 +16,7 @@ def _factory(response, parser_cls):
     if parser_cls == 'html5parser':
         result = html5parser.fromstring(body)
     else:
-        parser = parser_cls(recover=False, encoding='utf8')
+        parser = parser_cls(recover=True, encoding='utf8')
         result = etree.fromstring(body, parser=parser, base_url=url)
 
     return result

--- a/scrapy/selector/unified.py
+++ b/scrapy/selector/unified.py
@@ -25,6 +25,9 @@ _ctgroup = {
     'html': {'_parser': etree.HTMLParser,
              '_csstranslator': ScrapyHTMLTranslator(),
              '_tostring_method': 'html'},
+    'html5': {'_parser': 'html5parser',
+              '_csstranslator': ScrapyHTMLTranslator(),
+              '_tostring_method': 'html'},
     'xml': {'_parser': SafeXMLParser,
             '_csstranslator': ScrapyGenericTranslator(),
             '_tostring_method': 'xml'},
@@ -34,7 +37,7 @@ _ctgroup = {
 def _st(response, st):
     if st is None:
         return 'xml' if isinstance(response, XmlResponse) else 'html'
-    elif st in ('xml', 'html'):
+    elif st in ('xml', 'html', 'html5'):
         return st
     else:
         raise ValueError('Invalid type: %s' % st)

--- a/tests/test_selector.py
+++ b/tests/test_selector.py
@@ -360,6 +360,25 @@ class SelectorTestCase(unittest.TestCase):
 
         self.assertEqual(sel.extract(), '<foo>&xxe;</foo>')
 
+    def test_invalid_chars_lt(self):
+        elem = '< 100'
+        invalid_xml = '<html><head></head><body>'\
+                      '<div id="distance">{0}</div>'\
+                      '<body></html>'.format(elem)
+        response = HtmlResponse('http://example.com', body=invalid_xml)
+        sel = self.sscls(response=response, type='html5')
+        text = sel.xpath('//*[@id="distance"]//text()').extract()
+        self.assertEqual(text, [elem])
+
+    def test_invalid_chars_gt(self):
+        elem = '10,00 > 9,00'
+        invalid_xml = '<html><head></head><body>'\
+                      '<div id="distance">{0}</div>'\
+                      '<body></html>'.format(elem)
+        response = HtmlResponse('http://example.com', body=invalid_xml)
+        sel = self.sscls(response=response, type='html5')
+        text = sel.xpath('//*[@id="distance"]//text()').extract()
+        self.assertEqual(text, [elem])
 
 class DeprecatedXpathSelectorTest(unittest.TestCase):
 


### PR DESCRIPTION
#1039 using html5lib invalid chars as <, >, etc are not stripped. Safer, but a bit slower.
