### PR TITLE
Fix remaining warnings from pytest while collecting tests

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,6 @@
 [pytest]
 usefixtures = chdir
 python_files=test_*.py __init__.py
+python_classes=
 addopts = --doctest-modules --assert=plain
 twisted = 1


### PR DESCRIPTION
Running `tox -e py27 -- scrapy tests --collect-only -s -rw` shows that pytest issues 13 warnings from classes prefixed by `Test` that contain `__init__` methods. 

Since every TestCase we're using is a subclass from `unittest.TestCase` (`twisted.trial.unittest.TestCase` is a subclass of it too), we don't have to rely on discovering tests by their class name.

This PR overrides the default `python_class=Test` so the only test classes collected are the ones inherited from `unittest.TestCase`.