### PR TITLE
Support Batch Feed Export controlling batch size

### DIFF
--- a/docs/topics/feed-exports.rst
+++ b/docs/topics/feed-exports.rst
@@ -208,6 +208,7 @@ These are the settings used for configuring the feed exports:
  * :setting:`FEED_EXPORTERS`
  * :setting:`FEED_STORE_EMPTY`
  * :setting:`FEED_EXPORT_FIELDS`
+ * :setting:`FEED_BATCH_SIZE`
 
 .. currentmodule:: scrapy.extensions.feedexport
 
@@ -319,3 +320,16 @@ A dict containing the built-in feed exporters supported by Scrapy.
 .. _URI: http://en.wikipedia.org/wiki/Uniform_Resource_Identifier
 .. _Amazon S3: http://aws.amazon.com/s3/
 .. _boto: http://code.google.com/p/boto/
+
+FEED_BATCH_SIZE
+---------------
+
+Default: ``None``
+
+Allows to control the number of item exported in one file.
+
+The storage URI should define parameters to create a new file that get replaced when the feed is
+being created. These parameters are:
+
+ * ``%(start)s`` - gets replaced by a timestamp when the spider is being started
+ * ``%(time)s`` - gets replaced by a timestamp when the batch feed is being created

--- a/tests/test_feedexport.py
+++ b/tests/test_feedexport.py
@@ -7,6 +7,7 @@ import tempfile
 import shutil
 import six
 from six.moves.urllib.parse import urlparse
+import time
 
 from zope.interface.verify import verifyObject
 from twisted.trial import unittest
@@ -165,6 +166,36 @@ class FeedExportTest(unittest.TestCase):
         defer.returnValue(data)
 
     @defer.inlineCallbacks
+    def assertFileCount(self, items, file_count=1, settings=None):
+        settings = settings or {}
+        class BatchTestSpider(scrapy.Spider):
+            name = 'batchtestspider'
+            start_urls = ['http://localhost:8998/']
+
+            def parse(self, response):
+                for item in items:
+                    time.sleep(1)
+                    yield item
+
+        tmpdir = tempfile.mkdtemp() + '/res/'
+        res_name = tmpdir + '%(time)s'
+        defaults = {
+            'FEED_URI': 'file://' + res_name,
+            'FEED_FORMAT': 'csv',
+        }
+        defaults.update(settings or {})
+        try:
+            with MockServer() as s:
+                runner = CrawlerRunner(Settings(defaults))
+                yield runner.crawl(BatchTestSpider)
+
+            paths = os.listdir(tmpdir)
+            assert file_count == len(paths)
+
+        finally:
+            shutil.rmtree(tmpdir)
+
+    @defer.inlineCallbacks
     def assertExportedCsv(self, items, header, rows, settings=None, ordered=True):
         settings = settings or {}
         settings.update({'FEED_FORMAT': 'csv'})
@@ -295,3 +326,16 @@ class FeedExportTest(unittest.TestCase):
             ]
             yield self.assertExported(items, ['egg', 'baz'], rows,
                                       settings=settings, ordered=True)
+
+    @defer.inlineCallbacks
+    def test_export_batch_items(self):
+        # feed exporters use field names from Item
+        items = [
+            self.MyItem({'foo': 'bar1', 'egg': 'spam1'}),
+            self.MyItem({'foo': 'bar2', 'egg': 'spam2', 'baz': 'quux2'}),
+            self.MyItem({'foo': 'bar3', 'egg': 'spam2', 'baz': 'quux2'}),
+            self.MyItem({'foo': 'bar4', 'egg': 'spam2', 'baz': 'quux2'}),
+            self.MyItem({'foo': 'bar5', 'egg': 'spam2', 'baz': 'quux2'})
+        ]
+        settings = {'FEED_BATCH_SIZE': 2, 'FEED_FORMAT': 'jl'}
+        yield self.assertFileCount(items, 3, settings)


### PR DESCRIPTION
Hi Scrapy Team,

For our needs at 1science, we modified the feed exporter to support batch export controlling the size (number of item in a file) with a new settings ```FEED_BATCH_SIZE```.

We added a unit test and updated the documentation.

Please give me your feedbacks !

Nicolas Huray