### PR TITLE
TST pin pytest to 2.7.3

### DIFF
--- a/tests/requirements-py3.txt
+++ b/tests/requirements-py3.txt
@@ -1,4 +1,4 @@
-pytest>=2.6.0
+pytest==2.7.3
 pytest-twisted
 pytest-cov
 testfixtures

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -2,6 +2,7 @@
 mock
 mitmproxy==0.10.1
 netlib==0.10.1
+pytest==2.7.3
 pytest-twisted
 pytest-cov
 jmespath


### PR DESCRIPTION
Scrapy testing suite starts to fail with pytest==2.8.0. I wrongly assumed it was a [problem](https://github.com/pytest-dev/pytest-cov/issues/91) with pytest-cov, but it seems I was wrong. It is better to debug and fix the issue properly; in case nobody has time to do that now we can pin pytest to a working version.