### PR TITLE
Implement IPolicyForHTTPS for ScrapyClientContextFactory on Twisted 14+.

### DIFF
--- a/scrapy/core/downloader/contextfactory.py
+++ b/scrapy/core/downloader/contextfactory.py
@@ -1,20 +1,53 @@
 from OpenSSL import SSL
 from twisted.internet.ssl import ClientContextFactory
 
+from scrapy import twisted_version
 
-class ScrapyClientContextFactory(ClientContextFactory):
-    "A SSL context factory which is more permissive against SSL bugs."
-    # see https://github.com/scrapy/scrapy/issues/82
-    # and https://github.com/scrapy/scrapy/issues/26
+if twisted_version >= (14, 0, 0):
+    from twisted.internet.ssl import CertificateOptions
+    from twisted.internet._sslverify import ClientTLSOptions
+    from twisted.web.iweb import IPolicyForHTTPS
+    from zope.interface import implementer
 
-    def __init__(self):
-        # see this issue on why we use TLSv1_METHOD by default
-        # https://github.com/scrapy/scrapy/issues/194
-        self.method = SSL.TLSv1_METHOD
+    class ScrapyOpenSSLCertificateOptions(CertificateOptions):
+        # we need to subclass CertificateOptions because there's no way to
+        # update SSL context in ScrapyClientContextFactory or
+        # twisted.internet.ssl.optionsForClientTLS
 
-    def getContext(self, hostname=None, port=None):
-        ctx = ClientContextFactory.getContext(self)
-        # Enable all workarounds to SSL bugs as documented by
-        # http://www.openssl.org/docs/ssl/SSL_CTX_set_options.html
-        ctx.set_options(SSL.OP_ALL)
-        return ctx
+        def __init__(self, **kwargs):
+            super(ScrapyOpenSSLCertificateOptions, self).__init__(**kwargs)
+            self.method = SSL.TLSv1_METHOD
+
+        def getContext(self):
+            ctx = super(ScrapyOpenSSLCertificateOptions, self).getContext()
+            ctx.set_options(SSL.OP_ALL)
+            return ctx
+
+
+    @implementer(IPolicyForHTTPS)
+    class ScrapyClientContextFactory(object):
+
+        def creatorForNetloc(self, hostname, port):
+            certificateOptions = ScrapyOpenSSLCertificateOptions()
+            return ClientTLSOptions(
+                hostname.decode('utf-8'), certificateOptions.getContext()
+            )
+
+else:
+
+    class ScrapyClientContextFactory(ClientContextFactory):
+        "A SSL context factory which is more permissive against SSL bugs."
+        # see https://github.com/scrapy/scrapy/issues/82
+        # and https://github.com/scrapy/scrapy/issues/26
+
+        def __init__(self):
+            # see this issue on why we use TLSv1_METHOD by default
+            # https://github.com/scrapy/scrapy/issues/194
+            self.method = SSL.TLSv1_METHOD
+
+        def getContext(self, hostname=None, port=None):
+            ctx = ClientContextFactory.getContext(self)
+            # Enable all workarounds to SSL bugs as documented by
+            # http://www.openssl.org/docs/ssl/SSL_CTX_set_options.html
+            ctx.set_options(SSL.OP_ALL)
+            return ctx

--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,7 @@ setup(
         'queuelib',
         'lxml',
         'pyOpenSSL',
+        'service_identity',
         'cssselect>=0.9',
         'six>=1.5.2',
     ],


### PR DESCRIPTION
Fixes #784

Since py.test doesn't show deprecate warnings, it would be better
to run tests via unitest or similar test framework.