### PR TITLE
Dedupe for MiddlewareManager

### DIFF
--- a/scrapy/middleware.py
+++ b/scrapy/middleware.py
@@ -27,9 +27,17 @@ class MiddlewareManager(object):
     def from_settings(cls, settings, crawler=None):
         mwlist = cls._get_mwlist_from_settings(settings)
         middlewares = []
+        all_mwclss = {}
         for clspath in mwlist:
             try:
                 mwcls = load_object(clspath)
+                if mwcls in all_mwclss:
+                    logger.warning("Removed %(clspath)s, is identical to %(oldclspath)s",
+                                   {'clspath': clspath, 'oldclspath': all_mwclss[mwcls]},
+                                   extra={'crawler': crawler})
+                    continue
+                else:
+                    all_mwclss[mwcls] = clspath
                 if crawler and hasattr(mwcls, 'from_crawler'):
                     mw = mwcls.from_crawler(crawler)
                 elif hasattr(mwcls, 'from_settings'):

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -1,4 +1,3 @@
-import warnings
 from twisted.trial import unittest
 
 from scrapy.settings import Settings
@@ -94,8 +93,7 @@ class MiddlewareManagerTest(unittest.TestCase):
         mwman_cls = TestMiddlewareManager
         mwman_cls._get_mwlist_from_settings = _get_mwlist_with_clones
         settings = Settings()
-        with warnings.catch_warnings(record=True) as w:
-            mwman = mwman_cls.from_settings(settings)
-            self.assertEqual(len(mwman.middlewares), 1)
-            self.assertIsInstance(mwman.middlewares[0], M1)
+        mwman = mwman_cls.from_settings(settings)
+        self.assertEqual(len(mwman.middlewares), 1)
+        self.assertIsInstance(mwman.middlewares[0], M1)
 

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -1,3 +1,4 @@
+import warnings
 from twisted.trial import unittest
 
 from scrapy.settings import Settings
@@ -43,6 +44,9 @@ class MOff(object):
         raise NotConfigured
 
 
+M1Clone = M1
+
+
 class TestMiddlewareManager(MiddlewareManager):
 
     @classmethod
@@ -82,3 +86,16 @@ class MiddlewareManagerTest(unittest.TestCase):
         mwman = TestMiddlewareManager.from_settings(settings)
         classes = [x.__class__ for x in mwman.middlewares]
         self.assertEqual(classes, [M1, M3])
+
+    def test_noclones(self):
+        @classmethod
+        def _get_mwlist_with_clones(cls, settings):
+            return ['tests.test_middleware.%s' % x for x in ['M1', 'M1Clone']]
+        mwman_cls = TestMiddlewareManager
+        mwman_cls._get_mwlist_from_settings = _get_mwlist_with_clones
+        settings = Settings()
+        with warnings.catch_warnings(record=True) as w:
+            mwman = mwman_cls.from_settings(settings)
+            self.assertEqual(len(mwman.middlewares), 1)
+            self.assertIsInstance(mwman.middlewares[0], M1)
+


### PR DESCRIPTION
Possible quick fix for #1265. Does not check for settings priority; the only way I see to honour settings priorities is to already load the object in `build_component_list`, which might be overkill for what that function is supposed to do? :/