### PR TITLE
[MRG+1] Support for returning deferreds in middlewares

### DIFF
--- a/docs/topics/downloader-middleware.rst
+++ b/docs/topics/downloader-middleware.rst
@@ -879,12 +879,6 @@ RobotsTxtMiddleware
     To make sure Scrapy respects robots.txt make sure the middleware is enabled
     and the :setting:`ROBOTSTXT_OBEY` setting is enabled.
 
-    .. warning:: Keep in mind that, if you crawl using multiple concurrent
-       requests per domain, Scrapy could still download some forbidden pages
-       if they were requested before the robots.txt file was downloaded. This
-       is a known limitation of the current robots.txt middleware and will
-       be fixed in the future.
-
 .. reqmeta:: dont_obey_robotstxt
 
 If :attr:`Request.meta <scrapy.http.Request.meta>` has

--- a/docs/topics/downloader-middleware.rst
+++ b/docs/topics/downloader-middleware.rst
@@ -58,6 +58,8 @@ more of the following methods:
 
 .. class:: DownloaderMiddleware
 
+   .. note::  Any of the downloader middleware methods may also return a deferred.
+
    .. method:: process_request(request, spider)
 
       This method is called for each request that goes through the download

--- a/scrapy/core/downloader/middleware.py
+++ b/scrapy/core/downloader/middleware.py
@@ -4,10 +4,14 @@ Downloader Middleware manager
 See documentation in docs/topics/downloader-middleware.rst
 """
 import six
+
+from twisted.internet import defer
+
 from scrapy.http import Request, Response
 from scrapy.middleware import MiddlewareManager
 from scrapy.utils.defer import mustbe_deferred
 from scrapy.utils.conf import build_component_list
+
 
 class DownloaderMiddlewareManager(MiddlewareManager):
 
@@ -27,40 +31,45 @@ class DownloaderMiddlewareManager(MiddlewareManager):
             self.methods['process_exception'].insert(0, mw.process_exception)
 
     def download(self, download_func, request, spider):
+        @defer.inlineCallbacks
         def process_request(request):
             for method in self.methods['process_request']:
-                response = method(request=request, spider=spider)
+                response = yield method(request=request, spider=spider)
                 assert response is None or isinstance(response, (Response, Request)), \
                         'Middleware %s.process_request must return None, Response or Request, got %s' % \
                         (six.get_method_self(method).__class__.__name__, response.__class__.__name__)
                 if response:
-                    return response
-            return download_func(request=request, spider=spider)
+                    defer.returnValue(response)
+            defer.returnValue((yield download_func(request=request,spider=spider)))
 
+        @defer.inlineCallbacks
         def process_response(response):
             assert response is not None, 'Received None in process_response'
             if isinstance(response, Request):
-                return response
+                defer.returnValue(response)
 
             for method in self.methods['process_response']:
-                response = method(request=request, response=response, spider=spider)
+                response = yield method(request=request, response=response,
+                                        spider=spider)
                 assert isinstance(response, (Response, Request)), \
                     'Middleware %s.process_response must return Response or Request, got %s' % \
                     (six.get_method_self(method).__class__.__name__, type(response))
                 if isinstance(response, Request):
-                    return response
-            return response
+                    defer.returnValue(response)
+            defer.returnValue(response)
 
+        @defer.inlineCallbacks
         def process_exception(_failure):
             exception = _failure.value
             for method in self.methods['process_exception']:
-                response = method(request=request, exception=exception, spider=spider)
+                response = yield method(request=request, exception=exception,
+                                        spider=spider)
                 assert response is None or isinstance(response, (Response, Request)), \
                     'Middleware %s.process_exception must return None, Response or Request, got %s' % \
                     (six.get_method_self(method).__class__.__name__, type(response))
                 if response:
-                    return response
-            return _failure
+                    defer.returnValue(response)
+            defer.returnValue(_failure)
 
         deferred = mustbe_deferred(process_request, request)
         deferred.addErrback(process_exception)

--- a/tests/test_downloadermiddleware.py
+++ b/tests/test_downloadermiddleware.py
@@ -97,9 +97,11 @@ class ResponseFromProcessRequestTest(ManagerTestCase):
     """Tests middleware returning a response from process_request."""
 
     def test_download_func_not_called(self):
+        resp = Response('http://example.com/index.html')
+
         class ResponseMiddleware(object):
             def process_request(self, request, spider):
-                return Response(request.url)
+                return resp
 
         self.mwman._add_middleware(ResponseMiddleware())
 
@@ -110,5 +112,5 @@ class ResponseFromProcessRequestTest(ManagerTestCase):
         dfd.addBoth(results.append)
         self._wait(dfd)
 
-        self.assertIsInstance(results[0], Response)
+        self.assertIs(results[0], resp)
         self.assertFalse(download_func.called)

--- a/tests/test_downloadermiddleware_robotstxt.py
+++ b/tests/test_downloadermiddleware_robotstxt.py
@@ -111,7 +111,7 @@ class RobotsTxtMiddlewareTest(unittest.TestCase):
         self.crawler.engine.download.side_effect = return_failure
 
         middleware = RobotsTxtMiddleware(self.crawler)
-        middleware._logerror = mock.MagicMock(side_effect=lambda fail, req, spider: fail)
+        middleware._logerror = mock.MagicMock(side_effect=middleware._logerror)
         deferred = middleware.process_request(Request('http://site.local'), None)
         deferred.addCallback(lambda _: self.assertTrue(middleware._logerror.called))
         return deferred

--- a/tests/test_downloadermiddleware_robotstxt.py
+++ b/tests/test_downloadermiddleware_robotstxt.py
@@ -50,6 +50,12 @@ class RobotsTxtMiddlewareTest(unittest.TestCase):
             self.assertIgnored(Request('http://site.local/static/'), middleware)
         ], fireOnOneErrback=True)
 
+    def test_robotstxt_ready_parser(self):
+        middleware = RobotsTxtMiddleware(self._get_successful_crawler())
+        d = self.assertNotIgnored(Request('http://site.local/allowed'), middleware)
+        d.addCallback(lambda _: self.assertNotIgnored(Request('http://site.local/allowed'), middleware))
+        return d
+
     def test_robotstxt_meta(self):
         middleware = RobotsTxtMiddleware(self._get_successful_crawler())
         meta = {'dont_obey_robotstxt': True}


### PR DESCRIPTION
Adds support for returning deferreds in middlewares, and makes use of this to fix a limitation in RobotsTxtMiddleware.
#1471