### PR TITLE
public Crawler.create_crawler method

### DIFF
--- a/scrapy/crawler.py
+++ b/scrapy/crawler.py
@@ -148,9 +148,7 @@ class CrawlerRunner(object):
 
         :param dict kwargs: keyword arguments to initialize the spider
         """
-        crawler = crawler_or_spidercls
-        if not isinstance(crawler_or_spidercls, Crawler):
-            crawler = self._create_crawler(crawler_or_spidercls)
+        crawler = self.create_crawler(crawler_or_spidercls)
         return self._crawl(crawler, *args, **kwargs)
 
     def _crawl(self, crawler, *args, **kwargs):
@@ -164,6 +162,21 @@ class CrawlerRunner(object):
             return result
 
         return d.addBoth(_done)
+
+    def create_crawler(self, crawler_or_spidercls):
+        """
+        Return a :class:`~scrapy.crawler.Crawler` object.
+
+        * If `crawler_or_spidercls` is a Crawler, it is returned as-is.
+        * If `crawler_or_spidercls` is a Spider subclass, a new Crawler
+          is constructed for it.
+        * If `crawler_or_spidercls` is a string, this function finds
+          a spider with this name in a Scrapy project (using spider loader),
+          then creates a Crawler instance for it.
+        """
+        if isinstance(crawler_or_spidercls, Crawler):
+            return crawler_or_spidercls
+        return self._create_crawler(crawler_or_spidercls)
 
     def _create_crawler(self, spidercls):
         if isinstance(spidercls, six.string_types):

--- a/scrapy/utils/test.py
+++ b/scrapy/utils/test.py
@@ -30,7 +30,7 @@ def get_crawler(spidercls=None, settings_dict=None):
     from scrapy.spiders import Spider
 
     runner = CrawlerRunner(Settings(settings_dict))
-    return runner._create_crawler(spidercls or Spider)
+    return runner.create_crawler(spidercls or Spider)
 
 def get_pythonpath():
     """Return a PYTHONPATH suitable to use in processes so that they find this

--- a/scrapy/utils/test.py
+++ b/scrapy/utils/test.py
@@ -26,10 +26,9 @@ def get_crawler(spidercls=None, settings_dict=None):
     priority.
     """
     from scrapy.crawler import CrawlerRunner
-    from scrapy.settings import Settings
     from scrapy.spiders import Spider
 
-    runner = CrawlerRunner(Settings(settings_dict))
+    runner = CrawlerRunner(settings_dict)
     return runner.create_crawler(spidercls or Spider)
 
 def get_pythonpath():

--- a/tests/test_spiderloader/__init__.py
+++ b/tests/test_spiderloader/__init__.py
@@ -8,10 +8,12 @@ from twisted.trial import unittest
 
 # ugly hack to avoid cyclic imports of scrapy.spiders when running this test
 # alone
+import scrapy
 from scrapy.interfaces import ISpiderLoader
 from scrapy.spiderloader import SpiderLoader
 from scrapy.settings import Settings
 from scrapy.http import Request
+from scrapy.crawler import CrawlerRunner
 
 module_dir = os.path.dirname(os.path.abspath(__file__))
 
@@ -76,3 +78,14 @@ class SpiderLoaderTest(unittest.TestCase):
         settings = Settings({'SPIDER_MODULES': [module]})
         self.spider_loader = SpiderLoader.from_settings(settings)
         assert len(self.spider_loader._spiders) == 0
+
+    def test_crawler_runner_loading(self):
+        module = 'tests.test_spiderloader.test_spiders.spider1'
+        runner = CrawlerRunner({'SPIDER_MODULES': [module]})
+
+        self.assertRaisesRegexp(KeyError, 'Spider not found',
+                                runner.create_crawler, 'spider2')
+
+        crawler = runner.create_crawler('spider1')
+        self.assertTrue(issubclass(crawler.spidercls, scrapy.Spider))
+        self.assertEqual(crawler.spidercls.name, 'spider1')


### PR DESCRIPTION
CrawlerRunner.crawl returns a Deferred, but in all cases I used this method in addition to waiting for crawl to finish it was necessary to connect signal handlers, and you need Crawler instance for that. So 
```python
d = runner.crawl('spidername')  # or runner.create_crawler(spider_cls)
```
was not enough, I wanted

```python
crawler = runner.create_crawler('spidername')  # or runner.create_crawler(spider_cls)
crawler.signals.connect(...)
d = runner.crawl(crawler)
```

This means it was necessary to copy-paste the same code 
```python
crawler = crawler_or_spidercls
if not isinstance(crawler_or_spidercls, Crawler):
    crawler = runner._create_crawler(crawler_or_spidercls)
```
in all CrawlerRunner subclasses / wrappers, and using a private `_create_crawler` method. What about adding a public method for it? As a bonus point, we won't be using a private method in `scrapy.utils.test.get_crawler`.

