### PR TITLE
py3-ignores.txt supports comments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+/.vagrant
+/scrapy.iml
 *.pyc
 _trial_temp*
 dropin.cache

--- a/conftest.py
+++ b/conftest.py
@@ -9,9 +9,10 @@ if 'django' not in optional_features:
     collect_ignore.append("tests/test_djangoitem/models.py")
 
 if six.PY3:
-    for fn in open('tests/py3-ignores.txt'):
-        if fn.strip():
-            collect_ignore.append(fn.strip())
+    for line in open('tests/py3-ignores.txt'):
+        filePath = line.strip()
+        if len(filePath) > 0 and filePath[0] != '#':    
+            collect_ignore.append(filePath)
 
 class LogObservers:
     """Class for keeping track of log observers across test modules"""

--- a/conftest.py
+++ b/conftest.py
@@ -10,9 +10,9 @@ if 'django' not in optional_features:
 
 if six.PY3:
     for line in open('tests/py3-ignores.txt'):
-        filePath = line.strip()
-        if len(filePath) > 0 and filePath[0] != '#':    
-            collect_ignore.append(filePath)
+        file_path = line.strip()
+        if len(file_path) > 0 and file_path[0] != '#':
+            collect_ignore.append(file_path)
 
 class LogObservers:
     """Class for keeping track of log observers across test modules"""


### PR DESCRIPTION
Hi, I will work on porting Scrapy to Python3. I saw that all problematic tests for python3 are in py3-ignores.txt.
That's great since I know what should be fixed.
While checking few testcases I notice that sometimes fixing will require to modify or even wait for external project (e.g. Twisted).  It would be very helpful to be able to annotate those tests so I can leave them for later and focus on next problem. Example:
```
# Waiting for ticket: http:/github.com/ticket23
tests/test1.py
tests/test2.py
```
This PR skips lines which starts with '#' from py3-ignores.txt