### PR TITLE
fixed CrawlerProcess when settings are passed as dicts

### DIFF
--- a/scrapy/crawler.py
+++ b/scrapy/crawler.py
@@ -209,8 +209,8 @@ class CrawlerProcess(CrawlerRunner):
     def __init__(self, settings):
         super(CrawlerProcess, self).__init__(settings)
         install_shutdown_handlers(self._signal_shutdown)
-        configure_logging(settings)
-        log_scrapy_info(settings)
+        configure_logging(self.settings)
+        log_scrapy_info(self.settings)
 
     def _signal_shutdown(self, signum, _):
         install_shutdown_handlers(self._signal_kill)

--- a/tests/test_crawler.py
+++ b/tests/test_crawler.py
@@ -1,7 +1,7 @@
 import warnings
 import unittest
 
-from scrapy.crawler import Crawler, CrawlerRunner
+from scrapy.crawler import Crawler, CrawlerRunner, CrawlerProcess
 from scrapy.settings import Settings, default_settings
 from scrapy.spiderloader import SpiderLoader
 from scrapy.utils.spider import DefaultSpider
@@ -104,3 +104,13 @@ class CrawlerRunnerTestCase(unittest.TestCase):
             self.assertEqual(len(w), 1)
             self.assertIn('Please use SPIDER_LOADER_CLASS', str(w[0].message))
 
+
+class CrawlerProcessTest(unittest.TestCase):
+    def test_crawler_process_accepts_dict(self):
+        runner = CrawlerProcess({'foo': 'bar'})
+        self.assertEqual(runner.settings['foo'], 'bar')
+        self.assertEqual(
+            runner.settings['RETRY_ENABLED'],
+            default_settings.RETRY_ENABLED
+        )
+        self.assertIsInstance(runner.settings, Settings)


### PR DESCRIPTION
This is a follow-up to https://github.com/scrapy/scrapy/pull/1156.

Without this fix `CrawlerProcess({})` didn't work because `log_scrapy_info` wants `settings['BOT_NAME']`.