### PR TITLE
Use call to `inspect_reponse()` that works on 0.24.x

### DIFF
--- a/docs/topics/shell.rst
+++ b/docs/topics/shell.rst
@@ -186,7 +186,7 @@ Here's an example of how you would call it from your spider::
             # We want to inspect one specific response.
             if ".org" in response.url:
                 from scrapy.shell import inspect_response
-                inspect_response(response)
+                inspect_response(response, self)
 
             # Rest of parsing code.
 


### PR DESCRIPTION
Otherwise, when the spider is executed from a standalone script as described in http://doc.scrapy.org/en/stable/topics/practices.html#run-scrapy-from-a-script it triggers an exception like this:
```
.../site-packages/scrapy/shell.py", line 131, in inspect_response
...
from scrapy.project import crawler
...
exceptions.ImportError: cannot import name crawler
```