### PR TITLE
[MRG+1] Settings.updatedict() method to update dictionary-like settings

### DIFF
--- a/docs/topics/api.rst
+++ b/docs/topics/api.rst
@@ -249,6 +249,20 @@ Settings API
            :attr:`~scrapy.settings.SETTINGS_PRIORITIES` or an integer
        :type priority: string or int
 
+    .. method:: updatedict(name, values, priority='project')
+
+       Update a dictionary with given values.
+       
+       This is a convenience function that calls the ``update()`` method of the
+       given dictionary setting, unless the setting's current priority is
+       higher than the provided ``priority``.
+
+       :param name: the setting name
+       :type name: string
+
+       :param values: key/value pairs to be updated/inserted
+       :type values: dict or iterable of key/value pairs
+
     .. method:: get(name, default=None)
 
        Get a setting value without affecting its original type.

--- a/scrapy/settings/__init__.py
+++ b/scrapy/settings/__init__.py
@@ -110,6 +110,12 @@ class Settings(object):
             if key.isupper():
                 self.set(key, getattr(module, key), priority)
 
+    def updatedict(self, name, values, priority='project'):
+        self._assert_mutability()
+        d = self.getdict(name)
+        d.update(values)
+        self.set(name, d, priority)
+
     def _assert_mutability(self):
         if self.frozen:
             raise TypeError("Trying to modify an immutable Settings object")

--- a/tests/test_settings/__init__.py
+++ b/tests/test_settings/__init__.py
@@ -139,10 +139,11 @@ class SettingsTest(unittest.TestCase):
 
     def test_updatedict(self):
         self.settings.attributes = {}
-        self.settings.set('TEST_DICT', {}, 0)
-        self.settings.updatedict('TEST_DICT', { 'key': 123 })
-        self.assertIn('key', self.settings.get('TEST_DICT'))
-        self.assertEqual(self.settings.getdict('TEST_DICT')['key'], 123)
+        self.settings.set('TEST_DICT', { 'old': 123 }, 0)
+        self.settings.updatedict('TEST_DICT', { 'old': 456, 'new': 789 })
+        self.assertIn('new', self.settings.get('TEST_DICT'))
+        self.assertEqual(self.settings.getdict('TEST_DICT')['old'], 456)
+        self.assertEqual(self.settings.getdict('TEST_DICT')['new'], 789)
 
     def test_get(self):
         test_configuration = {

--- a/tests/test_settings/__init__.py
+++ b/tests/test_settings/__init__.py
@@ -137,6 +137,13 @@ class SettingsTest(unittest.TestCase):
             self.assertEqual(attr.value, ctrl_attr.value)
             self.assertEqual(attr.priority, ctrl_attr.priority)
 
+    def test_updatedict(self):
+        self.settings.attributes = {}
+        self.settings.set('TEST_DICT', {}, 0)
+        self.settings.updatedict('TEST_DICT', { 'key': 123 })
+        self.assertIn('key', self.settings.get('TEST_DICT'))
+        self.assertEqual(self.settings.getdict('TEST_DICT')['key'], 123)
+
     def test_get(self):
         test_configuration = {
             'TEST_ENABLED1': '1',


### PR DESCRIPTION
This is a small patch that provides a convenience function to update dictionary-like settings such as ``DOWNLOADER_MIDDLEWARES`` while respecting mutability and priority.

However, the current settings API does not support per-key priorities. Instead, there is one ``SettingsAttribute`` instance (and therefore a single priority) for the whole dictionary. Julia has suggested replacing the dict-like settings with instances of ``Settings`` and possibly a [dict-like interface](https://github.com/scrapy/scrapy/blob/master/scrapy/settings/__init__.py#L153) to allow for per-key priorities. I will open a separate issue for this.

Includes test and documentation.