### PR TITLE
extract CrawlerRunner._crawl method which always expects Crawler

### DIFF
--- a/scrapy/crawler.py
+++ b/scrapy/crawler.py
@@ -148,7 +148,9 @@ class CrawlerRunner(object):
         crawler = crawler_or_spidercls
         if not isinstance(crawler_or_spidercls, Crawler):
             crawler = self._create_crawler(crawler_or_spidercls)
+        return self._crawl(crawler, *args, **kwargs)
 
+    def _crawl(self, crawler, *args, **kwargs):
         self.crawlers.add(crawler)
         d = crawler.crawl(*args, **kwargs)
         self._active.add(d)


### PR DESCRIPTION
It provides an extension point where crawler instance is available; it should make it easier to write alternative CrawlerRunner.crawl implementations.

My use case: listen to signals from each crawler. As as @chekunkov pointed in https://github.com/scrapy/scrapy/pull/1256#issuecomment-105241481, currently it requires copy-pasting ~~large~~ chunks of code. After this change user can override CrawlerRunner._crawl method and connect signals there.

I don't know if we should make this method public & documented or not.