### PR TITLE
Link to boto repository

### DIFF
--- a/docs/topics/feed-exports.rst
+++ b/docs/topics/feed-exports.rst
@@ -318,4 +318,4 @@ A dict containing the built-in feed exporters supported by Scrapy.
 
 .. _URI: http://en.wikipedia.org/wiki/Uniform_Resource_Identifier
 .. _Amazon S3: http://aws.amazon.com/s3/
-.. _boto: http://code.google.com/p/boto/
+.. _boto: https://github.com/boto/boto


### PR DESCRIPTION
boto has moved from Google Code to Github.