### PR TITLE
fix typo middlware

### DIFF
--- a/docs/topics/downloader-middleware.rst
+++ b/docs/topics/downloader-middleware.rst
@@ -804,7 +804,7 @@ RetryMiddleware
 
 .. class:: RetryMiddleware
 
-   A middlware to retry failed requests that are potentially caused by
+   A middleware to retry failed requests that are potentially caused by
    temporary problems such as a connection timeout or HTTP 500 error.
 
 Failed pages are collected on the scraping process and rescheduled at the

--- a/docs/topics/exceptions.rst
+++ b/docs/topics/exceptions.rst
@@ -57,7 +57,7 @@ remain disabled. Those components include:
 
  * Extensions
  * Item pipelines
- * Downloader middlwares
+ * Downloader middlewares
  * Spider middlewares
 
 The exception must be raised in the component constructor.


### PR DESCRIPTION
fix typos in files docs/topics/downloader-middleware.rst and docs/topics/exceptions.rst,  middlware  -> middleware.