### PR TITLE
[MRG+1] PY3 redirect downloader mware

### DIFF
--- a/scrapy/downloadermiddlewares/redirect.py
+++ b/scrapy/downloadermiddlewares/redirect.py
@@ -62,7 +62,7 @@ class RedirectMiddleware(BaseRedirectMiddleware):
 
         location = None
         if 'Location' in response.headers:
-            location = response.headers['location']
+            location = response.headers['location'].decode('latin1')
 
         if location is not None and response.status in [301, 302, 303, 307]:
             redirected_url = urljoin(request.url, location)

--- a/scrapy/downloadermiddlewares/redirect.py
+++ b/scrapy/downloadermiddlewares/redirect.py
@@ -3,6 +3,7 @@ from six.moves.urllib.parse import urljoin
 
 from scrapy.http import HtmlResponse
 from scrapy.utils.response import get_meta_refresh
+from scrapy.utils.python import to_native_str
 from scrapy.exceptions import IgnoreRequest, NotConfigured
 
 logger = logging.getLogger(__name__)
@@ -62,7 +63,8 @@ class RedirectMiddleware(BaseRedirectMiddleware):
 
         location = None
         if 'Location' in response.headers:
-            location = response.headers['location'].decode('latin1')
+            # HTTP header is ascii or latin1, redirected url will be percent-encoded utf-8
+            location = to_native_str(response.headers['location'].decode('latin1'))
 
         if location is not None and response.status in [301, 302, 303, 307]:
             redirected_url = urljoin(request.url, location)

--- a/tests/py3-ignores.txt
+++ b/tests/py3-ignores.txt
@@ -10,7 +10,6 @@ tests/test_downloadermiddleware_httpcache.py
 tests/test_downloadermiddleware_httpcompression.py
 tests/test_downloadermiddleware_httpproxy.py
 tests/test_downloadermiddleware.py
-tests/test_downloadermiddleware_redirect.py
 tests/test_downloadermiddleware_retry.py
 tests/test_engine.py
 tests/test_mail.py

--- a/tests/test_downloadermiddleware_redirect.py
+++ b/tests/test_downloadermiddleware_redirect.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 import unittest
 
 from scrapy.downloadermiddlewares.redirect import RedirectMiddleware, MetaRefreshMiddleware
@@ -149,6 +151,14 @@ class RedirectMiddlewareTest(unittest.TestCase):
         _test_passthrough(Request(url, meta={'handle_httpstatus_list':
                                                            [404, 301, 302]}))
         _test_passthrough(Request(url, meta={'handle_httpstatus_all': True}))
+
+    def test_latin1_location(self):
+        req = Request('http://scrapytest.org/first')
+        latin1_path = u'/ação'.encode('latin1')
+        resp = Response('http://scrapytest.org/first', headers={'Location': latin1_path}, status=302)
+        req_result = self.mw.process_response(req, resp, self.spider)
+        perc_encoded_utf8_url = 'http://scrapytest.org/a%C3%A7%C3%A3o'
+        self.assertEquals(perc_encoded_utf8_url, req_result.url)
 
 
 class MetaRefreshMiddlewareTest(unittest.TestCase):

--- a/tests/test_downloadermiddleware_redirect.py
+++ b/tests/test_downloadermiddleware_redirect.py
@@ -177,18 +177,18 @@ class MetaRefreshMiddlewareTest(unittest.TestCase):
         self.mw = MetaRefreshMiddleware.from_crawler(crawler)
 
     def _body(self, interval=5, url='http://example.org/newpage'):
-        return """<html><head><meta http-equiv="refresh" content="{0};url={1}"/></head></html>"""\
-                .format(interval, url)
+        html = u"""<html><head><meta http-equiv="refresh" content="{0};url={1}"/></head></html>"""
+        return html.format(interval, url).encode('utf-8')
 
     def test_priority_adjust(self):
         req = Request('http://a.com')
-        rsp = HtmlResponse(req.url, body=self._body(), encoding='utf-8')
+        rsp = HtmlResponse(req.url, body=self._body())
         req2 = self.mw.process_response(req, rsp, self.spider)
         assert req2.priority > req.priority
 
     def test_meta_refresh(self):
         req = Request(url='http://example.org')
-        rsp = HtmlResponse(req.url, body=self._body(), encoding='utf-8')
+        rsp = HtmlResponse(req.url, body=self._body())
         req2 = self.mw.process_response(req, rsp, self.spider)
         assert isinstance(req2, Request)
         self.assertEqual(req2.url, 'http://example.org/newpage')
@@ -205,7 +205,7 @@ class MetaRefreshMiddlewareTest(unittest.TestCase):
     def test_meta_refresh_trough_posted_request(self):
         req = Request(url='http://example.org', method='POST', body='test',
                       headers={'Content-Type': 'text/plain', 'Content-length': '4'})
-        rsp = HtmlResponse(req.url, body=self._body(), encoding='utf-8')
+        rsp = HtmlResponse(req.url, body=self._body())
         req2 = self.mw.process_response(req, rsp, self.spider)
 
         assert isinstance(req2, Request)
@@ -221,7 +221,7 @@ class MetaRefreshMiddlewareTest(unittest.TestCase):
     def test_max_redirect_times(self):
         self.mw.max_redirect_times = 1
         req = Request('http://scrapytest.org/max')
-        rsp = HtmlResponse(req.url, body=self._body(), encoding='utf-8')
+        rsp = HtmlResponse(req.url, body=self._body())
 
         req = self.mw.process_response(req, rsp, self.spider)
         assert isinstance(req, Request)
@@ -232,7 +232,7 @@ class MetaRefreshMiddlewareTest(unittest.TestCase):
     def test_ttl(self):
         self.mw.max_redirect_times = 100
         req = Request('http://scrapytest.org/302', meta={'redirect_ttl': 1})
-        rsp = HtmlResponse(req.url, body=self._body(), encoding='utf-8')
+        rsp = HtmlResponse(req.url, body=self._body())
 
         req = self.mw.process_response(req, rsp, self.spider)
         assert isinstance(req, Request)
@@ -240,10 +240,10 @@ class MetaRefreshMiddlewareTest(unittest.TestCase):
 
     def test_redirect_urls(self):
         req1 = Request('http://scrapytest.org/first')
-        rsp1 = HtmlResponse(req1.url, body=self._body(url='/redirected'), encoding='utf-8')
+        rsp1 = HtmlResponse(req1.url, body=self._body(url='/redirected'))
         req2 = self.mw.process_response(req1, rsp1, self.spider)
         assert isinstance(req2, Request), req2
-        rsp2 = HtmlResponse(req2.url, body=self._body(url='/redirected2'), encoding='utf-8')
+        rsp2 = HtmlResponse(req2.url, body=self._body(url='/redirected2'))
         req3 = self.mw.process_response(req2, rsp2, self.spider)
         assert isinstance(req3, Request), req3
         self.assertEqual(req2.url, 'http://scrapytest.org/redirected')

--- a/tests/test_downloadermiddleware_redirect.py
+++ b/tests/test_downloadermiddleware_redirect.py
@@ -164,13 +164,13 @@ class MetaRefreshMiddlewareTest(unittest.TestCase):
 
     def test_priority_adjust(self):
         req = Request('http://a.com')
-        rsp = HtmlResponse(req.url, body=self._body())
+        rsp = HtmlResponse(req.url, body=self._body(), encoding='utf-8')
         req2 = self.mw.process_response(req, rsp, self.spider)
         assert req2.priority > req.priority
 
     def test_meta_refresh(self):
         req = Request(url='http://example.org')
-        rsp = HtmlResponse(req.url, body=self._body())
+        rsp = HtmlResponse(req.url, body=self._body(), encoding='utf-8')
         req2 = self.mw.process_response(req, rsp, self.spider)
         assert isinstance(req2, Request)
         self.assertEqual(req2.url, 'http://example.org/newpage')
@@ -178,14 +178,16 @@ class MetaRefreshMiddlewareTest(unittest.TestCase):
     def test_meta_refresh_with_high_interval(self):
         # meta-refresh with high intervals don't trigger redirects
         req = Request(url='http://example.org')
-        rsp = HtmlResponse(url='http://example.org', body=self._body(interval=1000))
+        rsp = HtmlResponse(url='http://example.org',
+                           body=self._body(interval=1000),
+                           encoding='utf-8')
         rsp2 = self.mw.process_response(req, rsp, self.spider)
         assert rsp is rsp2
 
     def test_meta_refresh_trough_posted_request(self):
         req = Request(url='http://example.org', method='POST', body='test',
                       headers={'Content-Type': 'text/plain', 'Content-length': '4'})
-        rsp = HtmlResponse(req.url, body=self._body())
+        rsp = HtmlResponse(req.url, body=self._body(), encoding='utf-8')
         req2 = self.mw.process_response(req, rsp, self.spider)
 
         assert isinstance(req2, Request)
@@ -201,7 +203,7 @@ class MetaRefreshMiddlewareTest(unittest.TestCase):
     def test_max_redirect_times(self):
         self.mw.max_redirect_times = 1
         req = Request('http://scrapytest.org/max')
-        rsp = HtmlResponse(req.url, body=self._body())
+        rsp = HtmlResponse(req.url, body=self._body(), encoding='utf-8')
 
         req = self.mw.process_response(req, rsp, self.spider)
         assert isinstance(req, Request)
@@ -212,7 +214,7 @@ class MetaRefreshMiddlewareTest(unittest.TestCase):
     def test_ttl(self):
         self.mw.max_redirect_times = 100
         req = Request('http://scrapytest.org/302', meta={'redirect_ttl': 1})
-        rsp = HtmlResponse(req.url, body=self._body())
+        rsp = HtmlResponse(req.url, body=self._body(), encoding='utf-8')
 
         req = self.mw.process_response(req, rsp, self.spider)
         assert isinstance(req, Request)
@@ -220,16 +222,17 @@ class MetaRefreshMiddlewareTest(unittest.TestCase):
 
     def test_redirect_urls(self):
         req1 = Request('http://scrapytest.org/first')
-        rsp1 = HtmlResponse(req1.url, body=self._body(url='/redirected'))
+        rsp1 = HtmlResponse(req1.url, body=self._body(url='/redirected'), encoding='utf-8')
         req2 = self.mw.process_response(req1, rsp1, self.spider)
         assert isinstance(req2, Request), req2
-        rsp2 = HtmlResponse(req2.url, body=self._body(url='/redirected2'))
+        rsp2 = HtmlResponse(req2.url, body=self._body(url='/redirected2'), encoding='utf-8')
         req3 = self.mw.process_response(req2, rsp2, self.spider)
         assert isinstance(req3, Request), req3
         self.assertEqual(req2.url, 'http://scrapytest.org/redirected')
         self.assertEqual(req2.meta['redirect_urls'], ['http://scrapytest.org/first'])
         self.assertEqual(req3.url, 'http://scrapytest.org/redirected2')
         self.assertEqual(req3.meta['redirect_urls'], ['http://scrapytest.org/first', 'http://scrapytest.org/redirected'])
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_downloadermiddleware_redirect.py
+++ b/tests/test_downloadermiddleware_redirect.py
@@ -154,10 +154,18 @@ class RedirectMiddlewareTest(unittest.TestCase):
 
     def test_latin1_location(self):
         req = Request('http://scrapytest.org/first')
-        latin1_path = u'/ação'.encode('latin1')
-        resp = Response('http://scrapytest.org/first', headers={'Location': latin1_path}, status=302)
+        latin1_location = u'/ação'.encode('latin1')  # HTTP historically supports latin1
+        resp = Response('http://scrapytest.org/first', headers={'Location': latin1_location}, status=302)
         req_result = self.mw.process_response(req, resp, self.spider)
         perc_encoded_utf8_url = 'http://scrapytest.org/a%C3%A7%C3%A3o'
+        self.assertEquals(perc_encoded_utf8_url, req_result.url)
+
+    def test_location_with_wrong_encoding(self):
+        req = Request('http://scrapytest.org/first')
+        utf8_location = u'/ação'  # header with wrong encoding (utf-8)
+        resp = Response('http://scrapytest.org/first', headers={'Location': utf8_location}, status=302)
+        req_result = self.mw.process_response(req, resp, self.spider)
+        perc_encoded_utf8_url = 'http://scrapytest.org/a%C3%83%C2%A7%C3%83%C2%A3o'
         self.assertEquals(perc_encoded_utf8_url, req_result.url)
 
 


### PR DESCRIPTION
Hey fellows!

So, here is my stab at porting the redirect downloader middleware to Python 3.
The important change here is decoding the `Location` header as latin1.

To verify that it's a reasonable assumption I wrote a [small Flask app](https://gist.github.com/eliasdorneles/ffd12f05811fee803fa0) and tested it on Chrome and FF.

You can see the screenshots of the app for Chrome here: http://imgur.com/a/1AfMt
Note that when using UTF-8 in the Location header we get a mojibake but things work normally when using latin1.

Se also this [related SO answer](http://stackoverflow.com/a/4410331/149872).

The other changes are a minor refactoring and adding the encoding argument to HtmlResponse in the tests.

Does this look good?