### PR TITLE
[MRG+1] Fix bug on XMLItemExporter with non-string fields in items

### DIFF
--- a/scrapy/exporters.py
+++ b/scrapy/exporters.py
@@ -144,8 +144,10 @@ class XmlItemExporter(BaseItemExporter):
         elif is_listlike(serialized_value):
             for value in serialized_value:
                 self._export_xml_field('value', value)
-        else:
+        elif isinstance(serialized_value, six.text_type):
             self._xg_characters(serialized_value)
+        else:
+            self._xg_characters(str(serialized_value))
         self.xg.endElement(name)
 
     # Workaround for http://bugs.python.org/issue17606

--- a/tests/test_exporters.py
+++ b/tests/test_exporters.py
@@ -376,6 +376,20 @@ class XmlItemExporterTest(BaseItemExporterTest):
             b'</items>'
         )
 
+    def test_nonstring_types_item(self):
+        item = self._get_nonstring_types_item()
+        self.assertExportResult(item,
+            b'<?xml version="1.0" encoding="utf-8"?>\n'
+            b'<items>'
+               b'<item>'
+                   b'<float>3.14</float>'
+                   b'<boolean>False</boolean>'
+                   b'<number>22</number>'
+                   b'<time>2015-01-01 01:01:01</time>'
+               b'</item>'
+            b'</items>'
+        )
+
 
 class JsonLinesItemExporterTest(BaseItemExporterTest):
 


### PR DESCRIPTION
This PR fixes https://github.com/scrapy/scrapy/issues/1738