### PR TITLE
MRG+1 fixed FeedExporter shutdown log messages

### DIFF
--- a/scrapy/extensions/feedexport.py
+++ b/scrapy/extensions/feedexport.py
@@ -177,7 +177,7 @@ class FeedExporter(object):
         if not slot.itemcount and not self.store_empty:
             return
         slot.exporter.finish_exporting()
-        logfmt = "%%s %(format)s feed (%(itemcount)d items) in: %(uri)s"
+        logfmt = "%s %%(format)s feed (%%(itemcount)d items) in: %%(uri)s"
         log_args = {'format': self.format,
                     'itemcount': slot.itemcount,
                     'uri': slot.uri}


### PR DESCRIPTION
``logfmt % "Stored"`` happens before logger formats the message, so `%` vs `%%` needs to be reversed.

This fixes the following error during shutdown:
```
2015-05-18 19:21:45+0500 [scrapy] ERROR: Error caught on signal handler: <bound method ?.close_spider of <scrapy.extensions.feedexport.FeedExporter object at 0x10c7ea390>>
Traceback (most recent call last):
 File "/Users/kmike/envs/scraping/lib/python2.7/site-packages/twisted/internet/defer.py", line 577, in _runCallbacks
   current.result = callback(current.result, *args, **kw)
 File "/Users/kmike/envs/scraping/lib/python2.7/site-packages/Scrapy-0.25.1-py2.7.egg/scrapy/extensions/feedexport.py", line 187, in <lambda>
   d.addErrback(lambda f: logger.error(logfmt % "Error storing", log_args,
TypeError: format requires a mapping
```

Export is successful, but error handler is called because there is the same exception in success handler.

To get it try @eliasdorneles's example from here: https://github.com/scrapy/scrapy.github.io/pull/29 (`scrapy runspider example.py -o res.json`)