### PR TITLE
[MRG+1] Fix PythonItemExporter and CSVExporter for non-string item types

### DIFF
--- a/scrapy/exporters.py
+++ b/scrapy/exporters.py
@@ -200,7 +200,7 @@ class CsvItemExporter(BaseItemExporter):
             try:
                 yield to_native_str(s)
             except TypeError:
-                yield to_native_str(repr(s))
+                yield to_native_str(str(s))
 
     def _write_headers_and_set_fields_to_export(self, item):
         if self.include_headers_line:

--- a/scrapy/exporters.py
+++ b/scrapy/exporters.py
@@ -200,7 +200,7 @@ class CsvItemExporter(BaseItemExporter):
             try:
                 yield to_native_str(s)
             except TypeError:
-                yield to_native_str(str(s))
+                yield s
 
     def _write_headers_and_set_fields_to_export(self, item):
         if self.include_headers_line:

--- a/scrapy/exporters.py
+++ b/scrapy/exporters.py
@@ -273,10 +273,10 @@ class PythonItemExporter(BaseItemExporter):
             return dict(self._serialize_dict(value))
         if is_listlike(value):
             return [self._serialize_value(v) for v in value]
-        if self.binary:
-            return to_bytes(value, encoding=self.encoding)
-        else:
-            return to_unicode(value, encoding=self.encoding)
+        encode_func = to_bytes if self.binary else to_unicode
+        if isinstance(value, (six.text_type, bytes)):
+            return encode_func(value, encoding=self.encoding)
+        return value
 
     def _serialize_dict(self, value):
         for key, val in six.iteritems(value):

--- a/tests/test_exporters.py
+++ b/tests/test_exporters.py
@@ -271,6 +271,21 @@ class CsvItemExporterTest(BaseItemExporterTest):
             expected='"[4, 8]",John\r\n',
         )
 
+    def test_other_python_types_item(self):
+        from datetime import datetime
+        now = datetime(2015, 1, 1, 1, 1, 1)
+        item = {
+            'boolean': False,
+            'number': 22,
+            'time': now,
+            'float': 3.14,
+        }
+        self.assertExportResult(
+            item=item,
+            include_headers_line=False,
+            expected='22,False,3.14,2015-01-01 01:01:01\r\n'
+        )
+
 
 class XmlItemExporterTest(BaseItemExporterTest):
 

--- a/tests/test_exporters.py
+++ b/tests/test_exporters.py
@@ -134,6 +134,19 @@ class PythonItemExporterTest(BaseItemExporterTest):
         expected = {b'name': b'John\xc2\xa3', b'age': b'22'}
         self.assertEqual(expected, exporter.export_item(value))
 
+    def test_other_python_types_item(self):
+        from datetime import datetime
+        now = datetime.now()
+        item = {
+            'boolean': False,
+            'number': 22,
+            'time': now,
+            'float': 3.14,
+        }
+        ie = self._get_exporter()
+        exported = ie.export_item(item)
+        self.assertEqual(exported, item)
+
 
 class PprintItemExporterTest(BaseItemExporterTest):
 


### PR DESCRIPTION
This PR fixes the error related to PythonItemExporter with non-string types reported here: https://github.com/scrapy/scrapy/commit/c76190d491fca9f35b6758bdc06c34d77f5d9be9#commitcomment-15693798.

It also fixes how CSVItemExporter represents non-string datatypes in CSV.

Instead of generating this (for a datetime object):
   ```2,True,False,2015-01-01 01:01:01```

It was generating this:
    ```True,2,False,"datetime.datetime(2015, 1, 1, 1, 1, 1)"```
