### PR TITLE
Add timezones to native times

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ env:
 install:
 - "./.travis-workarounds.sh"
 - pip install -U tox
+- pip install -r requirements.txt
 script: tox
 notifications:
   irc:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 Twisted>=10.0.0
 lxml
 pyOpenSSL
+pytz==2014.10
 cssselect>=0.9
 w3lib>=1.8.0
 queuelib

--- a/scrapy/contrib/corestats.py
+++ b/scrapy/contrib/corestats.py
@@ -2,6 +2,7 @@
 Extension for collecting core stats like items scraped and start/finish times
 """
 import datetime
+import pytz
 
 from scrapy import signals
 
@@ -21,10 +22,10 @@ class CoreStats(object):
         return o
 
     def spider_opened(self, spider):
-        self.stats.set_value('start_time', datetime.datetime.utcnow(), spider=spider)
+        self.stats.set_value('start_time', datetime.datetime.utcnow().replace(tzinfo=pytz.utc), spider=spider)
 
     def spider_closed(self, spider, reason):
-        self.stats.set_value('finish_time', datetime.datetime.utcnow(), spider=spider)
+        self.stats.set_value('finish_time', datetime.datetime.utcnow().replace(tzinfo=pytz.utc), spider=spider)
         self.stats.set_value('finish_reason', reason, spider=spider)
 
     def item_scraped(self, item, spider):

--- a/scrapy/contrib/feedexport.py
+++ b/scrapy/contrib/feedexport.py
@@ -7,6 +7,7 @@ See documentation in docs/topics/feed-exports.rst
 import sys, os, posixpath
 from tempfile import TemporaryFile
 from datetime import datetime
+import pytz
 from six.moves.urllib.parse import urlparse
 from ftplib import FTP
 
@@ -228,7 +229,7 @@ class FeedExporter(object):
         params = {}
         for k in dir(spider):
             params[k] = getattr(spider, k)
-        ts = datetime.utcnow().replace(microsecond=0).isoformat().replace(':', '-')
+        ts = datetime.utcnow().replace(tzinfo=pytz.utc, microsecond=0).isoformat().replace(':', '-')
         params['time'] = ts
         self._uripar(params, spider)
         return params


### PR DESCRIPTION
Django is yelling at me that I'm inserting native times into timezone aware fields.  Let's make these dates precise!
