### PR TITLE
fix utils.template.render_templatefile() bug +test

### DIFF
--- a/scrapy/utils/template.py
+++ b/scrapy/utils/template.py
@@ -10,7 +10,8 @@ def render_templatefile(path, **kwargs):
 
     content = string.Template(raw).substitute(**kwargs)
 
-    with open(path.rstrip('.tmpl'), 'wb') as file:
+    render_path = path[:-len('.tmpl')] if path.endswith('.tmpl') else path
+    with open(render_path, 'wb') as file:
         file.write(content)
     if path.endswith('.tmpl'):
         os.remove(path)

--- a/tests/test_utils_template.py
+++ b/tests/test_utils_template.py
@@ -1,1 +1,42 @@
+import os
+from shutil import rmtree
+from tempfile import mkdtemp
+import unittest
+from scrapy.utils.template import render_templatefile
+
+
 __doctests__ = ['scrapy.utils.template']
+
+
+class UtilsRenderTemplateFileTestCase(unittest.TestCase):
+
+    def setUp(self):
+        self.tmp_path = mkdtemp()
+
+    def tearDown(self):
+        rmtree(self.tmp_path)
+
+    def test_simple_render(self):
+
+        context = dict(project_name='proj', name='spi', classname='TheSpider')
+        template = u'from ${project_name}.spiders.${name} import ${classname}'
+        rendered = u'from proj.spiders.spi import TheSpider'
+
+        template_path = os.path.join(self.tmp_path, 'templ.py.tmpl')
+        render_path = os.path.join(self.tmp_path, 'templ.py')
+
+        with open(template_path, 'wb') as tmpl_file:
+            tmpl_file.write(template.encode('utf8'))
+        assert os.path.isfile(template_path)  # Failure of test itself
+
+        render_templatefile(template_path, **context)
+
+        self.assertFalse(os.path.exists(template_path))
+        with open(render_path, 'rb') as result:
+            self.assertEqual(result.read().decode('utf8'), rendered)
+
+        os.remove(render_path)
+        assert not os.path.exists(render_path)  # Failure of test iself
+
+if '__main__' == __name__:
+    unittest.main()


### PR DESCRIPTION
I fixed a potential bug (untriggered so far because of the `.py` extension of the template files)
but while writing the test, it ended taking up most of the changes done in this PR.
Please comment whether I should just push the bugfix.

The potential bug is that `.rstrip()` in `utils.template.render_templatefile()`
is used like it is expected to strip a string, not a character class
(think of using `re.sub(r'[\.tmpl]*$, '', path)` instead of `re.sub(r'\.tmpl$', '', path)`.
On filepaths that always end with '.py.tmpl', the problem goes unnoticed.

Also, shouldn't there be some expectation or even an assertion
that the template files have the '.tmpl' extension?