### PR TITLE
disable scrapy.telnet if twisted.conch is not available

### DIFF
--- a/scrapy/telnet.py
+++ b/scrapy/telnet.py
@@ -6,9 +6,13 @@ See documentation in docs/topics/telnetconsole.rst
 
 import pprint
 
-from twisted.conch import manhole, telnet
-from twisted.conch.insults import insults
 from twisted.internet import protocol
+try:
+    from twisted.conch import manhole, telnet
+    from twisted.conch.insults import insults
+    TWISTED_CONCH_AVAILABLE = True
+except ImportError:
+    TWISTED_CONCH_AVAILABLE = False
 
 from scrapy.exceptions import NotConfigured
 from scrapy import log, signals
@@ -31,6 +35,8 @@ class TelnetConsole(protocol.ServerFactory):
 
     def __init__(self, crawler):
         if not crawler.settings.getbool('TELNETCONSOLE_ENABLED'):
+            raise NotConfigured
+        if not TWISTED_CONCH_AVAILABLE:
             raise NotConfigured
         self.crawler = crawler
         self.noisy = False

--- a/tests/py3-ignores.txt
+++ b/tests/py3-ignores.txt
@@ -97,5 +97,4 @@ scrapy/contrib/statsmailer.py
 scrapy/contrib/memusage.py
 scrapy/commands/deploy.py
 scrapy/commands/bench.py
-scrapy/telnet.py
 scrapy/mail.py


### PR DESCRIPTION
A simple fix to disable telnet in Python 3 until twisted.conch is ported to Python 3.