### PR TITLE
drop coveralls support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,11 +11,10 @@ env:
  - TOXENV=py33
  - TOXENV=docs
 install:
- - pip install -U tox twine wheel codecov coveralls
+ - pip install -U tox twine wheel codecov
 script: tox
 after_success:
   - codecov
-  - coveralls
 notifications:
   irc:
     use_notice: true


### PR DESCRIPTION
I don't know why, but coveralls uploads on Travis started to take 30s recently. And we're not using them anyways. What about removing coveralls support?