### PR TITLE
Nextcall heartbeats in engine (event loop halting)

### DIFF
--- a/scrapy/core/engine.py
+++ b/scrapy/core/engine.py
@@ -7,7 +7,7 @@ For more information see docs/topics/architecture.rst
 import logging
 from time import time
 
-from twisted.internet import defer
+from twisted.internet import defer, task
 from twisted.python.failure import Failure
 
 from scrapy import signals
@@ -30,6 +30,7 @@ class Slot(object):
         self.close_if_idle = close_if_idle
         self.nextcall = nextcall
         self.scheduler = scheduler
+        self.heartbeat = task.LoopingCall(nextcall.schedule)
 
     def add_request(self, request):
         self.inprogress.add(request)
@@ -47,6 +48,7 @@ class Slot(object):
         if self.closing and not self.inprogress:
             if self.nextcall:
                 self.nextcall.cancel()
+                self.heartbeat.stop()
             self.closing.callback(None)
 
 
@@ -113,7 +115,6 @@ class ExecutionEngine(object):
             return
 
         if self.paused:
-            slot.nextcall.schedule(5)
             return
 
         while not self._needs_backout(spider):
@@ -254,6 +255,7 @@ class ExecutionEngine(object):
         self.crawler.stats.open_spider(spider)
         yield self.signals.send_catch_log_deferred(signals.spider_opened, spider=spider)
         slot.nextcall.schedule()
+        slot.heartbeat.start(5)
 
     def _spider_idle(self, spider):
         """Called when a spider gets idle. This function is called when there
@@ -267,7 +269,6 @@ class ExecutionEngine(object):
             spider=spider, dont_log=DontCloseSpider)
         if any(isinstance(x, Failure) and isinstance(x.value, DontCloseSpider) \
                 for _, x in res):
-            self.slot.nextcall.schedule(5)
             return
 
         if self.spider_is_idle(spider):


### PR DESCRIPTION
Hi guys,
during fixing premature spider closing bugs in Frontera (https://github.com/scrapinghub/frontera/issues/33), I faced with engine activity halt. 

Activity halt happens when scheduler constantly reports that there are requests available, by returning ``True`` from ``has_pending_requests()`` call, but doesn't returns them from ``next_request()`` call. This is done when it's known there are requests for processing, but backend is overloaded generating new batches and it needs some time to "rest". This could also happen in distributed system where not all parts have the same performance.

Halt happens because of downloading-driven nature of execution engine, meaning if no downloading/scraping happens there will be no calls to main engine function where all checks are happening ``_next_request(self, spider)``. In other words, if engine isn't closed, and nothing is downloaded the reactor event loop is halt.

It's worth to mention that Frontera uses it's own custom scheduler. 