### PR TITLE
Fix Windows tests

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,39 @@
+environment:
+  global:
+    LXML_CACHE_DIR: "%APPVEYOR_BUILD_FOLDER%\\lxml-binaries"
+    TOX_TESTENV_PASSENV: "USERNAME"
+  matrix:
+    - PYTHON: "C:\\Python27-x64"
+      TOXENV: "py27-win"
+    - PYTHON: "C:\\Python33-x64"
+      TOXENV: "py33-win"
+    - PYTHON: "C:\\Python35-x64"
+      TOXENV: "py35-win"
+
+version: '{branch}-{build}'
+
+branches:
+  only:
+    - master
+    - /^v\d+\.\d+\.\d+[\w\-]*$/
+
+cache:
+  - '%LXML_CACHE_DIR%'
+
+install:
+  - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
+  - ps: >-
+      If(!(Test-Path $env:LXML_CACHE_DIR)) {
+        Write-Host "Downloading lxml binaries";
+        Start-Process -FilePath "git" -ArgumentList "clone https://gist.github.com/36d27f9b57f6e33bae0d.git $env:LXML_CACHE_DIR" -Wait;
+      } Else {
+        Write-Host "Updating lxml binaries";
+        Start-Process -FilePath "git" -ArgumentList "pull" -WorkingDirectory "$env:LXML_CACHE_DIR" -Wait;
+      }
+  - "python -m pip install tox twine wheel"
+
+build: off
+
+test_script:
+  - "python --version"
+  - "python -m tox"

--- a/conftest.py
+++ b/conftest.py
@@ -2,6 +2,7 @@ import glob
 import six
 import pytest
 from twisted import version as twisted_version
+from twisted.python.runtime import platform
 
 
 def _py_files(folder):
@@ -31,11 +32,16 @@ if (twisted_version.major, twisted_version.minor, twisted_version.micro) >= (15,
     collect_ignore += _py_files("scrapy/xlib/tx")
 
 
-if six.PY3:
-    for line in open('tests/py3-ignores.txt'):
+def load_ignores(filename):
+    for line in open(filename):
         file_path = line.strip()
         if file_path and file_path[0] != '#':
             collect_ignore.append(file_path)
+
+if six.PY3:
+    load_ignores('tests/py3-ignores.txt')
+    if platform.isWindows():
+        load_ignores('tests/py3-win-ignores.txt')
 
 
 @pytest.fixture()

--- a/scrapy/commands/startproject.py
+++ b/scrapy/commands/startproject.py
@@ -68,7 +68,7 @@ class Command(ScrapyCommand):
                 string.Template(path).substitute(project_name=project_name))
             render_templatefile(tplfile, project_name=project_name,
                 ProjectName=string_camelcase(project_name))
-        print("New Scrapy project %r, using template directory %r, created in:" % \
+        print("New Scrapy project '%s', using template directory '%s', created in:" % \
               (project_name, self.templates_dir))
         print("    %s\n" % abspath(project_name))
         print("You can start your first spider with:")

--- a/scrapy/utils/test.py
+++ b/scrapy/utils/test.py
@@ -4,7 +4,9 @@ This module contains some assorted functions used in tests
 
 import os
 
+import six
 from importlib import import_module
+from twisted.python.runtime import platform
 from twisted.trial.unittest import SkipTest
 
 
@@ -50,3 +52,6 @@ def assert_samelines(testcase, text1, text2, msg=None):
     line endings between platforms
     """
     testcase.assertEqual(text1.splitlines(), text2.splitlines(), msg)
+
+def win_and_py3():
+    return platform.isWindows() and six.PY3

--- a/scrapy/utils/testproc.py
+++ b/scrapy/utils/testproc.py
@@ -4,12 +4,17 @@ import os
 
 from twisted.internet import reactor, defer, protocol
 
+from scrapy.utils.test import win_and_py3
+
 
 class ProcessTest(object):
 
     command = None
     prefix = [sys.executable, '-m', 'scrapy.cmdline']
     cwd = os.getcwd()  # trial chdirs to temp dir
+
+    if win_and_py3():
+        skip = "twisted.internet._dumbwin32proc not yet ported"
 
     def execute(self, args, check_code=True, settings=None):
         env = os.environ.copy()

--- a/scrapy/utils/trackref.py
+++ b/scrapy/utils/trackref.py
@@ -10,12 +10,17 @@ alias to object in that case).
 """
 
 from __future__ import print_function
+import platform
+import time
 import weakref
-from time import time
 from operator import itemgetter
 from collections import defaultdict
 import six
 
+if platform.system() == "Windows":
+    make_timestamp = time.clock
+else:
+    make_timestamp = time.time
 
 NoneType = type(None)
 live_refs = defaultdict(weakref.WeakKeyDictionary)
@@ -29,14 +34,14 @@ class object_ref(object):
 
     def __new__(cls, *args, **kwargs):
         obj = object.__new__(cls)
-        live_refs[cls][obj] = time()
+        live_refs[cls][obj] = make_timestamp()
         return obj
 
 
 def format_live_refs(ignore=NoneType):
     """Return a tabular representation of tracked objects"""
     s = "Live References\n\n"
-    now = time()
+    now = make_timestamp()
     for cls, wdict in sorted(six.iteritems(live_refs),
                              key=lambda x: x[0].__name__):
         if not wdict:

--- a/tests/py3-win-ignores.txt
+++ b/tests/py3-win-ignores.txt
@@ -1,0 +1,18 @@
+# Twisted's web client cannot be used on Windows in Py3 because there is no
+# port for twisted.internet._win32stdio (as of 15.5.0)
+
+# Scrapy modules that import webclient
+scrapy/core/downloader/webclient.py
+scrapy/core/downloader/handlers/http.py
+scrapy/core/downloader/handlers/http11.py
+scrapy/downloadermiddlewares/httpcache.py
+scrapy/downloadermiddlewares/retry.py
+
+# Test modules that directly import webclient
+tests/test_downloader_handlers.py
+tests/test_downloadermiddleware_httpcache.py
+tests/test_downloadermiddleware_retry.py
+tests/test_webclient.py
+
+# Test modules that import Scrapy modules that import webclient
+tests/test_downloadermiddleware.py

--- a/tests/test_closespider.py
+++ b/tests/test_closespider.py
@@ -1,11 +1,14 @@
 from twisted.internet import defer
 from twisted.trial.unittest import TestCase
-from scrapy.utils.test import get_crawler
+from scrapy.utils.test import get_crawler, win_and_py3
 from tests.spiders import FollowAllSpider, ItemSpider, ErrorSpider
 from tests.mockserver import MockServer
 
 
 class TestCloseSpider(TestCase):
+
+    if win_and_py3():
+        skip = "twisted.internet._win32stdio not yet ported"
 
     def setUp(self):
         self.mockserver = MockServer()

--- a/tests/test_cmdline/__init__.py
+++ b/tests/test_cmdline/__init__.py
@@ -52,7 +52,8 @@ class CmdlineTest(unittest.TestCase):
             stats.print_stats()
             out.seek(0)
             stats = out.read()
-            self.assertIn('scrapy/commands/version.py', stats)
+            self.assertIn(os.path.join('scrapy', 'commands', 'version.py'),
+                          stats)
             self.assertIn('tottime', stats)
         finally:
             shutil.rmtree(path)

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -13,7 +13,7 @@ from twisted.internet import defer
 
 import scrapy
 from scrapy.utils.python import to_native_str
-from scrapy.utils.test import get_testenv
+from scrapy.utils.test import get_testenv, win_and_py3
 from scrapy.utils.testsite import SiteTest
 from scrapy.utils.testproc import ProcessTest
 
@@ -153,6 +153,9 @@ class MiscCommandsTest(CommandTest):
 class RunSpiderCommandTest(CommandTest):
 
     def test_runspider(self):
+        if win_and_py3():
+            raise unittest.SkipTest("twisted.internet._win32stdio not yet "
+                                    "ported")
         tmpdir = self.mktemp()
         os.mkdir(tmpdir)
         fname = abspath(join(tmpdir, 'myspider.py'))
@@ -263,6 +266,9 @@ ITEM_PIPELINES = {'%s.pipelines.MyPipeline': 1}
 
 
 class BenchCommandTest(CommandTest):
+
+    if win_and_py3():
+        skip = "twisted.internet._win32stdio not yet ported"
 
     def test_run(self):
         _, log = self.proc('bench', '-s', 'LOGSTATS_INTERVAL=0.001',

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -90,7 +90,7 @@ class StartprojectTemplatesTest(ProjectTest):
 
         args = ['--set', 'TEMPLATES_DIR=%s' % self.tmpl]
         out, err = self.proc('startproject', self.project_name, *args)
-        self.assertIn("New Scrapy project %r, using template directory" % self.project_name, out)
+        self.assertIn("New Scrapy project '%s', using template directory" % self.project_name, out)
         self.assertIn(self.tmpl_proj, out)
         assert exists(join(self.proj_path, 'root_template'))
 

--- a/tests/test_crawl.py
+++ b/tests/test_crawl.py
@@ -9,6 +9,7 @@ from twisted.trial.unittest import TestCase
 from scrapy.http import Request
 from scrapy.crawler import CrawlerRunner
 from scrapy.utils.python import to_unicode
+from scrapy.utils.test import win_and_py3
 from tests import mock
 from tests.spiders import FollowAllSpider, DelaySpider, SimpleSpider, \
     BrokenStartRequestsSpider, SingleRequestSpider, DuplicateStartRequestsSpider
@@ -16,6 +17,9 @@ from tests.mockserver import MockServer
 
 
 class CrawlTestCase(TestCase):
+
+    if win_and_py3():
+        skip = "twisted.internet._win32stdio not yet ported"
 
     def setUp(self):
         self.mockserver = MockServer()

--- a/tests/test_downloader_handlers.py
+++ b/tests/test_downloader_handlers.py
@@ -1,5 +1,6 @@
 import os
 import six
+import tempfile
 
 from twisted.trial import unittest
 from twisted.protocols.policies import WrappingFactory
@@ -644,14 +645,15 @@ class FTPTestCase(unittest.TestCase):
         return self._add_test_callbacks(d, _test)
 
     def test_ftp_local_filename(self):
-        local_fname = "/tmp/file.txt"
+        f, local_fname = tempfile.mkstemp()
+        os.close(f)
         request = Request(url="ftp://127.0.0.1:%s/file.txt" % self.portNum,
                 meta={"ftp_user": self.username, "ftp_password": self.password, "ftp_local_filename": local_fname})
         d = self.download_handler.download_request(request, None)
 
         def _test(r):
             self.assertEqual(r.body, local_fname)
-            self.assertEqual(r.headers, {'Local Filename': ['/tmp/file.txt'], 'Size': ['17']})
+            self.assertEqual(r.headers, {'Local Filename': [local_fname], 'Size': ['17']})
             self.assertTrue(os.path.exists(local_fname))
             with open(local_fname) as f:
                 self.assertEqual(f.read(), "I have the power!")

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -20,7 +20,7 @@ from twisted.trial import unittest
 
 from scrapy import signals
 from scrapy.core.engine import ExecutionEngine
-from scrapy.utils.test import get_crawler
+from scrapy.utils.test import get_crawler, win_and_py3
 from pydispatch import dispatcher
 from tests import tests_datadir
 from scrapy.spiders import Spider
@@ -157,6 +157,9 @@ class CrawlerRun(object):
 
 
 class EngineTest(unittest.TestCase):
+
+    if win_and_py3():
+        skip = "twisted.internet._win32stdio not yet ported"
 
     @defer.inlineCallbacks
     def test_crawler(self):

--- a/tests/test_feedexport.py
+++ b/tests/test_feedexport.py
@@ -21,7 +21,7 @@ from scrapy.extensions.feedexport import (
     IFeedStorage, FileFeedStorage, FTPFeedStorage,
     S3FeedStorage, StdoutFeedStorage
 )
-from scrapy.utils.test import assert_aws_environ
+from scrapy.utils.test import assert_aws_environ, win_and_py3
 from scrapy.utils.python import to_native_str
 
 
@@ -120,6 +120,9 @@ class StdoutFeedStorageTest(unittest.TestCase):
 
 
 class FeedExportTest(unittest.TestCase):
+
+    if win_and_py3():
+        skip = "twisted.internet._win32stdio not yet ported"
 
     class MyItem(scrapy.Item):
         foo = scrapy.Field()

--- a/tests/test_feedexport.py
+++ b/tests/test_feedexport.py
@@ -5,7 +5,8 @@ import json
 from io import BytesIO
 import tempfile
 import shutil
-from six.moves.urllib.parse import urlparse
+from six.moves.urllib.parse import urljoin, urlparse
+from six.moves.urllib.request import pathname2url
 
 from zope.interface.verify import verifyObject
 from twisted.trial import unittest
@@ -129,9 +130,10 @@ class FeedExportTest(unittest.TestCase):
     def run_and_export(self, spider_cls, settings=None):
         """ Run spider with specified settings; return exported data. """
         tmpdir = tempfile.mkdtemp()
-        res_name = tmpdir + '/res'
+        res_path = os.path.join(tmpdir, 'res')
+        res_uri = urljoin('file:', pathname2url(res_path))
         defaults = {
-            'FEED_URI': 'file://' + res_name,
+            'FEED_URI': res_uri,
             'FEED_FORMAT': 'csv',
         }
         defaults.update(settings or {})
@@ -140,7 +142,7 @@ class FeedExportTest(unittest.TestCase):
                 runner = CrawlerRunner(Settings(defaults))
                 yield runner.crawl(spider_cls)
 
-            with open(res_name, 'rb') as f:
+            with open(res_path, 'rb') as f:
                 defer.returnValue(f.read())
 
         finally:

--- a/tests/test_spidermiddleware_httperror.py
+++ b/tests/test_spidermiddleware_httperror.py
@@ -4,7 +4,7 @@ from testfixtures import LogCapture
 from twisted.trial.unittest import TestCase as TrialTestCase
 from twisted.internet import defer
 
-from scrapy.utils.test import get_crawler
+from scrapy.utils.test import get_crawler, win_and_py3
 from tests.mockserver import MockServer
 from scrapy.http import Response, Request
 from scrapy.spiders import Spider
@@ -157,6 +157,10 @@ class TestHttpErrorMiddlewareHandleAll(TestCase):
 
 
 class TestHttpErrorMiddlewareIntegrational(TrialTestCase):
+
+    if win_and_py3():
+        skip = "twisted.internet._win32stdio not yet ported"
+
     def setUp(self):
         self.mockserver = MockServer()
         self.mockserver.__enter__()

--- a/tests/test_utils_iterators.py
+++ b/tests/test_utils_iterators.py
@@ -7,7 +7,7 @@ from scrapy.utils.iterators import csviter, xmliter, _body_or_str, xmliter_lxml
 from scrapy.http import XmlResponse, TextResponse, Response
 from tests import get_testdata
 
-FOOBAR_NL = u"foo" + os.linesep + u"bar"
+FOOBAR_NL = u"foo\nbar"
 
 
 class XmliterTestCase(unittest.TestCase):

--- a/tests/test_webclient.py
+++ b/tests/test_webclient.py
@@ -3,6 +3,7 @@ from twisted.internet import defer
 Tests borrowed from the twisted.web.client tests.
 """
 import os
+import shutil
 import six
 from six.moves.urllib.parse import urlparse
 
@@ -230,6 +231,7 @@ class WebClientTestCase(unittest.TestCase):
 
     def setUp(self):
         name = self.mktemp()
+        self.tmpdir_name = name
         os.mkdir(name)
         FilePath(name).child("file").setContent(b"0123456789")
         r = static.File(name)
@@ -247,6 +249,7 @@ class WebClientTestCase(unittest.TestCase):
         self.portno = self.port.getHost().port
 
     def tearDown(self):
+        shutil.rmtree(self.tmpdir_name)
         return self.port.stopListening()
 
     def getURL(self, path):
@@ -351,15 +354,15 @@ class WebClientTestCase(unittest.TestCase):
                 b'    </head>\n    <body bgcolor="#FFFFFF" text="#000000">\n    '
                 b'<a href="/file">click here</a>\n    </body>\n</html>\n')
 
-    def test_Encoding(self):
+    def test_encoding(self):
         """ Test that non-standart body encoding matches
         Content-Encoding header """
         body = b'\xd0\x81\xd1\x8e\xd0\xaf'
         return getPage(
             self.getURL('encoding'), body=body, response_transform=lambda r: r)\
-            .addCallback(self._check_Encoding, body)
+            .addCallback(self._check_encoding, body)
 
-    def _check_Encoding(self, response, original_body):
+    def _check_encoding(self, response, original_body):
         content_encoding = to_unicode(response.headers[b'Content-Encoding'])
         self.assertEquals(content_encoding, EncodingResource.out_encoding)
         self.assertEquals(

--- a/tox.ini
+++ b/tox.ini
@@ -52,6 +52,60 @@ deps = {[testenv:py33]deps}
 basepython = python3.5
 deps = {[testenv:py33]deps}
 
+[testenv:py27-win]
+deps =
+    # Specific to Windows
+    pypiwin32
+    lxml-binaries/lxml-3.5.0-cp27-none-win32.whl
+    # Copied from requirements.txt (except lxml)
+    Twisted>=10.0.0
+    pyOpenSSL
+    cssselect>=0.9
+    w3lib>=1.8.0
+    queuelib
+    six>=1.5.2
+    PyDispatcher>=2.0.5
+    service_identity
+    parsel>=0.9.5
+    # Extras
+    boto
+    Pillow != 3.0.0
+    # leveldb  # Not available for Windows
+    -rtests/requirements.txt
+
+[testenv:py3X-win]
+deps =
+    # Specific to Windows
+    pypiwin32
+    # Copied from requirements-py3.txt (except lxml)
+    Twisted >= 15.5.0
+    pyOpenSSL>=0.13.1
+    cssselect>=0.9
+    queuelib>=1.1.1
+    w3lib>=1.8.0
+    service_identity
+    # Extras
+    Pillow
+    # Copied from tests/requirements-py3.txt
+    pytest==2.7.3
+    pytest-twisted
+    pytest-cov
+    testfixtures
+    jmespath
+    # leveldb  # Not available for Windows
+    bpython
+    ipython
+
+[testenv:py33-win]
+deps =
+    {[testenv:py3X-win]deps}
+    lxml-binaries/lxml-3.5.0-cp33-none-win32.whl
+
+[testenv:py35-win]
+deps =
+    {[testenv:py3X-win]deps}
+    lxml-binaries/lxml-3.5.0-cp35-none-win32.whl
+
 [docs]
 changedir = docs
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -92,6 +92,7 @@ deps =
     pytest-cov
     testfixtures
     jmespath
+    boto
     # leveldb  # Not available for Windows
     bpython
     ipython


### PR DESCRIPTION
Based on #1736.

Fixes #1758.

A couple of minor changes to the tests to make them compatible with Windows.

Also addresses two smaller issues within Scrapy:
- Small change to output foramatting of the `startproject` command. (Project name and template path were outputted as `%r` instead of `'%s'`, which screwed up paths that contain backslashes)
- In `scrapy.utils.trackref`, on Windows (only), use `time.clock` instead of `time.time` for timestamping to restore deterministic ordering of tracked references
