### PR TITLE
[MRG+1] Make data_path work when outside project (used by HttpCacheMiddleware and Deltafetch plugin)

### DIFF
--- a/scrapy/utils/project.py
+++ b/scrapy/utils/project.py
@@ -43,8 +43,9 @@ def project_data_dir(project='default'):
 
 
 def data_path(path, createdir=False):
-    """If inside the project and path is relative, return the given path
-    as relative to the project data dir, otherwise return it unmodified
+    """
+    Return the given path joined with the .scrapy data directory.
+    If given an absolute path, return it unmodified.
     """
     if not isabs(path):
         if inside_project():

--- a/scrapy/utils/project.py
+++ b/scrapy/utils/project.py
@@ -12,6 +12,7 @@ from scrapy.exceptions import NotConfigured
 ENVVAR = 'SCRAPY_SETTINGS_MODULE'
 DATADIR_CFG_SECTION = 'datadir'
 
+
 def inside_project():
     scrapy_module = os.environ.get('SCRAPY_SETTINGS_MODULE')
     if scrapy_module is not None:
@@ -22,6 +23,7 @@ def inside_project():
         else:
             return True
     return bool(closest_scrapy_cfg())
+
 
 def project_data_dir(project='default'):
     """Return the current project data dir, creating it if it doesn't exist"""
@@ -39,15 +41,20 @@ def project_data_dir(project='default'):
         os.makedirs(d)
     return d
 
+
 def data_path(path, createdir=False):
     """If inside the project and path is relative, return the given path
-    as relative the project data dir, otherwise return it unmodified
+    as relative to the project data dir, otherwise return it unmodified
     """
-    if inside_project() and not isabs(path):
-        path = join(project_data_dir(), path)
+    if not isabs(path):
+        if inside_project():
+            path = join(project_data_dir(), path)
+        else:
+            path = join('.scrapy', path)
     if createdir and not exists(path):
         os.makedirs(path)
     return path
+
 
 def get_project_settings():
     if ENVVAR not in os.environ:

--- a/scrapy/utils/project.py
+++ b/scrapy/utils/project.py
@@ -40,10 +40,10 @@ def project_data_dir(project='default'):
     return d
 
 def data_path(path, createdir=False):
-    """If path is relative, return the given path inside the project data dir,
-    otherwise return the path unmodified
+    """If inside the project and path is relative, return the given path
+    as relative the project data dir, otherwise return it unmodified
     """
-    if not isabs(path):
+    if inside_project() and not isabs(path):
         path = join(project_data_dir(), path)
     if createdir and not exists(path):
         os.makedirs(path)

--- a/tests/test_utils_project.py
+++ b/tests/test_utils_project.py
@@ -1,0 +1,34 @@
+import unittest
+import os
+import tempfile
+import shutil
+import contextlib
+from scrapy.utils.project import data_path
+
+
+@contextlib.contextmanager
+def inside_a_project():
+    prev_dir = os.getcwd()
+    project_dir = tempfile.mkdtemp()
+
+    try:
+        os.chdir(project_dir)
+        with open('scrapy.cfg', 'w') as f:
+            # create an empty scrapy.cfg
+            f.close()
+
+        yield project_dir
+    finally:
+        os.chdir(prev_dir)
+        shutil.rmtree(project_dir)
+
+
+class ProjectUtilsTest(unittest.TestCase):
+    def test_data_path_outside_project(self):
+        self.assertEquals('.scrapy/somepath', data_path('somepath'))
+
+    def test_data_path_inside_project(self):
+        with inside_a_project() as proj_path:
+            expected = os.path.join(proj_path, '.scrapy', 'somepath')
+            self.assertEquals(expected, data_path('somepath'))
+            self.assertEquals('/absolute/path', data_path('/absolute/path'))

--- a/tests/test_utils_project.py
+++ b/tests/test_utils_project.py
@@ -26,6 +26,7 @@ def inside_a_project():
 class ProjectUtilsTest(unittest.TestCase):
     def test_data_path_outside_project(self):
         self.assertEquals('.scrapy/somepath', data_path('somepath'))
+        self.assertEquals('/absolute/path', data_path('/absolute/path'))
 
     def test_data_path_inside_project(self):
         with inside_a_project() as proj_path:


### PR DESCRIPTION
I ran into an issue trying to enable cache with `scrapy runspider`: the middleware gets disabled because it tries to create the `httpcache` directory inside a project data directory.

The [`utils.project.data_path`](https://github.com/scrapy/scrapy/blob/389882eb131250a1eb8418580b165625dd854bf0/scrapy/utils/project.py#L42) currently assumes that you're inside the project dir (maybe reasonably, since it's in the project module?).

I know this solution breaks compatibility a little bit, but IMO it would be solving a bug.

Btw, I noticed that this `data_path()` function is only being used by the HttpCacheMiddleware -- does it make sense to keep it as an util function?