### PR TITLE
Replace logger.exception calls to logger.error for Python compatibility

### DIFF
--- a/scrapy/core/engine.py
+++ b/scrapy/core/engine.py
@@ -112,8 +112,8 @@ class ExecutionEngine(object):
                 slot.start_requests = None
             except Exception:
                 slot.start_requests = None
-                logger.exception('Error while obtaining start requests',
-                                 extra={'spider': spider})
+                logger.error('Error while obtaining start requests',
+                             exc_info=True, extra={'spider': spider})
             else:
                 self.crawl(request, spider)
 

--- a/scrapy/core/scheduler.py
+++ b/scrapy/core/scheduler.py
@@ -83,9 +83,9 @@ class Scheduler(object):
             self.dqs.push(reqd, -request.priority)
         except ValueError as e: # non serializable request
             if self.logunser:
-                logger.exception("Unable to serialize request: %(request)s - reason: %(reason)s",
-                                 {'request': request, 'reason': e},
-                                 extra={'spider': self.spider})
+                logger.error("Unable to serialize request: %(request)s - reason: %(reason)s",
+                             {'request': request, 'reason': e},
+                             exc_info=True, extra={'spider': self.spider})
             return
         else:
             return True

--- a/scrapy/pipelines/files.py
+++ b/scrapy/pipelines/files.py
@@ -272,11 +272,11 @@ class FilesPipeline(MediaPipeline):
             )
             raise
         except Exception as exc:
-            logger.exception(
+            logger.error(
                 'File (unknown-error): Error processing file from %(request)s '
                 'referred in <%(referer)s>',
                 {'request': request, 'referer': referer},
-                extra={'spider': info.spider}
+                exc_info=True, extra={'spider': info.spider}
             )
             raise FileException(str(exc))
 

--- a/scrapy/utils/signal.py
+++ b/scrapy/utils/signal.py
@@ -30,8 +30,9 @@ def send_catch_log(signal=Any, sender=Anonymous, *arguments, **named):
             result = Failure()
         except Exception:
             result = Failure()
-            logger.exception("Error caught on signal handler: %(receiver)s",
-                             {'receiver': receiver}, extra={'spider': spider})
+            logger.error("Error caught on signal handler: %(receiver)s",
+                         {'receiver': receiver},
+                         exc_info=True, extra={'spider': spider})
         else:
             result = response
         responses.append((receiver, result))

--- a/tests/test_utils_log.py
+++ b/tests/test_utils_log.py
@@ -28,7 +28,7 @@ class FailureFormatterTest(unittest.TestCase):
             try:
                 0/0
             except ZeroDivisionError:
-                self.logger.exception('test log msg')
+                self.logger.error('test log msg', exc_info=True)
                 failure = Failure()
 
             self.logger.error('test log msg', extra={'failure': failure})


### PR DESCRIPTION
`logger.exception()` method didn't support keyword arguments until python 2.7.7.

I'm replacing all occurrences of this function (even those that don't have keyword arguments such as `extra`) so we discourage its usage.