### PR TITLE
Don't let Item and Django model diverge

### DIFF
--- a/scrapy/contrib/djangoitem.py
+++ b/scrapy/contrib/djangoitem.py
@@ -32,6 +32,16 @@ class DjangoItem(Item):
         self._instance = None
         self._errors = None
 
+    def __setitem__(self, key, value):
+        super(DjangoItem, self).__setitem__(key, value)
+        if self._instance is not None:
+            setattr(self._instance, key, value)
+
+    def __delitem__(self, key):
+        if self._instance is not None:
+            self._instance = None
+        return super(DjangoItem, self).__delitem__(key)
+
     def save(self, commit=True):
         if commit:
             self.instance.save()

--- a/scrapy/contrib/djangoitem.py
+++ b/scrapy/contrib/djangoitem.py
@@ -28,9 +28,9 @@ class DjangoItem(Item):
     django_model = None
 
     def __init__(self, *args, **kwargs):
-        super(DjangoItem, self).__init__(*args, **kwargs)
         self._instance = None
         self._errors = None
+        super(DjangoItem, self).__init__(*args, **kwargs)
 
     def __setitem__(self, key, value):
         super(DjangoItem, self).__setitem__(key, value)

--- a/tests/test_djangoitem/__init__.py
+++ b/tests/test_djangoitem/__init__.py
@@ -101,3 +101,17 @@ class DjangoItemTest(unittest.TestCase):
         i = BasePersonItem()
         person = i.save(commit=False)
         self.assertEqual(person.name, 'Robot')
+
+    def test_setitem(self):
+        i = BasePersonItem()
+        i['age'] = 22
+        self.assertEqual(i.instance.age, 22)
+        i['name'] = 'John'
+        self.assertEqual(i.instance.name, 'John')
+
+    def test_delitem(self):
+        i = BasePersonItem()
+        i['age'] = 22
+        self.assertEqual(i.instance.age, 22)
+        del i['age']
+        self.assertEqual(i.instance.age, None)


### PR DESCRIPTION
I got bit by referencing `DjangoItem.instance` in the middle of setting properties.  I later realized days later that I had blank values in some of my fields :sob:  The crux of the bug can be seen in the unit test.

This fix makes it so the scrapy item & Django model won't diverge!