### PR TITLE
Fix typos in scrapy/commands/setting.py

### DIFF
--- a/scrapy/commands/settings.py
+++ b/scrapy/commands/settings.py
@@ -14,16 +14,16 @@ class Command(ScrapyCommand):
 
     def add_options(self, parser):
         ScrapyCommand.add_options(self, parser)
-        parser.add_option("--get", dest="get", metavar="SETTING", \
+        parser.add_option("--get", dest="get", metavar="SETTING",
             help="print raw setting value")
-        parser.add_option("--getbool", dest="getbool", metavar="SETTING", \
-            help="print setting value, intepreted as a boolean")
-        parser.add_option("--getint", dest="getint", metavar="SETTING", \
-            help="print setting value, intepreted as an integer")
-        parser.add_option("--getfloat", dest="getfloat", metavar="SETTING", \
-            help="print setting value, intepreted as an float")
-        parser.add_option("--getlist", dest="getlist", metavar="SETTING", \
-            help="print setting value, intepreted as an float")
+        parser.add_option("--getbool", dest="getbool", metavar="SETTING",
+            help="print setting value, interpreted as a boolean")
+        parser.add_option("--getint", dest="getint", metavar="SETTING",
+            help="print setting value, interpreted as an integer")
+        parser.add_option("--getfloat", dest="getfloat", metavar="SETTING",
+            help="print setting value, interpreted as a float")
+        parser.add_option("--getlist", dest="getlist", metavar="SETTING",
+            help="print setting value, interpreted as a list")
 
     def run(self, args, opts):
         settings = self.crawler_process.settings


### PR DESCRIPTION
[Cherry-picked from https://github.com/scrapy/scrapy/compare/scrapy:master...berkerpeksag:python3]

* intepreted -> interpreted
* "a list" instead of "an float" in --getlist help
* "an float"-> "a float"

Also, backslashes were redundant. So I removed them.