### PR TITLE
New DownloaderMiddleware flow

### DIFF
--- a/scrapy/contrib/downloadermiddleware/ajaxcrawl.py
+++ b/scrapy/contrib/downloadermiddleware/ajaxcrawl.py
@@ -28,19 +28,18 @@ class AjaxCrawlMiddleware(object):
         return cls(crawler.settings)
 
     def process_response(self, request, response, spider):
-
         if not isinstance(response, HtmlResponse) or response.status != 200:
-            return response
+            return
 
         if request.method != 'GET':
             # other HTTP methods are either not safe or don't have a body
-            return response
+            return
 
         if 'ajax_crawlable' in request.meta:  # prevent loops
-            return response
+            return
 
         if not self._has_ajax_crawlable_variant(response):
-            return response
+            return
 
         # scrapy already handles #! links properly
         ajax_crawl_request = request.replace(url=request.url+'#!')

--- a/scrapy/contrib/downloadermiddleware/chunked.py
+++ b/scrapy/contrib/downloadermiddleware/chunked.py
@@ -10,4 +10,4 @@ class ChunkedTransferMiddleware(object):
         if response.headers.get('Transfer-Encoding') == 'chunked':
             body = decode_chunked_transfer(response.body)
             return response.replace(body=body)
-        return response
+        return

--- a/scrapy/contrib/downloadermiddleware/cookies.py
+++ b/scrapy/contrib/downloadermiddleware/cookies.py
@@ -38,7 +38,7 @@ class CookiesMiddleware(object):
 
     def process_response(self, request, response, spider):
         if request.meta.get('dont_merge_cookies', False):
-            return response
+            return
 
         # extract cookies from Set-Cookie and drop invalid/expired cookies
         cookiejarkey = request.meta.get("cookiejar")
@@ -46,7 +46,7 @@ class CookiesMiddleware(object):
         jar.extract_cookies(response, request)
         self._debug_set_cookie(response, spider)
 
-        return response
+        return
 
     def _debug_cookie(self, request, spider):
         if self.debug:

--- a/scrapy/contrib/downloadermiddleware/httpcache.py
+++ b/scrapy/contrib/downloadermiddleware/httpcache.py
@@ -57,12 +57,12 @@ class HttpCacheMiddleware(object):
 
     def process_response(self, request, response, spider):
         if request.meta.get('dont_cache', False):
-            return response
+            return
 
         # Skip cached responses and uncacheable requests
         if 'cached' in response.flags or '_dont_cache' in request.meta:
             request.meta.pop('_dont_cache', None)
-            return response
+            return
 
         # RFC2616 requires origin server to set Date header,
         # http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.18
@@ -74,7 +74,7 @@ class HttpCacheMiddleware(object):
         if cachedresponse is None:
             self.stats.inc_value('httpcache/firsthand', spider=spider)
             self._cache_response(spider, response, request, cachedresponse)
-            return response
+            return
 
         if self.policy.is_cached_response_valid(cachedresponse, response, request):
             self.stats.inc_value('httpcache/revalidate', spider=spider)
@@ -82,7 +82,6 @@ class HttpCacheMiddleware(object):
 
         self.stats.inc_value('httpcache/invalidate', spider=spider)
         self._cache_response(spider, response, request, cachedresponse)
-        return response
 
     def _cache_response(self, spider, response, request, cachedresponse):
         if self.policy.should_cache_response(response, request):

--- a/scrapy/contrib/downloadermiddleware/httpcompression.py
+++ b/scrapy/contrib/downloadermiddleware/httpcompression.py
@@ -9,34 +9,32 @@ from scrapy.exceptions import NotConfigured
 class HttpCompressionMiddleware(object):
     """This middleware allows compressed (gzip, deflate) traffic to be
     sent/received from web sites"""
-    
+
     @classmethod
     def from_crawler(cls, crawler):
         if not crawler.settings.getbool('COMPRESSION_ENABLED'):
             raise NotConfigured
         return cls()
-    
+
     def process_request(self, request, spider):
         request.headers.setdefault('Accept-Encoding', 'gzip,deflate')
 
     def process_response(self, request, response, spider):
-        if isinstance(response, Response):
-            content_encoding = response.headers.getlist('Content-Encoding')
-            if content_encoding and not is_gzipped(response):
-                encoding = content_encoding.pop()
-                decoded_body = self._decode(response.body, encoding.lower())
-                respcls = responsetypes.from_args(headers=response.headers, \
-                    url=response.url)
-                kwargs = dict(cls=respcls, body=decoded_body)
-                if issubclass(respcls, TextResponse):
-                    # force recalculating the encoding until we make sure the
-                    # responsetypes guessing is reliable
-                    kwargs['encoding'] = None
-                response = response.replace(**kwargs)
-                if not content_encoding:
-                    del response.headers['Content-Encoding']
-
-        return response
+        content_encoding = response.headers.getlist('Content-Encoding')
+        if content_encoding and not is_gzipped(response):
+            encoding = content_encoding.pop()
+            decoded_body = self._decode(response.body, encoding.lower())
+            respcls = responsetypes.from_args(headers=response.headers, \
+                url=response.url)
+            kwargs = dict(cls=respcls, body=decoded_body)
+            if issubclass(respcls, TextResponse):
+                # force recalculating the encoding until we make sure the
+                # responsetypes guessing is reliable
+                kwargs['encoding'] = None
+            response = response.replace(**kwargs)
+            if not content_encoding:
+                del response.headers['Content-Encoding']
+            return response
 
     def _decode(self, body, encoding):
         if encoding == 'gzip' or encoding == 'x-gzip':

--- a/scrapy/contrib/downloadermiddleware/redirect.py
+++ b/scrapy/contrib/downloadermiddleware/redirect.py
@@ -53,7 +53,7 @@ class RedirectMiddleware(BaseRedirectMiddleware):
 
     def process_response(self, request, response, spider):
         if request.meta.get('dont_redirect', False):
-            return response
+            return
 
         if request.method == 'HEAD':
             if response.status in [301, 302, 303, 307] and 'Location' in response.headers:
@@ -61,7 +61,7 @@ class RedirectMiddleware(BaseRedirectMiddleware):
                 redirected = request.replace(url=redirected_url)
                 return self._redirect(redirected, request, spider, response.status)
             else:
-                return response
+                return
 
         if response.status in [302, 303] and 'Location' in response.headers:
             redirected_url = urljoin(request.url, response.headers['location'])
@@ -72,8 +72,6 @@ class RedirectMiddleware(BaseRedirectMiddleware):
             redirected_url = urljoin(request.url, response.headers['location'])
             redirected = request.replace(url=redirected_url)
             return self._redirect(redirected, request, spider, response.status)
-
-        return response
 
 
 class MetaRefreshMiddleware(BaseRedirectMiddleware):
@@ -88,12 +86,10 @@ class MetaRefreshMiddleware(BaseRedirectMiddleware):
     def process_response(self, request, response, spider):
         if request.meta.get('dont_redirect', False) or request.method == 'HEAD' or \
                 not isinstance(response, HtmlResponse):
-            return response
+            return
 
         if isinstance(response, HtmlResponse):
             interval, url = get_meta_refresh(response)
             if url and interval < self._maxdelay:
                 redirected = self._redirect_request_using_get(request, url)
                 return self._redirect(redirected, request, spider, 'meta refresh')
-
-        return response

--- a/scrapy/contrib/downloadermiddleware/stats.py
+++ b/scrapy/contrib/downloadermiddleware/stats.py
@@ -24,7 +24,6 @@ class DownloaderStats(object):
         self.stats.inc_value('downloader/response_status_count/%s' % response.status, spider=spider)
         reslen = len(response_httprepr(response))
         self.stats.inc_value('downloader/response_bytes', reslen, spider=spider)
-        return response
 
     def process_exception(self, request, exception, spider):
         ex_class = "%s.%s" % (exception.__class__.__module__, exception.__class__.__name__)

--- a/scrapy/core/engine.py
+++ b/scrapy/core/engine.py
@@ -193,7 +193,7 @@ class ExecutionEngine(object):
         slot = self.slot
         slot.add_request(request)
         def _on_success(response):
-            assert isinstance(response, (Response, Request))
+            assert isinstance(response, (Response, Request)), '{}'.format(type(response))
             if isinstance(response, Response):
                 response.request = request # tie request to response received
                 logkws = self.logformatter.crawled(request, response, spider)

--- a/tests/test_downloadermiddleware_ajaxcrawlable.py
+++ b/tests/test_downloadermiddleware_ajaxcrawlable.py
@@ -24,13 +24,13 @@ class AjaxCrawlMiddlewareTest(unittest.TestCase):
     def test_non_get(self):
         req, resp = self._req_resp('http://example.com/', {'method': 'HEAD'})
         resp2 = self.mw.process_response(req, resp, self.spider)
-        self.assertEqual(resp, resp2)
+        self.assertEqual(resp2, None)
 
     def test_binary_response(self):
         req = Request('http://example.com/')
         resp = Response('http://example.com/', body=b'foobar\x00\x01\x02', request=req)
         resp2 = self.mw.process_response(req, resp, self.spider)
-        self.assertIs(resp, resp2)
+        self.assertIs(resp2, None)
 
     def test_ajaxcrawl(self):
         req, resp = self._req_resp(
@@ -45,14 +45,13 @@ class AjaxCrawlMiddlewareTest(unittest.TestCase):
     def test_ajaxcrawl_loop(self):
         req, resp = self._req_resp('http://example.com/', {}, {'body': self._ajaxcrawlable_body()})
         req2 = self.mw.process_response(req, resp, self.spider)
+        assert isinstance(req2, Request)
         resp2 = HtmlResponse(req2.url, body=resp.body, request=req2)
         resp3 = self.mw.process_response(req2, resp2, self.spider)
-
-        assert isinstance(resp3, HtmlResponse), (resp3.__class__, resp3)
-        self.assertEqual(resp3.request.url, 'http://example.com/?_escaped_fragment_=')
-        assert resp3 is resp2
+        assert resp3 is None
+        self.assertEqual(resp2.request.url, 'http://example.com/?_escaped_fragment_=')
 
     def test_noncrawlable_body(self):
         req, resp = self._req_resp('http://example.com/', {}, {'body': '<html></html>'})
         resp2 = self.mw.process_response(req, resp, self.spider)
-        self.assertIs(resp, resp2)
+        self.assertIs(resp2, None)

--- a/tests/test_downloadermiddleware_cookies.py
+++ b/tests/test_downloadermiddleware_cookies.py
@@ -28,7 +28,7 @@ class CookiesMiddlewareTest(TestCase):
         assert 'Cookie' not in req.headers
 
         res = Response('http://scrapytest.org/', headers=headers)
-        assert self.mw.process_response(req, res, self.spider) is res
+        assert self.mw.process_response(req, res, self.spider) is None
 
         #assert res.cookies
 
@@ -41,7 +41,7 @@ class CookiesMiddlewareTest(TestCase):
         headers = {'Set-Cookie': 'C1=value1; path=/'}
         req = Request('http://scrapytest.org/')
         res = Response('http://scrapytest.org/', headers=headers)
-        assert self.mw.process_response(req, res, self.spider) is res
+        assert self.mw.process_response(req, res, self.spider) is None
 
         # test Cookie header is not seted to request
         req = Request('http://scrapytest.org/dontmerge', meta={'dont_merge_cookies': 1})
@@ -50,7 +50,7 @@ class CookiesMiddlewareTest(TestCase):
 
         # check that returned cookies are not merged back to jar
         res = Response('http://scrapytest.org/dontmerge', headers={'Set-Cookie': 'dont=mergeme; path=/'})
-        assert self.mw.process_response(req, res, self.spider) is res
+        assert self.mw.process_response(req, res, self.spider) is None
 
         # check that cookies are merged back
         req = Request('http://scrapytest.org/mergeme')
@@ -95,7 +95,7 @@ class CookiesMiddlewareTest(TestCase):
 
         headers = {'Set-Cookie': 'C1=value1; path=/'}
         res = Response('http://scrapytest.org/', headers=headers)
-        assert self.mw.process_response(req, res, self.spider) is res
+        assert self.mw.process_response(req, res, self.spider) is None
 
         req2 = Request('http://scrapytest.org/sub1/')
         assert self.mw.process_request(req2, self.spider) is None
@@ -109,7 +109,7 @@ class CookiesMiddlewareTest(TestCase):
 
         headers = {'Set-Cookie': 'C1=value1; path=/'}
         res = Response('http://scrapytest.org/', headers=headers, request=req)
-        assert self.mw.process_response(req, res, self.spider) is res
+        assert self.mw.process_response(req, res, self.spider) is None
 
         req2 = Request('http://scrapytest.org/', meta=res.meta)
         assert self.mw.process_request(req2, self.spider) is None
@@ -121,7 +121,7 @@ class CookiesMiddlewareTest(TestCase):
 
         headers = {'Set-Cookie': 'C2=value2; path=/'}
         res2 = Response('http://scrapytest.org/', headers=headers, request=req3)
-        assert self.mw.process_response(req3, res2, self.spider) is res2
+        assert self.mw.process_response(req3, res2, self.spider) is None
 
         req4 = Request('http://scrapytest.org/', meta=res2.meta)
         assert self.mw.process_request(req4, self.spider) is None
@@ -133,7 +133,7 @@ class CookiesMiddlewareTest(TestCase):
 
         headers = {'Set-Cookie': 'C1=value1; path=/'}
         res5_1 = Response('http://scrapytest.org:1104/', headers=headers, request=req5_1)
-        assert self.mw.process_response(req5_1, res5_1, self.spider) is res5_1
+        assert self.mw.process_response(req5_1, res5_1, self.spider) is None
 
         req5_2 = Request('http://scrapytest.org:1104/some-redirected-path')
         assert self.mw.process_request(req5_2, self.spider) is None

--- a/tests/test_downloadermiddleware_httpcompression.py
+++ b/tests/test_downloadermiddleware_httpcompression.py
@@ -87,9 +87,8 @@ class HttpCompressionTest(TestCase):
         request = Request('http://scrapytest.org')
 
         assert not response.headers.get('Content-Encoding')
-        newresponse = self.mw.process_response(request, response, self.spider)
-        assert newresponse is response
-        assert newresponse.body.startswith('<!DOCTYPE')
+        result = self.mw.process_response(request, response, self.spider)
+        assert result is None
 
     def test_multipleencodings(self):
         response = self._getresponse('gzip')
@@ -141,6 +140,6 @@ class HttpCompressionTest(TestCase):
         request = response.request
 
         newresponse = self.mw.process_response(request, response, self.spider)
-        self.assertIs(newresponse, response)
+        self.assertIs(newresponse, None)
         self.assertEqual(response.headers['Content-Encoding'], 'gzip')
         self.assertEqual(response.headers['Content-Type'], 'application/gzip')

--- a/tests/test_downloadermiddleware_redirect.py
+++ b/tests/test_downloadermiddleware_redirect.py
@@ -34,7 +34,7 @@ class RedirectMiddlewareTest(unittest.TestCase):
 
             # response without Location header but with status code is 3XX should be ignored
             del rsp.headers['Location']
-            assert self.mw.process_response(req, rsp, self.spider) is rsp
+            assert self.mw.process_response(req, rsp, self.spider) is None
 
         _test('GET')
         _test('POST')
@@ -47,17 +47,14 @@ class RedirectMiddlewareTest(unittest.TestCase):
         rsp = Response(url, headers={'Location': url2}, status=301)
 
         r = self.mw.process_response(req, rsp, self.spider)
-        assert isinstance(r, Response)
-        assert r is rsp
+        assert r is None
 
         # Test that it redirects when dont_redirect is False
         req = Request(url, meta={'dont_redirect': False})
         rsp = Response(url2, status=200)
 
         r = self.mw.process_response(req, rsp, self.spider)
-        assert isinstance(r, Response)
-        assert r is rsp
-
+        assert r is None
 
     def test_redirect_302(self):
         url = 'http://www.example.com/302'
@@ -79,7 +76,7 @@ class RedirectMiddlewareTest(unittest.TestCase):
 
         # response without Location header but with status code is 3XX should be ignored
         del rsp.headers['Location']
-        assert self.mw.process_response(req, rsp, self.spider) is rsp
+        assert self.mw.process_response(req, rsp, self.spider) is None
 
     def test_redirect_302_head(self):
         url = 'http://www.example.com/302'
@@ -94,7 +91,7 @@ class RedirectMiddlewareTest(unittest.TestCase):
 
         # response without Location header but with status code is 3XX should be ignored
         del rsp.headers['Location']
-        assert self.mw.process_response(req, rsp, self.spider) is rsp
+        assert self.mw.process_response(req, rsp, self.spider) is None
 
 
     def test_max_redirect_times(self):
@@ -158,7 +155,7 @@ class MetaRefreshMiddlewareTest(unittest.TestCase):
         req = Request(url='http://example.org')
         rsp = HtmlResponse(url='http://example.org', body=self._body(interval=1000))
         rsp2 = self.mw.process_response(req, rsp, self.spider)
-        assert rsp is rsp2
+        assert rsp2 is None
 
     def test_meta_refresh_trough_posted_request(self):
         req = Request(url='http://example.org', method='POST', body='test',

--- a/tests/test_downloadermiddleware_retry.py
+++ b/tests/test_downloadermiddleware_retry.py
@@ -30,7 +30,7 @@ class RetryTest(unittest.TestCase):
         rsp = Response('http://www.scrapytest.org/404', body='', status=404)
 
         # dont retry 404s
-        assert self.mw.process_response(req, rsp, self.spider) is rsp
+        assert self.mw.process_response(req, rsp, self.spider) is None
 
     def test_dont_retry(self):
         req = Request('http://www.scrapytest.org/503', meta={'dont_retry': True})
@@ -38,7 +38,7 @@ class RetryTest(unittest.TestCase):
 
         # first retry
         r = self.mw.process_response(req, rsp, self.spider)
-        assert r is rsp
+        assert r is None
 
         # Test retry when dont_retry set to False
         req = Request('http://www.scrapytest.org/503', meta={'dont_retry': False})
@@ -46,7 +46,7 @@ class RetryTest(unittest.TestCase):
 
         # first retry
         r = self.mw.process_response(req, rsp, self.spider)
-        assert r is rsp
+        assert r is None
 
     def test_dont_retry_exc(self):
         req = Request('http://www.scrapytest.org/503', meta={'dont_retry': True})
@@ -69,7 +69,7 @@ class RetryTest(unittest.TestCase):
         self.assertEqual(req.meta['retry_times'], 2)
 
         # discard it
-        assert self.mw.process_response(req, rsp, self.spider) is rsp
+        assert self.mw.process_response(req, rsp, self.spider) is None
 
     def test_twistederrors(self):
         exceptions = [defer.TimeoutError, TCPTimedOutError, TimeoutError,


### PR DESCRIPTION
Older flow:
![downloadermdw flow](https://cloud.githubusercontent.com/assets/1042865/6755373/657d54ee-cf01-11e4-9570-9b9c1dd977fb.png)

Proposed flow:
![downloadermdw flow_new](https://cloud.githubusercontent.com/assets/1042865/6755413/aff5aab2-cf01-11e4-9e82-08619d979721.png)

Implementation might not be the best, but I'm open to suggestions.
- `process_request` (nothing changed)
- `process_response`
  - returning None will keep the same response going in the chain.
  - Response objects are queued in the `process_response` chain.
  - can raise exceptions and these are sent to the `process_exception` chain.
- `process_exception` (keep one or split in two - process_request_exception, process_response_exception).
  - Will can a request or response instead of just a request.
