### PR TITLE
Fix #1265

### DIFF
--- a/scrapy/utils/deprecate.py
+++ b/scrapy/utils/deprecate.py
@@ -121,3 +121,37 @@ def _clspath(cls, forced=None):
     if forced is not None:
         return forced
     return '{}.{}'.format(cls.__module__, cls.__name__)
+
+
+DEPRECATION_RULES = [
+    ('scrapy.contrib_exp.downloadermiddleware.decompression.', 'scrapy.downloadermiddlewares.decompression.'),
+    ('scrapy.contrib_exp.iterators.', 'scrapy.utils.iterators.'),
+    ('scrapy.contrib.downloadermiddleware.', 'scrapy.downloadermiddlewares.'),
+    ('scrapy.contrib.exporter.', 'scrapy.exporters.'),
+    ('scrapy.contrib.linkextractors.', 'scrapy.linkextractors.'),
+    ('scrapy.contrib.loader.processor.', 'scrapy.loader.processors.'),
+    ('scrapy.contrib.loader.', 'scrapy.loader.'),
+    ('scrapy.contrib.pipeline.', 'scrapy.pipelines.'),
+    ('scrapy.contrib.spidermiddleware.', 'scrapy.spidermiddlewares.'),
+    ('scrapy.contrib.spiders.', 'scrapy.spiders.'),
+    ('scrapy.contrib.', 'scrapy.extensions.'),
+    ('scrapy.command.', 'scrapy.commands.'),
+    ('scrapy.dupefilter.', 'scrapy.dupefilters.'),
+    ('scrapy.linkextractor.', 'scrapy.linkextractors.'),
+    ('scrapy.spider.', 'scrapy.spiders.'),
+    ('scrapy.squeue.', 'scrapy.squeues.'),
+    ('scrapy.statscol.', 'scrapy.statscollectors.'),
+    ('scrapy.utils.decorator.', 'scrapy.utils.decorators.'),
+    ('scrapy.spidermanager.SpiderManager', 'scrapy.spiderloader.SpiderLoader'),
+]
+
+
+def update_classpath(path):
+    """Update a deprecated path from an object with its new location"""
+    for prefix, replacement in DEPRECATION_RULES:
+        if path.startswith(prefix):
+            new_path = path.replace(prefix, replacement, 1)
+            warnings.warn("`{}` class is deprecated, use `{}` instead".format(path, new_path),
+                          ScrapyDeprecationWarning)
+            return new_path
+    return path

--- a/tests/test_utils_conf.py
+++ b/tests/test_utils_conf.py
@@ -2,16 +2,41 @@ import unittest
 
 from scrapy.utils.conf import build_component_list, arglist_to_dict
 
-class UtilsConfTestCase(unittest.TestCase):
 
-    def test_build_component_list(self):
+class BuildComponentListTest(unittest.TestCase):
+
+    def test_build_dict(self):
         base = {'one': 1, 'two': 2, 'three': 3, 'five': 5, 'six': None}
         custom = {'two': None, 'three': 8, 'four': 4}
-        self.assertEqual(build_component_list(base, custom),
+        self.assertEqual(build_component_list(base, custom, lambda x: x),
                          ['one', 'four', 'five', 'three'])
 
+    def test_return_list(self):
         custom = ['a', 'b', 'c']
-        self.assertEqual(build_component_list(base, custom), custom)
+        self.assertEqual(build_component_list(None, custom, lambda x: x),
+                         custom)
+
+    def test_map_dict(self):
+        custom = {'one': 1, 'two': 2, 'three': 3}
+        self.assertEqual(build_component_list({}, custom, lambda x: x.upper()),
+                         ['ONE', 'TWO', 'THREE'])
+
+    def test_map_list(self):
+        custom = ['a', 'b', 'c']
+        self.assertEqual(build_component_list(None, custom, lambda x: x.upper()),
+                         ['A', 'B', 'C'])
+
+    def test_duplicate_components_in_dict(self):
+        duplicate_dict = {'one': 1, 'two': 2, 'ONE': 4}
+        self.assertRaises(ValueError,
+                          build_component_list, {}, duplicate_dict, lambda x: x.lower())
+
+    def test_duplicate_components_in_list(self):
+        duplicate_list = ['a', 'b', 'a']
+        self.assertRaises(ValueError,
+                          build_component_list, None, duplicate_list, lambda x: x)
+
+class UtilsConfTestCase(unittest.TestCase):
 
     def test_arglist_to_dict(self):
         self.assertEqual(arglist_to_dict(['arg1=val1', 'arg2=val2']),


### PR DESCRIPTION
Attempt to solve #1265 by normalizing the paths in `build_component_list`, a helper used to merge component settings with their base settings. This solution is not bulletproof regarding priority sorting, but I think it's as close as we can get it to be. 

Example of a use-case that is still broken:
```python
>>> EXTENSIONS =  {'new_path.Obj': 10,'another_path.Another': 20, 'old_path.Obj': 30}
>>> build_components({}, EXTENSIONS)
>>> ['another_path.Another', 'new_path.Obj']
```

Current implementation will load each object once, but it will give preference to the old path ordering. That isn't always what we want, the problem here is that we can't know which path was updated/added to the dictionary first (Another reason why #1149 is going to be really helpful, though those pairings could still have the same priority). For a concrete example, Scrapy Cloud uses addons with old paths, users won't be able to update them if they use the new paths since the old ones take precedence.

I don't see how we can fix that in Scrapy side, I just hope those are really rare cases (mixing old paths and new ones in the same dictionary should be uncommon) so we can move forward with the fix.