### PR TITLE
Add a shortcut method `idled()` for `spider_idle` signal.

### DIFF
--- a/docs/topics/spiders.rst
+++ b/docs/topics/spiders.rst
@@ -196,6 +196,11 @@ scrapy.Spider
        Called when the spider closes. This method provides a shortcut to
        signals.connect() for the :signal:`spider_closed` signal.
 
+   .. method:: idled()
+
+        Called when the spider idles. This method provides a shortcut to
+        signals.connect() for the :signal:`spider_idle` signal.
+
 Let's see an example::
 
     import scrapy

--- a/scrapy/spiders/__init__.py
+++ b/scrapy/spiders/__init__.py
@@ -105,8 +105,10 @@ class Spider(object_ref):
         from scrapy.utils.spider import iterate_spider_output
 
         idled = getattr(spider, 'idled', None)
-        if callable(idled):
-            cb_response = iterate_spider_output(idled())
+        if not callable(idled):
+            return
+        cb_response = iterate_spider_output(idled())
+        if cb_response:
             for request in cb_response:
                 spider.crawler.engine.crawl(request, spider)
             raise DontCloseSpider

--- a/tests/test_spider.py
+++ b/tests/test_spider.py
@@ -79,6 +79,23 @@ class SpiderTest(unittest.TestCase):
                                        spider=spider, reason=None)
         self.assertTrue(spider.closed_called)
 
+    def test_idled_signal_call(self):
+        class TestSpider(self.spider_class):
+            idled_called = False
+
+            def idled(self):
+                self.idled_called = True
+
+        crawler = get_crawler()
+        spider = TestSpider.from_crawler(crawler, 'example.com')
+        crawler.signals.send_catch_log(signal=signals.spider_opened,
+                                       spider=spider)
+        crawler.signals.send_catch_log(signal=signals.spider_idle,
+                                       spider=spider)
+        crawler.signals.send_catch_log(signal=signals.spider_closed,
+                                       spider=spider, reason=None)
+        self.assertTrue(spider.idled_called)
+
     def test_update_settings(self):
         spider_settings = {'TEST1': 'spider', 'TEST2': 'spider'}
         project_settings = {'TEST1': 'project', 'TEST3': 'project'}


### PR DESCRIPTION
Fixes #740

@dangra,
I require some clarification here: Is a `Crawler`<>`Spider` relationship always 1:1 nowadays? Or does a Crawler object ever handle multiple Spiders, in parallel?

`crawler.signals.connect(self.idle, signals.spider_idle)` inside the `Spider` class connects the Spider/s to the SignalManager for the Crawler instance.
So we shouldn't get any signals from any other Crawler instance, correct?
Now in the past, there has been code checking in a spider instance like this:`def idle(self): if spider != self: return`.

If I am correct, a Crawler will always only have one Spider, so `spider` will always only be `self` here now, right? So this can be a staticmethod.
