### PR TITLE
Added deployment section covering scrapyd-deploy and shub

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -150,7 +150,7 @@ Solving specific problems
    topics/leaks
    topics/images
    topics/ubuntu
-   topics/scrapyd
+   topics/deployment
    topics/autothrottle
    topics/benchmarking
    topics/jobs
@@ -186,7 +186,7 @@ Solving specific problems
 :doc:`topics/ubuntu`
     Install latest Scrapy packages easily on Ubuntu
 
-:doc:`topics/scrapyd`
+:doc:`topics/deployment`
     Deploying your Scrapy project in production.
 
 :doc:`topics/autothrottle`

--- a/docs/topics/deployment.rst
+++ b/docs/topics/deployment.rst
@@ -1,0 +1,29 @@
+.. _topics-deployment:
+
+==========
+Deployment
+==========
+
+The recommended way to deploy Scrapy projects to a server is through `Scrapyd`_.
+
+.. _Scrapyd: https://github.com/scrapy/scrapyd
+
+Deploying to a Scrapyd Server
+=============================
+
+You can deploy to a Scrapyd server using the `Scrapyd client <https://github.com/scrapy/scrapyd-client>`_. You can add targets to your ``scrapy.cfg`` file which can be deployed to using the ``scrapyd-deploy`` command.
+
+The basic syntax is as follows:
+
+    scrapyd-deploy <target> -p <project>
+
+For more information please refer to the `Deploying your project`_ section.
+
+.. _Deploying your project: https://scrapyd.readthedocs.org/en/latest/deploy.html
+
+Deploying to Scrapinghub
+========================
+
+You can deploy to Scrapinghub using Scrapinghub's command line client, `shub`_. The configuration is read from the ``scrapy.cfg`` file just like ``scrapyd-deploy``.
+
+.. _shub: https://github.com/scrapinghub/shub


### PR DESCRIPTION
Added a deploymention section to point readers towards scrapyd-deploy and shub documentation. Should we should also update the docs to reflect that ``scrapy deploy`` is now deprecated? I can update the PR if so.