### PR TITLE
Allow Request/Response conversion to dict

### DIFF
--- a/scrapy/http/request/__init__.py
+++ b/scrapy/http/request/__init__.py
@@ -83,6 +83,15 @@ class Request(object_ref):
 
     __repr__ = __str__
 
+    def keys(self):
+        return ['url', 'method', 'headers', 'body', 'cookies', 'meta',
+                'encoding', 'priority', 'dont_filter', 'callback', 'errback']
+
+    def __getitem__(self, item):
+        if item in self.keys():
+            return getattr(self, item)
+        raise KeyError(item)
+
     def copy(self):
         """Return a copy of this Request"""
         return self.replace()
@@ -91,8 +100,7 @@ class Request(object_ref):
         """Create a new Request with the same attributes except for those
         given new values.
         """
-        for x in ['url', 'method', 'headers', 'body', 'cookies', 'meta',
-                  'encoding', 'priority', 'dont_filter', 'callback', 'errback']:
+        for x in self.keys():
             kwargs.setdefault(x, getattr(self, x))
         cls = kwargs.pop('cls', self.__class__)
         return cls(*args, **kwargs)

--- a/scrapy/http/response/__init__.py
+++ b/scrapy/http/response/__init__.py
@@ -67,6 +67,14 @@ class Response(object_ref):
 
     __repr__ = __str__
 
+    def keys(self):
+        return ['url', 'status', 'headers', 'body', 'request', 'flags']
+
+    def __getitem__(self, item):
+        if item in self.keys():
+            return getattr(self, item)
+        raise KeyError(item)
+
     def copy(self):
         """Return a copy of this Response"""
         return self.replace()
@@ -75,7 +83,7 @@ class Response(object_ref):
         """Create a new Response with the same attributes except for those
         given new values.
         """
-        for x in ['url', 'status', 'headers', 'body', 'request', 'flags']:
+        for x in self.keys():
             kwargs.setdefault(x, getattr(self, x))
         cls = kwargs.pop('cls', self.__class__)
         return cls(*args, **kwargs)


### PR DESCRIPTION
(from #1450 )
Just the basic dict interface here, so that this works:

``` py
r = dict(response)
r.update({'request': dict(response.request)})
print(r['request']['headers']['User-Agent'])
```

Is this worth considering?
