### PR TITLE
remove unnecessary check from scrapy.utils.spider.iter_spider_output

### DIFF
--- a/scrapy/utils/spider.py
+++ b/scrapy/utils/spider.py
@@ -3,13 +3,13 @@ import inspect
 import six
 
 from scrapy import log
-from scrapy.item import BaseItem
 from scrapy.spider import Spider
 from scrapy.utils.misc import  arg_to_iter
 
 
 def iterate_spider_output(result):
-    return [result] if isinstance(result, BaseItem) else arg_to_iter(result)
+    return arg_to_iter(result)
+
 
 def iter_spider_classes(module):
     """Return an iterator over all spider classes defined in the given module


### PR DESCRIPTION
arg_to_iter handles Items since https://github.com/scrapy/scrapy/commit/2bbd92742b796e1a565d4914a77889c884dd01ac.

I'm not sure about keeping `iter_spider_output` vs removing/deprecating it, but kept it for now because it seems its name can be more clear in some cases. 