### PR TITLE
Support Batch Feed Export controlling batch size

### DIFF
--- a/docs/topics/feed-exports.rst
+++ b/docs/topics/feed-exports.rst
@@ -324,7 +324,7 @@ A dict containing the built-in feed exporters supported by Scrapy.
 FEED_BATCH_SIZE
 ---------------
 
-Default: ``None``
+Default: ``None``. (a single file is created)
 
 Allows to control the number of item exported in one file.
 
@@ -333,3 +333,22 @@ being created. These parameters are:
 
  * ``%(start)s`` - gets replaced by a timestamp when the spider is being started
  * ``%(time)s`` - gets replaced by a timestamp when the batch feed is being created
+ * ``%(index)s`` - gets replaced by an index when the batch feed is being created
+
+Here's an example using the ```time``` to batch feed ::
+
+    Storage URI : /tmp/%(start)s/%(time)s.json
+
+    /tmp
+      |_ 2015-07-03T20-29-01 (start)
+         |_ 2015-07-03T20-29-04.json (time)
+         |_ 2015-07-03T20-52-06.json (time)
+
+Here's an example using the ```index``` to batch feed ::
+
+    Storage URI : /tmp/%(start)s/feed-%(index)s.json
+
+    /tmp
+      |_ 2015-07-03T20-29-01 (start)
+         |_ feed-00001.json (index)
+         |_ feed-00002.json (index)

--- a/docs/topics/feed-exports.rst
+++ b/docs/topics/feed-exports.rst
@@ -208,6 +208,7 @@ These are the settings used for configuring the feed exports:
  * :setting:`FEED_EXPORTERS`
  * :setting:`FEED_STORE_EMPTY`
  * :setting:`FEED_EXPORT_FIELDS`
+ * :setting:`FEED_BATCH_SIZE`
 
 .. currentmodule:: scrapy.extensions.feedexport
 
@@ -319,3 +320,16 @@ A dict containing the built-in feed exporters supported by Scrapy.
 .. _URI: http://en.wikipedia.org/wiki/Uniform_Resource_Identifier
 .. _Amazon S3: http://aws.amazon.com/s3/
 .. _boto: http://code.google.com/p/boto/
+
+FEED_BATCH_SIZE
+---------------
+
+Default: ``None``
+
+Allows to control the number of item exported in one file.
+
+The storage URI should define parameters to create a new file that get replaced when the feed is
+being created. These parameters are:
+
+ * ``%(start)s`` - gets replaced by a timestamp when the spider is being started
+ * ``%(time)s`` - gets replaced by a timestamp when the batch feed is being created

--- a/scrapy/extensions/feedexport.py
+++ b/scrapy/extensions/feedexport.py
@@ -140,6 +140,8 @@ class FeedExporter(object):
 
     def __init__(self, settings):
         self.settings = settings
+        self.indexfmt = '{:05d}'
+        self.index = 1
         self.urifmt = settings['FEED_URI']
         if not self.urifmt:
             raise NotConfigured
@@ -225,6 +227,8 @@ class FeedExporter(object):
         ts = datetime.utcnow().replace(microsecond=0).isoformat().replace(':', '-')
         params['time'] = ts
         params['start'] = self.start
+        params['index'] = self.indexfmt.format(self.index)
+        self.index += 1
         self._uripar(params, spider)
         return params
 

--- a/tests/test_feedexport.py
+++ b/tests/test_feedexport.py
@@ -7,6 +7,7 @@ import tempfile
 import shutil
 import six
 from six.moves.urllib.parse import urlparse
+import time
 
 from zope.interface.verify import verifyObject
 from twisted.trial import unittest
@@ -165,6 +166,36 @@ class FeedExportTest(unittest.TestCase):
         defer.returnValue(data)
 
     @defer.inlineCallbacks
+    def assertFileCount(self, items, file_count=1, settings=None):
+        settings = settings or {}
+        class BatchTestSpider(scrapy.Spider):
+            name = 'batchtestspider'
+            start_urls = ['http://localhost:8998/']
+
+            def parse(self, response):
+                for item in items:
+                    time.sleep(1)
+                    yield item
+
+        tmpdir = tempfile.mkdtemp() + '/res/'
+        res_name = tmpdir + '%(time)s'
+        defaults = {
+            'FEED_URI': 'file://' + res_name,
+            'FEED_FORMAT': 'csv',
+        }
+        defaults.update(settings or {})
+        try:
+            with MockServer() as s:
+                runner = CrawlerRunner(Settings(defaults))
+                yield runner.crawl(BatchTestSpider)
+
+            paths = os.listdir(tmpdir)
+            assert file_count == len(paths)
+
+        finally:
+            shutil.rmtree(tmpdir)
+
+    @defer.inlineCallbacks
     def assertExportedCsv(self, items, header, rows, settings=None, ordered=True):
         settings = settings or {}
         settings.update({'FEED_FORMAT': 'csv'})
@@ -295,3 +326,16 @@ class FeedExportTest(unittest.TestCase):
             ]
             yield self.assertExported(items, ['egg', 'baz'], rows,
                                       settings=settings, ordered=True)
+
+    @defer.inlineCallbacks
+    def test_export_batch_items(self):
+        # feed exporters use field names from Item
+        items = [
+            self.MyItem({'foo': 'bar1', 'egg': 'spam1'}),
+            self.MyItem({'foo': 'bar2', 'egg': 'spam2', 'baz': 'quux2'}),
+            self.MyItem({'foo': 'bar3', 'egg': 'spam2', 'baz': 'quux2'}),
+            self.MyItem({'foo': 'bar4', 'egg': 'spam2', 'baz': 'quux2'}),
+            self.MyItem({'foo': 'bar5', 'egg': 'spam2', 'baz': 'quux2'})
+        ]
+        settings = {'FEED_BATCH_SIZE': 2, 'FEED_FORMAT': 'jl'}
+        yield self.assertFileCount(items, 3, settings)


### PR DESCRIPTION
Hi Scrapy Team,

For our needs at 1science, we modified the feed exporter to support batch export controlling the size (number of item in a file) with a new settings FEED_BATCH_SIZE.

We added a unit test and updated the documentation.

Please give me your feedbacks !

Nicolas Huray
