### PR TITLE
Fix reference in tutorial.

### DIFF
--- a/docs/intro/tutorial.rst
+++ b/docs/intro/tutorial.rst
@@ -505,8 +505,8 @@ doesn't find one -- handy for crawling blogs, forums and other sites with
 pagination.
 
 Another common pattern is to build an item with data from more than one page,
-using a `trick to pass additional data to the callbacks
-<topics-request-response-ref-request-callback-arguments>`_.
+using a :ref:`trick to pass additional data to the callbacks
+<topics-request-response-ref-request-callback-arguments>`.
 
 
 .. note::


### PR DESCRIPTION
Reference to passing additional data in callbacks was broken (had reference suffix instead of interpreted role prefix).