### PR TITLE
Make list of enabled middlewares more readable

### DIFF
--- a/scrapy/middleware.py
+++ b/scrapy/middleware.py
@@ -1,5 +1,6 @@
-import logging
 from collections import defaultdict
+import logging
+import pprint
 
 from scrapy.exceptions import NotConfigured
 from scrapy.utils.misc import load_object
@@ -43,11 +44,9 @@ class MiddlewareManager(object):
                     logger.warning("Disabled %(clsname)s: %(eargs)s",
                                    {'clsname': clsname, 'eargs': e.args[0]},
                                    extra={'crawler': crawler})
-
-        enabled = [x.__class__.__name__ for x in middlewares]
-        logger.info("Enabled %(componentname)ss: %(enabledlist)s",
+        logger.info("Enabled %(componentname)ss:\n%(enabledlist)s",
                     {'componentname': cls.component_name,
-                     'enabledlist': ', '.join(enabled)},
+                     'enabledlist': pprint.pformat(mwlist)},
                     extra={'crawler': crawler})
         return cls(*middlewares)
 


### PR DESCRIPTION
Inspired by today's mail from @dangra.

Before:

```
2015-05-29 09:45:57+0000 [scrapy] INFO: Enabled downloader middlewares: HttpAuthMiddleware,
DownloadTimeoutMiddleware, UserAgentMiddleware, RetryMiddleware, CustomRetryMiddleware,
SlotDelayMiddleware, DefaultHeadersMiddleware, MetaRefreshMiddleware, 
MetaRefreshMiddleware, HttpCompressionMiddleware, RedirectMiddleware, RedirectMiddleware,
CrawleraMiddleware, CustomCookiesMiddleware, CookiesMiddleware, SplashMiddleware,
HttpCompressionMiddleware, CustomHttpProxyMiddleware, RotateUserAgentMiddleware,
ChunkedTransferMiddleware, ResponseStats, DownloaderStats
```

After: 

```
2015-05-29 09:44:15+0000 [scrapy] INFO: Enabled downloader middlewares:
- HttpAuthMiddleware
- DownloadTimeoutMiddleware
- UserAgentMiddleware
- RetryMiddleware
- CustomRetryMiddleware
- SlotDelayMiddleware
- DefaultHeadersMiddleware
- MetaRefreshMiddleware
- MetaRefreshMiddleware
- HttpCompressionMiddleware
- RedirectMiddleware
- RedirectMiddleware
- CrawleraMiddleware
- CustomCookiesMiddleware
- CookiesMiddleware
- SplashMiddleware
- HttpCompressionMiddleware
- CustomHttpProxyMiddleware
- RotateUserAgentMiddleware
- ChunkedTransferMiddleware
- ResponseStats
- DownloaderStats
```

A bit easier to read and detect problems IMO