### PR TITLE
Add CRAWLER setting to be able to set custom crawler via settings file

### DIFF
--- a/docs/topics/settings.rst
+++ b/docs/topics/settings.rst
@@ -215,6 +215,14 @@ This setting also affects :setting:`DOWNLOAD_DELAY`:
 if :setting:`CONCURRENT_REQUESTS_PER_IP` is non-zero, download delay is
 enforced per IP, not per domain.
 
+.. setting:: CRAWLER
+
+CRAWLER
+-------
+
+Default: ``'scrapy.crawler.Crawler'``
+
+The crawler to use for crawling.
 
 .. setting:: DEFAULT_ITEM_CLASS
 

--- a/scrapy/crawler.py
+++ b/scrapy/crawler.py
@@ -162,7 +162,8 @@ class CrawlerRunner(object):
     def _create_crawler(self, spidercls):
         if isinstance(spidercls, six.string_types):
             spidercls = self.spider_loader.load(spidercls)
-        return Crawler(spidercls, self.settings)
+        crawler_cls = load_object(self.settings['CRAWLER'])
+        return crawler_cls(spidercls, self.settings)
 
     def stop(self):
         """

--- a/scrapy/settings/default_settings.py
+++ b/scrapy/settings/default_settings.py
@@ -40,6 +40,8 @@ CONCURRENT_REQUESTS_PER_IP = 0
 COOKIES_ENABLED = True
 COOKIES_DEBUG = False
 
+CRAWLER = 'scrapy.crawler.Crawler'
+
 DEFAULT_ITEM_CLASS = 'scrapy.item.Item'
 
 DEFAULT_REQUEST_HEADERS = {

--- a/tests/test_crawler.py
+++ b/tests/test_crawler.py
@@ -52,7 +52,6 @@ class CrawlerTestCase(unittest.TestCase):
         self.assertIsInstance(crawler.settings, Settings)
 
 
-
 class SpiderLoaderWithWrongInterface(object):
 
     def unneeded_method(self):
@@ -60,6 +59,10 @@ class SpiderLoaderWithWrongInterface(object):
 
 
 class CustomSpiderLoader(SpiderLoader):
+    pass
+
+
+class CustomCrawler(Crawler):
     pass
 
 
@@ -104,3 +107,16 @@ class CrawlerRunnerTestCase(unittest.TestCase):
             self.assertEqual(len(w), 1)
             self.assertIn('Please use SPIDER_LOADER_CLASS', str(w[0].message))
 
+    def _test_crawler_class(self, runner, expected_crawler_class):
+        self.assertEqual(len(runner.crawlers), 0)
+        runner.crawl(DefaultSpider)
+        self.assertEqual(len(runner.crawlers), 1)
+        self.assertIsInstance(list(runner.crawlers)[0], expected_crawler_class)
+
+    def test_default_crawler(self):
+        runner = CrawlerRunner({})
+        self._test_crawler_class(runner, Crawler)
+
+    def test_custom_crawler(self):
+        runner = CrawlerRunner({'CRAWLER': 'tests.test_crawler.CustomCrawler'})
+        self._test_crawler_class(runner, CustomCrawler)


### PR DESCRIPTION
In my case it's needed for ScrapyRT - we are using custom Crawler class there.

I started working on this PR before I noticed #1147, so now I have doubts if it will be useful. Theoretically now I can override `.crawl` method and pass custom crawler object there. So I decided to leave it to your judgment. I'll add test case if this PR wouldn't be rejected.
