### PR TITLE
[MRG+1] Fix logging of enabled middlewares

### DIFF
--- a/scrapy/middleware.py
+++ b/scrapy/middleware.py
@@ -44,9 +44,11 @@ class MiddlewareManager(object):
                     logger.warning("Disabled %(clsname)s: %(eargs)s",
                                    {'clsname': clsname, 'eargs': e.args[0]},
                                    extra={'crawler': crawler})
+
+        enabled = [x.__class__.__name__ for x in middlewares]
         logger.info("Enabled %(componentname)ss:\n%(enabledlist)s",
                     {'componentname': cls.component_name,
-                     'enabledlist': pprint.pformat(mwlist)},
+                     'enabledlist': pprint.pformat(enabled)},
                     extra={'crawler': crawler})
         return cls(*middlewares)
 


### PR DESCRIPTION
Wrong middlewares list was being pretty-printed
(introduced in #1263)

I noticed this while trying to disabled `CloseSpider`, it was still appearing in `scrapy shell`

Before (current `master` branch)
```
2016-01-26 12:44:20 [scrapy] INFO: Enabled extensions:
['scrapy.extensions.closespider.CloseSpider',
 'scrapy.extensions.feedexport.FeedExporter',
 'scrapy.extensions.memdebug.MemoryDebugger',
 'scrapy.extensions.memusage.MemoryUsage',
 'scrapy.extensions.logstats.LogStats',
 'scrapy.extensions.telnet.TelnetConsole',
 'scrapy.extensions.corestats.CoreStats',
 'scrapy.extensions.spiderstate.SpiderState',
 'scrapy.extensions.throttle.AutoThrottle']
```

With this fix, it now shows like this:

```
2016-01-26 12:54:53 [scrapy] INFO: Enabled extensions:
['scrapy.extensions.telnet.TelnetConsole',
 'scrapy.extensions.corestats.CoreStats',
 'scrapy.extensions.spiderstate.SpiderState']
```