### PR TITLE
(idea) Convert Spiders to Spider behaviours/logic (mixins)

### DIFF
--- a/scrapy/spiders/crawl.py
+++ b/scrapy/spiders/crawl.py
@@ -27,12 +27,12 @@ class Rule(object):
         else:
             self.follow = follow
 
-class CrawlSpider(Spider):
+class CrawlMixin(object):
 
     rules = ()
 
     def __init__(self, *a, **kw):
-        super(CrawlSpider, self).__init__(*a, **kw)
+        super(CrawlMixin, self).__init__(*a, **kw)
         self._compile_rules()
 
     def parse(self, response):
@@ -88,11 +88,15 @@ class CrawlSpider(Spider):
 
     @classmethod
     def from_crawler(cls, crawler, *args, **kwargs):
-        spider = super(CrawlSpider, cls).from_crawler(crawler, *args, **kwargs)
+        spider = super(CrawlMixin, cls).from_crawler(crawler, *args, **kwargs)
         spider._follow_links = crawler.settings.getbool(
             'CRAWLSPIDER_FOLLOW_LINKS', True)
         return spider
 
     def set_crawler(self, crawler):
-        super(CrawlSpider, self).set_crawler(crawler)
+        super(CrawlMixin, self).set_crawler(crawler)
         self._follow_links = crawler.settings.getbool('CRAWLSPIDER_FOLLOW_LINKS', True)
+
+
+class CrawlSpider(CrawlMixin, Spider):
+    """CrawlSpider"""

--- a/scrapy/spiders/feed.py
+++ b/scrapy/spiders/feed.py
@@ -11,7 +11,7 @@ from scrapy.selector import Selector
 from scrapy.exceptions import NotConfigured, NotSupported
 
 
-class XMLFeedSpider(Spider):
+class XMLFeedMixin(object):
     """
     This class intends to be the base class for spiders that scrape
     from XML feeds.
@@ -91,7 +91,11 @@ class XMLFeedSpider(Spider):
             selector.register_namespace(prefix, uri)
 
 
-class CSVFeedSpider(Spider):
+class XMLFeedSpider(XMLFeedMixin, Spider):
+    """Spider for parsing XML feeds."""
+
+
+class CSVFeedMixin(object):
     """Spider for parsing CSV feeds.
     It receives a CSV file in a response; iterates through each of its rows,
     and calls parse_row with a dict containing each field's data.
@@ -134,3 +138,6 @@ class CSVFeedSpider(Spider):
         response = self.adapt_response(response)
         return self.parse_rows(response)
 
+
+class CSVFeedSpider(CSVFeedMixin, Spider):
+    """Spider for parsing CSV feeds."""

--- a/scrapy/spiders/init.py
+++ b/scrapy/spiders/init.py
@@ -1,11 +1,11 @@
 from scrapy.spiders import Spider
 from scrapy.utils.spider import iterate_spider_output
 
-class InitSpider(Spider):
-    """Base Spider with initialization facilities"""
+class InitMixin(object):
+    """Spider with initialization facilities"""
 
     def start_requests(self):
-        self._postinit_reqs = super(InitSpider, self).start_requests()
+        self._postinit_reqs = super(InitMixin, self).start_requests()
         return iterate_spider_output(self.init_request())
 
     def initialized(self, response=None):
@@ -29,3 +29,6 @@ class InitSpider(Spider):
         """
         return self.initialized()
 
+
+class InitSpider(InitMixin, Spider):
+    """Spider with initialization facilities"""

--- a/scrapy/spiders/sitemap.py
+++ b/scrapy/spiders/sitemap.py
@@ -8,8 +8,22 @@ from scrapy.utils.gz import gunzip, is_gzipped
 
 logger = logging.getLogger(__name__)
 
+def regex(x):
+    if isinstance(x, basestring):
+        return re.compile(x)
+    return x
 
-class SitemapSpider(Spider):
+def iterloc(it, alt=False):
+    for d in it:
+        yield d['loc']
+
+        # Also consider alternate URLs (xhtml:link rel="alternate")
+        if alt and 'alternate' in d:
+            for l in d['alternate']:
+                yield l
+
+
+class SitemapMixin(object):
 
     sitemap_urls = ()
     sitemap_rules = [('', 'parse')]
@@ -17,7 +31,7 @@ class SitemapSpider(Spider):
     sitemap_alternate_links = False
 
     def __init__(self, *a, **kw):
-        super(SitemapSpider, self).__init__(*a, **kw)
+        super(SitemapMixin, self).__init__(*a, **kw)
         self._cbs = []
         for r, c in self.sitemap_rules:
             if isinstance(c, basestring):
@@ -64,16 +78,6 @@ class SitemapSpider(Spider):
         elif response.url.endswith('.xml.gz'):
             return gunzip(response.body)
 
-def regex(x):
-    if isinstance(x, basestring):
-        return re.compile(x)
-    return x
 
-def iterloc(it, alt=False):
-    for d in it:
-        yield d['loc']
-
-        # Also consider alternate URLs (xhtml:link rel="alternate")
-        if alt and 'alternate' in d:
-            for l in d['alternate']:
-                yield l
+class SitemapSpider(SitemapMixin, Spider):
+    """SitemapSpider"""


### PR DESCRIPTION
The idea here would be to propagate a coding practice of defining
custom spiders from a collection of re-useable behaviours.

IMO this could help shift to a coding mindset of building/releasing more logic parts of a Spider as re-useable Mixins.

Some of the current existing spiders could already be combined, such as the `CrawlSpider` could be fed by the `SitemapSpider`, the `InitSpider` could be combined with pretty much any other.

That could look like
`MySpider(InitMixin, SitemapMixin, CrawlMixin, Spider)` or
`MySpider(RedisURLFeederLogic, PageLoginLogic, CrawlLogic, Spider)`...

But the approach needs consideration on how to fix the current methods,
so that mixins don't mess with each other (`start_requests` overriding each other and such).

I'd be interested in discussion whether this change would be good or bad,
and ideas or help on how to do it.
