### PR TITLE
Fix deprecated settings API in tests

### DIFF
--- a/tests/test_cmdline/settings.py
+++ b/tests/test_cmdline/settings.py
@@ -1,5 +1,5 @@
-EXTENSIONS = [
-    'tests.test_cmdline.extensions.TestExtension'
-]
+EXTENSIONS = {
+    'tests.test_cmdline.extensions.TestExtension': 0,
+}
 
 TEST1 = 'default'


### PR DESCRIPTION
This small fix updates the deprecated settings API in `tests/test_cmdline/settings.py`, where `EXTENSIONS` was given as a list instead of a dictionary.