### PR TITLE
Allow to silently drop items

### DIFF
--- a/scrapy/core/scraper.py
+++ b/scrapy/core/scraper.py
@@ -222,7 +222,11 @@ class Scraper(object):
         self.slot.itemproc_size -= 1
         if isinstance(output, Failure):
             ex = output.value
-            if isinstance(ex, DropItem):
+            if isinstance(ex, SilentDropItem):
+                return self.signals.send_catch_log_deferred(
+                    signal=signals.item_dropped, item=item, response=response,
+                    spider=spider, exception=output.value, dont_log=True)
+            elif isinstance(ex, DropItem):
                 logkws = self.logformatter.dropped(item, ex, response, spider)
                 logger.log(*logformatter_adapter(logkws), extra={'spider': spider})
                 return self.signals.send_catch_log_deferred(

--- a/scrapy/exceptions.py
+++ b/scrapy/exceptions.py
@@ -33,6 +33,10 @@ class DropItem(Exception):
     """Drop item from the item pipeline"""
     pass
 
+class SilentDropItem(DropItem):
+    """Drop item from the item pipeline without logging it"""
+    pass
+
 class NotSupported(Exception):
     """Indicates a feature or method is not supported"""
     pass


### PR DESCRIPTION
Currently there is no way (that I've found) to avoid DropItem to print on the log if it's not changing the configuration parameters, which may not be convenient in large applications with many different spiders

This is just a suggestion...