### PR TITLE
Fix list formatting

### DIFF
--- a/docs/topics/request-response.rst
+++ b/docs/topics/request-response.rst
@@ -227,7 +227,7 @@ Those are:
 * :reqmeta:`handle_httpstatus_all`
 * ``dont_merge_cookies`` (see ``cookies`` parameter of :class:`Request` constructor)
 * :reqmeta:`cookiejar`
-  :reqmeta:`dont_cache`
+* :reqmeta:`dont_cache`
 * :reqmeta:`redirect_urls`
 * :reqmeta:`bindaddress`
 * :reqmeta:`dont_obey_robotstxt`


### PR DESCRIPTION
I don't believe it was intended to squish `cookiejar` and `dont_cache` onto a single list item on http://doc.scrapy.org/en/1.0/topics/request-response.html#topics-request-response-ref-request-callback-arguments:
![ekrano nuotrauka is 2015-09-28 12-29-50](https://cloud.githubusercontent.com/assets/159967/10131983/a3b29810-65dc-11e5-83ec-941a9049b048.png)
