### PR TITLE
[MRG+1] show download warnsize once

### DIFF
--- a/scrapy/core/downloader/handlers/http11.py
+++ b/scrapy/core/downloader/handlers/http11.py
@@ -292,6 +292,7 @@ class _ResponseReader(protocol.Protocol):
         self._bodybuf = BytesIO()
         self._maxsize  = maxsize
         self._warnsize  = warnsize
+        self._reached_warnsize = False
         self._bytes_received = 0
 
     def dataReceived(self, bodyBytes):
@@ -305,11 +306,12 @@ class _ResponseReader(protocol.Protocol):
                           'maxsize': self._maxsize})
             self._finished.cancel()
 
-        if self._warnsize and self._bytes_received > self._warnsize:
-            logger.warning("Received (%(bytes)s) bytes larger than download "
-                           "warn size (%(warnsize)s).",
-                           {'bytes': self._bytes_received,
-                            'warnsize': self._warnsize})
+        if self._warnsize and self._bytes_received > self._warnsize and not self._reached_warnsize:
+            self._reached_warnsize = True
+            logger.warning("Received more bytes than download "
+                           "warn size (%(warnsize)s) in request %(request)s.",
+                           {'warnsize': self._warnsize,
+                            'request': self._request})
 
     def connectionLost(self, reason):
         if self._finished.called:


### PR DESCRIPTION
## PR Overview 

See  #1303
The warning message was too verbose. Now it is shown only a warning message per request. 
The warning message is updated to show the request and the DOWNLOAD_WARNSIZE variable.

    2015-12-30 13:00:18 [scrapy] WARNING: Received more bytes than download warn size (1000) in request <GET https://codeload.github.com/aron-bordin/Android-Tutorials/zip/master>.
