### PR TITLE
spider_error doesn't support deferreds

### DIFF
--- a/docs/topics/signals.rst
+++ b/docs/topics/signals.rst
@@ -174,6 +174,8 @@ spider_error
 
     Sent when a spider callback generates an error (ie. raises an exception).
 
+    This signal does not support returning deferreds from their handlers.
+
     :param failure: the exception raised as a Twisted `Failure`_ object
     :type failure: `Failure`_ object
 


### PR DESCRIPTION
For all other signals it is documented whether they support deferreds or not.