### PR TITLE
Py3: port s3 downloaders

### DIFF
--- a/scrapy/core/downloader/handlers/s3.py
+++ b/scrapy/core/downloader/handlers/s3.py
@@ -2,6 +2,8 @@ from six.moves.urllib.parse import unquote
 
 from scrapy.exceptions import NotConfigured
 from scrapy.utils.httpobj import urlparse_cached
+from scrapy.utils.datatypes import CaselessDict
+from scrapy.utils.python import to_unicode
 from .http import HTTPDownloadHandler
 
 
@@ -19,7 +21,9 @@ def get_s3_connection():
     class _v20_S3Connection(S3Connection):
         """A dummy S3Connection wrapper that doesn't do any synchronous download"""
         def _mexe(self, http_request, *args, **kwargs):
-            http_request._headers_quoted = True  # FIXME - hack hack
+            # Py3 fix: headers are already converted to ascii in
+            # S3DownloadHandler.download_request
+            http_request._headers_quoted = True
             http_request.authorize(connection=self)
             return http_request.headers
 
@@ -66,15 +70,30 @@ class S3DownloadHandler(object):
         bucket = p.hostname
         path = p.path + '?' + p.query if p.query else p.path
         url = '%s://%s.s3.amazonaws.com%s' % (scheme, bucket, path)
+        # boto headers are different from scrapy headers:
+        # they expect unicode keys and values in python 3 and do not handle
+        # multiple values.
+        headers_to_sign = CaselessDict()
+        for key, values in request.headers.items():
+            value = b','.join(values)
+            try:
+                value = to_unicode(value, encoding='ascii')
+                key = to_unicode(key, encoding='ascii')
+            except UnicodeDecodeError:
+                pass  # safe to skip as there are no non-ascii headers to sign
+            else:
+                headers_to_sign[key] = value
         signed_headers = self.conn.make_request(
                 method=request.method,
                 bucket=bucket,
                 key=unquote(p.path),
                 query_args=unquote(p.query),
-                headers={ # FIXME - encoding, multiple values
-                    k.decode('utf-8'): vs[0].decode('utf-8')
-                    for k, vs in request.headers.items()},
-               #headers=request.headers,
+                headers=headers_to_sign,
                 data=request.body)
-        httpreq = request.replace(url=url, headers=signed_headers)
+        headers = request.headers.copy()
+        # Copy values changed in signed_headers.
+        for k, v in signed_headers.items():
+            if v != headers_to_sign.get(k):
+                headers[k] = v
+        httpreq = request.replace(url=url, headers=headers)
         return self._download_http(httpreq, spider)

--- a/scrapy/core/downloader/handlers/s3.py
+++ b/scrapy/core/downloader/handlers/s3.py
@@ -19,6 +19,7 @@ def get_s3_connection():
     class _v20_S3Connection(S3Connection):
         """A dummy S3Connection wrapper that doesn't do any synchronous download"""
         def _mexe(self, http_request, *args, **kwargs):
+            http_request._headers_quoted = True  # FIXME - hack hack
             http_request.authorize(connection=self)
             return http_request.headers
 
@@ -70,7 +71,10 @@ class S3DownloadHandler(object):
                 bucket=bucket,
                 key=unquote(p.path),
                 query_args=unquote(p.query),
-                headers=request.headers,
+                headers={ # FIXME - encoding, multiple values
+                    k.decode('utf-8'): vs[0].decode('utf-8')
+                    for k, vs in request.headers.items()},
+               #headers=request.headers,
                 data=request.body)
         httpreq = request.replace(url=url, headers=signed_headers)
         return self._download_http(httpreq, spider)

--- a/tests/py3-ignores.txt
+++ b/tests/py3-ignores.txt
@@ -7,7 +7,6 @@ scrapy/xlib/tx/endpoints.py
 scrapy/xlib/tx/client.py
 scrapy/xlib/tx/_newclient.py
 scrapy/xlib/tx/__init__.py
-scrapy/core/downloader/handlers/s3.py
 scrapy/core/downloader/handlers/ftp.py
 scrapy/linkextractors/sgml.py
 scrapy/linkextractors/regex.py

--- a/tests/test_downloader_handlers.py
+++ b/tests/test_downloader_handlers.py
@@ -484,7 +484,7 @@ class S3TestCase(unittest.TestCase):
                 headers={'Date': 'Tue, 27 Mar 2007 19:36:42 +0000'})
         httpreq = self.download_request(req, self.spider)
         self.assertEqual(httpreq.headers['Authorization'], \
-                'AWS 0PN5J17HBGZHT7JJ3X82:xXjDGYUmKxnwqr5KXNPGldn5LbA=')
+                b'AWS 0PN5J17HBGZHT7JJ3X82:xXjDGYUmKxnwqr5KXNPGldn5LbA=')
 
     def test_request_signing2(self):
         # puts an object into the johnsmith bucket.
@@ -495,7 +495,7 @@ class S3TestCase(unittest.TestCase):
             })
         httpreq = self.download_request(req, self.spider)
         self.assertEqual(httpreq.headers['Authorization'], \
-                'AWS 0PN5J17HBGZHT7JJ3X82:hcicpDDvL9SsO6AkvxqmIWkmOuQ=')
+                b'AWS 0PN5J17HBGZHT7JJ3X82:hcicpDDvL9SsO6AkvxqmIWkmOuQ=')
 
     def test_request_signing3(self):
         # lists the content of the johnsmith bucket.
@@ -506,7 +506,7 @@ class S3TestCase(unittest.TestCase):
                     })
         httpreq = self.download_request(req, self.spider)
         self.assertEqual(httpreq.headers['Authorization'], \
-                'AWS 0PN5J17HBGZHT7JJ3X82:jsRt/rhG+Vtp88HrYL706QhE4w4=')
+                b'AWS 0PN5J17HBGZHT7JJ3X82:jsRt/rhG+Vtp88HrYL706QhE4w4=')
 
     def test_request_signing4(self):
         # fetches the access control policy sub-resource for the 'johnsmith' bucket.
@@ -514,7 +514,7 @@ class S3TestCase(unittest.TestCase):
                 method='GET', headers={'Date': 'Tue, 27 Mar 2007 19:44:46 +0000'})
         httpreq = self.download_request(req, self.spider)
         self.assertEqual(httpreq.headers['Authorization'], \
-                'AWS 0PN5J17HBGZHT7JJ3X82:thdUi9VAkzhkniLj96JIrOPGi0g=')
+                b'AWS 0PN5J17HBGZHT7JJ3X82:thdUi9VAkzhkniLj96JIrOPGi0g=')
 
     def test_request_signing5(self):
         # deletes an object from the 'johnsmith' bucket using the
@@ -526,7 +526,7 @@ class S3TestCase(unittest.TestCase):
                     })
         httpreq = self.download_request(req, self.spider)
         self.assertEqual(httpreq.headers['Authorization'], \
-                'AWS 0PN5J17HBGZHT7JJ3X82:k3nL7gH3+PadhTEVn5Ip83xlYzk=')
+                b'AWS 0PN5J17HBGZHT7JJ3X82:k3nL7gH3+PadhTEVn5Ip83xlYzk=')
 
     def test_request_signing6(self):
         # uploads an object to a CNAME style virtual hosted bucket with metadata.
@@ -547,7 +547,7 @@ class S3TestCase(unittest.TestCase):
                     })
         httpreq = self.download_request(req, self.spider)
         self.assertEqual(httpreq.headers['Authorization'], \
-                'AWS 0PN5J17HBGZHT7JJ3X82:C0FlOtU8Ylb9KDTpZqYkZPX91iI=')
+                b'AWS 0PN5J17HBGZHT7JJ3X82:C0FlOtU8Ylb9KDTpZqYkZPX91iI=')
 
     def test_request_signing7(self):
         # ensure that spaces are quoted properly before signing
@@ -561,7 +561,7 @@ class S3TestCase(unittest.TestCase):
         httpreq = self.download_request(req, self.spider)
         self.assertEqual(
             httpreq.headers['Authorization'],
-            'AWS 0PN5J17HBGZHT7JJ3X82:+CfvG8EZ3YccOrRVMXNaK2eKZmM=')
+            b'AWS 0PN5J17HBGZHT7JJ3X82:+CfvG8EZ3YccOrRVMXNaK2eKZmM=')
 
 
 class FTPTestCase(unittest.TestCase):


### PR DESCRIPTION
This is a little complicated due to the need to fix the way boto handles headers in py3 (more details here #1718). We currently have to pass headers as unicode, but also set ``http_request._headers_quoted = True`` because otherwise boto will escape spaces for unicode values. We known that the headers interesting to boto can all have only ascii values, and discard any other headers - perhaps a more conservative approach would be to use utf-8.
This looks hacky, but the only other option I see is to pull about 100 lines from boto and fix py3 problems in them (while still depending on boto for getting credentials).