### PR TITLE
Ignore missing HTTP Status code explanation in HTTPClientParser

### DIFF
--- a/scrapy/xlib/tx/__init__.py
+++ b/scrapy/xlib/tx/__init__.py
@@ -1,9 +1,9 @@
 from scrapy import twisted_version
 if twisted_version > (13, 0, 0):
-    from twisted.web import client
+    from twisted.web import client, _newclient
     from twisted.internet import endpoints
 if twisted_version >= (11, 1, 0):
-    from . import client, endpoints
+    from . import client, endpoints, _newclient
 else:
     from scrapy.exceptions import NotSupported
     class _Mocked(object):
@@ -21,3 +21,11 @@ ResponseDone = client.ResponseDone
 ResponseFailed = client.ResponseFailed
 HTTPConnectionPool = client.HTTPConnectionPool
 TCP4ClientEndpoint = endpoints.TCP4ClientEndpoint
+_HTTP11ClientFactory = client._HTTP11ClientFactory
+
+HTTP11ClientProtocol = _newclient.HTTP11ClientProtocol
+HTTPClientParser = _newclient.HTTPClientParser
+TransportProxyProducer = _newclient.TransportProxyProducer
+Response = _newclient.Response
+ParseError = _newclient.ParseError
+RequestNotSent = _newclient.RequestNotSent

--- a/tests/test_crawl.py
+++ b/tests/test_crawl.py
@@ -150,6 +150,20 @@ with multiples lines
         self.assertEqual(log.count("Got response 200"), 1)
 
     @defer.inlineCallbacks
+    def test_missing_status_code_explanation(self):
+        from urllib import urlencode
+        query = urlencode({'raw': '''\
+HTTP/1.1 200
+Content-Length: 3
+Connection: close
+
+foo'''})
+        crawler = get_crawler(SimpleSpider)
+        yield crawler.crawl("http://localhost:8998/raw?{0}".format(query))
+        log = get_testlog()
+        self.assertEqual(log.count("Got response 200"), 1, log)
+
+    @defer.inlineCallbacks
     def test_retry_conn_lost(self):
         # connection lost after receiving data
         crawler = get_crawler(SimpleSpider)


### PR DESCRIPTION
This should fix HTTP downloader errors on missing HTTP status code strings ("OK", "Gone", "Bad Gateway", ...) for #345.
I followed the suggested solution by @dangra (https://github.com/scrapy/scrapy/issues/345#issuecomment-23914813), but the outcome is truly suckish.

I haven't particularly cleaned this up, as I don't think anyone really cares to merge this ugly.
Supposedly putting a monkey patch (as posted in #345) in `scrapy/_monkeypatches.py` or such would feel cleaner than this.

Also I tried hard, but ultimately couldn't figure out how to write a testcase for this. The mockserver seems to generate it's own correct status lines from integer status codes, and I didn't manage to create raw responses (including a custom status code line).