### PR TITLE
[+1 MRG]look in ~/.config/scrapy.cfg for user config

### DIFF
--- a/docs/topics/commands.rst
+++ b/docs/topics/commands.rst
@@ -13,6 +13,27 @@ just call "commands" or "Scrapy commands".
 The Scrapy tool provides several commands, for multiple purposes, and each one
 accepts a different set of arguments and options.
 
+Configuration settings
+======================
+
+Scrapy will look for configuration parameters in ini-style ``scrapy.cfg`` files
+in standard locations:
+
+1. ``/etc/scrapy.cfg`` or ``c:\scrapy\scrapy.cfg`` (system-wide),
+2. ``~/.config/scrapy.cfg`` (``$XDG_CONFIG_HOME``) and ``~/.scrapy.cfg`` (``$HOME``)
+  for global (user-wide) settings, and
+3. ``scrapy.cfg`` inside a scrapy project's root (see next section).
+
+Settings from these files are merged in the listed order of preference:
+user-defined values have higher priority than system-wide defaults
+and project-wide settings will override all others, when defined.
+
+Scrapy also understands, and can be configured through, a number of environment
+variables. Currently these are:
+
+* ``SCRAPY_SETTINGS_MODULE`` (See :ref:`topics-settings-module-envvar`)
+* ``SCRAPY_PROJECT``
+
 .. _topics-project-structure:
 
 Default structure of Scrapy projects

--- a/docs/topics/settings.rst
+++ b/docs/topics/settings.rst
@@ -16,6 +16,8 @@ project (in case you have many).
 
 For a list of available built-in settings see: :ref:`topics-settings-ref`.
 
+.. _topics-settings-module-envvar:
+
 Designating the settings
 ========================
 

--- a/scrapy/utils/conf.py
+++ b/scrapy/utils/conf.py
@@ -63,7 +63,10 @@ def get_config(use_closest=True):
 
 
 def get_sources(use_closest=True):
+    xdg_config_home = os.environ.get('XDG_CONFIG_HOME') or \
+        os.path.expanduser('~/.config')
     sources = ['/etc/scrapy.cfg', r'c:\scrapy\scrapy.cfg',
+               xdg_config_home + '/scrapy.cfg',
                os.path.expanduser('~/.scrapy.cfg')]
     if use_closest:
         sources.append(closest_scrapy_cfg())


### PR DESCRIPTION
Just a slight enhancement.
I like to keep my `~` cleaner by having config files in `~/.config/`.