### PR TITLE
[MRG+1] Raise minimal twisted version for py3

### DIFF
--- a/requirements-py3.txt
+++ b/requirements-py3.txt
@@ -1,4 +1,4 @@
-Twisted >= 15.1.0
+Twisted >= 15.5.0
 lxml>=3.2.4
 pyOpenSSL>=0.13.1
 cssselect>=0.9


### PR DESCRIPTION
This is the latest Twisted release. There is no point in trying to check if it can be made lower, yes?