### PR TITLE
[MRG+1] #1487 add_scheme_if_missing for `scrapy shell` command

### DIFF
--- a/scrapy/commands/shell.py
+++ b/scrapy/commands/shell.py
@@ -9,6 +9,7 @@ from threading import Thread
 from scrapy.commands import ScrapyCommand
 from scrapy.shell import Shell
 from scrapy.http import Request
+from scrapy.utils.url import add_scheme_if_missing
 from scrapy.utils.spider import spidercls_for_request, DefaultSpider
 
 
@@ -41,6 +42,8 @@ class Command(ScrapyCommand):
 
     def run(self, args, opts):
         url = args[0] if args else None
+        if url:
+            url = add_scheme_if_missing(url)
         spider_loader = self.crawler_process.spider_loader
 
         spidercls = DefaultSpider

--- a/scrapy/commands/shell.py
+++ b/scrapy/commands/shell.py
@@ -9,7 +9,7 @@ from threading import Thread
 from scrapy.commands import ScrapyCommand
 from scrapy.shell import Shell
 from scrapy.http import Request
-from scrapy.utils.url import add_scheme_if_missing
+from scrapy.utils.url import add_http_if_no_scheme
 from scrapy.utils.spider import spidercls_for_request, DefaultSpider
 
 
@@ -43,7 +43,7 @@ class Command(ScrapyCommand):
     def run(self, args, opts):
         url = args[0] if args else None
         if url:
-            url = add_scheme_if_missing(url)
+            url = add_http_if_no_scheme(url)
         spider_loader = self.crawler_process.spider_loader
 
         spidercls = DefaultSpider

--- a/scrapy/utils/url.py
+++ b/scrapy/utils/url.py
@@ -111,10 +111,11 @@ def escape_ajax(url):
         return url
     return add_or_replace_parameter(defrag, '_escaped_fragment_', frag[1:])
 
-def add_scheme_if_missing(url):
+def add_http_if_no_scheme(url):
+    """Adds http as the default scheme if it is missing from the url"""
     parser = parse_url(url)
-    if not parser.scheme:
-        if not parser.netloc:
-            parser = parser._replace(netloc=parser.path, path='')
-        parser = parser._replace(scheme='http')
-    return parser.geturl() 
+    if url.startswith('//'):
+        url = 'http:' + url
+    elif not parser.scheme or not parser.netloc:
+        url = 'http://' + url
+    return url

--- a/scrapy/utils/url.py
+++ b/scrapy/utils/url.py
@@ -110,3 +110,11 @@ def escape_ajax(url):
     if not frag.startswith('!'):
         return url
     return add_or_replace_parameter(defrag, '_escaped_fragment_', frag[1:])
+
+def add_scheme_if_missing(url):
+    parser = parse_url(url)
+    if not parser.scheme:
+        if not parser.netloc:
+            parser = parser._replace(netloc=parser.path, path='')
+        parser = parser._replace(scheme='http')
+    return parser.geturl() 

--- a/scrapy/utils/url.py
+++ b/scrapy/utils/url.py
@@ -111,11 +111,13 @@ def escape_ajax(url):
         return url
     return add_or_replace_parameter(defrag, '_escaped_fragment_', frag[1:])
 
+
 def add_http_if_no_scheme(url):
-    """Adds http as the default scheme if it is missing from the url"""
-    parser = parse_url(url)
+    """Add http as the default scheme if it is missing from the url."""
     if url.startswith('//'):
         url = 'http:' + url
-    elif not parser.scheme or not parser.netloc:
+        return url
+    parser = parse_url(url)
+    if not parser.scheme or not parser.netloc:
         url = 'http://' + url
     return url

--- a/tests/test_utils_url.py
+++ b/tests/test_utils_url.py
@@ -73,48 +73,6 @@ class UrlUtilsTest(unittest.TestCase):
         self.assertTrue(url_is_from_spider('http://www.example.net/some/page.html', MySpider))
         self.assertFalse(url_is_from_spider('http://www.example.us/some/page.html', MySpider))
 
-    def test_add_http_if_no_scheme(self):
-        self.assertEqual(add_http_if_no_scheme('http://www.example.com'),
-                                               'http://www.example.com')
-        self.assertEqual(add_http_if_no_scheme('http://www.example.com/some/page.html'),
-                                               'http://www.example.com/some/page.html')
-        self.assertEqual(add_http_if_no_scheme('http://example.com'),
-                                               'http://example.com')
-        self.assertEqual(add_http_if_no_scheme('www.example.com'),
-                                               'http://www.example.com')
-        self.assertEqual(add_http_if_no_scheme('example.com'),
-                                               'http://example.com')
-        self.assertEqual(add_http_if_no_scheme('//example.com'),
-                                               'http://example.com')
-        self.assertEqual(add_http_if_no_scheme('//www.example.com/some/page.html'),
-                                               'http://www.example.com/some/page.html')
-        self.assertEqual(add_http_if_no_scheme('www.example.com:80'),
-                                               'http://www.example.com:80')
-        self.assertEqual(add_http_if_no_scheme('www.example.com:80/some/page.html'),
-                                               'http://www.example.com:80/some/page.html')
-        self.assertEqual(add_http_if_no_scheme('http://www.example.com:80/some/page.html'),
-                                               'http://www.example.com:80/some/page.html')
-        self.assertEqual(add_http_if_no_scheme('www.example.com/some/page#frag'),
-                                               'http://www.example.com/some/page#frag')
-        self.assertEqual(add_http_if_no_scheme('http://www.example.com/some/page#frag'),
-                                               'http://www.example.com/some/page#frag')
-        self.assertEqual(add_http_if_no_scheme('www.example.com/do?a=1&b=2&c=3'),
-                                               'http://www.example.com/do?a=1&b=2&c=3')
-        self.assertEqual(add_http_if_no_scheme('http://www.example.com/do?a=1&b=2&c=3'),
-                                               'http://www.example.com/do?a=1&b=2&c=3')
-        self.assertEqual(add_http_if_no_scheme('username:password@example.com/some/page.html'),
-                                               'http://username:password@example.com/some/page.html')
-        self.assertEqual(add_http_if_no_scheme('http://username:password@example.com/some/page.html'),
-                                               'http://username:password@example.com/some/page.html')
-        self.assertEqual(add_http_if_no_scheme('username:password@example.com:80/some/part?a=1&b=2&c=3#frag'),
-                                               'http://username:password@example.com:80/some/part?a=1&b=2&c=3#frag')
-        self.assertEqual(add_http_if_no_scheme('http://username:password@example.com:80/some/part?a=1&b=2&c=3#frag'),
-                                               'http://username:password@example.com:80/some/part?a=1&b=2&c=3#frag')
-        self.assertEqual(add_http_if_no_scheme('https://www.example.com'),
-                                               'https://www.example.com')
-        self.assertEqual(add_http_if_no_scheme('ftp://www.example.com'),
-                                               'ftp://www.example.com')
-
 
 class CanonicalizeUrlTest(unittest.TestCase):
 
@@ -227,6 +185,113 @@ class CanonicalizeUrlTest(unittest.TestCase):
                          "http://foo.com/AC%2FDC+rocks%3F/?yeah=1")
         self.assertEqual(canonicalize_url("http://foo.com/AC%2FDC/"),
                          "http://foo.com/AC%2FDC/")
+
+
+class AddHttpIfNoScheme(unittest.TestCase):
+    
+    def test_add_scheme(self):
+        self.assertEqual(add_http_if_no_scheme('www.example.com'),
+                                               'http://www.example.com')
+
+    def test_without_subdomain(self):
+        self.assertEqual(add_http_if_no_scheme('example.com'),
+                                               'http://example.com')
+
+    def test_path(self):
+        self.assertEqual(add_http_if_no_scheme('www.example.com/some/page.html'),
+                                               'http://www.example.com/some/page.html')
+
+    def test_port(self):
+        self.assertEqual(add_http_if_no_scheme('www.example.com:80'),
+                                               'http://www.example.com:80')
+
+    def test_fragment(self):
+        self.assertEqual(add_http_if_no_scheme('www.example.com/some/page#frag'),
+                                               'http://www.example.com/some/page#frag')
+
+    def test_query(self):
+        self.assertEqual(add_http_if_no_scheme('www.example.com/do?a=1&b=2&c=3'),
+                                               'http://www.example.com/do?a=1&b=2&c=3')
+
+    def test_username_password(self):
+        self.assertEqual(add_http_if_no_scheme('username:password@www.example.com'),
+                                               'http://username:password@www.example.com')
+    
+    def test_complete_url(self):
+        self.assertEqual(add_http_if_no_scheme('username:password@www.example.com:80/some/page/do?a=1&b=2&c=3#frag'),
+                                               'http://username:password@www.example.com:80/some/page/do?a=1&b=2&c=3#frag')
+
+    def test_preserve_http(self):
+        self.assertEqual(add_http_if_no_scheme('http://www.example.com'),
+                                               'http://www.example.com')
+
+    def test_preserve_http_without_subdomain(self):
+        self.assertEqual(add_http_if_no_scheme('http://example.com'),
+                                               'http://example.com')
+
+    def test_preserve_http_path(self):
+        self.assertEqual(add_http_if_no_scheme('http://www.example.com/some/page.html'),
+                                               'http://www.example.com/some/page.html')
+
+    def test_preserve_http_port(self):
+        self.assertEqual(add_http_if_no_scheme('http://www.example.com:80'),
+                                               'http://www.example.com:80')
+
+    def test_preserve_http_fragment(self):
+        self.assertEqual(add_http_if_no_scheme('http://www.example.com/some/page#frag'),
+                                               'http://www.example.com/some/page#frag')
+
+    def test_preserve_http_query(self):
+        self.assertEqual(add_http_if_no_scheme('http://www.example.com/do?a=1&b=2&c=3'),
+                                               'http://www.example.com/do?a=1&b=2&c=3')
+
+    def test_preserve_http_username_password(self):
+        self.assertEqual(add_http_if_no_scheme('http://username:password@www.example.com'),
+                                               'http://username:password@www.example.com')
+
+    def test_preserve_http_complete_url(self):
+        self.assertEqual(add_http_if_no_scheme('http://username:password@www.example.com:80/some/page/do?a=1&b=2&c=3#frag'),
+                                               'http://username:password@www.example.com:80/some/page/do?a=1&b=2&c=3#frag')
+
+    def test_protocol_relative(self):
+        self.assertEqual(add_http_if_no_scheme('//www.example.com'),
+                                               'http://www.example.com')
+
+    def test_protocol_relative_without_subdomain(self):
+        self.assertEqual(add_http_if_no_scheme('//example.com'),
+                                               'http://example.com')
+
+    def test_protocol_relative_path(self):
+        self.assertEqual(add_http_if_no_scheme('//www.example.com/some/page.html'),
+                                               'http://www.example.com/some/page.html')
+
+    def test_protocol_relative_port(self):
+        self.assertEqual(add_http_if_no_scheme('//www.example.com:80'),
+                                               'http://www.example.com:80')
+
+    def test_protocol_relative_fragment(self):
+        self.assertEqual(add_http_if_no_scheme('//www.example.com/some/page#frag'),
+                                               'http://www.example.com/some/page#frag')
+
+    def test_protocol_relative_query(self):
+        self.assertEqual(add_http_if_no_scheme('//www.example.com/do?a=1&b=2&c=3'),
+                                               'http://www.example.com/do?a=1&b=2&c=3')
+
+    def test_protocol_relative_username_password(self):
+        self.assertEqual(add_http_if_no_scheme('//username:password@www.example.com'),
+                                               'http://username:password@www.example.com')
+
+    def test_protocol_relative_complete_url(self):
+        self.assertEqual(add_http_if_no_scheme('//username:password@www.example.com:80/some/page/do?a=1&b=2&c=3#frag'),
+                                               'http://username:password@www.example.com:80/some/page/do?a=1&b=2&c=3#frag')
+
+    def test_preserve_https(self):
+        self.assertEqual(add_http_if_no_scheme('https://www.example.com'),
+                                               'https://www.example.com')
+
+    def test_preserve_ftp(self):
+        self.assertEqual(add_http_if_no_scheme('ftp://www.example.com'),
+                                               'ftp://www.example.com')
 
 
 if __name__ == "__main__":

--- a/tests/test_utils_url.py
+++ b/tests/test_utils_url.py
@@ -4,7 +4,7 @@ import unittest
 import six
 from scrapy.spiders import Spider
 from scrapy.utils.url import (url_is_from_any_domain, url_is_from_spider,
-                              canonicalize_url, add_scheme_if_missing)
+                              canonicalize_url, add_http_if_no_scheme)
 
 __doctests__ = ['scrapy.utils.url']
 
@@ -73,21 +73,47 @@ class UrlUtilsTest(unittest.TestCase):
         self.assertTrue(url_is_from_spider('http://www.example.net/some/page.html', MySpider))
         self.assertFalse(url_is_from_spider('http://www.example.us/some/page.html', MySpider))
 
-    def test_add_scheme_if_missing(self):
-        self.assertEqual(add_scheme_if_missing('http://www.example.com'),
+    def test_add_http_if_no_scheme(self):
+        self.assertEqual(add_http_if_no_scheme('http://www.example.com'),
                                                'http://www.example.com')
-        self.assertEqual(add_scheme_if_missing('http://www.example.com/some/page.html'),
+        self.assertEqual(add_http_if_no_scheme('http://www.example.com/some/page.html'),
                                                'http://www.example.com/some/page.html')
-        self.assertEqual(add_scheme_if_missing('http://example.com'),
+        self.assertEqual(add_http_if_no_scheme('http://example.com'),
                                                'http://example.com')
-        self.assertEqual(add_scheme_if_missing('www.example.com'),
+        self.assertEqual(add_http_if_no_scheme('www.example.com'),
                                                'http://www.example.com')
-        self.assertEqual(add_scheme_if_missing('example.com'),
+        self.assertEqual(add_http_if_no_scheme('example.com'),
                                                'http://example.com')
-        self.assertEqual(add_scheme_if_missing('//example.com'),
+        self.assertEqual(add_http_if_no_scheme('//example.com'),
                                                'http://example.com')
-        self.assertEqual(add_scheme_if_missing('https://www.example.com'),
+        self.assertEqual(add_http_if_no_scheme('//www.example.com/some/page.html'),
+                                               'http://www.example.com/some/page.html')
+        self.assertEqual(add_http_if_no_scheme('www.example.com:80'),
+                                               'http://www.example.com:80')
+        self.assertEqual(add_http_if_no_scheme('www.example.com:80/some/page.html'),
+                                               'http://www.example.com:80/some/page.html')
+        self.assertEqual(add_http_if_no_scheme('http://www.example.com:80/some/page.html'),
+                                               'http://www.example.com:80/some/page.html')
+        self.assertEqual(add_http_if_no_scheme('www.example.com/some/page#frag'),
+                                               'http://www.example.com/some/page#frag')
+        self.assertEqual(add_http_if_no_scheme('http://www.example.com/some/page#frag'),
+                                               'http://www.example.com/some/page#frag')
+        self.assertEqual(add_http_if_no_scheme('www.example.com/do?a=1&b=2&c=3'),
+                                               'http://www.example.com/do?a=1&b=2&c=3')
+        self.assertEqual(add_http_if_no_scheme('http://www.example.com/do?a=1&b=2&c=3'),
+                                               'http://www.example.com/do?a=1&b=2&c=3')
+        self.assertEqual(add_http_if_no_scheme('username:password@example.com/some/page.html'),
+                                               'http://username:password@example.com/some/page.html')
+        self.assertEqual(add_http_if_no_scheme('http://username:password@example.com/some/page.html'),
+                                               'http://username:password@example.com/some/page.html')
+        self.assertEqual(add_http_if_no_scheme('username:password@example.com:80/some/part?a=1&b=2&c=3#frag'),
+                                               'http://username:password@example.com:80/some/part?a=1&b=2&c=3#frag')
+        self.assertEqual(add_http_if_no_scheme('http://username:password@example.com:80/some/part?a=1&b=2&c=3#frag'),
+                                               'http://username:password@example.com:80/some/part?a=1&b=2&c=3#frag')
+        self.assertEqual(add_http_if_no_scheme('https://www.example.com'),
                                                'https://www.example.com')
+        self.assertEqual(add_http_if_no_scheme('ftp://www.example.com'),
+                                               'ftp://www.example.com')
 
 
 class CanonicalizeUrlTest(unittest.TestCase):

--- a/tests/test_utils_url.py
+++ b/tests/test_utils_url.py
@@ -4,7 +4,7 @@ import unittest
 import six
 from scrapy.spiders import Spider
 from scrapy.utils.url import (url_is_from_any_domain, url_is_from_spider,
-                              canonicalize_url)
+                              canonicalize_url, add_scheme_if_missing)
 
 __doctests__ = ['scrapy.utils.url']
 
@@ -72,6 +72,22 @@ class UrlUtilsTest(unittest.TestCase):
         self.assertTrue(url_is_from_spider('http://www.example.org/some/page.html', MySpider))
         self.assertTrue(url_is_from_spider('http://www.example.net/some/page.html', MySpider))
         self.assertFalse(url_is_from_spider('http://www.example.us/some/page.html', MySpider))
+
+    def test_add_scheme_if_missing(self):
+        self.assertEqual(add_scheme_if_missing('http://www.example.com'),
+                                               'http://www.example.com')
+        self.assertEqual(add_scheme_if_missing('http://www.example.com/some/page.html'),
+                                               'http://www.example.com/some/page.html')
+        self.assertEqual(add_scheme_if_missing('http://example.com'),
+                                               'http://example.com')
+        self.assertEqual(add_scheme_if_missing('www.example.com'),
+                                               'http://www.example.com')
+        self.assertEqual(add_scheme_if_missing('example.com'),
+                                               'http://example.com')
+        self.assertEqual(add_scheme_if_missing('//example.com'),
+                                               'http://example.com')
+        self.assertEqual(add_scheme_if_missing('https://www.example.com'),
+                                               'https://www.example.com')
 
 
 class CanonicalizeUrlTest(unittest.TestCase):


### PR DESCRIPTION
This change addresses the enhancement mentioned in #1487.

The add_scheme_if_missing function uses the parse_url function to parse the url. It checks if the scheme is missing, if it is, 'http' is added as the default scheme. It checks if the netloc field is empty. If it is empty, it replaces it with the path field and changes the path field to empty. This is done because when handing invalid url's like "www.example.com" where the scheme is missing, the parse_url function(which uses urlparse itself) leaves the netloc empty and puts the entire url in path. This leads to incorrect url generation when geturl() is called.

The add_scheme_if_missing function is called by the shell command right after it extracts the url from the arguments list. A check is performed to ensure that a null value is not passed to the function.

The test tests some common url variations.