### PR TITLE
Use long classes names for enabled middlewares in startup logs

### DIFF
--- a/scrapy/middleware.py
+++ b/scrapy/middleware.py
@@ -28,6 +28,7 @@ class MiddlewareManager(object):
     def from_settings(cls, settings, crawler=None):
         mwlist = cls._get_mwlist_from_settings(settings)
         middlewares = []
+        enabled = []
         for clspath in mwlist:
             try:
                 mwcls = load_object(clspath)
@@ -38,6 +39,7 @@ class MiddlewareManager(object):
                 else:
                     mw = mwcls()
                 middlewares.append(mw)
+                enabled.append(clspath)
             except NotConfigured as e:
                 if e.args:
                     clsname = clspath.split('.')[-1]
@@ -45,7 +47,6 @@ class MiddlewareManager(object):
                                    {'clsname': clsname, 'eargs': e.args[0]},
                                    extra={'crawler': crawler})
 
-        enabled = [x.__class__.__name__ for x in middlewares]
         logger.info("Enabled %(componentname)ss:\n%(enabledlist)s",
                     {'componentname': cls.component_name,
                      'enabledlist': pprint.pformat(enabled)},


### PR DESCRIPTION
Continuation of https://github.com/scrapy/scrapy/pull/1722