### PR TITLE
add support for a nested loaders

### DIFF
--- a/docs/topics/loaders.rst
+++ b/docs/topics/loaders.rst
@@ -432,9 +432,17 @@ ItemLoader objects
         <topics-loaders-processors>` to get the final value to assign to each
         item field.
 
-    .. method:: nested_loader(xpath=selector, css=selector)
+    .. method:: nested_xpath(xpath)
 
-        Create a nested loader with either an xpath selector or css selector.
+        Create a nested loader with an xpath selector.
+        The supplied selector is applied relative to selector associated
+        with this :class:`ItemLoader`. The nested loader shares the :class:`Item`
+        with the parent :class:`ItemLoader` so calls to :meth:`add_xpath`,
+        :meth:`add_value`, :meth:`replace_value`, etc. will behave as expected.
+
+    .. method:: nested_css(css)
+
+        Create a nested loader with a css selector.
         The supplied selector is applied relative to selector associated
         with this :class:`ItemLoader`. The nested loader shares the :class:`Item`
         with the parent :class:`ItemLoader` so calls to :meth:`add_xpath`,
@@ -534,7 +542,7 @@ Example::
 
     loader = ItemLoader(item=Item())
     # load stuff not in the footer
-    footer_loader = loader.nested_loader(xpath='//footer')
+    footer_loader = loader.nested_xpath('//footer')
     footer_loader.add_xpath('social', 'a[@class = "social"]/@href')
     footer_loader.add_xpath('email', 'a[@class = "email"]/@href')
     # no need to call footer_loader.load_item()

--- a/docs/topics/loaders.rst
+++ b/docs/topics/loaders.rst
@@ -432,6 +432,14 @@ ItemLoader objects
         <topics-loaders-processors>` to get the final value to assign to each
         item field.
 
+    .. method:: nested_loader(xpath=selector, css=selector)
+
+        Create a nested loader with either an xpath selector or css selector.
+        The supplied selector is applied relative to selector associated
+        with this :class:`ItemLoader`. The nested loader shares the :class:`Item`
+        with the parent :class:`ItemLoader` so calls to :meth:`add_xpath`,
+        :meth:`add_value`, :meth:`replace_value`, etc. will behave as expected.
+
     .. method:: get_collected_values(field_name)
 
         Return the collected values for the given field.
@@ -489,6 +497,52 @@ ItemLoader objects
         the response given in the constructor using the
         :attr:`default_selector_class`. This attribute is meant to be
         read-only.
+
+.. _topics-loaders-nested:
+
+Nested Loaders
+==============
+
+When parsing related values from a subsection of a document, it can be
+useful to create nested loaders.  Imagine you're extracting details from
+a footer of a page that looks something like:
+
+Example::
+
+    <footer>
+        <a class="social" href="http://facebook.com/whatever">Like Us</a>
+        <a class="social" href="http://twitter.com/whatever">Follow Us</a>
+        <a class="email" href="mailto:whatever@example.com">Email Us</a>
+    </footer>
+
+Without nested loaders, you need to specify the full xpath (or css) for each value
+that you wish to extract.
+
+Example::
+
+    loader = ItemLoader(item=Item())
+    # load stuff not in the footer
+    loader.add_xpath('social', '//footer/a[@class = "social"]/@href')
+    loader.add_xpath('email', '//footer/a[@class = "email"]/@href')
+    loader.load_item()
+
+Instead, you can create a nested loader with the footer selector and add values
+relative to the footer.  The functionality is the same but you avoid repeating
+the footer selector.
+
+Example::
+
+    loader = ItemLoader(item=Item())
+    # load stuff not in the footer
+    footer_loader = loader.nested_loader(xpath='//footer')
+    footer_loader.add_xpath('social', 'a[@class = "social"]/@href')
+    footer_loader.add_xpath('email', 'a[@class = "email"]/@href')
+    # no need to call footer_loader.load_item()
+    loader.load_item()
+
+You can nest loaders arbitrarilly and they work with either xpath or css selectors.
+As a general guideline, use nested loaders when they make your code simpler but do
+not go overboard with nesting or your parser can become difficult to read.
 
 .. _topics-loaders-extending:
 

--- a/scrapy/loader/__init__.py
+++ b/scrapy/loader/__init__.py
@@ -50,18 +50,19 @@ class ItemLoader(object):
         else:
             return self._local_item
 
-    def nested_loader(self, xpath=None, css=None):
-        if xpath is not None and css is not None:
-            raise ValueError("Cannot nest a loader with both a xpath selector and a css selector")
-
-        if xpath is not None:
-            selector = self.selector.xpath(xpath)
-
-        if css is not None:
-            selector = self.selector.css(css)
-
+    def nested_xpath(self, xpath, **context):
+        selector = self.selector.xpath(xpath)
+        context.update(selector=selector)
         subloader = self.__class__(
-            item=self.item, selector=selector, parent=self
+            item=self.item, parent=self, **context
+        )
+        return subloader
+
+    def nested_css(self, css, **context):
+        selector = self.selector.css(css)
+        context.update(selector=selector)
+        subloader = self.__class__(
+            item=self.item, parent=self, **context
         )
         return subloader
 

--- a/scrapy/loader/__init__.py
+++ b/scrapy/loader/__init__.py
@@ -115,9 +115,6 @@ class ItemLoader(object):
             if value is not None:
                 item[field_name] = value
 
-        # for loader in self._subloaders:
-        #     loader.load_item()
-
         return item
 
     def get_output_value(self, field_name):

--- a/scrapy/loader/__init__.py
+++ b/scrapy/loader/__init__.py
@@ -24,16 +24,46 @@ class ItemLoader(object):
     default_output_processor = Identity()
     default_selector_class = Selector
 
-    def __init__(self, item=None, selector=None, response=None, **context):
+    def __init__(self, item=None, selector=None, response=None, parent=None, **context):
         if selector is None and response is not None:
             selector = self.default_selector_class(response)
         self.selector = selector
         context.update(selector=selector, response=response)
         if item is None:
             item = self.default_item_class()
-        self.item = context['item'] = item
         self.context = context
-        self._values = defaultdict(list)
+        self.parent = parent
+        self._local_item = context['item'] = item
+        self._local_values = defaultdict(list)
+
+    @property
+    def _values(self):
+        if self.parent is not None:
+            return self.parent._values
+        else:
+            return self._local_values
+
+    @property
+    def item(self):
+        if self.parent is not None:
+            return self.parent.item
+        else:
+            return self._local_item
+
+    def nested_loader(self, xpath=None, css=None):
+        if xpath is not None and css is not None:
+            raise ValueError("Cannot nest a loader with both a xpath selector and a css selector")
+
+        if xpath is not None:
+            selector = self.selector.xpath(xpath)
+
+        if css is not None:
+            selector = self.selector.css(css)
+
+        subloader = self.__class__(
+            item=self.item, selector=selector, parent=self
+        )
+        return subloader
 
     def add_value(self, field_name, value, *processors, **kw):
         value = self.get_value(value, *processors, **kw)
@@ -84,6 +114,10 @@ class ItemLoader(object):
             value = self.get_output_value(field_name)
             if value is not None:
                 item[field_name] = value
+
+        # for loader in self._subloaders:
+        #     loader.load_item()
+
         return item
 
     def get_output_value(self, field_name):
@@ -167,6 +201,5 @@ class ItemLoader(object):
         self._check_selector_method()
         csss = arg_to_iter(csss)
         return flatten([self.selector.css(css).extract() for css in csss])
-
 
 XPathItemLoader = create_deprecated_class('XPathItemLoader', ItemLoader)

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -19,9 +19,22 @@ class TestItem(NameItem):
     summary = Field()
 
 
+class TestNestedItem(Item):
+    name = Field()
+    name_div = Field()
+    name_value = Field()
+
+    url = Field()
+    image = Field()
+
+
 # test item loaders
 class NameItemLoader(ItemLoader):
     default_item_class = TestItem
+
+
+class NestedItemLoader(ItemLoader):
+    default_item_class = TestNestedItem
 
 
 class TestItemLoader(NameItemLoader):
@@ -598,6 +611,101 @@ class SelectortemLoaderTest(unittest.TestCase):
         self.assertEqual(l.get_output_value('url'), [u'http://www.scrapy.org'])
         l.replace_css('url', 'a::attr(href)', re='http://www\.(.+)')
         self.assertEqual(l.get_output_value('url'), [u'scrapy.org'])
+
+
+class SubselectorLoaderTest(unittest.TestCase):
+    response = HtmlResponse(url="", encoding='utf-8', body=b"""
+    <html>
+    <body>
+    <header>
+      <div id="id">marta</div>
+      <p>paragraph</p>
+    </header>
+    <footer class="footer">
+      <a href="http://www.scrapy.org">homepage</a>
+      <img src="/images/logo.png" width="244" height="65" alt="Scrapy">
+    </footer>
+    </body>
+    </html>
+    """)
+
+    def test_nested_xpath(self):
+        l = NestedItemLoader(response=self.response)
+        nl = l.nested_loader(xpath="//header")
+        nl.add_xpath('name', 'div/text()')
+        nl.add_css('name_div', '#id')
+        nl.add_value('name_value', nl.selector.xpath('div[@id = "id"]/text()').extract())
+
+        self.assertEqual(l.get_output_value('name'), [u'marta'])
+        self.assertEqual(l.get_output_value('name_div'), [u'<div id="id">marta</div>'])
+        self.assertEqual(l.get_output_value('name_value'),  [u'marta'])
+
+        self.assertEqual(l.get_output_value('name'), nl.get_output_value('name'))
+        self.assertEqual(l.get_output_value('name_div'), nl.get_output_value('name_div'))
+        self.assertEqual(l.get_output_value('name_value'), nl.get_output_value('name_value'))
+
+    def test_nested_css(self):
+        l = NestedItemLoader(response=self.response)
+        nl = l.nested_loader(css="header")
+        nl.add_xpath('name', 'div/text()')
+        nl.add_css('name_div', '#id')
+        nl.add_value('name_value', nl.selector.xpath('div[@id = "id"]/text()').extract())
+
+        self.assertEqual(l.get_output_value('name'), [u'marta'])
+        self.assertEqual(l.get_output_value('name_div'), [u'<div id="id">marta</div>'])
+        self.assertEqual(l.get_output_value('name_value'),  [u'marta'])
+
+        self.assertEqual(l.get_output_value('name'), nl.get_output_value('name'))
+        self.assertEqual(l.get_output_value('name_div'), nl.get_output_value('name_div'))
+        self.assertEqual(l.get_output_value('name_value'), nl.get_output_value('name_value'))
+
+    def test_nested_replace(self):
+        l = NestedItemLoader(response=self.response)
+        nl1 = l.nested_loader(xpath='//footer')
+        nl2 = nl1.nested_loader(xpath='a')
+
+        l.add_xpath('url', '//footer/a/@href')
+        self.assertEqual(l.get_output_value('url'), [u'http://www.scrapy.org'])
+        nl1.replace_xpath('url', 'img/@src')
+        self.assertEqual(l.get_output_value('url'), [u'/images/logo.png'])
+        nl2.replace_xpath('url', '@href')
+        self.assertEqual(l.get_output_value('url'), [u'http://www.scrapy.org'])
+
+    def test_nested_ordering(self):
+        l = NestedItemLoader(response=self.response)
+        nl1 = l.nested_loader(xpath='//footer')
+        nl2 = nl1.nested_loader(xpath='a')
+
+        nl1.add_xpath('url', 'img/@src')
+        l.add_xpath('url', '//footer/a/@href')
+        nl2.add_xpath('url', 'text()')
+        l.add_xpath('url', '//footer/a/@href')
+
+        self.assertEqual(l.get_output_value('url'), [
+            u'/images/logo.png',
+            u'http://www.scrapy.org',
+            u'homepage',
+            u'http://www.scrapy.org',
+        ])
+
+    def test_nested_load_item(self):
+        l = NestedItemLoader(response=self.response)
+        nl1 = l.nested_loader(xpath='//footer')
+        nl2 = nl1.nested_loader(xpath='img')
+
+        l.add_xpath('name', '//header/div/text()')
+        nl1.add_xpath('url', 'a/@href')
+        nl2.add_xpath('image', '@src')
+
+        item = l.load_item()
+
+        assert item is l.item
+        assert item is nl1.item
+        assert item is nl2.item
+
+        self.assertEqual(item['name'], [u'marta'])
+        self.assertEqual(item['url'], [u'http://www.scrapy.org'])
+        self.assertEqual(item['image'], [u'/images/logo.png'])
 
 
 class SelectJmesTestCase(unittest.TestCase):

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -631,7 +631,7 @@ class SubselectorLoaderTest(unittest.TestCase):
 
     def test_nested_xpath(self):
         l = NestedItemLoader(response=self.response)
-        nl = l.nested_loader(xpath="//header")
+        nl = l.nested_xpath("//header")
         nl.add_xpath('name', 'div/text()')
         nl.add_css('name_div', '#id')
         nl.add_value('name_value', nl.selector.xpath('div[@id = "id"]/text()').extract())
@@ -646,7 +646,7 @@ class SubselectorLoaderTest(unittest.TestCase):
 
     def test_nested_css(self):
         l = NestedItemLoader(response=self.response)
-        nl = l.nested_loader(css="header")
+        nl = l.nested_css("header")
         nl.add_xpath('name', 'div/text()')
         nl.add_css('name_div', '#id')
         nl.add_value('name_value', nl.selector.xpath('div[@id = "id"]/text()').extract())
@@ -661,8 +661,8 @@ class SubselectorLoaderTest(unittest.TestCase):
 
     def test_nested_replace(self):
         l = NestedItemLoader(response=self.response)
-        nl1 = l.nested_loader(xpath='//footer')
-        nl2 = nl1.nested_loader(xpath='a')
+        nl1 = l.nested_xpath('//footer')
+        nl2 = nl1.nested_xpath('a')
 
         l.add_xpath('url', '//footer/a/@href')
         self.assertEqual(l.get_output_value('url'), [u'http://www.scrapy.org'])
@@ -673,8 +673,8 @@ class SubselectorLoaderTest(unittest.TestCase):
 
     def test_nested_ordering(self):
         l = NestedItemLoader(response=self.response)
-        nl1 = l.nested_loader(xpath='//footer')
-        nl2 = nl1.nested_loader(xpath='a')
+        nl1 = l.nested_xpath('//footer')
+        nl2 = nl1.nested_xpath('a')
 
         nl1.add_xpath('url', 'img/@src')
         l.add_xpath('url', '//footer/a/@href')
@@ -690,8 +690,8 @@ class SubselectorLoaderTest(unittest.TestCase):
 
     def test_nested_load_item(self):
         l = NestedItemLoader(response=self.response)
-        nl1 = l.nested_loader(xpath='//footer')
-        nl2 = nl1.nested_loader(xpath='img')
+        nl1 = l.nested_xpath('//footer')
+        nl2 = nl1.nested_xpath('img')
 
         l.add_xpath('name', '//header/div/text()')
         nl1.add_xpath('url', 'a/@href')
@@ -706,11 +706,6 @@ class SubselectorLoaderTest(unittest.TestCase):
         self.assertEqual(item['name'], [u'marta'])
         self.assertEqual(item['url'], [u'http://www.scrapy.org'])
         self.assertEqual(item['image'], [u'/images/logo.png'])
-
-    def test_nested_bad_arguments(self):
-        l = NestedItemLoader(response=self.response)
-        with self.assertRaises(ValueError):
-            l.nested_loader(css="#id", xpath="//footer")
 
 
 class SelectJmesTestCase(unittest.TestCase):

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -707,6 +707,11 @@ class SubselectorLoaderTest(unittest.TestCase):
         self.assertEqual(item['url'], [u'http://www.scrapy.org'])
         self.assertEqual(item['image'], [u'/images/logo.png'])
 
+    def test_nested_bad_arguments(self):
+        l = NestedItemLoader(response=self.response)
+        with self.assertRaises(ValueError):
+            l.nested_loader(css="#id", xpath="//footer")
+
 
 class SelectJmesTestCase(unittest.TestCase):
         test_list_equals = {


### PR DESCRIPTION
Adds a nested_loader() method to ItemLoader.  This is useful when you're selecting several related fields from a sub section of the document.  Because the nested loader shares the item and values with it's parent, everything works as expected.

For example, here is a snippet of scraping code using the new functionality:

```python
loader = MyLoader(item=MyItem(), response=response)
loader.add_xpath('images', "//div[@class = 'event_title_image']/img/@src")
header_loader = loader.nested_loader(xpath="//div[@id = 'event_header']")
header_loader.add_xpath('event_name', "//span[@class = 'summary']/text()")
header_loader.add_xpath('start_date', "//meta[@itemprop = 'startDate']/@content")
header_loader.add_xpath('end_date', "//meta[@itemprop = 'endDate']/@content")
loader.load_item()
```

You can achieve something similar by externally creating the nested loader, but you have to wire it up manually and remember to call `load_item()` on the nested loader.

```python
loader = MyLoader(item=MyItem(), response=response)
loader.add_xpath('images', "//div[@class = 'event_title_image']/img/@src")

# boilerplate that must be updated if MyLoader class is changed
header_loader = MyLoader(
    item=loader.item, 
    response=loader.response, 
    selector=loader.selector.xpath("//div[@id = 'event_header']"),
)
header_loader.add_xpath('event_name', "//span[@class = 'summary']/text()")
header_loader.add_xpath('start_date', "//meta[@itemprop = 'startDate']/@content")
header_loader.add_xpath('end_date', "//meta[@itemprop = 'endDate']/@content")
header_loader.load_item()  # easy to forget
loader.load_item()
```

Tests have been added to ensure everything works correctly, including the ordering of values and that `replace_*` calls work correctly.