### PR TITLE
Use mitmproxy and netlib 0.15

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 Twisted>=10.0.0
 lxml
-pyOpenSSL
+pyOpenSSL>=0.15
 cssselect>=0.9
 w3lib>=1.8.0
 queuelib

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,7 +1,7 @@
 # Tests requirements
 mock
-mitmproxy==0.10.1
-netlib==0.10.1
+mitmproxy==0.15
+netlib==0.15.1
 pytest==2.7.3
 pytest-twisted
 jmespath

--- a/tests/test_proxy_connect.py
+++ b/tests/test_proxy_connect.py
@@ -4,7 +4,7 @@ import time
 
 from threading import Thread
 from libmproxy import controller, proxy
-from netlib import http_auth
+from netlib.http import authentication
 from testfixtures import LogCapture
 
 from twisted.internet import defer
@@ -18,14 +18,14 @@ from tests.mockserver import MockServer
 class HTTPSProxy(controller.Master, Thread):
 
     def __init__(self, port):
-        password_manager = http_auth.PassManSingleUser('scrapy', 'scrapy')
-        authenticator = http_auth.BasicProxyAuth(password_manager, "mitmproxy")
+        password_manager = authentication.PassManSingleUser('scrapy', 'scrapy')
+        authenticator = authentication.BasicProxyAuth(password_manager, "mitmproxy")
         cert_path = os.path.join(os.path.abspath(os.path.dirname(__file__)),
-            'keys', 'mitmproxy-ca.pem')
+            'keys')
         server = proxy.ProxyServer(proxy.ProxyConfig(
             authenticator = authenticator,
-            cacert = cert_path),
-            port)
+            cadir = cert_path,
+            port = port))
         Thread.__init__(self)
         controller.Master.__init__(self, server)
 


### PR DESCRIPTION
Some changes to make test_proxy_connect more friendly to netlib/mitmproxy 0.15 series. However, there is still one failure here that I don't know how to fix:

```
__________________________________________________________ ProxyConnectTestCase.test_https_noconnect __________________________________________________________

result = None, g = <generator object test_https_noconnect at 0x7f36400c54b0>, deferred = <Deferred at 0x7f363505fd40 current result: None>

    def _inlineCallbacks(result, g, deferred):
        """
        See L{inlineCallbacks}.
        """
        # This function is complicated by the need to prevent unbounded recursion
        # arising from repeatedly yielding immediately ready deferreds.  This while
        # loop and the waiting variable solve that by manually unfolding the
        # recursion.

        waiting = [True, # waiting for result?
                   None] # result

        while 1:
            try:
                # Send the last result back as the result of the yield expression.
                isFailure = isinstance(result, failure.Failure)
                if isFailure:
                    result = result.throwExceptionIntoGenerator(g)
                else:
>                   result = g.send(result)

/usr/lib/python2.7/site-packages/twisted/internet/defer.py:1128:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
/home/felix/projects/scrapy/tests/test_proxy_connect.py:64: in test_https_noconnect
    self._assert_got_response_code(200, l)
/home/felix/projects/scrapy/tests/test_proxy_connect.py:104: in _assert_got_response_code
    self.assertEqual(str(log).count('Crawled (%d)' % code), 1)
/usr/lib/python2.7/site-packages/twisted/trial/_synctest.py:437: in assertEqual
    super(_Assertions, self).assertEqual(first, second, msg)
E   FailTest: 0 != 1
```

I tried to print the logs for that test, and got:

```
boto DEBUG
  Using access key found in config file.
boto DEBUG
  Using secret key found in config file.
scrapy.middleware INFO
  Enabled downloader middlewares: HttpAuthMiddleware, DownloadTimeoutMiddleware, UserAgentMiddleware, RetryMiddleware, DefaultHeadersMiddleware, MetaRefreshMiddleware, HttpCompressionMiddleware, RedirectMiddleware, CookiesMiddleware, HttpProxyMiddleware, ChunkedTransferMiddleware, DownloaderStats
scrapy.middleware INFO
  Enabled spider middlewares: HttpErrorMiddleware, OffsiteMiddleware, RefererMiddleware, UrlLengthMiddleware, DepthMiddleware
scrapy.middleware INFO
  Enabled item pipelines:
scrapy.core.engine INFO
  Spider opened
scrapy.extensions.logstats INFO
  Crawled 0 pages (at 0 pages/min), scraped 0 items (at 0 items/min)
scrapy.telnet DEBUG
  Telnet console listening on 127.0.0.1:6023
scrapy.downloadermiddlewares.retry DEBUG
  Retrying <GET https://localhost:8999/status?n=200> (failed 1 times): 400 Bad Request
scrapy.downloadermiddlewares.retry DEBUG
  Retrying <GET https://localhost:8999/status?n=200> (failed 2 times): 400 Bad Request
scrapy.downloadermiddlewares.retry DEBUG
  Gave up retrying <GET https://localhost:8999/status?n=200> (failed 3 times): 400 Bad Request
scrapy.core.engine DEBUG
  Crawled (400) <GET https://localhost:8999/status?n=200> (referer: None)
scrapy.spidermiddlewares.httperror DEBUG
  Ignoring response <400 https://localhost:8999/status?n=200>: HTTP status code is not handled or not allowed
scrapy.core.engine INFO
  Closing spider (finished)
scrapy.statscollectors INFO
  Dumping Scrapy stats:
{'downloader/request_bytes': 804,
 'downloader/request_count': 3,
 'downloader/request_method_count/GET': 3,
 'downloader/response_bytes': 774,
 'downloader/response_count': 3,
 'downloader/response_status_count/400': 3,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2016, 2, 4, 5, 42, 56, 719896),
 'response_received_count': 1,
 'scheduler/dequeued': 3,
 'scheduler/dequeued/memory': 3,
 'scheduler/enqueued': 3,
 'scheduler/enqueued/memory': 3,
 'start_time': datetime.datetime(2016, 2, 4, 5, 42, 56, 556138)}
scrapy.core.engine INFO
  Spider closed (finished)
```

Please let me know what else should be adjusted to fix this. Thanks!
