### PR TITLE
[MRG+1] drop deprecated "optional_features" set

### DIFF
--- a/scrapy/__init__.py
+++ b/scrapy/__init__.py
@@ -2,7 +2,7 @@
 Scrapy - a web crawling and web scraping framework written for Python
 """
 
-__all__ = ['__version__', 'version_info', 'optional_features', 'twisted_version',
+__all__ = ['__version__', 'version_info', 'twisted_version',
            'Spider', 'Request', 'FormRequest', 'Selector', 'Item', 'Field']
 
 # Scrapy version
@@ -27,15 +27,8 @@ del warnings
 from . import _monkeypatches
 del _monkeypatches
 
-# WARNING: optional_features set is deprecated and will be removed soon. Do not use.
-optional_features = set()
-# TODO: backwards compatibility, remove for Scrapy 0.20
-optional_features.add('ssl')
-
 from twisted import version as _txv
 twisted_version = (_txv.major, _txv.minor, _txv.micro)
-if twisted_version >= (11, 1, 0):
-    optional_features.add('http11')
 
 # Declare top-level shortcuts
 from scrapy.spiders import Spider

--- a/scrapy/core/downloader/handlers/http.py
+++ b/scrapy/core/downloader/handlers/http.py
@@ -1,7 +1,7 @@
-from scrapy import optional_features
+from scrapy import twisted_version
 from .http10 import HTTP10DownloadHandler
 
-if 'http11' in optional_features:
+if twisted_version >= (11, 1, 0):
     from .http11 import HTTP11DownloadHandler as HTTPDownloadHandler
 else:
     HTTPDownloadHandler = HTTP10DownloadHandler

--- a/scrapy/utils/log.py
+++ b/scrapy/utils/log.py
@@ -126,9 +126,6 @@ def log_scrapy_info(settings):
     logger.info("Scrapy %(version)s started (bot: %(bot)s)",
                 {'version': scrapy.__version__, 'bot': settings['BOT_NAME']})
 
-    logger.info("Optional features available: %(features)s",
-                {'features': ", ".join(scrapy.optional_features)})
-
     d = dict(overridden_settings(settings))
     logger.info("Overridden settings: %(settings)r", {'settings': d})
 

--- a/tests/test_downloader_handlers.py
+++ b/tests/test_downloader_handlers.py
@@ -27,7 +27,6 @@ from scrapy.core.downloader.handlers.ftp import FTPDownloadHandler
 from scrapy.spiders import Spider
 from scrapy.http import Request
 from scrapy.settings import Settings
-from scrapy import optional_features
 from scrapy.utils.test import get_crawler
 from scrapy.exceptions import NotConfigured
 
@@ -220,7 +219,7 @@ class Http10TestCase(HttpTestCase):
 class Http11TestCase(HttpTestCase):
     """HTTP 1.1 test case"""
     download_handler_cls = HTTP11DownloadHandler
-    if 'http11' not in optional_features:
+    if twisted_version < (11, 1, 0):
         skip = 'HTTP1.1 not supported in twisted < 11.1.0'
 
     def test_download_without_maxsize_limit(self):
@@ -267,7 +266,7 @@ class Http11TestCase(HttpTestCase):
 
 class Http11MockServerTestCase(unittest.TestCase):
     """HTTP 1.1 test case with MockServer"""
-    if 'http11' not in optional_features:
+    if twisted_version < (11, 1, 0):
         skip = 'HTTP1.1 not supported in twisted < 11.1.0'
 
     def setUp(self):
@@ -392,7 +391,7 @@ class Http10ProxyTestCase(HttpProxyTestCase):
 
 class Http11ProxyTestCase(HttpProxyTestCase):
     download_handler_cls = HTTP11DownloadHandler
-    if 'http11' not in optional_features:
+    if twisted_version < (11, 1, 0):
         skip = 'HTTP1.1 not supported in twisted < 11.1.0'
 
 

--- a/tests/test_downloadermiddleware_retry.py
+++ b/tests/test_downloadermiddleware_retry.py
@@ -4,7 +4,7 @@ from twisted.internet.error import TimeoutError, DNSLookupError, \
         ConnectionRefusedError, ConnectionDone, ConnectError, \
         ConnectionLost, TCPTimedOutError
 
-from scrapy import optional_features
+from scrapy import twisted_version
 from scrapy.downloadermiddlewares.retry import RetryMiddleware
 from scrapy.xlib.tx import ResponseFailed
 from scrapy.spiders import Spider
@@ -75,7 +75,7 @@ class RetryTest(unittest.TestCase):
         exceptions = [defer.TimeoutError, TCPTimedOutError, TimeoutError,
                 DNSLookupError, ConnectionRefusedError, ConnectionDone,
                 ConnectError, ConnectionLost]
-        if 'http11' in optional_features:
+        if twisted_version >= (11, 1, 0): # http11 available
             exceptions.append(ResponseFailed)
 
         for exc in exceptions:

--- a/tests/test_toplevel.py
+++ b/tests/test_toplevel.py
@@ -11,10 +11,6 @@ class ToplevelTestCase(TestCase):
     def test_version_info(self):
         self.assertIs(type(scrapy.version_info), tuple)
 
-    def test_optional_features(self):
-        self.assertIs(type(scrapy.optional_features), set)
-        self.assertIn('ssl', scrapy.optional_features)
-
     def test_request_shortcut(self):
         from scrapy.http import Request, FormRequest
         self.assertIs(scrapy.Request, Request)


### PR DESCRIPTION
remove all `optional_features` support after the removal of 'boto' (#1357)