### PR TITLE
allow additon of objects instead of paths to settings

### DIFF
--- a/scrapy/middleware.py
+++ b/scrapy/middleware.py
@@ -29,7 +29,10 @@ class MiddlewareManager(object):
         middlewares = []
         for clspath in mwlist:
             try:
-                mwcls = load_object(clspath)
+                if isinstance(clspath, str):
+                    mwcls = load_object(clspath)
+                else:
+                    mwcls = clspath
                 if crawler and hasattr(mwcls, 'from_crawler'):
                     mw = mwcls.from_crawler(crawler)
                 elif hasattr(mwcls, 'from_settings'):


### PR DESCRIPTION
Make this available:

```python
class CustomHttpProxyMiddleware(object):
    ...

def main():
    settings = Settings({
        DOWNLOADER_MIDDLEWARES{
            CustomHttpProxyMiddleware: 400    #! Here
        }
    })
    crawler = CrawlerProcess(settings)
    crawler.crawl(spider)
    crawler.start()
```