### PR TITLE
DOC: Add AjaxCrawlMiddleware to DOWNLOADER_MIDDLEWARES_BASE

### DIFF
--- a/docs/topics/settings.rst
+++ b/docs/topics/settings.rst
@@ -341,6 +341,7 @@ Default::
         'scrapy.downloadermiddlewares.useragent.UserAgentMiddleware': 400,
         'scrapy.downloadermiddlewares.retry.RetryMiddleware': 500,
         'scrapy.downloadermiddlewares.defaultheaders.DefaultHeadersMiddleware': 550,
+        'scrapy.downloadermiddlewares.ajaxcrawl.AjaxCrawlMiddleware': 560,
         'scrapy.downloadermiddlewares.redirect.MetaRefreshMiddleware': 580,
         'scrapy.downloadermiddlewares.httpcompression.HttpCompressionMiddleware': 590,
         'scrapy.downloadermiddlewares.redirect.RedirectMiddleware': 600,


### PR DESCRIPTION
 A setting variable `DOWNLOADER_MIDDLEWARES_BASE` contains `AjaxCrawlMiddleware` in the code, but the middleware is not listed in the document of 1.0.

Code:
https://github.com/scrapy/scrapy/blob/1.0/scrapy/settings/default_settings.py#L89

Document:
http://doc.scrapy.org/en/1.0/topics/settings.html#downloader-middlewares-base

Note that this problem has already fixed in the [master branch](http://doc.scrapy.org/en/master/topics/settings.html#downloader-middlewares-base).