### PR TITLE
Use psutil if available to measure RSS on memusage extension

### DIFF
--- a/docs/topics/extensions.rst
+++ b/docs/topics/extensions.rst
@@ -203,7 +203,8 @@ Memory usage extension
 
 .. class:: scrapy.extensions.memusage.MemoryUsage
 
-.. note:: This extension does not work in Windows.
+.. note:: psutil_ package is highly recommended, but also required to use this
+          extension in Windows.
 
 Monitors the memory used by the Scrapy process that runs the spider and:
 
@@ -222,6 +223,8 @@ can be configured with the following settings:
 * :setting:`MEMUSAGE_WARNING_MB`
 * :setting:`MEMUSAGE_NOTIFY_MAIL`
 * :setting:`MEMUSAGE_REPORT`
+
+.. _psutil: https://pypi.python.org/pypi/psutil
 
 Memory debugger extension
 ~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
memusage extension fires immediately when the scrapy process is `exec()`'ed from another process whose max resident memory is higher than `MEMUSAGE_LIMIT_MB`.

The limitation comes from the use of stdlib `resource` package that can measure _max RSS_ and not _current RSS_. The overcome this limiation this PR proposes to use [psutil](https://github.com/giampaolo/psutil)

For a proof on how max RSS propagates across exec() calls see:

_memtest_

``` python
#!/usr/bin/env python
import os
import sys
import resource
import psutil
from argparse import ArgumentParser

def _mem():
    rss, vms = psutil.Process().memory_info()
    maxrss = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
    return {'maxrss': maxrss, 'rss': rss / 1024, 'vms': vms / 1024}

def _allocate_mb(mb):
    return open('/dev/urandom', 'rb').read(mb * 1024**2)

def main():
    ap = ArgumentParser()
    ap.add_argument('-a', '--allocate', type=int, default=0)
    ap.add_argument('subcmd', nargs="*")
    args = ap.parse_args()

    if args.allocate:
        _ = _allocate_mb(args.allocate)

    print("{} {}".format(_mem(), sys.argv))

    if args.subcmd:
        os.execvp(args.subcmd[0], args.subcmd)


if __name__ == '__main__':
    sys.exit(main())
```

Running it:

```
$ ./memtest -- ./memtest -a 10 -- ./memtest 
{'maxrss': 11792, 'vms': 71084, 'rss': 11792} ['./memtest', '--', './memtest', '-a', '10', '--', './memtest']
{'maxrss': 22232, 'vms': 81328, 'rss': 22232} ['./memtest', '-a', '10', '--', './memtest']
{'maxrss': 22236, 'vms': 71084, 'rss': 11992} ['./memtest']
```

See how RSS goes from 11792 to 22232 and then back to 11992, but maxrss jumps from 11792 to 22232 and is inherited by third memtest.

This is particulary problematic when running spiders inside docker containers because docker daemon can take up to GBs of RAM and its max_rss is propagated to init process of the docker container.

The following Dockerfile was used to build an image to test memtest script with docker:

``` Dockerfile
FROM ubuntu:12.04
RUN apt-get update -q && apt-get install -qy python python-dev
ADD https://raw.github.com/pypa/pip/master/contrib/get-pip.py /get-pip.py
RUN python /get-pip.py && pip install -U wheel==0.24.0
RUN pip install psutil
COPY memtest /bin/memtest
ENTRYPOINT ["/bin/memtest"]
```

then built and ran:

``` bash
$ docker build -t memtest .
...

$ docker run -it --rm memtest -- memtest -a 10 -- memtest
{'maxrss': 8021068, 'vms': 40528, 'rss': 11504} ['/bin/memtest', '--', 'memtest', '-a', '10', '--', 'memtest']
{'maxrss': 8021068, 'vms': 50772, 'rss': 21672} ['/bin/memtest', '-a', '10', 'memtest']
{'maxrss': 8021068, 'vms': 40516, 'rss': 11416} ['/bin/memtest']

$ ps v -p 26812
  PID TTY      STAT   TIME  MAJFL   TRS   DRS   RSS %MEM COMMAND
26812 ?        Ssl  649:53      0     0 26969720 8032092 12.1 /usr/bin/docker -d --iptables=false
```

See how memtest maxrss reports ~8GB which coincides with docker daemon RSS reported by @ps@ unix command.
