### PR TITLE
[MRG+1] PY3 fixed CrawlerRunner.stop

### DIFF
--- a/scrapy/crawler.py
+++ b/scrapy/crawler.py
@@ -189,7 +189,7 @@ class CrawlerRunner(object):
 
         Returns a deferred that is fired when they all have ended.
         """
-        return defer.DeferredList([c.stop() for c in self.crawlers])
+        return defer.DeferredList([c.stop() for c in list(self.crawlers)])
 
     @defer.inlineCallbacks
     def join(self):


### PR DESCRIPTION
I'm not sure why (probably `stop` method removes crawler from self.crawlers), but in Python 3 existing code sometimes raises the following error at shutdown:

```
2016-02-03 00:58:57 [twisted] CRITICAL: Unhandled Error
Traceback (most recent call last):
  File "/Users/kmike/svn/scrapy/scrapy/commands/crawl.py", line 58, in run
    self.crawler_process.start()
  File "/Users/kmike/svn/scrapy/scrapy/crawler.py", line 269, in start
    reactor.run(installSignalHandlers=False)  # blocking call
  File "/Users/kmike/envs/dl/lib/python3.5/site-packages/Twisted-15.5.0-py3.5.egg/twisted/internet/base.py", line 1194, in run
    self.mainLoop()
  File "/Users/kmike/envs/dl/lib/python3.5/site-packages/Twisted-15.5.0-py3.5.egg/twisted/internet/base.py", line 1203, in mainLoop
    self.runUntilCurrent()
--- <exception caught here> ---
  File "/Users/kmike/envs/dl/lib/python3.5/site-packages/Twisted-15.5.0-py3.5.egg/twisted/internet/base.py", line 798, in runUntilCurrent
    f(*a, **kw)
  File "/Users/kmike/svn/scrapy/scrapy/crawler.py", line 283, in _graceful_stop_reactor
    d = self.stop()
  File "/Users/kmike/svn/scrapy/scrapy/crawler.py", line 192, in stop
    return defer.DeferredList([c.stop() for c in self.crawlers])
  File "/Users/kmike/svn/scrapy/scrapy/crawler.py", line 192, in <listcomp>
    return defer.DeferredList([c.stop() for c in self.crawlers])
builtins.RuntimeError: Set changed size during iteration
```

I've got these errors when there is an unhandled exception in Scheduler. I haven't checked that Python 2.x doesn't raise the same exception.