### PR TITLE
Use Shields.io SVGs for README badges

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,15 +2,17 @@
 Scrapy
 ======
 
-.. image:: https://badge.fury.io/py/Scrapy.png
-   :target: http://badge.fury.io/py/Scrapy
+.. image:: https://img.shields.io/pypi/v/Scrapy.svg
+   :target: https://pypi.python.org/pypi/Scrapy
+   :alt: PyPI Version
 
-.. image:: https://secure.travis-ci.org/scrapy/scrapy.png?branch=master
+.. image:: https://img.shields.io/travis/scrapy/scrapy/master.svg
    :target: http://travis-ci.org/scrapy/scrapy
+   :alt: Build Status
 
-.. image:: https://pypip.in/wheel/Scrapy/badge.png
-    :target: https://pypi.python.org/pypi/Scrapy/
-    :alt: Wheel Status
+.. image:: https://img.shields.io/badge/wheel-yes-brightgreen.svg
+   :target: https://pypi.python.org/pypi/Scrapy
+   :alt: Wheel Status
 
 Overview
 ========


### PR DESCRIPTION
This PR changes the README badges to use [Shields.io](http://shields.io) SVGs, which are more friendly to retina displays and have a standardized appearance (see the comparison below). I also added alt text to the PyPI version and build status badges. I wasn't sure how important the wheel status badge is, but I replicated it anyways using Shields' custom badge functionality.

![Badge Comparison](https://cloud.githubusercontent.com/assets/2434728/6703155/41c2b670-ccf4-11e4-8bed-84b5adb3a306.png)
