### PR TITLE
Replace FailureFormatter with direct failure to exc_info conversions in log calls

### DIFF
--- a/scrapy/downloadermiddlewares/robotstxt.py
+++ b/scrapy/downloadermiddlewares/robotstxt.py
@@ -11,6 +11,7 @@ from six.moves.urllib import robotparser
 from scrapy.exceptions import NotConfigured, IgnoreRequest
 from scrapy.http import Request
 from scrapy.utils.httpobj import urlparse_cached
+from scrapy.utils.log import failure_to_exc_info
 
 logger = logging.getLogger(__name__)
 
@@ -59,7 +60,8 @@ class RobotsTxtMiddleware(object):
         if failure.type is not IgnoreRequest:
             logger.error("Error downloading %(request)s: %(f_exception)s",
                          {'request': request, 'f_exception': failure.value},
-                         extra={'spider': spider, 'failure': failure})
+                         exc_info=failure_to_exc_info(failure),
+                         extra={'spider': spider})
 
     def _parse_robots(self, response):
         rp = robotparser.RobotFileParser(response.url)

--- a/scrapy/extensions/feedexport.py
+++ b/scrapy/extensions/feedexport.py
@@ -22,6 +22,7 @@ from scrapy.utils.ftp import ftp_makedirs_cwd
 from scrapy.exceptions import NotConfigured
 from scrapy.utils.misc import load_object
 from scrapy.utils.python import get_func_args
+from scrapy.utils.log import failure_to_exc_info
 
 logger = logging.getLogger(__name__)
 
@@ -184,7 +185,8 @@ class FeedExporter(object):
         d.addCallback(lambda _: logger.info(logfmt % "Stored", log_args,
                                             extra={'spider': spider}))
         d.addErrback(lambda f: logger.error(logfmt % "Error storing", log_args,
-                                            extra={'spider': spider, 'failure': f}))
+                                            exc_info=failure_to_exc_info(f),
+                                            extra={'spider': spider}))
         return d
 
     def item_scraped(self, item, spider):

--- a/scrapy/log.py
+++ b/scrapy/log.py
@@ -8,6 +8,7 @@ import warnings
 from twisted.python.failure import Failure
 
 from scrapy.exceptions import ScrapyDeprecationWarning
+from scrapy.utils.log import failure_to_exc_info
 
 logger = logging.getLogger(__name__)
 
@@ -48,4 +49,4 @@ def err(_stuff=None, _why=None, **kw):
     level = kw.pop('level', logging.ERROR)
     failure = kw.pop('failure', _stuff) or Failure()
     message = kw.pop('why', _why) or failure.value
-    logger.log(level, message, *[kw] if kw else [], extra={'failure': failure})
+    logger.log(level, message, *[kw] if kw else [], exc_info=failure_to_exc_info(failure))

--- a/scrapy/pipelines/files.py
+++ b/scrapy/pipelines/files.py
@@ -25,6 +25,7 @@ from scrapy.pipelines.media import MediaPipeline
 from scrapy.exceptions import NotConfigured, IgnoreRequest
 from scrapy.http import Request
 from scrapy.utils.misc import md5sum
+from scrapy.utils.log import failure_to_exc_info
 
 logger = logging.getLogger(__name__)
 
@@ -212,7 +213,8 @@ class FilesPipeline(MediaPipeline):
         dfd.addErrback(
             lambda f:
             logger.error(self.__class__.__name__ + '.store.stat_file',
-                         extra={'spider': info.spider, 'failure': f})
+                         exc_info=failure_to_exc_info(f),
+                         extra={'spider': info.spider})
         )
         return dfd
 

--- a/scrapy/pipelines/media.py
+++ b/scrapy/pipelines/media.py
@@ -8,6 +8,7 @@ from twisted.python.failure import Failure
 from scrapy.utils.defer import mustbe_deferred, defer_result
 from scrapy.utils.request import request_fingerprint
 from scrapy.utils.misc import arg_to_iter
+from scrapy.utils.log import failure_to_exc_info
 
 logger = logging.getLogger(__name__)
 
@@ -70,7 +71,7 @@ class MediaPipeline(object):
         dfd.addCallback(self._check_media_to_download, request, info)
         dfd.addBoth(self._cache_result_and_execute_waiters, fp, info)
         dfd.addErrback(lambda f: logger.error(
-            f.value, extra={'spider': info.spider, 'failure': f})
+            f.value, exc_info=failure_to_exc_info(f), extra={'spider': info.spider})
         )
         return dfd.addBoth(lambda _: wad)  # it must return wad at last
 
@@ -127,6 +128,7 @@ class MediaPipeline(object):
                     logger.error(
                         '%(class)s found errors processing %(item)s',
                         {'class': self.__class__.__name__, 'item': item},
-                        extra={'spider': info.spider, 'failure': value}
+                        exc_info=failure_to_exc_info(value),
+                        extra={'spider': info.spider}
                     )
         return item

--- a/scrapy/utils/log.py
+++ b/scrapy/utils/log.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 
-import os
 import sys
 import logging
 import warnings
@@ -16,22 +15,10 @@ from scrapy.exceptions import ScrapyDeprecationWarning
 logger = logging.getLogger(__name__)
 
 
-class FailureFormatter(logging.Filter):
-    """Extract exc_info from Failure instances provided as contextual data
-
-    This filter mimics Twisted log.err formatting for its first `_stuff`
-    argument, which means that reprs of non Failure objects are appended to the
-    log messages.
-    """
-
-    def filter(self, record):
-        failure = record.__dict__.get('failure')
-        if failure:
-            if isinstance(failure, Failure):
-                record.exc_info = (failure.type, failure.value, failure.tb)
-            else:
-                record.msg += os.linesep + repr(failure)
-        return True
+def failure_to_exc_info(failure):
+    """Extract exc_info from Failure instances"""
+    if isinstance(failure, Failure):
+        return (failure.type, failure.value, failure.tb)
 
 
 class TopLevelFormatter(logging.Filter):
@@ -58,15 +45,9 @@ class TopLevelFormatter(logging.Filter):
 DEFAULT_LOGGING = {
     'version': 1,
     'disable_existing_loggers': False,
-    'filters': {
-        'failure_formatter': {
-            '()': 'scrapy.utils.log.FailureFormatter',
-        },
-    },
     'loggers': {
         'scrapy': {
             'level': 'DEBUG',
-            'filters': ['failure_formatter'],
         },
         'twisted': {
             'level': 'ERROR',

--- a/scrapy/utils/log.py
+++ b/scrapy/utils/log.py
@@ -18,7 +18,7 @@ logger = logging.getLogger(__name__)
 def failure_to_exc_info(failure):
     """Extract exc_info from Failure instances"""
     if isinstance(failure, Failure):
-        return (failure.type, failure.value, failure.tb)
+        return (failure.type, failure.value, failure.getTracebackObject())
 
 
 class TopLevelFormatter(logging.Filter):

--- a/scrapy/utils/signal.py
+++ b/scrapy/utils/signal.py
@@ -8,6 +8,7 @@ from twisted.python.failure import Failure
 from scrapy.xlib.pydispatch.dispatcher import Any, Anonymous, liveReceivers, \
     getAllReceivers, disconnect
 from scrapy.xlib.pydispatch.robustapply import robustApply
+from scrapy.utils.log import failure_to_exc_info
 
 logger = logging.getLogger(__name__)
 
@@ -47,7 +48,8 @@ def send_catch_log_deferred(signal=Any, sender=Anonymous, *arguments, **named):
         if dont_log is None or not isinstance(failure.value, dont_log):
             logger.error("Error caught on signal handler: %(receiver)s",
                          {'receiver': recv},
-                         extra={'spider': spider, 'failure': failure})
+                         exc_info=failure_to_exc_info(failure),
+                         extra={'spider': spider})
         return failure
 
     dont_log = named.pop('dont_log', None)

--- a/tests/test_pipeline_media.py
+++ b/tests/test_pipeline_media.py
@@ -9,6 +9,7 @@ from scrapy.http import Request, Response
 from scrapy.spiders import Spider
 from scrapy.utils.request import request_fingerprint
 from scrapy.pipelines.media import MediaPipeline
+from scrapy.utils.log import failure_to_exc_info
 from scrapy.utils.signal import disconnect_all
 from scrapy import signals
 
@@ -66,7 +67,7 @@ class BaseMediaPipelineTestCase(unittest.TestCase):
         assert len(l.records) == 1
         record = l.records[0]
         assert record.levelname == 'ERROR'
-        assert record.failure is fail
+        self.assertTupleEqual(record.exc_info, failure_to_exc_info(fail))
 
         # disable failure logging and check again
         self.pipe.LOG_FAILED_RESULTS = False


### PR DESCRIPTION
`logging.Filter`s can't override log messages in logger children, they can only do so in the logger they are attached. That's why FailureFormatter (the filter that takes care of extracting the exc_info from failures to print tracebacks) doesn't propagate to the descendants of the `scrapy` logger.

(TopLevelFormatter works because it doesn't override the "entire" log message, just the logger name, which is formatted at the end with string like `'%(name)s %(msg)'`. It's only the `msg` variable that is compute on the first logger and then propagated to the parents as it is).

I fixed it by converting each failure to exc_info before making the log call.

This pr fixes #1229 and fixes #1230.