### PR TITLE
Setting the default method of `ScrapyClientContextFactory` to `SSLv23_METHOD`

### DIFF
--- a/scrapy/core/downloader/contextfactory.py
+++ b/scrapy/core/downloader/contextfactory.py
@@ -14,9 +14,7 @@ class ScrapyClientContextFactory(ClientContextFactory):
     # and https://github.com/scrapy/scrapy/issues/981
 
     def __init__(self):
-        # see this issue on why we use TLSv1_METHOD by default
-        # https://github.com/scrapy/scrapy/issues/194
-        self.method = SSL.TLSv1_METHOD
+        self.method = SSL.SSLv23_METHOD
 
     def getContext(self, hostname=None, port=None):
         ctx = ClientContextFactory.getContext(self)


### PR DESCRIPTION
The upstream issue described in #194 has been fixed in OpenSSL: https://rt.openssl.org/Ticket/Display.html?id=2771 and also in Ubuntu: https://bugs.launchpad.net/ubuntu/+source/openssl/+bug/965371

Maybe it's time to introduce `SSLv23_METHOD` back again as it comes with more compatibility: https://docs.python.org/dev/library/ssl.html#ssl.wrap_socket