### PR TITLE
Correct login request example

### DIFF
--- a/docs/topics/request-response.rst
+++ b/docs/topics/request-response.rst
@@ -367,7 +367,7 @@ method for this job. Here's an example spider which uses it::
         def after_login(self, response):
             # check login succeed before going on
             if "authentication failed" in response.body:
-                self.log("Login failed", level=log.ERROR)
+                self.log("Login failed", level=scrapy.log.ERROR)
                 return
 
             # continue scraping with authenticated session...


### PR DESCRIPTION
In the example log is not imported
and not found in the global name space

For more recent branches than 0.24
requests documentation is adapted
with newer logging methods
so this patch is not needed
