### PR TITLE
Make Sphinx autodoc use local, not system-wide Scrapy

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -18,7 +18,6 @@ from os import path
 # is relative to the documentation root, use os.path.abspath to make it
 # absolute, like shown here.
 sys.path.append(path.join(path.dirname(__file__), "_ext"))
-sys.path.append(path.join(path.dirname(path.dirname(__file__)), "scrapy"))
 sys.path.insert(0, path.dirname(path.dirname(__file__)))
 
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -19,6 +19,7 @@ from os import path
 # absolute, like shown here.
 sys.path.append(path.join(path.dirname(__file__), "_ext"))
 sys.path.append(path.join(path.dirname(path.dirname(__file__)), "scrapy"))
+sys.path.insert(0, path.dirname(path.dirname(__file__)))
 
 
 # General configuration


### PR DESCRIPTION
This is more a question than a 'definitive' pull request. Without this line, Sphinx' `autodoc` extension uses my system-wide Scrapy installation (in my case, from `/usr/lib/python2.7/site-packages/scrapy`) instead of the one in my git working directory.

While I guess this is not a problem for the server which builds the docs from a current repository copy and probably doesn't have a system-wide Scrapy installation, it does build docs from the (possibly outdated) system-wide doctrings for me (w/ `make html`), and throws errors when I add new functions/classes and document them with `autodoc`. I don't quite see how it could be, but is this specific to my setup?