### PR TITLE
[MRG+1] Let allowed domains be updated in offsite middleware

### DIFF
--- a/scrapy/spidermiddlewares/offsite.py
+++ b/scrapy/spidermiddlewares/offsite.py
@@ -42,7 +42,8 @@ class OffsiteMiddleware(object):
                 yield x
 
     def should_follow(self, request, spider):
-        regex = self.host_regex
+        # Possibly update allowed_domains.
+        regex = self.get_host_regex(spider)
         # hostname can be None for wrong urls (like javascript links)
         host = urlparse_cached(request).hostname or ''
         return bool(regex.search(host))

--- a/tests/test_spidermiddleware_offsite.py
+++ b/tests/test_spidermiddleware_offsite.py
@@ -36,7 +36,6 @@ class TestOffsiteMiddleware(TestCase):
         out = list(self.mw.process_spider_output(res, reqs, self.spider))
         self.assertEquals(out, onsite_reqs)
 
-
     def test_updating_allowed_domains(self):
         res = Response('http://scrapytest.org')
 


### PR DESCRIPTION
Hi,

This is a very small change code-wise but it allows for some interesting flexibility.

So far, `get_host_regex()`, which reads spider attribute `allowed_domains`, is only called when _opening_ the spider (by method `spider_opened()`). With this change, if/when `allowed_domains` are updated after opening the spider, these updates can be taken into account. This allows for more control.

Credits for inspiration go to @nhuray.

Thank you for your consideration.

Fixes: #3119