### PR TITLE
[MRG +1] LogCounterHandler is never removed from root handlers list, fix that

### DIFF
--- a/scrapy/crawler.py
+++ b/scrapy/crawler.py
@@ -35,8 +35,10 @@ class Crawler(object):
 
         handler = LogCounterHandler(self, level=settings.get('LOG_LEVEL'))
         logging.root.addHandler(handler)
-        self.signals.connect(lambda: logging.root.removeHandler(handler),
-                             signals.engine_stopped)
+        # lambda is assigned to Crawler attribute because this way it is not
+        # garbage collected after leaving __init__ scope
+        self.__remove_handler = lambda: logging.root.removeHandler(handler)
+        self.signals.connect(self.__remove_handler, signals.engine_stopped)
 
         lf_cls = load_object(self.settings['LOG_FORMATTER'])
         self.logformatter = lf_cls.from_crawler(self)


### PR DESCRIPTION
lambda is garbage collected and because receiver is added as weak reference by default - when `signals.engine_stopped` is fired `logging.root.removeHandler` is not executed. Fixed that by assigning lambda to a private argument and not by using `connect(..., weak=False)` because I believe this lambda function should be collected with crawler object and not stay in `dispatcher.connections` forever.

Tested in ScrapyRT where multiple crawls are running in the same process. Before the fix:

```
(Pdb) logging.root.handlers
[<scrapy.utils.log.LogCounterHandler object at 0x7f93caafca10>, <scrapy.utils.log.LogCounterHandler object at 0x7f93ca0ee690>, <scrapy.utils.log.LogCounterHandler object at 0x7f93c8048110>, <scrapy.utils.log.LogCounterHandler object at 0x7f93c806ba10>, <logging.FileHandler object at 0x7f93c38cce90>, <scrapy.utils.log.LogCounterHandler object at 0x7f93c38dc310>]
```

After the fix:

```
(Pdb) logging.root.handlers
[<logging.FileHandler object at 0x7f603536ce50>, <scrapy.utils.log.LogCounterHandler object at 0x7f60352c1510>]
```