### PR TITLE
[MRG+1] py3: fix test_mail

### DIFF
--- a/tests/py3-ignores.txt
+++ b/tests/py3-ignores.txt
@@ -1,6 +1,5 @@
 tests/test_exporters.py
 tests/test_linkextractors_deprecated.py
-tests/test_mail.py
 tests/test_pipeline_files.py
 tests/test_pipeline_images.py
 tests/test_proxy_connect.py
@@ -22,4 +21,3 @@ scrapy/linkextractors/htmlparser.py
 scrapy/downloadermiddlewares/cookies.py
 scrapy/extensions/statsmailer.py
 scrapy/extensions/memusage.py
-scrapy/mail.py

--- a/tests/test_mail.py
+++ b/tests/test_mail.py
@@ -53,8 +53,8 @@ class MailSenderTest(unittest.TestCase):
         self.assertEqual(len(payload), 2)
 
         text, attach = payload
-        self.assertEqual(text.get_payload(decode=True), 'body')
-        self.assertEqual(attach.get_payload(decode=True), 'content')
+        self.assertEqual(text.get_payload(decode=True), b'body')
+        self.assertEqual(attach.get_payload(decode=True), b'content')
 
     def _catch_mail_sent(self, **kwargs):
         self.catched_msg = dict(**kwargs)


### PR DESCRIPTION
Here are py3 docs for Message.get_payload https://docs.python.org/3/library/email.message.html#email.message.Message.get_payload - it returns bytes when decode is True.