### PR TITLE
[MRG+1] Startproject templates override

### DIFF
--- a/docs/topics/settings.rst
+++ b/docs/topics/settings.rst
@@ -1046,7 +1046,12 @@ TEMPLATES_DIR
 Default: ``templates`` dir inside scrapy module
 
 The directory where to look for templates when creating new projects with
-:command:`startproject` command.
+:command:`startproject` command and new spiders with :command:`genspider` 
+command.
+
+The project name must not conflict with the name of custom files or directories
+in the ``project`` subdirectory.
+
 
 .. setting:: URLLENGTH_LIMIT
 

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -4,13 +4,14 @@ import subprocess
 import tempfile
 from time import sleep
 from os.path import exists, join, abspath
-from shutil import rmtree
+from shutil import rmtree, copytree
 from tempfile import mkdtemp
 import six
 
 from twisted.trial import unittest
 from twisted.internet import defer
 
+import scrapy
 from scrapy.utils.python import to_native_str
 from scrapy.utils.python import retry_on_eintr
 from scrapy.utils.test import get_testenv
@@ -71,6 +72,26 @@ class StartprojectTest(ProjectTest):
         self.assertEqual(1, self.call('startproject', self.project_name))
         self.assertEqual(1, self.call('startproject', 'wrong---project---name'))
         self.assertEqual(1, self.call('startproject', 'sys'))
+    
+
+class StartprojectTemplatesTest(ProjectTest):
+
+    def setUp(self):
+        super(StartprojectTemplatesTest, self).setUp()
+        self.tmpl = join(self.temp_path, 'templates')
+        self.tmpl_proj = join(self.tmpl, 'project')
+        
+    def test_startproject_template_override(self):
+        copytree(join(scrapy.__path__[0], 'templates'), self.tmpl)
+        os.mknod(join(self.tmpl_proj, 'root_template'))
+        assert exists(join(self.tmpl_proj, 'root_template'))
+
+        args = ['--set', 'TEMPLATES_DIR=%s' % self.tmpl]
+        p = self.proc('startproject', self.project_name, *args)
+        out = to_native_str(retry_on_eintr(p.stdout.read))
+        self.assertIn("New Scrapy project %r, using template directory %r, created in:" % \
+                      (self.project_name, join(self.tmpl, 'project')), out)
+        assert exists(join(self.proj_path, 'root_template'))
 
 
 class CommandTest(ProjectTest):


### PR DESCRIPTION
Hello Scrapy-makers :-)

This would be my first, modest, contribution to Scrapy, that I have been pleased to use on and off for a couple of years now.

This is an attempt to address the missing override of TEMPLATES_DIR at project creation described in issue #671. 

I saw PR #1035, but it seems to be on a dead end, and the reasons for that seem to be:
- it implemented multiple override levels in a way that is not compatible with the new override mechanism,
- considering that there is no settings.py (let alone spiders) at startproject time, the only level of override is the command-line, so it was possibly a bit over-engineered.

With this in mind, this PR keeps to the simple route proposed in the issue and copies/pastes from genspider.py.

Looking forwards to your feedback.