### PR TITLE
Add docs build to travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ env:
 - TOXENV=py27
 - TOXENV=precise
 - TOXENV=py33
+- TOXENV=docs
 install:
 - "./.travis-workarounds.sh"
 - pip install -U tox

--- a/tox.ini
+++ b/tox.ini
@@ -57,10 +57,19 @@ deps =
 basepython = python3.4
 deps = {[testenv:py33]deps}
 
-[testenv:docs]
+[docs]
 changedir = docs
 deps =
     Sphinx
+
+[testenv:docs]
+changedir = {[docs]changedir}
+deps = {[docs]deps}
 commands =
     sphinx-build -W -b html . {envtmpdir}/html
+
+[testenv:docs-links]
+changedir = {[docs]changedir}
+deps = {[docs]deps}
+commands =
     sphinx-build -W -b linkcheck . {envtmpdir}/linkcheck

--- a/tox.ini
+++ b/tox.ini
@@ -62,5 +62,5 @@ changedir = docs
 deps =
     Sphinx
 commands =
-    sphinx-build -W -b html . build/html
-    sphinx-build -W -b linkcheck . build/linkcheck
+    sphinx-build -W -b html . {envtmpdir}/html
+    sphinx-build -W -b linkcheck . {envtmpdir}/linkcheck


### PR DESCRIPTION
`docs` build was removed from travis in 6c402d3cc4f because it took too long to run `sphinx-build linkcheck`. I separated two tox enviroments, one that only checks if the docs can be built without errors, and another one for checking links. I put the first one back in .travis.yml so we can avoid fixing manually occasional errors introduced in docs (#1127, #1219).