### PR TITLE
[WIP] Conda recipe

### DIFF
--- a/conda.recipe/bld.bat
+++ b/conda.recipe/bld.bat
@@ -1,0 +1,8 @@
+"%PYTHON%" setup.py install
+if errorlevel 1 exit 1
+
+:: Add more build steps here, if they are necessary.
+
+:: See
+:: http://docs.continuum.io/conda/build.html
+:: for a list of environment variables that are set during the build process.

--- a/conda.recipe/build.sh
+++ b/conda.recipe/build.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+$PYTHON setup.py install
+
+# Add more build steps here, if they are necessary.
+
+# See
+# http://docs.continuum.io/conda/build.html
+# for a list of environment variables that are set during the build process.

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -1,0 +1,54 @@
+package:
+  name: scrapy
+  version: 1.1.0dev1
+
+source:
+  path: ../
+
+build:
+  entry_points:
+    - scrapy = scrapy.cmdline:execute
+
+requirements:
+  build:
+    - python 
+    - twisted >=10.0.0
+    - w3lib >=1.8.0
+    - queuelib
+    - lxml
+    - pyopenssl
+    - cssselect >=0.9
+    - six >=1.5.2
+    - parsel >=0.9.3
+    - pydispatcher >=2.0.5
+
+  run:
+    - python
+    - twisted >=10.0.0
+    - w3lib >=1.8.0
+    - queuelib
+    - lxml
+    - pyopenssl
+    - cssselect >=0.9
+    - six >=1.5.2
+    - parsel >=0.9.3
+    - pydispatcher >=2.0.5
+
+test:
+  imports:
+    - scrapy
+
+  commands:
+    - scrapy version
+    #- py.test  # Assertion error failure.
+
+  requires:
+    - mock
+    #- testfixtures  # Not available.
+    #- mitmproxy  # Not available.
+    - pytest
+
+about:
+  home: http://scrapy.org
+  summary: A high-level Web Crawling and Web Scraping framework.
+  license: BSD License


### PR DESCRIPTION
This PR adds a default [Conda Recipe](http://conda.pydata.org/docs/build.html) to build Scrapy using the command `conda build` provided by the [Conda](http://conda.pydata.org/docs/) package management system, which is available by installing either [Miniconda](http://conda.pydata.org/miniconda.html) or [Anaconda](https://store.continuum.io/cshop/anaconda/).

This recipe is a very simple one without much tweaks, but I don't think it's ready for merge because we need to address the following major issues:

1. we need to read the version automatically from `scrapy/VERSION` file;
2. [parsel](https://github.com/scrapy/parsel) and  [PyDispatcher](http://pydispatcher.sourceforge.net) are not available through conda;
3. [service_identity](https://github.com/pyca/service_identity) and its dependencies (`pyasn1`, `pyasn1-modules`, `characteristic`) is not available through conda.

The point 1. can be solved by automatically generating the `meta.yaml` specification file, it would help also to update automatically the build, install and tests dependencies from the files `setup.py` and `requirements-tests.txt`.

The point 2. can be solved by adding a conda recipe to the `parsel` project and providing one for `pydispatcher`.

The point 3. is more tricky because these are many packages. Perhaps it will be better to make a PR to [conda-recipes](https://github.com/conda/conda-recipes) and expect it gets merged soon enough so that these packages are officially available through conda. However, we could also provide third-party recipes and publish the packages in the channel provided by Scrapinghub for this matter. In this way we have better control about the versions published. I'm not sure how necessary is this for `service_identity`'s related dependencies, though.

I appreciate any comment.

PD: I uploaded test packages built with this recipe to my channel https://anaconda.org/rolando/scrapy and can be installed by running `conda install -c rolando scrapy==1.1.0dev1` (only platforms `linux-64` and `osx-64` are available for now).