### PR TITLE
[MRG+1] BF: robustify _monkeypatches check for twisted - str() name first (Closes #1634)

### DIFF
--- a/scrapy/_monkeypatches.py
+++ b/scrapy/_monkeypatches.py
@@ -20,6 +20,6 @@ if sys.version_info[0] == 2:
 import twisted.persisted.styles  # NOQA
 # Remove only entries with twisted serializers for non-twisted types.
 for k, v in frozenset(copyreg.dispatch_table.items()):
-    if not getattr(k, '__module__', '').startswith('twisted') \
-            and getattr(v, '__module__', '').startswith('twisted'):
+    if not str(getattr(k, '__module__', '')).startswith('twisted') \
+            and str(getattr(v, '__module__', '')).startswith('twisted'):
         copyreg.dispatch_table.pop(k)


### PR DESCRIPTION
In my case, while running datalad tests using nose, scrapy was failing
since v was None