### PR TITLE
[MRG+1] Add optional external dependencies to extras_require

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -45,4 +45,9 @@ setup(
         'cssselect>=0.9',
         'six>=1.5.2',
     ],
+    extras_require={
+        'IPython': ['ipython'],
+        'S3': ['boto'],
+        'JMESPath': ['jmespath'],
+    },
 )


### PR DESCRIPTION
Having the external dependencies in extras_require would be useful to raise
awareness of our optional features, let projects that depend on those features
declare it in the proper syntax (like `scrapy[JMESpath]`) and have us thinking
twice before adding more of those.
