### PR TITLE
[MRG+1] deprecated unused and untested code in scrapy.utils.datatypes

### DIFF
--- a/scrapy/utils/datatypes.py
+++ b/scrapy/utils/datatypes.py
@@ -137,10 +137,18 @@ class MultiValueDict(dict):
         for key, value in six.iteritems(kwargs):
             self.setlistdefault(key, []).append(value)
 
+
 class SiteNode(object):
     """Class to represent a site node (page, image or any other file)"""
 
     def __init__(self, url):
+        warnings.warn(
+            "scrapy.utils.datatypes.SiteNode is deprecated "
+            "and will be removed in future releases.",
+            category=ScrapyDeprecationWarning,
+            stacklevel=2
+        )
+
         self.url = url
         self.itemnames = []
         self.children = []

--- a/scrapy/utils/datatypes.py
+++ b/scrapy/utils/datatypes.py
@@ -7,11 +7,22 @@ This module must not depend on any module outside the Standard Library.
 
 import copy
 import six
+import warnings
 from collections import OrderedDict
+
+from scrapy.exceptions import ScrapyDeprecationWarning
 
 
 class MultiValueDictKeyError(KeyError):
-    pass
+    def __init__(self, *args, **kwargs):
+        warnings.warn(
+            "scrapy.utils.datatypes.MultiValueDictKeyError is deprecated "
+            "and will be removed in future releases.",
+            category=ScrapyDeprecationWarning,
+            stacklevel=2
+        )
+        super(MultiValueDictKeyError, self).__init__(*args, **kwargs)
+
 
 class MultiValueDict(dict):
     """
@@ -31,6 +42,10 @@ class MultiValueDict(dict):
     single name-value pairs.
     """
     def __init__(self, key_to_list_mapping=()):
+        warnings.warn("scrapy.utils.datatypes.MultiValueDict is deprecated "
+                      "and will be removed in future releases.",
+                      category=ScrapyDeprecationWarning,
+                      stacklevel=2)
         dict.__init__(self, key_to_list_mapping)
 
     def __repr__(self):


### PR DESCRIPTION
Hey,

It seems we have some dead code in scrapy.utils.datatypes: https://codecov.io/github/scrapy/scrapy/scrapy/utils/datatypes.py?ref=b20463183c6ae39f1e0f84fe0b5abbe4b2db44c2 - MultiValueDict and SiteNode are untested and not used by scrapy itself. I checked our internal codebase and haven't found a single usage of these classes; I also checked github briefly, and haven't found it either.

MultiValueDict looks like an unmaintained copy-paste of django code; I have no idea what is SiteNode origin.