### PR TITLE
[MRG+1] interpreting json-amazonui-streaming as TextResponse

### DIFF
--- a/scrapy/responsetypes.py
+++ b/scrapy/responsetypes.py
@@ -25,6 +25,7 @@ class ResponseTypes(object):
         'application/xml': 'scrapy.http.XmlResponse',
         'application/json': 'scrapy.http.TextResponse',
         'application/x-json': 'scrapy.http.TextResponse',
+        'application/json-amazonui-streaming': 'scrapy.http.TextResponse',
         'application/javascript': 'scrapy.http.TextResponse',
         'application/x-javascript': 'scrapy.http.TextResponse',
         'text/xml': 'scrapy.http.XmlResponse',

--- a/tests/test_responsetypes.py
+++ b/tests/test_responsetypes.py
@@ -36,6 +36,7 @@ class ResponseTypesTest(unittest.TestCase):
             ('application/xml; charset=UTF-8', XmlResponse),
             ('application/octet-stream', Response),
             ('application/x-json; encoding=UTF8;charset=UTF-8', TextResponse),
+            ('application/json-amazonui-streaming;charset=UTF-8', TextResponse),
         ]
         for source, cls in mappings:
             retcls = responsetypes.from_content_type(source)


### PR DESCRIPTION
Amazon is using this content type to load reviews with ajax:

```
ipdb> response.headers['Content-Type']
'application/json-amazonui-streaming;charset=UTF-8'
```

Don't know if we want to add it since it's Amazon-specific.