### PR TITLE
Add support for multipart upload to the S3 feed storage

### DIFF
--- a/scrapy/utils/test.py
+++ b/scrapy/utils/test.py
@@ -14,11 +14,9 @@ def assert_aws_environ():
     """
     try:
         import boto
+        import moto
     except ImportError as e:
         raise SkipTest(str(e))
-
-    if 'AWS_ACCESS_KEY_ID' not in os.environ:
-        raise SkipTest("AWS keys not found")
 
 def get_crawler(spidercls=None, settings_dict=None):
     """Return an unconfigured Crawler object. If settings_dict is given, it

--- a/tox.ini
+++ b/tox.ini
@@ -11,6 +11,7 @@ deps =
     -rrequirements.txt
     # Extras
     boto
+    moto
     Pillow != 3.0.0
     leveldb
     -rtests/requirements.txt
@@ -24,6 +25,7 @@ deps =
     lxml==2.3.2
     Twisted==11.1.0
     boto==2.2.2
+    moto==0.4.1
     Pillow<2.0
     cssselect==0.9.1
     zope.interface==3.6.1


### PR DESCRIPTION
This PR adds support for multipart upload to the S3 feed storage. It aims to allow uploading of large files (e.g. items containing HTML from a big crawl) and to fix the issue #960.

Source snippets:
- http://boto.readthedocs.org/en/latest/s3_tut.html#storing-large-data
- boto/boto#2704
