### PR TITLE
Put a blurb about support channels in CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,2 +1,6 @@
 The guidelines for contributing are available here:
 http://doc.scrapy.org/en/master/contributing.html
+
+Please do not abuse the issue tracker for support questions.
+If your issue topic can be rephrased to "How to ...?", please use the
+support channels to get it answered: http://scrapy.org/community/


### PR DESCRIPTION
In response to more support questions on the issue tracker, add some text to `CONTRIBUTING` which GitHub links when creating new issues.

Unless you believe that would be too discouraging and being more lenient with these.