### PR TITLE
add service_identity to scrapy install_requires. Fix GH-1418 and GH-850.

### DIFF
--- a/requirements-py3.txt
+++ b/requirements-py3.txt
@@ -4,3 +4,4 @@ pyOpenSSL>=0.13.1
 cssselect>=0.9
 queuelib>=1.1.1
 w3lib>=1.8.0
+service_identity

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ w3lib>=1.8.0
 queuelib
 six>=1.5.2
 PyDispatcher>=2.0.5
+service_identity

--- a/setup.py
+++ b/setup.py
@@ -45,5 +45,6 @@ setup(
         'cssselect>=0.9',
         'six>=1.5.2',
         'PyDispatcher>=2.0.5',
+        'service_identity',
     ],
 )

--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,6 @@ deps =
     boto
     Pillow
     leveldb
-    service_identity
     -rtests/requirements.txt
 commands =
     py.test {posargs:scrapy tests}
@@ -43,7 +42,6 @@ deps =
     -rrequirements-py3.txt
     # Extras
     Pillow
-    service_identity
     -rtests/requirements-py3.txt
 
 [testenv:py34]


### PR DESCRIPTION
It looks like missing service_identity package is a common issue; #1418 is not the first time someone complains.