### PR TITLE
[MRG+1] 0 delay inside utils/defer.py->defer_succeed makes reactor not to be async enough

### DIFF
--- a/scrapy/utils/defer.py
+++ b/scrapy/utils/defer.py
@@ -12,7 +12,7 @@ def defer_fail(_failure):
     next reactor loop
     """
     d = defer.Deferred()
-    reactor.callLater(0, d.errback, _failure)
+    reactor.callLater(0.1, d.errback, _failure)
     return d
 
 def defer_succeed(result):
@@ -20,7 +20,7 @@ def defer_succeed(result):
     next reactor loop
     """
     d = defer.Deferred()
-    reactor.callLater(0, d.callback, result)
+    reactor.callLater(0.1, d.callback, result)
     return d
 
 def defer_result(result):


### PR DESCRIPTION

This will make scrapy to be more async by letting the reactor spend extra cycles to accomplish its needs.