### PR TITLE
Add support to Selectors for querying by tag name and attribute filters

### DIFF
--- a/scrapy/selector/querytranslator.py
+++ b/scrapy/selector/querytranslator.py
@@ -1,0 +1,88 @@
+import re
+from enum import Enum
+from lxml import html
+
+
+class QueryComparison(Enum):
+    contains = 1
+    starts_with = 2
+    ends_with = 3
+    equals = 4
+
+
+class QueryTranslator:
+    def __init__(self, markup):
+        self.root = html.fromstring(markup)
+
+    @staticmethod
+    def generate_condition(attr, value, comparison):
+        prefix = '^' if comparison == QueryComparison.starts_with or comparison == QueryComparison.equals else ''
+        suffix = '$' if comparison == QueryComparison.ends_with or comparison == QueryComparison.equals else ''
+        return 're:test(@{0}, \'{1}{2}{3}\')'.format(attr, prefix, value, suffix)
+
+    @staticmethod
+    def generate_xpath(tag, attrs, comparison):
+        conditions = []
+        for x in attrs:
+            conditions.append(QueryTranslator.generate_condition(x, attrs[x], comparison))
+        xpath = '//{0}'.format(tag)
+        if len(conditions) > 0:
+            xpath += '[{0}]'.format(' and '.join(conditions))
+        return xpath
+
+    def get_elements(self, tag, attrs, comparison=QueryComparison.contains):
+        ns = 'http://exslt.org/regular-expressions'
+        expr = QueryTranslator.generate_xpath(tag, attrs, comparison)
+        elements = self.root.xpath(expr, namespaces={'re': ns})
+        return elements
+
+    def in_element(self, element):
+        self.root = html.fromstring(html.tostring(element))
+        return self
+
+    def get_value(self):
+        element = QueryElement(self.root.text_content())
+        return element
+
+    def get_attr(self, name):
+        element = QueryElement(self.root.attrib[name])
+        return element
+
+    def get_value_of(self, tag, attrs):
+        elements = self.get_elements(tag, attrs)
+        if len(elements) > 0:
+            return self.in_element(elements[0]).get_value()
+        else:
+            return QueryElement.empty()
+
+    def get_attr_of(self, tag, attrs, name):
+        elements = self.get_elements(tag, attrs)
+        if len(elements) > 0:
+            return self.in_element(elements[0]).get_attr(name)
+        else:
+            return QueryElement.empty()
+
+
+class QueryElement:
+    def __init__(self, element):
+        self.element = element
+
+    def as_text(self):
+        result = str(self.element)
+        return result
+
+    def as_clean_text(self):
+        result = self.as_text().strip("\\r \\n \\t")
+        result = re.sub(r"(\\r|\\n|\\t){2,}", " ", result)
+        return result
+
+    def as_float(self):
+        try:
+            result = self.as_clean_text().replace(",", "")
+            return float(result)
+        except ValueError:
+            return float('nan')
+
+    @staticmethod
+    def empty():
+        return QueryElement('')

--- a/scrapy/selector/unified.py
+++ b/scrapy/selector/unified.py
@@ -110,11 +110,11 @@ class Selector(object_ref):
                   for x in result]
         return SelectorList(result)
 
-    def by_attrs(self, attrs, comparison=QueryComparison.equals):
-        return self.query.get_elements(attrs, comparison)
+    def find(self, attrs, comparison=QueryComparison.equals):
+        return self.query.find(attrs, comparison)
 
-    def in_element(self, element):
-        return self.query.in_element(element)
+    def inside(self, element):
+        return self.query.inside(element)
 
     def css(self, query):
         return self.xpath(self._css2xpath(query))

--- a/scrapy/selector/unified.py
+++ b/scrapy/selector/unified.py
@@ -4,6 +4,7 @@ XPath selectors based on lxml
 
 from lxml import etree
 import six
+from scrapy.selector.querytranslator import QueryComparison, QueryTranslator
 
 from scrapy.utils.misc import extract_regex
 from scrapy.utils.trackref import object_ref
@@ -85,6 +86,7 @@ class Selector(object_ref):
             self.namespaces.update(namespaces)
         self._root = _root
         self._expr = _expr
+        self.query = QueryTranslator(self._root)
 
     def xpath(self, query):
         try:
@@ -107,6 +109,12 @@ class Selector(object_ref):
                                  type=self.type)
                   for x in result]
         return SelectorList(result)
+
+    def by_attrs(self, attrs, comparison=QueryComparison.equals):
+        return self.query.get_elements(attrs, comparison)
+
+    def in_element(self, element):
+        return self.query.in_element(element)
 
     def css(self, query):
         return self.xpath(self._css2xpath(query))


### PR DESCRIPTION
Hi, I thought it would be nice to have an alternative way to xpath/re/css selectors when searching for elements, that uses python built-in dictionaries in a declarative manner. While it feels simple and familiar it still provides a lot of flexibility and expressiveness. I have included an example in scrapy/selector/querytranslator.py. If you like my idea I can also update the unit tests and docs in a new pull-request. Thanks!
