### PR TITLE
[MRG] Removed pywin32 from conda install instructions as it's already declared as dependency.

### DIFF
--- a/docs/intro/install.rst
+++ b/docs/intro/install.rst
@@ -44,13 +44,10 @@ Anaconda
 If you already have installed `Anaconda`_ or `Miniconda`_, the company
 `Scrapinghub`_ maintains official conda packages for Linux, Windows and OS X.
 
-To install Scrapy in Linux or OS X, use:
+To install Scrapy using ``conda``, run::
 
   conda install -c scrapinghub scrapy 
 
-To install Scrapy in Windows, use:
-
-  conda install -c scrapinghub scrapy pywin32
 
 Windows
 -------


### PR DESCRIPTION
Latest build now include ``pywin32`` as dependency for the ``win`` packages.