### PR TITLE
Append like behavior to item on different callbacks

### DIFF
--- a/scrapy/loader/__init__.py
+++ b/scrapy/loader/__init__.py
@@ -41,10 +41,10 @@ class CompoundItem(MutableMapping):
             del self.item[key]
 
     def __iter__(self):
-        return iter(set(self.external_item.keys()) | set(self.item.keys()))
+        return self.item.__iter__()
 
     def __len__(self):
-        return len(list(self.__iter__()))
+        return self.item.__len__()
 
 
 class ItemLoader(object):

--- a/scrapy/loader/__init__.py
+++ b/scrapy/loader/__init__.py
@@ -114,8 +114,10 @@ class ItemLoader(object):
         for field_name in tuple(self._values):
             value = self.get_output_value(field_name)
             if value is not None:
-                item[field_name] = value
-
+                if item.get(field_name) and isinstance(item[field_name], list):
+                    item[field_name] += value
+                else:
+                    item[field_name] = value
         return item
 
     def get_output_value(self, field_name):

--- a/scrapy/loader/__init__.py
+++ b/scrapy/loader/__init__.py
@@ -34,7 +34,7 @@ class ItemLoader(object):
         self.context = context
         self.parent = parent
         self._local_item = context['item'] = item
-        self._local_values = defaultdict(list)
+        self._local_values = defaultdict(list, item)
 
     @property
     def _values(self):
@@ -114,10 +114,7 @@ class ItemLoader(object):
         for field_name in tuple(self._values):
             value = self.get_output_value(field_name)
             if value is not None:
-                if item.get(field_name) and isinstance(item[field_name], list):
-                    item[field_name] += value
-                else:
-                    item[field_name] = value
+                item[field_name] = value
         return item
 
     def get_output_value(self, field_name):

--- a/scrapy/loader/__init__.py
+++ b/scrapy/loader/__init__.py
@@ -35,7 +35,7 @@ class ItemLoader(object):
         self.context = context
         self.parent = parent
         self._local_item = context['item'] = item
-        self._local_values = defaultdict(list, copy.deepcopy(item or {}))
+        self._local_values = defaultdict(list, copy.deepcopy(item) or {})
 
     @property
     def _values(self):

--- a/scrapy/loader/__init__.py
+++ b/scrapy/loader/__init__.py
@@ -115,6 +115,7 @@ class ItemLoader(object):
             value = self.get_output_value(field_name)
             if value is not None:
                 item[field_name] = value
+
         return item
 
     def get_output_value(self, field_name):

--- a/scrapy/loader/__init__.py
+++ b/scrapy/loader/__init__.py
@@ -5,6 +5,7 @@ See documentation in docs/topics/loaders.rst
 """
 from collections import defaultdict
 import six
+import copy
 
 from scrapy.item import Item
 from scrapy.selector import Selector
@@ -34,7 +35,7 @@ class ItemLoader(object):
         self.context = context
         self.parent = parent
         self._local_item = context['item'] = item
-        self._local_values = defaultdict(list, item)
+        self._local_values = defaultdict(list, copy.deepcopy(item or {}))
 
     @property
     def _values(self):
@@ -122,10 +123,10 @@ class ItemLoader(object):
         proc = self.get_output_processor(field_name)
         proc = wrap_loader_context(proc, self.context)
         try:
-            return proc(self._values[field_name])
+            return proc(self.get_collected_values(field_name))
         except Exception as e:
             raise ValueError("Error with output processor: field=%r value=%r error='%s: %s'" % \
-                (field_name, self._values[field_name], type(e).__name__, str(e)))
+                (field_name, self.get_collected_values(field_name), type(e).__name__, str(e)))
 
     def get_collected_values(self, field_name):
         return self._values[field_name]

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -248,8 +248,9 @@ class BasicItemLoaderTest(unittest.TestCase):
         i['summary'] = u'lala'
 
         output = []
+        item = i
         for times in range(10):
-            il = DefaultedItemLoader(item=i)
+            il = DefaultedItemLoader(item=item)
             il.add_value('name', u'lolo')
             output.append(u'lol')
             item = il.load_item()

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -210,6 +210,24 @@ class BasicItemLoaderTest(unittest.TestCase):
         il.add_value('name', u'marta')
         self.assertEqual(il.get_output_value('name'), [u'mart'])
 
+    def test_load_item_using_default_loader_and_replace(self):
+        i = TestItem()
+        i['summary'] = u'lala'
+        il = ItemLoader(item=i)
+        il.add_value('name', u'marta')
+        item = il.load_item()
+
+        assert item is i
+        self.assertEqual(item['summary'], u'lala')
+        self.assertEqual(item['name'], [u'marta'])
+
+        il.replace_value('summary', u'lolo')
+        self.assertEqual(il.get_output_value('summary'), [u'lolo'])
+
+        item = il.load_item()
+        assert item is i
+        self.assertEqual(item['summary'], [u'lolo'])
+
     def test_load_item_and_replace_from_previous_item(self):
         il1 = DefaultedItemLoader()
         il1.add_value('name', u'marta')

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -222,7 +222,7 @@ class BasicItemLoaderTest(unittest.TestCase):
         il1.add_value('name', u'marta')
 
         il2 = DefaultedItemLoader(item=il1.load_item())
-        self.assertEqual(il2.get_output_value('name'), [])
+        self.assertEqual(il2.get_output_value('name'), [u'mart'])
         self.assertEqual(il2.load_item()['name'], [u'mart'])
 
     def test_load_item_from_previous_item_adding_more_values(self):
@@ -231,18 +231,31 @@ class BasicItemLoaderTest(unittest.TestCase):
 
         il2 = DefaultedItemLoader(item=il1.load_item())
         il2.add_value('name', u'maria')
-        self.assertEqual(il2.get_output_value('name'), [u'mari'])
+        self.assertEqual(il2.get_output_value('name'), [u'mart', u'mari'])
         self.assertEqual(il2.load_item()['name'], [u'mart', u'mari'])
 
     def test_load_item_from_previous_item_adding_item_without_field_type(self):
         il1 = DefaultedItemLoader()
         il1.add_value('name', u'marta')
 
-        item = il1.load_item()
-        il2 = DefaultedItemLoader(item=item)
-        il2.add_value(None, item)
-        self.assertEqual(il2.get_output_value('name'), [u'mar'])
+        il2 = DefaultedItemLoader(item=il1.load_item())
+        il2.add_value(None, il1.load_item())
+        self.assertEqual(il2.get_output_value('name'), [u'mart', u'mar'])
         self.assertEqual(il2.load_item()['name'], [u'mart', u'mar'])
+
+    def test_load_item_with_multiple_additions_on_same_field(self):
+        i = TestItem()
+        i['summary'] = u'lala'
+
+        output = []
+        for times in range(10):
+            il = DefaultedItemLoader(item=i)
+            il.add_value('name', u'lolo')
+            output.append(u'lol')
+            item = il.load_item()
+            assert item is i
+            self.assertEqual(item['summary'], u'lala')
+            self.assertEqual(item['name'], output)
 
     def test_inherited_default_input_processor(self):
         class InheritDefaultedItemLoader(DefaultedItemLoader):

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -210,6 +210,15 @@ class BasicItemLoaderTest(unittest.TestCase):
         il.add_value('name', u'marta')
         self.assertEqual(il.get_output_value('name'), [u'mart'])
 
+    def test_load_item_and_replace_from_previous_item(self):
+        il1 = DefaultedItemLoader()
+        il1.add_value('name', u'marta')
+
+        il2 = DefaultedItemLoader(item=il1.load_item())
+        il2.replace_value('name', u'pedro')
+        self.assertEqual(il2.get_output_value('name'), [u'pedr'])
+        self.assertEqual(il2.load_item()['name'], [u'pedr'])
+
     def test_load_item_and_output_value_from_previous_item(self):
         il1 = DefaultedItemLoader()
         il1.add_value('name', u'marta')

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -210,14 +210,7 @@ class BasicItemLoaderTest(unittest.TestCase):
         il.add_value('name', u'marta')
         self.assertEqual(il.get_output_value('name'), [u'mart'])
 
-    def test_load_item_from_previous_item(self):
-        il1 = DefaultedItemLoader()
-        il1.add_value('name', u'marta')
-
-        il2 = DefaultedItemLoader(item=il1.load_item())
-        self.assertEqual(il2.load_item()['name'], [u'mart'])
-
-    def test_load_item_from_previous_item_with_no_output_value(self):
+    def test_load_item_and_output_value_from_previous_item(self):
         il1 = DefaultedItemLoader()
         il1.add_value('name', u'marta')
 

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -210,6 +210,40 @@ class BasicItemLoaderTest(unittest.TestCase):
         il.add_value('name', u'marta')
         self.assertEqual(il.get_output_value('name'), [u'mart'])
 
+    def test_load_item_from_previous_item(self):
+        il1 = DefaultedItemLoader()
+        il1.add_value('name', u'marta')
+
+        il2 = DefaultedItemLoader(item=il1.load_item())
+        self.assertEqual(il2.load_item()['name'], [u'mart'])
+
+    def test_load_item_from_previous_item_with_no_output_value(self):
+        il1 = DefaultedItemLoader()
+        il1.add_value('name', u'marta')
+
+        il2 = DefaultedItemLoader(item=il1.load_item())
+        self.assertEqual(il2.get_output_value('name'), [])
+        self.assertEqual(il2.load_item()['name'], [u'mart'])
+
+    def test_load_item_from_previous_item_adding_more_values(self):
+        il1 = DefaultedItemLoader()
+        il1.add_value('name', u'marta')
+
+        il2 = DefaultedItemLoader(item=il1.load_item())
+        il2.add_value('name', u'maria')
+        self.assertEqual(il2.get_output_value('name'), [u'mari'])
+        self.assertEqual(il2.load_item()['name'], [u'mart', u'mari'])
+
+    def test_load_item_from_previous_item_adding_item_without_field_type(self):
+        il1 = DefaultedItemLoader()
+        il1.add_value('name', u'marta')
+
+        item = il1.load_item()
+        il2 = DefaultedItemLoader(item=item)
+        il2.add_value(None, item)
+        self.assertEqual(il2.get_output_value('name'), [u'mar'])
+        self.assertEqual(il2.load_item()['name'], [u'mart', u'mar'])
+
     def test_inherited_default_input_processor(self):
         class InheritDefaultedItemLoader(DefaultedItemLoader):
             pass


### PR DESCRIPTION
Allows to add values on different callbacks to the same field of an item using the 'item=' constructor of the ItemLoader class
