### PR TITLE
Fix #1287 - FilesPipeline properly handles file extensions when URL has parameters

### DIFF
--- a/scrapy/pipelines/files.py
+++ b/scrapy/pipelines/files.py
@@ -334,6 +334,9 @@ class FilesPipeline(MediaPipeline):
 
         media_guid = hashlib.sha1(to_bytes(url)).hexdigest()  # change to request.url after deprecation
         media_ext = os.path.splitext(url)[1]  # change to request.url after deprecation
+        if not media_ext[1:].isalpha():
+            media_base_url = url.split('?', 1)[0]  # change to request.url after deprecation
+            media_ext = os.path.splitext(media_base_url)[1]
         return 'full/%s%s' % (media_guid, media_ext)
 
     # deprecated

--- a/tests/test_pipeline_files.py
+++ b/tests/test_pipeline_files.py
@@ -51,6 +51,10 @@ class FilesPipelineTestCase(unittest.TestCase):
                                    response=Response("http://www.dorma.co.uk/images/product_details/2532"),
                                    info=object()),
                          'full/244e0dd7d96a3b7b01f54eded250c9e272577aa1')
+        self.assertEqual(file_path(Request("http://localhost:8050/render.png?url=http://www.test.ca&timeout=30wait=3")),
+                          'full/1691f03855fb23bc1e3be2618889a8d0d7ce15f8.png')
+        self.assertEqual(file_path(Request("http://foo.bar/baz.txt?fizz")),
+                          'full/a2b4913a62f65445aeae2bac08cd8c3b41d7195e.txt')
 
     def test_fs_store(self):
         assert isinstance(self.pipeline.store, FSFilesStore)


### PR DESCRIPTION
First (original) method extracts extension from entire URL, but if that extension is null or has non-alpha characters, fall back to second (new) method of extracting extension from base url (without parameters).  Maintains existing behavior for previous tests.

*Before*
```python
>>> file_path(Request("http://localhost:8050/render.png?url=http://www.test.ca&timeout=30wait=3"))
'full/1691f03855fb23bc1e3be2618889a8d0d7ce15f8.ca&timeout=30wait=3'

>>> file_path(Request("http://foo.bar/baz.txt?fizz"))
'full/a2b4913a62f65445aeae2bac08cd8c3b41d7195e.txt?fizz'
```
*After*
```python
>>> file_path(Request("http://localhost:8050/render.png?url=http://www.test.ca&timeout=30wait=3"))
'full/1691f03855fb23bc1e3be2618889a8d0d7ce15f8.png'

>>> file_path(Request("http://foo.bar/baz.txt?fizz"))
'full/a2b4913a62f65445aeae2bac08cd8c3b41d7195e.txt'