### PR TITLE
[MRG+1] PY3 fix downloader slots GC

### DIFF
--- a/scrapy/core/downloader/__init__.py
+++ b/scrapy/core/downloader/__init__.py
@@ -194,6 +194,6 @@ class Downloader(object):
 
     def _slot_gc(self, age=60):
         mintime = time() - age
-        for key, slot in self.slots.items():
+        for key, slot in list(self.slots.items()):
             if not slot.active and slot.lastseen + slot.delay < mintime:
                 self.slots.pop(key).close()


### PR DESCRIPTION
I'm getting this error without a fix:

```
2016-01-28 02:54:17 [twisted] CRITICAL: Unhandled error in Deferred:


Traceback (most recent call last):
  File "/Users/kmike/envs/dl/lib/python3.5/site-packages/Twisted-15.5.0-py3.5.egg/twisted/internet/base.py", line 1194, in run
    self.mainLoop()
  File "/Users/kmike/envs/dl/lib/python3.5/site-packages/Twisted-15.5.0-py3.5.egg/twisted/internet/base.py", line 1203, in mainLoop
    self.runUntilCurrent()
  File "/Users/kmike/envs/dl/lib/python3.5/site-packages/Twisted-15.5.0-py3.5.egg/twisted/internet/base.py", line 825, in runUntilCurrent
    call.func(*call.args, **call.kw)
  File "/Users/kmike/envs/dl/lib/python3.5/site-packages/Twisted-15.5.0-py3.5.egg/twisted/internet/task.py", line 213, in __call__
    d = defer.maybeDeferred(self.f, *self.a, **self.kw)
--- <exception caught here> ---
  File "/Users/kmike/envs/dl/lib/python3.5/site-packages/Twisted-15.5.0-py3.5.egg/twisted/internet/defer.py", line 150, in maybeDeferred
    result = f(*args, **kw)
  File "/Users/kmike/svn/scrapy/scrapy/core/downloader/__init__.py", line 197, in _slot_gc
    for key, slot in self.slots.items():
builtins.RuntimeError: dictionary changed size during iteration
```