### PR TITLE
fix Python 3 syntax errors in ajaxcrawl.py

### DIFF
--- a/scrapy/contrib/downloadermiddleware/ajaxcrawl.py
+++ b/scrapy/contrib/downloadermiddleware/ajaxcrawl.py
@@ -1,11 +1,13 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import
 import re
+import six
+from w3lib import html
 from scrapy import log
 from scrapy.exceptions import NotConfigured
 from scrapy.http import HtmlResponse
 from scrapy.utils.response import _noscript_re, _script_re
-from w3lib import html
+
 
 class AjaxCrawlMiddleware(object):
     """
@@ -61,7 +63,7 @@ class AjaxCrawlMiddleware(object):
 
 
 # XXX: move it to w3lib?
-_ajax_crawlable_re = re.compile(ur'<meta\s+name=["\']fragment["\']\s+content=["\']!["\']/?>')
+_ajax_crawlable_re = re.compile(six.u(r'<meta\s+name=["\']fragment["\']\s+content=["\']!["\']/?>'))
 def _has_ajaxcrawlable_meta(text):
     """
     >>> _has_ajaxcrawlable_meta('<html><head><meta name="fragment"  content="!"/></head><body></body></html>')

--- a/tests/py3-ignores.txt
+++ b/tests/py3-ignores.txt
@@ -92,7 +92,6 @@ scrapy/contrib/linkextractors/htmlparser.py
 scrapy/contrib/downloadermiddleware/retry.py
 scrapy/contrib/downloadermiddleware/httpproxy.py
 scrapy/contrib/downloadermiddleware/cookies.py
-scrapy/contrib/downloadermiddleware/ajaxcrawl.py
 scrapy/contrib/statsmailer.py
 scrapy/contrib/memusage.py
 scrapy/commands/deploy.py


### PR DESCRIPTION
Tests for _has_ajaxcrawlable_meta pass in Python 3.