### PR TITLE
Twisted 15.0.0 Support

### DIFF
--- a/scrapy/core/downloader/handlers/http11.py
+++ b/scrapy/core/downloader/handlers/http11.py
@@ -19,7 +19,7 @@ from scrapy.http import Headers
 from scrapy.responsetypes import responsetypes
 from scrapy.core.downloader.webclient import _parse
 from scrapy.utils.misc import load_object
-from scrapy import log
+from scrapy import log, twisted_version
 
 
 class HTTP11DownloadHandler(object):
@@ -142,10 +142,19 @@ class TunnelingAgent(Agent):
         self._proxyConf = proxyConf
         self._contextFactory = contextFactory
 
-    def _getEndpoint(self, scheme, host, port):
-        return TunnelingTCP4ClientEndpoint(self._reactor, host, port,
-            self._proxyConf, self._contextFactory, self._connectTimeout,
-            self._bindAddress)
+    if twisted_version >= (15, 0, 0):
+        def _getEndpoint(self, uri):
+            return TunnelingTCP4ClientEndpoint(
+                self._reactor, uri.host, uri.port, self._proxyConf,
+                self._contextFactory, self._endpointFactory._connectTimeout,
+                self._endpointFactory._bindAddress)
+    else:
+        def _getEndpoint(self, scheme, host, port):
+            return TunnelingTCP4ClientEndpoint(
+                self._reactor, host, port, self._proxyConf,
+                self._contextFactory, self._connectTimeout,
+                self._bindAddress)
+
 
 
 class ScrapyAgent(object):


### PR DESCRIPTION
There were a few changes on Twisted's Agent API in 15.0.0 release ([Release Notes](https://twistedmatrix.com/trac/browser/tags/releases/twisted-15.0.0/twisted/web/topfiles/NEWS#L9)) which can be seen here: [changeset/42679](https://twistedmatrix.com/trac/changeset/42679).

Agent's API now supports providing a custom EndpointFactory, which should return an Endpoint for a given URI (this object replaces explicit (scheme, host, port) parameters). With this new API we shouldn't need additional Agents as on [ScrapyAgent._get_agent](https://github.com/scrapy/scrapy/blob/09ba4ff68a7ecb00036d02ffda9ee48f48b69402/scrapy/core/downloader/handlers/http11.py#L166), but we can adopt it later.

This PR fixes bug  #1034.