### PR TITLE
[MRG+1] DOC: Add captions to toctrees which appear in sidebar

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -28,6 +28,7 @@ First steps
 ===========
 
 .. toctree::
+   :caption: First steps
    :hidden:
 
    intro/overview
@@ -53,6 +54,7 @@ Basic concepts
 ==============
 
 .. toctree::
+   :caption: Basic concepts
    :hidden:
 
    topics/commands
@@ -110,6 +112,7 @@ Built-in services
 =================
 
 .. toctree::
+   :caption: Built-in services
    :hidden:
 
    topics/logging
@@ -138,6 +141,7 @@ Solving specific problems
 =========================
 
 .. toctree::
+   :caption: Solving specific problems
    :hidden:
 
    faq
@@ -203,6 +207,7 @@ Extending Scrapy
 ================
 
 .. toctree::
+   :caption: Extending Scrapy
    :hidden:
 
    topics/architecture
@@ -240,6 +245,7 @@ All the rest
 ============
 
 .. toctree::
+   :caption: All the rest
    :hidden:
 
    news


### PR DESCRIPTION
This improve readability of TOC in the sidebar. As toctrees are all hidden, captions don't appear in other place (e.g. main content of index page), as far as I know.

Before                |  After
:-------------------------:|:-------------------------:
<img width="289" alt="before" src="https://cloud.githubusercontent.com/assets/532251/11760793/93a13ecc-a0ec-11e5-8b01-6bce563d1caa.png"> | <img width="290" alt="after" src="https://cloud.githubusercontent.com/assets/532251/11760794/93a2119e-a0ec-11e5-9875-e0fe76765b6b.png">