### PR TITLE
[MRG+1] Doc improve log formating examples

### DIFF
--- a/docs/topics/debug.rst
+++ b/docs/topics/debug.rst
@@ -138,7 +138,7 @@ available in all future runs should they be necessary again::
             # populate more `item` fields
             return item
         else:
-            self.logger.warning('No item received for %s', response.url)
+            self.logger.warning('No item received for %s' % response.url)
 
 For more information, check the :ref:`topics-logging` section.
 

--- a/docs/topics/extensions.rst
+++ b/docs/topics/extensions.rst
@@ -135,15 +135,15 @@ Here is the code of such extension::
             return ext
 
         def spider_opened(self, spider):
-            logger.info("opened spider %s", spider.name)
+            logger.info("opened spider %s" % spider.name)
 
         def spider_closed(self, spider):
-            logger.info("closed spider %s", spider.name)
+            logger.info("closed spider %s" % spider.name)
 
         def item_scraped(self, item, spider):
             self.items_scraped += 1
             if self.items_scraped % self.item_count == 0:
-                logger.info("scraped %d items", self.items_scraped)
+                logger.info("scraped %d items" % self.items_scraped)
 
 
 .. _topics-extensions-ref:

--- a/docs/topics/logging.rst
+++ b/docs/topics/logging.rst
@@ -105,7 +105,7 @@ instance, that can be accessed and used like this::
         start_urls = ['http://scrapinghub.com']
 
         def parse(self, response):
-            self.logger.info('Parse function called on %s', response.url)
+            self.logger.info('Parse function called on %s' % response.url)
 
 That logger is created using the Spider's name, but you can use any custom
 Python logger you want. For example::
@@ -121,7 +121,7 @@ Python logger you want. For example::
         start_urls = ['http://scrapinghub.com']
 
         def parse(self, response):
-            logger.info('Parse function called on %s', response.url)
+            logger.info('Parse function called on %s' % response.url)
 
 .. _topics-logging-configuration:
 

--- a/docs/topics/request-response.rst
+++ b/docs/topics/request-response.rst
@@ -189,7 +189,7 @@ Example::
 
     def parse_page2(self, response):
         # this would log http://www.example.com/some_page.html
-        self.logger.info("Visited %s", response.url)
+        self.logger.info("Visited %s" % response.url)
 
 In some cases you may be interested in passing arguments to those callback
 functions so you can receive the arguments later, in the second callback. You

--- a/docs/topics/spiders.rst
+++ b/docs/topics/spiders.rst
@@ -224,7 +224,7 @@ Let's see an example::
         ]
 
         def parse(self, response):
-            self.logger.info('A response from %s just arrived!', response.url)
+            self.logger.info('A response from %s just arrived!' % response.url)
 
 Return multiple Requests and items from a single callback::
 
@@ -411,7 +411,7 @@ Let's now take a look at an example CrawlSpider with rules::
         )
 
         def parse_item(self, response):
-            self.logger.info('Hi, this is an item page! %s', response.url)
+            self.logger.info('Hi, this is an item page! %s' % response.url)
             item = scrapy.Item()
             item['id'] = response.xpath('//td[@id="item_id"]/text()').re(r'ID: (\d+)')
             item['name'] = response.xpath('//td[@id="item_name"]/text()').extract()
@@ -525,7 +525,7 @@ These spiders are pretty easy to use, let's have a look at one example::
         itertag = 'item'
 
         def parse_node(self, response, node):
-            self.logger.info('Hi, this is a <%s> node!: %s', self.itertag, ''.join(node.extract()))
+            self.logger.info('Hi, this is a <%s> node!: %s' % (self.itertag, ''.join(node.extract())))
 
             item = TestItem()
             item['id'] = node.xpath('@id').extract()
@@ -586,7 +586,7 @@ Let's see an example similar to the previous one, but using a
         headers = ['id', 'name', 'description']
 
         def parse_row(self, response, row):
-            self.logger.info('Hi, this is a row!: %r', row)
+            self.logger.info('Hi, this is a row!: %r' % row)
 
             item = TestItem()
             item['id'] = row['id']

--- a/docs/topics/spiders.rst
+++ b/docs/topics/spiders.rst
@@ -525,7 +525,7 @@ These spiders are pretty easy to use, let's have a look at one example::
         itertag = 'item'
 
         def parse_node(self, response, node):
-            self.logger.info('Hi, this is a <%s> node!: %s' % (self.itertag, ''.join(node.extract())))
+            self.logger.info('Hi, this is a <%s> node!: %r' % (self.itertag, node.extract()))
 
             item = TestItem()
             item['id'] = node.xpath('@id').extract()


### PR DESCRIPTION
When the formatting is done by the logger (`logger.info('%s', val)`)
and a formatting exception occurs, there are several problems:
- The exception & stacktrace is printed to stderr, not the log (#2450)
- The debugger is not invoked by twisted (#1551)
- Extensions don't see errors; Errors are not even counted in the stats.
- It's impossible to see the full stacktrace
  with frames from the caller of the logger

I demonstrated some of this in #1551.
This is why I prefer early formatting when logging.

Code updated like this is backward incompatible
because exceptions will occur early, in the caller of the log
stopping execution of any code that failed formatting.
(This is irrelevant to deprecation policy,
 I only update documentation examples)

Edit: I also updated another formatting example that could be simple.
Edit2: Build fails because of the twisted update
