### PR TITLE
[MRG+1] added more verbosity for log and for exception when download is cancelled because of a size limit

### DIFF
--- a/scrapy/core/downloader/handlers/http11.py
+++ b/scrapy/core/downloader/handlers/http11.py
@@ -239,13 +239,11 @@ class ScrapyAgent(object):
         expected_size = txresponse.length if txresponse.length != UNKNOWN_LENGTH else -1
 
         if maxsize and expected_size > maxsize:
-            error_message = (
-                "Cancelling download of {url}: expected response "
-                "size ({size}) larger than "
-                "download max size ({maxsize}).".format(
-                    url=request.url, size=expected_size, maxsize=maxsize
-                )
-            )
+            error_message = ("Cancelling download of {url}: expected response "
+                             "size ({size}) larger than "
+                             "download max size ({maxsize})."
+            ).format(url=request.url, size=expected_size, maxsize=maxsize)
+
             logger.error(error_message)
             txresponse._transport._producer.loseConnection()
             raise defer.CancelledError(error_message)

--- a/scrapy/core/downloader/handlers/http11.py
+++ b/scrapy/core/downloader/handlers/http11.py
@@ -239,11 +239,16 @@ class ScrapyAgent(object):
         expected_size = txresponse.length if txresponse.length != UNKNOWN_LENGTH else -1
 
         if maxsize and expected_size > maxsize:
-            logger.error("Expected response size (%(size)s) larger than "
-                         "download max size (%(maxsize)s).",
-                         {'size': expected_size, 'maxsize': maxsize})
+            error_message = (
+                "Cancelling download of {url}: expected response "
+                "size ({size}) larger than "
+                "download max size ({maxsize}).".format(
+                    url=request.url, size=expected_size, maxsize=maxsize
+                )
+            )
+            logger.error(error_message)
             txresponse._transport._producer.loseConnection()
-            raise defer.CancelledError()
+            raise defer.CancelledError(error_message)
 
         if warnsize and expected_size > warnsize:
             logger.warning("Expected response size (%(size)s) larger than "


### PR DESCRIPTION
We got some troubles when we needed to  process such errors in our project. It is hard to link error in log with the specific download url.