### PR TITLE
Try bpython if ipython isn't available in shell

### DIFF
--- a/scrapy/utils/console.py
+++ b/scrapy/utils/console.py
@@ -1,11 +1,15 @@
 
-def start_python_console(namespace=None, noipython=False, banner=''):
-    """Start Python console binded to the given namespace. If IPython is
-    available, an IPython console will be started instead, unless `noipython`
-    is True. Also, tab completion will be used on Unix systems.
+def start_python_console(namespace=None, noipython=False, banner=None):
+    """Start Python console bound to the given namespace. If IPython or
+    bpython are available, they will be started instead, unless `noipython`
+    is True. If both IPython and bpython are available, IPython will be
+    preferred. If neither is available, the built in console will be used,
+    with tab completion enabled if on a system with readline.
     """
     if namespace is None:
         namespace = {}
+    if banner is None:
+        banner = ''
 
     try:
         try: # use IPython if available
@@ -19,19 +23,32 @@ def start_python_console(namespace=None, noipython=False, banner=''):
                 from IPython.frontend.terminal.embed import InteractiveShellEmbed
                 from IPython.frontend.terminal.ipapp import load_default_config
 
+        except ImportError:
+            pass
+        else:
             config = load_default_config()
             shell = InteractiveShellEmbed(
                 banner1=banner, user_ns=namespace, config=config)
             shell()
+            return
+
+        try:
+            import bpython
         except ImportError:
-            import code
-            try: # readline module is only available on unix systems
-                import readline
-            except ImportError:
-                pass
-            else:
-                import rlcompleter
-                readline.parse_and_bind("tab:complete")
-            code.interact(banner=banner, local=namespace)
+            pass
+        else:
+            # start bpython
+            bpython.embed(locals_=namespace, banner=banner)
+            return
+
+        import code
+        try: # readline module is only available on unix systems
+            import readline
+        except ImportError:
+            pass
+        else:
+            import rlcompleter
+            readline.parse_and_bind("tab:complete")
+        code.interact(banner=banner, local=namespace)
     except SystemExit: # raised when using exit() in python code.interact
         pass


### PR DESCRIPTION
Also refactor first help message printed, so that it can be passed
through to the bpython embed function's banner field. bpython usually starts
in fullscreen, and the help message is not visible when bpython is
fullscreen.

Tested ipython, bpython, and builtin shell; all print the message
visibly when first opened, and shelp() works correctly in all of them.
Also ran the automated tests, which passed, and checked shell -c, which
does not print the shelp() message, just like it shouldn't.

---------------------------------------------

Note: this commit does not add any tests for bpython, as I don't know how one would test this in an automated fashion. 