### PR TITLE
disable log on startproject command

### DIFF
--- a/scrapy/commands/startproject.py
+++ b/scrapy/commands/startproject.py
@@ -27,6 +27,7 @@ IGNORE = ignore_patterns('*.pyc', '.svn')
 class Command(ScrapyCommand):
 
     requires_project = False
+    default_settings = {'LOG_ENABLED': False}
 
     def syntax(self):
         return "<project_name>"


### PR DESCRIPTION
shouldn't scrapy log be disabled on `startproject` command, like it is on `genspider` command?