### PR TITLE
Add openssl version to version command

### DIFF
--- a/scrapy/commands/version.py
+++ b/scrapy/commands/version.py
@@ -3,6 +3,7 @@ import sys
 import platform
 
 import twisted
+import OpenSSL
 
 import scrapy
 from scrapy.commands import ScrapyCommand
@@ -26,11 +27,22 @@ class Command(ScrapyCommand):
             import lxml.etree
             lxml_version = ".".join(map(str, lxml.etree.LXML_VERSION))
             libxml2_version = ".".join(map(str, lxml.etree.LIBXML_VERSION))
-            print("Scrapy  : %s" % scrapy.__version__)
-            print("lxml    : %s" % lxml_version)
-            print("libxml2 : %s" % libxml2_version)
-            print("Twisted : %s" % twisted.version.short())
-            print("Python  : %s" % sys.version.replace("\n", "- "))
-            print("Platform: %s" % platform.platform())
+            print("Scrapy    : %s" % scrapy.__version__)
+            print("lxml      : %s" % lxml_version)
+            print("libxml2   : %s" % libxml2_version)
+            print("Twisted   : %s" % twisted.version.short())
+            print("Python    : %s" % sys.version.replace("\n", "- "))
+            print("pyOpenSSL : %s" % self._get_openssl_version())
+            print("Platform  : %s" % platform.platform())
         else:
             print("Scrapy %s" % scrapy.__version__)
+
+    def _get_openssl_version(self):
+        try:
+            openssl = OpenSSL.SSL.SSLeay_version(OpenSSL.SSL.SSLEAY_VERSION)\
+                .decode('ascii', errors='replace')
+        # pyOpenSSL 0.12 does not expose openssl version
+        except AttributeError:
+            openssl = 'Unknown OpenSSL version'
+
+        return '{} ({})'.format(OpenSSL.version.__version__, openssl)


### PR DESCRIPTION
Motivated by #1429
 
```
$ scrapy version -v
Scrapy  : 1.1.0dev1
lxml    : 3.4.4.0
libxml2 : 2.9.2
Twisted : 15.3.0
Python  : 3.4.3 (default, Mar 25 2015, 17:13:50) - [GCC 4.9.2 20150304 (prerelease)]
OpenSSL : 0.15.1
Platform: Linux-4.1.4-1-ARCH-x86_64-with-arch
```