### PR TITLE
TST don't use broken Pillow version in tests

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,7 @@ deps =
     -rrequirements.txt
     # Extras
     boto
-    Pillow
+    Pillow != 3.0.0
     leveldb
     -rtests/requirements.txt
 commands =


### PR DESCRIPTION
Pillow 3.0.1 should be released soon; in the meantime we can exclude Pillow 3.0.0 to make tests pass. 
See https://github.com/python-pillow/Pillow/issues/1460.