### PR TITLE
[MRG+1] Add ExecutionEngine.close() method

### DIFF
--- a/scrapy/core/engine.py
+++ b/scrapy/core/engine.py
@@ -84,6 +84,21 @@ class ExecutionEngine(object):
         dfd = self._close_all_spiders()
         return dfd.addBoth(lambda _: self._finish_stopping_engine())
 
+    def close(self):
+        """Close the execution engine gracefully.
+
+        If it has already been started, stop it. In all cases, close all spiders
+        and the downloader.
+        """
+        if self.running:
+            # Will also close spiders and downloader
+            return self.stop()
+        elif self.open_spiders:
+            # Will also close downloader
+            return self._close_all_spiders()
+        else:
+            return defer.succeed(self.downloader.close())
+
     def pause(self):
         """Pause the execution engine"""
         self.paused = True

--- a/scrapy/crawler.py
+++ b/scrapy/crawler.py
@@ -73,8 +73,11 @@ class Crawler(object):
             yield self.engine.open_spider(self.spider, start_requests)
             yield defer.maybeDeferred(self.engine.start)
         except Exception:
+            exc = defer.fail()
             self.crawling = False
-            raise
+            if self.engine is not None:
+                yield self.engine.close()
+            yield exc
 
     def _create_spider(self, *args, **kwargs):
         return self.spidercls.from_crawler(self, *args, **kwargs)


### PR DESCRIPTION
Depending on what state the engine is in, there are different measures that need to be taken to shut it down gracefully (i.e. leaving the reactor clean): Stop the engine, close the spider, or close the downloader.

This PR adds a new method as a single entry point for shutting down the engine and integrates it into `Crawler.crawl()` for graceful error handling during the crawling process.