### PR TITLE
[MRG+1] Unset environment proxies for tests

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -6,6 +6,13 @@ see http://doc.scrapy.org/en/latest/contributing.html#running-tests
 
 import os
 
+# ignore system-wide proxies for tests
+# which would send requests to a totally unsuspecting server
+# (e.g. because urllib does not fully understand the proxy spec)
+os.environ['http_proxy'] = ''
+os.environ['https_proxy'] = ''
+os.environ['ftp_proxy'] = ''
+
 try:
     import unittest.mock as mock
 except ImportError:


### PR DESCRIPTION
because urllib doesn't handle `$no_proxy` env correctly
and the unittest webserver is always local.