### PR TITLE
fixed backwards compatibility for scrapy.contrib.exporter.PythonItemExporter

### DIFF
--- a/scrapy/contrib/exporter/__init__.py
+++ b/scrapy/contrib/exporter/__init__.py
@@ -5,3 +5,4 @@ warnings.warn("Module `scrapy.contrib.exporter` is deprecated, "
               ScrapyDeprecationWarning, stacklevel=2)
 
 from scrapy.exporters import *
+from scrapy.exporters import PythonItemExporter


### PR DESCRIPTION
PythonItemExporter is not in `__all__`, so `from scrapy.contrib.exporter import PythonItemExporter` stopped working.