### PR TITLE
py33 bad, py34 good.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ branches:
 env:
  - TOXENV=py27
  - TOXENV=precise
- - TOXENV=py33
+ - TOXENV=py34
  - TOXENV=docs
 install:
  - pip install -U tox twine wheel codecov coveralls


### PR DESCRIPTION
Python 3.4 + is a nicer place to be maintaining a dual py2/py3 project.

- This switches TravisCI to test against Python 2.7 and Python 3.4 instead of Python 2.7 and Python 3.3