### PR TITLE
[MRG+1] default return value for extract_first

### DIFF
--- a/docs/topics/selectors.rst
+++ b/docs/topics/selectors.rst
@@ -149,6 +149,11 @@ It returns ``None`` if no element was found:
     >>> sel.xpath('//div/[id="not-exists"]/text()').extract_first() is None
     True
 
+A default return value can be provided as an argument, to be used instead of ``None``:
+
+    >>> sel.xpath('//div/[id="not-exists"]/text()').extract_first(default='not-found')
+    'not-found'
+
 Notice that CSS selectors can select text or attribute nodes using CSS3
 pseudo-elements::
 

--- a/scrapy/selector/unified.py
+++ b/scrapy/selector/unified.py
@@ -184,7 +184,9 @@ class SelectorList(list):
 
     def extract_first(self, default=None):
         for x in self:
-            return x.extract() or default
+            return x.extract()
+        else:
+            return default
 
     @deprecated(use_instead='.extract()')
     def extract_unquoted(self):

--- a/scrapy/selector/unified.py
+++ b/scrapy/selector/unified.py
@@ -182,9 +182,9 @@ class SelectorList(list):
     def extract(self):
         return [x.extract() for x in self]
 
-    def extract_first(self):
+    def extract_first(self, default=None):
         for x in self:
-            return x.extract()
+            return x.extract() or default
 
     @deprecated(use_instead='.extract()')
     def extract_unquoted(self):

--- a/tests/test_selector.py
+++ b/tests/test_selector.py
@@ -72,6 +72,14 @@ class SelectorTestCase(unittest.TestCase):
 
         self.assertEqual(sel.xpath('/ul/li[@id="doesnt-exist"]/text()').extract_first(), None)
 
+    def test_extract_first_default(self):
+        """Test if extract_first() returns default value when no results found"""
+        body = '<ul><li id="1">1</li><li id="2">2</li></ul>'
+        response = TextResponse(url="http://example.com", body=body)
+        sel = self.sscls(response)
+
+        self.assertEqual(sel.xpath('//div/text()').extract_first(default='missing'), 'missing')
+
     def test_re_first(self):
         """Test if re_first() returns first matched element"""
         body = '<ul><li id="1">1</li><li id="2">2</li></ul>'


### PR DESCRIPTION
It would be useful to have a default return value for `extract_first`, to avoid additional data type checks. 

For example, when expecting a string, this would raise an exception:
`something = selector.extract_first().lower()`

Allowing an optional `default` value can solve this elegantly:
`something = selector.extract_first(default='').lower()`