### PR TITLE
don't run tests twice on Travis if a PR is made from a scrapy/scrapy branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,10 @@
 language: python
 python: 2.7
 sudo: false
+branches:
+  only:
+    - master
+    - /^\d\.\d+$/
 env:
  - TOXENV=py27
  - TOXENV=precise


### PR DESCRIPTION
Currently if a PR is open from a branch in main repo tests run twice.

If this PR is merged we'll have to add each new release branch to travis.yml. 
We can also add them all now? 1.0, 1.1, 1.2, etc.
