### PR TITLE
interpreting application/x-json as TextResponse

### DIFF
--- a/scrapy/responsetypes.py
+++ b/scrapy/responsetypes.py
@@ -24,6 +24,7 @@ class ResponseTypes(object):
         'application/vnd.wap.xhtml+xml': 'scrapy.http.HtmlResponse',
         'application/xml': 'scrapy.http.XmlResponse',
         'application/json': 'scrapy.http.TextResponse',
+        'application/x-json': 'scrapy.http.TextResponse',
         'application/javascript': 'scrapy.http.TextResponse',
         'application/x-javascript': 'scrapy.http.TextResponse',
         'text/xml': 'scrapy.http.XmlResponse',

--- a/tests/test_responsetypes.py
+++ b/tests/test_responsetypes.py
@@ -35,6 +35,7 @@ class ResponseTypesTest(unittest.TestCase):
             ('application/vnd.wap.xhtml+xml; charset=utf-8', HtmlResponse),
             ('application/xml; charset=UTF-8', XmlResponse),
             ('application/octet-stream', Response),
+            ('application/x-json; encoding=UTF8;charset=UTF-8', TextResponse),
         ]
         for source, cls in mappings:
             retcls = responsetypes.from_content_type(source)


### PR DESCRIPTION
This content type is found in the ajax pagination on store.apple.com (eg http://store.apple.com/us/search/logitech).

```
ipdb> response.headers['Content-Type']
'application/x-json; encoding=UTF8;charset=UTF-8'
```

Currently gets returned as `Response`.