### PR TITLE
[MRG+1] DOC(ENH): specify path to rtd theme explicitly

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -108,7 +108,10 @@ html_theme = 'sphinx_rtd_theme'
 #html_theme_options = {}
 
 # Add any paths that contain custom themes here, relative to this directory.
-#html_theme_path = []
+# Add path to the RTD explicitly to robustify builds (otherwise might
+# fail in a clean Debian build env)
+import sphinx_rtd_theme
+html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
 
 
 # The style sheet to use for HTML and HTML Help pages. A file of that name


### PR DESCRIPTION
I am not precisely sure why build without this patch works ok on my laptop but fails in a clean debian sid env, but I thought this wouldn't hurt ;-)