### PR TITLE
install service_identity package in tests to prevent warnings

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -14,6 +14,7 @@ deps =
     Pillow
     django
     leveldb
+    service_identity
     -rtests/requirements.txt
 commands =
     py.test {posargs:scrapy tests}
@@ -41,14 +42,14 @@ commands =
 [testenv:py33]
 basepython = python3.3
 deps =
-;    svn+svn://svn.twistedmatrix.com/svn/Twisted/trunk#egg=Twisted
-    Twisted >= 14.0.0
+    Twisted >= 15.1.0
     lxml>=3.2.4
     pyOpenSSL>=0.13.1
     cssselect>=0.9
     queuelib>=1.1.1
     w3lib>=1.8.0
     Pillow
+    service_identity
     # tests requirements
     pytest>=2.6.0
     pytest-twisted


### PR DESCRIPTION
Also, Twisted version is bumped for Python 3.x tests, just in case.

service_identity is not added to Scrapy requirements because Scrapy
supports older Twisted / PyOpenSSL versions which don't use it.