### PR TITLE
Create contract to handle errors occurring when websites are unavailable

### DIFF
--- a/docs/topics/contracts.rst
+++ b/docs/topics/contracts.rst
@@ -55,6 +55,15 @@ This callback is tested using three built-in contracts:
 
     @scrapes field_1 field_2 ...
 
+.. class:: IgnoreContract
+
+    This contract (``@ignore``) allows to ignore some errors which might occurred
+    sometimes when a website is slow or temporarily unavailable. In a context of
+    continuous integration this contract prevents to break the build for external reasons.
+    This contract is optional and must be used with caution::
+
+    @ignore TimeoutError
+
 Use the :command:`check` command to run the contract checks.
 
 Custom Contracts

--- a/scrapy/commands/check.py
+++ b/scrapy/commands/check.py
@@ -38,6 +38,14 @@ class TextTestResult(_TextTestResult):
         else:
             write("\n")
 
+    def addSkip(self, test, reason):
+        self.skipped.append((test, reason))
+        if self.showAll:
+            self.stream.writeln("IGNORED".format(reason))
+        elif self.dots:
+            self.stream.write("I")
+            self.stream.flush()
+
 
 class Command(ScrapyCommand):
     requires_project = True

--- a/scrapy/contracts/__init__.py
+++ b/scrapy/contracts/__init__.py
@@ -54,7 +54,7 @@ class ContractsManager(object):
             ignored_errors = set()
             for contract in contracts:
                 kwargs = contract.adjust_request_args(kwargs)
-                if contract.name is 'ignore':
+                if contract.name == 'ignore':
                     ignored_errors = getattr(contract, 'ignored_errors') or []
 
             # create and prepare request

--- a/scrapy/contracts/__init__.py
+++ b/scrapy/contracts/__init__.py
@@ -51,11 +51,11 @@ class ContractsManager(object):
             # calculate request args
             args, kwargs = get_spec(Request.__init__)
             kwargs['callback'] = method
-            ignored_errors = set()
+            ignored_errors = []
             for contract in contracts:
                 kwargs = contract.adjust_request_args(kwargs)
                 if contract.name == 'ignore':
-                    ignored_errors = getattr(contract, 'ignored_errors') or []
+                    ignored_errors += getattr(contract, 'ignored_errors') or []
 
             # create and prepare request
             args.remove('self')
@@ -68,7 +68,7 @@ class ContractsManager(object):
                 for contract in contracts:
                     request = contract.add_post_hook(request, results)
 
-                self._clean_req(request, method, results, ignored_errors)
+                self._clean_req(request, method, results, set(ignored_errors))
                 return request
 
     def _clean_req(self, request, method, results, ignored_errors):

--- a/scrapy/contracts/__init__.py
+++ b/scrapy/contracts/__init__.py
@@ -51,7 +51,7 @@ class ContractsManager(object):
             # calculate request args
             args, kwargs = get_spec(Request.__init__)
             kwargs['callback'] = method
-            ignored_errors = []
+            ignored_errors = set()
             for contract in contracts:
                 kwargs = contract.adjust_request_args(kwargs)
                 if contract.name is 'ignore':

--- a/scrapy/contracts/default.py
+++ b/scrapy/contracts/default.py
@@ -87,3 +87,20 @@ class ScrapesContract(Contract):
                 for arg in self.args:
                     if not arg in x:
                         raise ContractFail("'%s' field is missing" % arg)
+
+
+class IgnoreContract(Contract):
+    """
+    This contract allows to ignore some errors which might occurred
+    sometimes when a website is slow or temporarily unavailable. In a context of
+    continuous integration this contract prevents to break the build for external reasons.
+    This contract is optional and must be used with caution
+
+    @ignore TimeoutError
+    """
+
+    name = "ignore"
+
+    def __init__(self, *args, **kwargs):
+        super(IgnoreContract, self).__init__(*args, **kwargs)
+        self.ignored_errors = list(self.args)

--- a/scrapy/contracts/default.py
+++ b/scrapy/contracts/default.py
@@ -103,4 +103,4 @@ class IgnoreContract(Contract):
 
     def __init__(self, *args, **kwargs):
         super(IgnoreContract, self).__init__(*args, **kwargs)
-        self.ignored_errors = list(self.args)
+        self.ignored_errors = set(self.args)

--- a/scrapy/contracts/default.py
+++ b/scrapy/contracts/default.py
@@ -103,4 +103,4 @@ class IgnoreContract(Contract):
 
     def __init__(self, *args, **kwargs):
         super(IgnoreContract, self).__init__(*args, **kwargs)
-        self.ignored_errors = set(self.args)
+        self.ignored_errors = list(self.args)

--- a/scrapy/settings/default_settings.py
+++ b/scrapy/settings/default_settings.py
@@ -249,7 +249,8 @@ TELNETCONSOLE_PORT = [6023, 6073]
 TELNETCONSOLE_HOST = '127.0.0.1'
 
 SPIDER_CONTRACTS = {
-    'scrapy.contracts.default.UrlContract': 1,
-    'scrapy.contracts.default.ReturnsContract': 2,
-    'scrapy.contracts.default.ScrapesContract': 3,
+    'scrapy.contracts.default.IgnoreContract': 1,
+    'scrapy.contracts.default.UrlContract': 2,
+    'scrapy.contracts.default.ReturnsContract': 3,
+    'scrapy.contracts.default.ScrapesContract': 4,
 }

--- a/tests/test_contracts.py
+++ b/tests/test_contracts.py
@@ -1,11 +1,10 @@
-import sys
 from unittest import TextTestRunner
 
 from twisted.internet.defer import TimeoutError, CancelledError
 from twisted.python.failure import Failure
 from twisted.trial import unittest
-from scrapy.commands.check import TextTestResult
 
+from scrapy.commands.check import TextTestResult
 from scrapy.spidermiddlewares.httperror import HttpError
 from scrapy.spiders import Spider
 from scrapy.http import Request

--- a/tests/test_contracts.py
+++ b/tests/test_contracts.py
@@ -1,8 +1,10 @@
-from unittest import TextTestResult
+import sys
+from unittest import TextTestRunner
 
 from twisted.internet.defer import TimeoutError, CancelledError
 from twisted.python.failure import Failure
 from twisted.trial import unittest
+from scrapy.commands.check import TextTestResult
 
 from scrapy.spidermiddlewares.httperror import HttpError
 from scrapy.spiders import Spider
@@ -123,7 +125,9 @@ class ContractsManagerTest(unittest.TestCase):
 
     def setUp(self):
         self.conman = ContractsManager(self.contracts)
-        self.results = TextTestResult(stream=None, descriptions=False, verbosity=0)
+        # Change the verbosity to display the test results
+        runner = TextTestRunner(verbosity=1)
+        self.results = TextTestResult(runner.stream, runner.descriptions, runner.verbosity)
 
     def should_succeed(self):
         self.assertFalse(self.results.failures)


### PR DESCRIPTION
Hi Scrapy Team,

In my company, we developed a lot of spiders and we use contracts to be sure our crawling rules and our parsers still continue to work with the target websites. The project is setup in our CI to check continuously the spider contracts pass. 

These days we have some troubles with some target websites which are slow or sometimes totally unavailable. Obviously this implies our builds fails constantly and we have to fix it. 

Until now what we do is to remove the spider contracts and rerun the build but it's not a really convenient way to handle the errors which might occurred when a website is unavailable for unknown reasons.

So in this Pull Request we developed a spider contract to ignore these errors when occurs.
The errors are logged (marked as ignored) but are not considered as assertions errors or critical errors.

Here is an example ignoring TimeoutError :

```
    def parse(self, response):
        """ should return an item but ignore TimeoutError if occurs
        @url http://target-website/sometimes-unavailable
        @ignore TimeoutError
        @returns items 1 1
        """
        return Item(url=response.url)
```

We added some tests and updated the documentation.

Please give us your feedbacks.

Nicolas
