### PR TITLE
lazy-load downloadhandlers (continuation of #1357)

### DIFF
--- a/scrapy/core/downloader/handlers/__init__.py
+++ b/scrapy/core/downloader/handlers/__init__.py
@@ -1,11 +1,15 @@
 """Download handlers for different schemes"""
 
+import logging
 from twisted.internet import defer
 import six
 from scrapy.exceptions import NotSupported, NotConfigured
 from scrapy.utils.httpobj import urlparse_cached
 from scrapy.utils.misc import load_object
 from scrapy import signals
+
+
+logger = logging.getLogger(__name__)
 
 
 class DownloadHandlers(object):
@@ -39,10 +43,14 @@ class DownloadHandlers(object):
                     'no handler available for that scheme'
             return None
 
-        dhcls = load_object(self._schemes[scheme])
         try:
+            dhcls = load_object(self._schemes[scheme])
             dh = dhcls(self._crawler_settings)
         except NotConfigured as ex:
+            self._notconfigured[scheme] = str(ex)
+            return None
+        except Exception as ex:
+            logger.exception()
             self._notconfigured[scheme] = str(ex)
             return None
         else:

--- a/scrapy/core/downloader/handlers/__init__.py
+++ b/scrapy/core/downloader/handlers/__init__.py
@@ -43,14 +43,16 @@ class DownloadHandlers(object):
                     'no handler available for that scheme'
             return None
 
+        path = self._schemes[scheme]
         try:
-            dhcls = load_object(self._schemes[scheme])
+            dhcls = load_object(path)
             dh = dhcls(self._crawler_settings)
         except NotConfigured as ex:
             self._notconfigured[scheme] = str(ex)
             return None
         except Exception as ex:
-            logger.exception()
+            logger.exception('Loading "{}" for scheme "{}" handler'\
+                             .format(path, scheme))
             self._notconfigured[scheme] = str(ex)
             return None
         else:

--- a/scrapy/core/downloader/handlers/__init__.py
+++ b/scrapy/core/downloader/handlers/__init__.py
@@ -15,7 +15,7 @@ logger = logging.getLogger(__name__)
 class DownloadHandlers(object):
 
     def __init__(self, crawler):
-        self._crawler_settings = crawler.settings
+        self._crawler = crawler
         self._schemes = {}  # stores acceptable schemes on instancing
         self._handlers = {}  # stores instanced handlers for schemes
         self._notconfigured = {}  # remembers failed handlers
@@ -45,13 +45,14 @@ class DownloadHandlers(object):
         path = self._schemes[scheme]
         try:
             dhcls = load_object(path)
-            dh = dhcls(self._crawler_settings)
+            dh = dhcls(self._crawler.settings)
         except NotConfigured as ex:
             self._notconfigured[scheme] = str(ex)
             return None
         except Exception as ex:
-            logger.exception('Loading "{}" for scheme "{}" handler'
-                             .format(path, scheme))
+            logger.error('Loading "%(clspath)s" for scheme "%(scheme)s"',
+                         {"clspath": path, "scheme": scheme},
+                         exc_info=True,  extra={'crawler': self._crawler})
             self._notconfigured[scheme] = str(ex)
             return None
         else:

--- a/scrapy/core/downloader/handlers/__init__.py
+++ b/scrapy/core/downloader/handlers/__init__.py
@@ -16,9 +16,9 @@ class DownloadHandlers(object):
 
     def __init__(self, crawler):
         self._crawler_settings = crawler.settings
-        self._schemes = {} # stores acceptable schemes on instancing
-        self._handlers = {} # stores instanced handlers for schemes
-        self._notconfigured = {} # remembers failed handlers
+        self._schemes = {}  # stores acceptable schemes on instancing
+        self._handlers = {}  # stores instanced handlers for schemes
+        self._notconfigured = {}  # remembers failed handlers
         handlers = crawler.settings.get('DOWNLOAD_HANDLERS_BASE')
         handlers.update(crawler.settings.get('DOWNLOAD_HANDLERS', {}))
         for scheme, clspath in six.iteritems(handlers):
@@ -39,8 +39,7 @@ class DownloadHandlers(object):
         if scheme in self._notconfigured:
             return None
         if scheme not in self._schemes:
-            self._notconfigured[scheme] = \
-                    'no handler available for that scheme'
+            self._notconfigured[scheme] = 'no handler available for that scheme'
             return None
 
         path = self._schemes[scheme]
@@ -51,7 +50,7 @@ class DownloadHandlers(object):
             self._notconfigured[scheme] = str(ex)
             return None
         except Exception as ex:
-            logger.exception('Loading "{}" for scheme "{}" handler'\
+            logger.exception('Loading "{}" for scheme "{}" handler'
                              .format(path, scheme))
             self._notconfigured[scheme] = str(ex)
             return None
@@ -64,7 +63,7 @@ class DownloadHandlers(object):
         handler = self._get_handler(scheme)
         if not handler:
             raise NotSupported("Unsupported URL scheme '%s': %s" %
-                    (scheme, self._notconfigured[scheme]))
+                               (scheme, self._notconfigured[scheme]))
         return handler.download_request(request, spider)
 
     @defer.inlineCallbacks

--- a/scrapy/core/downloader/handlers/__init__.py
+++ b/scrapy/core/downloader/handlers/__init__.py
@@ -11,8 +11,10 @@ from scrapy import signals
 class DownloadHandlers(object):
 
     def __init__(self, crawler):
-        self._handlers = {}
-        self._notconfigured = {}
+        self._crawler_settings = crawler.settings
+        self._schemes = {} # stores acceptable schemes on instancing
+        self._handlers = {} # stores instanced handlers for schemes
+        self._notconfigured = {} # remembers failed handlers
         handlers = crawler.settings.get('DOWNLOAD_HANDLERS_BASE')
         handlers.update(crawler.settings.get('DOWNLOAD_HANDLERS', {}))
         for scheme, clspath in six.iteritems(handlers):
@@ -20,25 +22,40 @@ class DownloadHandlers(object):
             # component (extension, middleware, etc).
             if clspath is None:
                 continue
-            cls = load_object(clspath)
-            try:
-                dh = cls(crawler.settings)
-            except NotConfigured as ex:
-                self._notconfigured[scheme] = str(ex)
-            else:
-                self._handlers[scheme] = dh
+            self._schemes[scheme] = clspath
 
         crawler.signals.connect(self._close, signals.engine_stopped)
 
+    def _get_handler(self, scheme):
+        """Lazy-load the downloadhandler for a scheme
+        only on the first request for that scheme.
+        """
+        if scheme in self._handlers:
+            return self._handlers[scheme]
+        if scheme in self._notconfigured:
+            return None
+        if scheme not in self._schemes:
+            self._notconfigured[scheme] = \
+                    'no handler available for that scheme'
+            return None
+
+        dhcls = load_object(self._schemes[scheme])
+        try:
+            dh = dhcls(self._crawler_settings)
+        except NotConfigured as ex:
+            self._notconfigured[scheme] = str(ex)
+            return None
+        else:
+            self._handlers[scheme] = dh
+        return self._handlers[scheme]
+
     def download_request(self, request, spider):
         scheme = urlparse_cached(request).scheme
-        try:
-            handler = self._handlers[scheme].download_request
-        except KeyError:
-            msg = self._notconfigured.get(scheme, \
-                    'no handler available for that scheme')
-            raise NotSupported("Unsupported URL scheme '%s': %s" % (scheme, msg))
-        return handler(request, spider)
+        handler = self._get_handler(scheme)
+        if not handler:
+            raise NotSupported("Unsupported URL scheme '%s': %s" %
+                    (scheme, self._notconfigured[scheme]))
+        return handler.download_request(request, spider)
 
     @defer.inlineCallbacks
     def _close(self, *_a, **_kw):

--- a/tests/test_downloader_handlers.py
+++ b/tests/test_downloader_handlers.py
@@ -52,6 +52,9 @@ class LoadTestCase(unittest.TestCase):
         handlers = {'scheme': 'tests.test_downloader_handlers.DummyDH'}
         crawler = get_crawler(settings_dict={'DOWNLOAD_HANDLERS': handlers})
         dh = DownloadHandlers(crawler)
+        self.assertIn('scheme', dh._schemes)
+        for scheme in handlers: # force load handlers
+            dh._get_handler(scheme)
         self.assertIn('scheme', dh._handlers)
         self.assertNotIn('scheme', dh._notconfigured)
 
@@ -59,6 +62,9 @@ class LoadTestCase(unittest.TestCase):
         handlers = {'scheme': 'tests.test_downloader_handlers.OffDH'}
         crawler = get_crawler(settings_dict={'DOWNLOAD_HANDLERS': handlers})
         dh = DownloadHandlers(crawler)
+        self.assertIn('scheme', dh._schemes)
+        for scheme in handlers: # force load handlers
+            dh._get_handler(scheme)
         self.assertNotIn('scheme', dh._handlers)
         self.assertIn('scheme', dh._notconfigured)
 
@@ -66,8 +72,11 @@ class LoadTestCase(unittest.TestCase):
         handlers = {'scheme': None}
         crawler = get_crawler(settings_dict={'DOWNLOAD_HANDLERS': handlers})
         dh = DownloadHandlers(crawler)
+        self.assertNotIn('scheme', dh._schemes)
+        for scheme in handlers: # force load handlers
+            dh._get_handler(scheme)
         self.assertNotIn('scheme', dh._handlers)
-        self.assertNotIn('scheme', dh._notconfigured)
+        self.assertIn('scheme', dh._notconfigured)
 
 
 class FileTestCase(unittest.TestCase):


### PR DESCRIPTION
After this change it is possible to run `scrapy crawl` without having to port all handlers enabled by default.

For example for https://github.com/scrapinghub/testspiders the "loremipsum" spider, that only use `file://` urls, works under python 3. Errors in log are on purpose and part of spider code.

```
$ scrapy crawl loremipsum
2015-08-10 18:20:58 [scrapy] INFO: Scrapy 1.1.0dev1 started (bot: testspiders)
2015-08-10 18:20:58 [scrapy] INFO: Optional features available: http11, ssl
2015-08-10 18:20:58 [scrapy] INFO: Overridden settings: {'COOKIES_ENABLED': False, 'CLOSESPIDER_PAGECOUNT': 1000, 'NEWSPIDER_MODULE': 'testspiders.spiders', 'CLOSESPIDER_TIMEOUT': 3600, 'RETRY_ENABLED': False, 'SPIDER_MODULES': ['testspiders.spiders'], 'BOT_NAME': 'testspiders'}
2015-08-10 18:20:58 [scrapy] INFO: Enabled extensions: CoreStats, CloseSpider, LogStats, SpiderState
2015-08-10 18:20:58 [scrapy] INFO: Enabled downloader middlewares: RandomUserAgent, ErrorMonkeyMiddleware, HttpAuthMiddleware, DownloadTimeoutMiddleware, UserAgentMiddleware, DefaultHeadersMiddleware, MetaRefreshMiddleware, HttpCompressionMiddleware, RedirectMiddleware, ChunkedTransferMiddleware, DownloaderStats
2015-08-10 18:20:58 [scrapy] INFO: Enabled spider middlewares: HttpErrorMiddleware, OffsiteMiddleware, RefererMiddleware, UrlLengthMiddleware, DepthMiddleware
2015-08-10 18:20:58 [scrapy] INFO: Enabled item pipelines: 
2015-08-10 18:20:58 [scrapy] INFO: Spider opened
2015-08-10 18:20:58 [scrapy] INFO: Crawled 0 pages (at 0 pages/min), scraped 0 items (at 0 items/min)
2015-08-10 18:20:58 [scrapy] DEBUG: Crawled (200) <GET file:///tmp/tmpdhscrtwq> (referer: None)
2015-08-10 18:20:59 [loremipsum] DEBUG: b'Lorem ipsum dolor sit amet, co'
2015-08-10 18:20:59 [loremipsum] INFO: b'nsectetuer adipiscing elit, se'
2015-08-10 18:20:59 [loremipsum] WARNING: b'd\ndiam nonummy nibh euismod ti'
2015-08-10 18:20:59 [loremipsum] ERROR: b'ncidunt ut laoreet dolore magn'
2015-08-10 18:20:59 [scrapy] DEBUG: Scraped from <200 file:///tmp/tmpdhscrtwq>
{'body': b'Lorem ipsum dolor sit amet, consectetuer adipiscing elit, sed\ndiam nonummy nibh euismod tincidunt ut laoreet dolore magna aliquam erat\nvolutpat. Ut wisi enim ad minim veniam, quis nostrud exerci tation ullamcorper\nsuscipit lobortis nisl ut aliquip ex ea commodo consequat. Duis autem vel eum\niriure dolor in hendrerit in vulputate velit esse molestie consequat, vel illum\ndolore eu feugiat nulla facilisis at vero eros et accumsan et iusto odio\ndignissim qui blandit praesent luptatum zzril delenit augue duis dolore te\nfeugait nulla facilisi. Nam liber tempor cum soluta nobis eleifend option\ncongue nihil imperdiet doming id quod mazim placerat facer possim assum. Typi\nnon habent claritatem insitam; est usus legentis in iis qui facit eorum\nclaritatem. Investigationes demonstraverunt lectores legere me lius quod ii\nlegunt saepius. Claritas est etiam processus dynamicus, qui sequitur mutationem\nconsuetudium lectorum. Mirum est notare quam littera gothica, quam nunc putamus\nparum claram, anteposuerit litterarum formas humanitatis per seacula quarta\ndecima et quinta decima. Eodem modo typi, qui nunc nobis videntur parum clari,\nfiant sollemnes in futurum.',
 'title': b'Lorem ipsum dolor si',
 'url': 'file:///tmp/tmpdhscrtwq'}
2015-08-10 18:20:59 [scrapy] ERROR: Error downloading <GET file:///tmp/tmpdhscrtwq?x-error-response>
Traceback (most recent call last):
  File "/home/daniel/src/twisted/twisted/internet/defer.py", line 588, in _runCallbacks
    current.result = callback(current.result, *args, **kw)
  File "/home/daniel/src/scrapy/scrapy/core/downloader/middleware.py", line 46, in process_response
    response = method(request=request, response=response, spider=spider)
  File "/home/daniel/src/frankie/testspiders/testspiders/middleware.py", line 31, in process_response
    _ = 1 / 0
ZeroDivisionError: division by zero
2015-08-10 18:20:59 [scrapy] ERROR: Spider error processing <GET file:///tmp/tmpdhscrtwq?x-error-response> (referer: b'file:///tmp/tmpdhscrtwq')
Traceback (most recent call last):
  File "/home/daniel/src/twisted/twisted/internet/defer.py", line 588, in _runCallbacks
    current.result = callback(current.result, *args, **kw)
  File "/home/daniel/src/frankie/testspiders/testspiders/spiders/loremipsum.py", line 52, in recover
    raise ValueError('hoho')
ValueError: hoho
2015-08-10 18:20:59 [scrapy] INFO: Closing spider (finished)
2015-08-10 18:20:59 [scrapy] INFO: Dumping Scrapy stats:
{'downloader/request_bytes': 593,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 38,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2015, 8, 10, 21, 20, 59, 293849),
 'item_scraped_count': 1,
 'log_count/DEBUG': 3,
 'log_count/ERROR': 3,
 'log_count/INFO': 8,
 'log_count/WARNING': 1,
 'request_depth_max': 1,
 'response_received_count': 1,
 'scheduler/dequeued': 2,
 'scheduler/dequeued/memory': 2,
 'scheduler/enqueued': 2,
 'scheduler/enqueued/memory': 2,
 'spider_exceptions/ValueError': 1,
 'start_time': datetime.datetime(2015, 8, 10, 21, 20, 58, 959610)}
2015-08-10 18:20:59 [scrapy] INFO: Spider closed (finished)
``` 

For a spider with `http` urls it fails and log the errors properly:

```
$ scrapy crawl followall
2015-08-10 18:22:32 [scrapy] INFO: Scrapy 1.1.0dev1 started (bot: testspiders)
2015-08-10 18:22:32 [scrapy] INFO: Optional features available: http11, ssl
2015-08-10 18:22:32 [scrapy] INFO: Overridden settings: {'NEWSPIDER_MODULE': 'testspiders.spiders', 'CLOSESPIDER_PAGECOUNT': 1000, 'RETRY_ENABLED': False, 'CLOSESPIDER_TIMEOUT': 3600, 'SPIDER_MODULES': ['testspiders.spiders'], 'COOKIES_ENABLED': False, 'BOT_NAME': 'testspiders'}
2015-08-10 18:22:33 [scrapy] INFO: Enabled extensions: CloseSpider, SpiderState, LogStats, CoreStats
2015-08-10 18:22:33 [scrapy] INFO: Enabled downloader middlewares: RandomUserAgent, ErrorMonkeyMiddleware, HttpAuthMiddleware, DownloadTimeoutMiddleware, UserAgentMiddleware, DefaultHeadersMiddleware, MetaRefreshMiddleware, HttpCompressionMiddleware, RedirectMiddleware, ChunkedTransferMiddleware, DownloaderStats
2015-08-10 18:22:33 [scrapy] INFO: Enabled spider middlewares: HttpErrorMiddleware, OffsiteMiddleware, RefererMiddleware, UrlLengthMiddleware, DepthMiddleware
2015-08-10 18:22:33 [scrapy] INFO: Enabled item pipelines: 
2015-08-10 18:22:33 [scrapy] INFO: Spider opened
2015-08-10 18:22:33 [scrapy] INFO: Crawled 0 pages (at 0 pages/min), scraped 0 items (at 0 items/min)
2015-08-10 18:22:33 [scrapy] ERROR: Loading "scrapy.core.downloader.handlers.http.HTTPDownloadHandler" for scheme "http" handler
Traceback (most recent call last):
  File "/home/daniel/src/scrapy/scrapy/core/downloader/handlers/__init__.py", line 48, in _get_handler
    dhcls = load_object(path)
  File "/home/daniel/src/scrapy/scrapy/utils/misc.py", line 44, in load_object
    mod = import_module(module)
  File "/home/daniel/envs/scrapy3/lib/python3.4/importlib/__init__.py", line 109, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 2254, in _gcd_import
  File "<frozen importlib._bootstrap>", line 2237, in _find_and_load
  File "<frozen importlib._bootstrap>", line 2226, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 1200, in _load_unlocked
  File "<frozen importlib._bootstrap>", line 1129, in _exec
  File "<frozen importlib._bootstrap>", line 1471, in exec_module
  File "<frozen importlib._bootstrap>", line 321, in _call_with_frames_removed
  File "/home/daniel/src/scrapy/scrapy/core/downloader/handlers/http.py", line 5, in <module>
    from .http11 import HTTP11DownloadHandler as HTTPDownloadHandler
  File "/home/daniel/src/scrapy/scrapy/core/downloader/handlers/http11.py", line 268, in <module>
    class _RequestBodyProducer(object):
  File "/home/daniel/src/scrapy/scrapy/core/downloader/handlers/http11.py", line 269, in _RequestBodyProducer
    implements(IBodyProducer)
  File "/home/daniel/envs/scrapy3/lib/python3.4/site-packages/zope/interface/declarations.py", line 412, in implements
    raise TypeError(_ADVICE_ERROR % 'implementer')
TypeError: Class advice impossible in Python3.  Use the @implementer class decorator instead.
2015-08-10 18:22:33 [scrapy] ERROR: Error downloading <GET http://scrapinghub.com/>
Traceback (most recent call last):
  File "/home/daniel/src/scrapy/scrapy/utils/defer.py", line 45, in mustbe_deferred
    result = f(*args, **kw)
  File "/home/daniel/src/scrapy/scrapy/core/downloader/handlers/__init__.py", line 67, in download_request
    (scheme, self._notconfigured[scheme]))
scrapy.exceptions.NotSupported: Unsupported URL scheme 'http': Class advice impossible in Python3.  Use the @implementer class decorator instead.
2015-08-10 18:22:33 [scrapy] INFO: Closing spider (finished)
2015-08-10 18:22:33 [scrapy] INFO: Dumping Scrapy stats:
{'downloader/exception_count': 1,
 'downloader/exception_type_count/scrapy.exceptions.NotSupported': 1,
 'downloader/request_bytes': 237,
 'downloader/request_count': 1,
 'downloader/request_method_count/GET': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2015, 8, 10, 21, 22, 33, 579317),
 'log_count/ERROR': 2,
 'log_count/INFO': 7,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2015, 8, 10, 21, 22, 33, 259919)}
2015-08-10 18:22:33 [scrapy] INFO: Spider closed (finished)
``` 