### PR TITLE
[MRG+1] PY3 exporters

### DIFF
--- a/scrapy/exporters.py
+++ b/scrapy/exporters.py
@@ -192,8 +192,15 @@ class CsvItemExporter(BaseItemExporter):
 
         fields = self._get_serialized_fields(item, default_value='',
                                              include_empty=True)
-        values = [to_native_str(x) for _, x in fields]
+        values = list(self._build_row(x for _, x in fields))
         self.csv_writer.writerow(values)
+
+    def _build_row(self, values):
+        for s in values:
+            try:
+                yield to_native_str(s)
+            except TypeError:
+                yield to_native_str(repr(s))
 
     def _write_headers_and_set_fields_to_export(self, item):
         if self.include_headers_line:
@@ -204,7 +211,7 @@ class CsvItemExporter(BaseItemExporter):
                 else:
                     # use fields declared in Item
                     self.fields_to_export = list(item.fields.keys())
-            row = [to_native_str(s) for s in self.fields_to_export]
+            row = list(self._build_row(self.fields_to_export))
             self.csv_writer.writerow(row)
 
 

--- a/scrapy/exporters.py
+++ b/scrapy/exporters.py
@@ -11,7 +11,7 @@ from six.moves import cPickle as pickle
 from xml.sax.saxutils import XMLGenerator
 
 from scrapy.utils.serialize import ScrapyJSONEncoder
-from scrapy.utils.python import to_bytes, to_unicode
+from scrapy.utils.python import to_bytes, to_unicode, is_listlike
 from scrapy.item import BaseItem
 import warnings
 
@@ -139,8 +139,7 @@ class XmlItemExporter(BaseItemExporter):
         if hasattr(serialized_value, 'items'):
             for subname, value in serialized_value.items():
                 self._export_xml_field(subname, value)
-        elif (hasattr(serialized_value, '__iter__')
-              and not isinstance(serialized_value, six.string_types)):
+        elif is_listlike(serialized_value):
               for value in serialized_value:
                 self._export_xml_field('value', value)
         else:
@@ -261,8 +260,7 @@ class PythonItemExporter(BaseItemExporter):
             return self.export_item(value)
         if isinstance(value, dict):
             return dict(self._serialize_dict(value))
-        if hasattr(value, '__iter__') \
-                and not isinstance(value, six.string_types):
+        if is_listlike(value):
             return [self._serialize_value(v) for v in value]
         if self.binary:
             return to_bytes(value, encoding=self.encoding)

--- a/scrapy/exporters.py
+++ b/scrapy/exporters.py
@@ -140,7 +140,7 @@ class XmlItemExporter(BaseItemExporter):
             for subname, value in serialized_value.items():
                 self._export_xml_field(subname, value)
         elif is_listlike(serialized_value):
-              for value in serialized_value:
+            for value in serialized_value:
                 self._export_xml_field('value', value)
         else:
             self._xg_characters(serialized_value)

--- a/scrapy/exporters.py
+++ b/scrapy/exporters.py
@@ -272,7 +272,11 @@ class PythonItemExporter(BaseItemExporter):
 
     def _serialize_dict(self, value):
         for key, val in six.iteritems(value):
+            key = to_bytes(key) if self.binary else key
             yield key, self._serialize_value(val)
 
     def export_item(self, item):
-        return dict(self._get_serialized_fields(item))
+        result = dict(self._get_serialized_fields(item))
+        if self.binary:
+            result = dict(self._serialize_dict(result))
+        return result

--- a/scrapy/exporters.py
+++ b/scrapy/exporters.py
@@ -14,6 +14,7 @@ from xml.sax.saxutils import XMLGenerator
 from scrapy.utils.serialize import ScrapyJSONEncoder
 from scrapy.utils.python import to_bytes, to_unicode, to_native_str, is_listlike
 from scrapy.item import BaseItem
+from scrapy.exceptions import ScrapyDeprecationWarning
 import warnings
 
 
@@ -252,7 +253,7 @@ class PythonItemExporter(BaseItemExporter):
         if self.binary:
             warnings.warn(
                 "PythonItemExporter will drop support for binary export in the future",
-                PendingDeprecationWarning)
+                ScrapyDeprecationWarning)
 
     def serialize_field(self, field, name, value):
         serializer = field.get('serializer', self._serialize_value)

--- a/scrapy/exporters.py
+++ b/scrapy/exporters.py
@@ -158,7 +158,7 @@ class XmlItemExporter(BaseItemExporter):
             if not isinstance(serialized_value, six.text_type):
                 serialized_value = serialized_value.decode(self.encoding)
             return self.xg.characters(serialized_value)
-    else:
+    else:  # pragma: no cover
         def _xg_characters(self, serialized_value):
             return self.xg.characters(serialized_value)
 

--- a/tests/py3-ignores.txt
+++ b/tests/py3-ignores.txt
@@ -1,4 +1,3 @@
-tests/test_exporters.py
 tests/test_linkextractors_deprecated.py
 tests/test_mail.py
 tests/test_pipeline_files.py

--- a/tests/test_exporters.py
+++ b/tests/test_exporters.py
@@ -237,6 +237,13 @@ class CsvItemExporterTest(BaseItemExporterTest):
                 expected='"Mary,Paul",John\r\n',
             )
 
+    def test_join_multivalue_not_strings(self):
+        self.assertExportResult(
+            item=dict(name='John', friends=[4, 8]),
+            include_headers_line=False,
+            expected='"[4, 8]",John\r\n',
+        )
+
 
 class XmlItemExporterTest(BaseItemExporterTest):
 

--- a/tests/test_exporters.py
+++ b/tests/test_exporters.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import
 import re
 import json
 import unittest
+import warnings
 from io import BytesIO
 from six.moves import cPickle as pickle
 
@@ -114,6 +115,12 @@ class PythonItemExporterTest(BaseItemExporterTest):
         self.assertEqual(exported, {'age': [{'age': [{'age': '22', 'name': u'Joseph'}], 'name': u'Maria'}], 'name': 'Jesus'})
         self.assertEqual(type(exported['age'][0]), dict)
         self.assertEqual(type(exported['age'][0]['age'][0]), dict)
+
+    def test_export_binary(self):
+        exporter = PythonItemExporter(binary=True)
+        value = TestItem(name=u'John\xa3', age=u'22')
+        expected = {b'name': b'John\xc2\xa3', b'age': b'22'}
+        self.assertEqual(expected, exporter.export_item(value))
 
 
 class PprintItemExporterTest(BaseItemExporterTest):

--- a/tests/test_exporters.py
+++ b/tests/test_exporters.py
@@ -1,6 +1,8 @@
 from __future__ import absolute_import
 import re
 import json
+import marshal
+import tempfile
 import unittest
 from io import BytesIO
 from six.moves import cPickle as pickle
@@ -12,7 +14,8 @@ from scrapy.item import Item, Field
 from scrapy.utils.python import to_unicode
 from scrapy.exporters import (
     BaseItemExporter, PprintItemExporter, PickleItemExporter, CsvItemExporter,
-    XmlItemExporter, JsonLinesItemExporter, JsonItemExporter, PythonItemExporter
+    XmlItemExporter, JsonLinesItemExporter, JsonItemExporter,
+    PythonItemExporter, MarshalItemExporter
 )
 
 
@@ -161,6 +164,17 @@ class PickleItemExporterTest(BaseItemExporterTest):
         f.seek(0)
         self.assertEqual(pickle.load(f), i1)
         self.assertEqual(pickle.load(f), i2)
+
+
+class MarshalItemExporterTest(BaseItemExporterTest):
+
+    def _get_exporter(self, **kwargs):
+        self.output = tempfile.TemporaryFile()
+        return MarshalItemExporter(self.output, **kwargs)
+
+    def _check_output(self):
+        self.output.seek(0)
+        self._assert_expected_item(marshal.load(self.output))
 
 
 class CsvItemExporterTest(BaseItemExporterTest):

--- a/tests/test_exporters.py
+++ b/tests/test_exporters.py
@@ -90,6 +90,10 @@ class PythonItemExporterTest(BaseItemExporterTest):
     def _get_exporter(self, **kwargs):
         return PythonItemExporter(binary=False, **kwargs)
 
+    def test_invalid_option(self):
+        with self.assertRaisesRegexp(TypeError, "Unexpected options: invalid_option"):
+            PythonItemExporter(invalid_option='something')
+
     def test_nested_item(self):
         i1 = TestItem(name=u'Joseph', age='22')
         i2 = dict(name=u'Maria', age=i1)

--- a/tests/test_exporters.py
+++ b/tests/test_exporters.py
@@ -261,13 +261,13 @@ class XmlItemExporterTest(BaseItemExporterTest):
         self.assertXmlEquivalent(fp.getvalue(), expected_value)
 
     def _check_output(self):
-        expected_value = u'<?xml version="1.0" ?>\n<items><item><age>22</age><name>John\xa3</name></item></items>'
+        expected_value = b'<?xml version="1.0" encoding="utf-8"?>\n<items><item><age>22</age><name>John\xc2\xa3</name></item></items>'
         self.assertXmlEquivalent(self.output.getvalue(), expected_value)
 
     def test_multivalued_fields(self):
         self.assertExportResult(
             TestItem(name=[u'John\xa3', u'Doe']),
-            u'<?xml version="1.0" ?>\n<items><item><name><value>John\xa3</value><value>Doe</value></name></item></items>'
+            b'<?xml version="1.0" encoding="utf-8"?>\n<items><item><name><value>John\xc2\xa3</value><value>Doe</value></name></item></items>'
         )
 
     def test_nested_item(self):
@@ -276,19 +276,19 @@ class XmlItemExporterTest(BaseItemExporterTest):
         i3 = TestItem(name=u'buz', age=i2)
 
         self.assertExportResult(i3,
-            u'<?xml version="1.0" ?>\n'
-            u'<items>'
-                u'<item>'
-                    u'<age>'
-                        u'<age>'
-                            u'<age>22</age>'
-                            u'<name>foo\xa3hoo</name>'
-                        u'</age>'
-                        u'<name>bar</name>'
-                    u'</age>'
-                    u'<name>buz</name>'
-                u'</item>'
-            u'</items>'
+            b'<?xml version="1.0" encoding="utf-8"?>\n'
+            b'<items>'
+                b'<item>'
+                    b'<age>'
+                        b'<age>'
+                            b'<age>22</age>'
+                            b'<name>foo\xc2\xa3hoo</name>'
+                        b'</age>'
+                        b'<name>bar</name>'
+                    b'</age>'
+                    b'<name>buz</name>'
+                b'</item>'
+            b'</items>'
         )
 
     def test_nested_list_item(self):
@@ -297,16 +297,16 @@ class XmlItemExporterTest(BaseItemExporterTest):
         i3 = TestItem(name=u'buz', age=[i1, i2])
 
         self.assertExportResult(i3,
-            u'<?xml version="1.0" ?>\n'
-            u'<items>'
-                u'<item>'
-                    u'<age>'
-                        u'<value><name>foo</name></value>'
-                        u'<value><name>bar</name><v2><egg><value>spam</value></egg></v2></value>'
-                    u'</age>'
-                    u'<name>buz</name>'
-                u'</item>'
-            u'</items>'
+            b'<?xml version="1.0" encoding="utf-8"?>\n'
+            b'<items>'
+                b'<item>'
+                    b'<age>'
+                        b'<value><name>foo</name></value>'
+                        b'<value><name>bar</name><v2><egg><value>spam</value></egg></v2></value>'
+                    b'</age>'
+                    b'<name>buz</name>'
+                b'</item>'
+            b'</items>'
         )
 
 

--- a/tests/test_exporters.py
+++ b/tests/test_exporters.py
@@ -2,11 +2,11 @@ from __future__ import absolute_import
 import re
 import json
 import unittest
-import warnings
 from io import BytesIO
 from six.moves import cPickle as pickle
 
 import lxml.etree
+import six
 
 from scrapy.item import Item, Field
 from scrapy.utils.python import to_unicode
@@ -65,6 +65,11 @@ class BaseItemExporterTest(unittest.TestCase):
     def test_fields_to_export(self):
         ie = self._get_exporter(fields_to_export=['name'])
         self.assertEqual(list(ie._get_serialized_fields(self.i)), [('name', u'John\xa3')])
+
+        ie = self._get_exporter(fields_to_export=['name'], encoding='latin-1')
+        _, name = list(ie._get_serialized_fields(self.i))[0]
+        assert isinstance(name, six.text_type)
+        self.assertEqual(name, u'John\xa3')
 
     def test_field_custom_serializer(self):
         def custom_serializer(value):

--- a/tests/test_feedexport.py
+++ b/tests/test_feedexport.py
@@ -22,6 +22,7 @@ from scrapy.extensions.feedexport import (
     S3FeedStorage, StdoutFeedStorage
 )
 from scrapy.utils.test import assert_aws_environ
+from scrapy.utils.python import to_native_str
 
 
 class FileFeedStorageTest(unittest.TestCase):
@@ -120,8 +121,6 @@ class StdoutFeedStorageTest(unittest.TestCase):
 
 class FeedExportTest(unittest.TestCase):
 
-    skip = not six.PY2
-
     class MyItem(scrapy.Item):
         foo = scrapy.Field()
         egg = scrapy.Field()
@@ -170,7 +169,7 @@ class FeedExportTest(unittest.TestCase):
         settings.update({'FEED_FORMAT': 'csv'})
         data = yield self.exported_data(items, settings)
 
-        reader = csv.DictReader(data.splitlines())
+        reader = csv.DictReader(to_native_str(data).splitlines())
         got_rows = list(reader)
         if ordered:
             self.assertEqual(reader.fieldnames, header)
@@ -184,7 +183,7 @@ class FeedExportTest(unittest.TestCase):
         settings = settings or {}
         settings.update({'FEED_FORMAT': 'jl'})
         data = yield self.exported_data(items, settings)
-        parsed = [json.loads(line) for line in data.splitlines()]
+        parsed = [json.loads(to_native_str(line)) for line in data.splitlines()]
         rows = [{k: v for k, v in row.items() if v} for row in rows]
         self.assertEqual(rows, parsed)
 


### PR DESCRIPTION
Hey fellows,

I've started porting the exporters to Python 3, but I'm not sure how backward compatible we should be -- I'm creating the PR already hoping it'll help moving this forward.

There isn't much here yet, I just got the first few tests passing under Python 3, keeping the retrocompatibility. Current passings tests are:

```
tox -e py27,py34 -- tests/test_exporters.py::BaseItemExporterTest tests/test_exporters.py::PythonItemExporterTest tests/test_exporters.py::CustomItemExporterTest
```

According to issue #1080 (which I tend to agree), we should change the default output of BaseItemExporter to unicode text and only do encode to bytes for things that we can't use text (like CSV writer in Python 2 only). This would make porting easier, but would cause issues for users since we'd be changing the default file format/encoding.

The JSON encoder even rejects bytes in Python 3, trying to `json.dumps(b'hi')` gets you `TypeError: b'hi' is not JSON serializable`.

The CSV writer is particularly tricky because in PY2 it expects a binary stream to write and in PY3 it expects a text stream. The [Python 3 Porting guide proposes an interesting solution](http://python3porting.com/problems.html#csv-api-changes) which requires control of file opening, but our Item Exporters API gets a file handle.
To make matters more complicated, the FileFeedStorage in feed exports extension opens the file always in binary mode: https://github.com/scrapy/scrapy/blob/master/scrapy/extensions/feedexport.py#L79

I'd appreciate some guidance! :)