### PR TITLE
Allow updating dictionary-like settings with magic prefix

### DIFF
--- a/docs/topics/spiders.rst
+++ b/docs/topics/spiders.rst
@@ -92,6 +92,18 @@ scrapy.Spider
       configuration when running this spider. It must be defined as a class
       attribute since the settings are updated before instantiation.
 
+      If you wish to update, not replace, dictionary-like settings (e.g.), you
+      can prefix their name with ``update:``. For example, this will completely
+      overwrite the :setting:`SPIDER_MIDDLEWARES` setting, making
+      ``my_middleware`` the only enabled spider middleware::
+
+          custom_settings = {'SPIDER_MIDDLEWARES': {'my_middleware': 100}}
+
+      On the other hand, this will enable ``my_middleware`` *in addition to* all
+      other previously enabled spider middlewares::
+
+          custom_settings = {'update:SPIDER_MIDDLEWARES': {'my_middleware': 100}}
+
       For a list of available built-in settings see:
       :ref:`topics-settings-ref`.
 

--- a/scrapy/settings/__init__.py
+++ b/scrapy/settings/__init__.py
@@ -84,6 +84,8 @@ class BaseSettings(MutableMapping):
     highest priority will be retrieved.
     """
 
+    MAGIC_PREFIXES = ("update:", )
+
     def __init__(self, values=None, priority='project'):
         self.frozen = False
         self.attributes = {}
@@ -230,13 +232,33 @@ class BaseSettings(MutableMapping):
     def __setitem__(self, name, value):
         self.set(name, value)
 
+    def _split_prefix(self, name):
+        prefix = None
+        try:
+            if name.startswith(self.MAGIC_PREFIXES):
+                prefix, name = name.split(":", 1)
+        except AttributeError:
+            # No magic prefixes or non-string setting name
+            pass
+        return prefix, name
+
     def set(self, name, value, priority='project'):
         """
         Store a key/value attribute with a given priority.
 
-        Settings should be populated *before* configuring the Crawler object
-        (through the :meth:`~scrapy.crawler.Crawler.configure` method),
-        otherwise they won't have any effect.
+        For dictionary-like settings, you can prefix ``name`` with ``update:``
+        if you wish to update, not replace, the dictionary. E.g.::
+
+            >>> mysettings = BaseSettings({'MYDICT': {'key': 'val'}})
+            >>> mysettings['MYDICT']
+            {'key': 'val'}
+            >>> mysettings.set('update:MYDICT', {'new_key': 'new_val'})
+            >>> mysettings['MYDICT']
+            {'new_key': 'new_val', 'key': 'val'}
+
+        This is particularly useful when dealing with dictionary-like settings
+        from the command line or in a spider's
+        :attr:`~scrapy.spiders.Spider.custom_settings` attribute.
 
         :param name: the setting name
         :type name: string
@@ -250,13 +272,21 @@ class BaseSettings(MutableMapping):
         """
         self._assert_mutability()
         priority = get_settings_priority(priority)
-        if name not in self:
-            if isinstance(value, SettingsAttribute):
-                self.attributes[name] = value
+        prefix, name = self._split_prefix(name)
+        if prefix == 'update':
+            if isinstance(self[name], BaseSettings):
+                self[name].update(value, priority)
             else:
-                self.attributes[name] = SettingsAttribute(value, priority)
+                # Ignore priority
+                self[name].update(value)
         else:
-            self.attributes[name].set(value, priority)
+            if name not in self:
+                if isinstance(value, SettingsAttribute):
+                    self.attributes[name] = value
+                else:
+                    self.attributes[name] = SettingsAttribute(value, priority)
+            else:
+                self.attributes[name].set(value, priority)
 
     def setdict(self, values, priority='project'):
         self.update(values, priority)

--- a/tests/test_settings/__init__.py
+++ b/tests/test_settings/__init__.py
@@ -104,6 +104,20 @@ class BaseSettingsTest(unittest.TestCase):
                 mock_set.reset_mock()
                 mock_setattr.reset_mock()
 
+    def test_set_with_update_prefix(self):
+        self.settings['MYDICT'] = {'one': 1}
+        self.settings['update:MYDICT'] = {'two': 2}
+        self.assertEqual(self.settings['MYDICT'], {'one': 1, 'two': 2})
+        self.settings['MYDICT'] = {'three': 3}
+        self.assertEqual(self.settings['MYDICT'], {'three': 3})
+
+        self.settings['MYDICT'] = BaseSettings({'one': 1}, priority=0)
+        self.settings['MYDICT'].set('two', 2, priority=20)
+        self.settings['update:MYDICT'] = BaseSettings({'one': 10, 'two': 20},
+                                                      priority=10)
+        six.assertCountEqual(self, self.settings['MYDICT'],
+                             {'one': 10, 'two': 2})
+
     def test_setitem(self):
         settings = BaseSettings()
         settings.set('key', 'a', 'default')


### PR DESCRIPTION
This PR would ease updating, not replacing, dictionary settings from the command line and from `Spider.custom_settings` by introducing a magix prefix:

```python
>>> mysettings = BaseSettings({'MYDICT': {'key': 'val'}})
>>> mysettings['MYDICT']
{'key': 'val'}
>>> mysettings.set('update:MYDICT', {'new_key': 'new_val'})
>>> mysettings['MYDICT']
{'new_key': 'new_val', 'key': 'val'}
```