### PR TITLE
[MRG+1] Py3 S3 botocore

### DIFF
--- a/docs/topics/feed-exports.rst
+++ b/docs/topics/feed-exports.rst
@@ -99,12 +99,12 @@ The storages backends supported out of the box are:
 
  * :ref:`topics-feed-storage-fs`
  * :ref:`topics-feed-storage-ftp`
- * :ref:`topics-feed-storage-s3` (requires boto_)
+ * :ref:`topics-feed-storage-s3` (requires botocore_ or boto_)
  * :ref:`topics-feed-storage-stdout`
 
 Some storage backends may be unavailable if the required external libraries are
-not available. For example, the S3 backend is only available if the boto_
-library is installed.
+not available. For example, the S3 backend is only available if the botocore_
+or boto_ library is installed (Scrapy supports boto_ only on Python 2).
 
 
 .. _topics-feed-uri-params:
@@ -177,7 +177,7 @@ The feeds are stored on `Amazon S3`_.
    * ``s3://mybucket/path/to/export.csv``
    * ``s3://aws_key:aws_secret@mybucket/path/to/export.csv``
 
- * Required external libraries: `boto`_
+ * Required external libraries: `botocore`_ or `boto`_
 
 The AWS credentials can be passed as user/password in the URI, or they can be
 passed through the following settings:
@@ -332,4 +332,5 @@ format in :setting:`FEED_EXPORTERS`. E.g., to disable the built-in CSV exporter
 
 .. _URI: http://en.wikipedia.org/wiki/Uniform_Resource_Identifier
 .. _Amazon S3: http://aws.amazon.com/s3/
-.. _boto: http://code.google.com/p/boto/
+.. _boto: https://github.com/boto/boto
+.. _botocore: https://github.com/boto/botocore

--- a/scrapy/core/downloader/handlers/s3.py
+++ b/scrapy/core/downloader/handlers/s3.py
@@ -47,9 +47,10 @@ class S3DownloadHandler(object):
         # If no credentials could be found anywhere,
         # consider this an anonymous connection request by default;
         # unless 'anon' was set explicitly (True/False).
-        anon = kw.get('anon', None)
+        anon = kw.get('anon')
         if anon is None and not aws_access_key_id and not aws_secret_access_key:
             kw['anon'] = True
+        self.anon = kw.get('anon')
 
         self._signer = None
         try:
@@ -80,7 +81,9 @@ class S3DownloadHandler(object):
         bucket = p.hostname
         path = p.path + '?' + p.query if p.query else p.path
         url = '%s://%s.s3.amazonaws.com%s' % (scheme, bucket, path)
-        if self._signer is not None:
+        if self.anon:
+            request = request.replace(url=url)
+        elif self._signer is not None:
             import botocore.awsrequest
             from botocore.vendored.requests.structures import CaseInsensitiveDict
             print(url, request.headers)

--- a/scrapy/core/downloader/handlers/s3.py
+++ b/scrapy/core/downloader/handlers/s3.py
@@ -85,15 +85,10 @@ class S3DownloadHandler(object):
             request = request.replace(url=url)
         elif self._signer is not None:
             import botocore.awsrequest
-            from botocore.vendored.requests.structures import CaseInsensitiveDict
-            print(url, request.headers)
             awsrequest = botocore.awsrequest.AWSRequest(
                 method=request.method,
                 url='%s://s3.amazonaws.com/%s%s' % (scheme, bucket, path),
-                # TODO - move to a header method
-                headers=CaseInsensitiveDict(
-                    (to_unicode(key), to_unicode(b','.join(value)))
-                    for key, value in request.headers.items()),
+                headers=request.headers.to_native_string_dict(),
                 data=request.body)
             self._signer.add_auth(awsrequest)
             request = request.replace(

--- a/scrapy/core/downloader/handlers/s3.py
+++ b/scrapy/core/downloader/handlers/s3.py
@@ -68,10 +68,10 @@ class S3DownloadHandler(object):
             except Exception as ex:
                 raise NotConfigured(str(ex))
         else:
-            SignerCls = botocore.auth.AUTH_TYPE_MAPS['s3']
-            # TODO - anon
-            self._signer = SignerCls(botocore.credentials.Credentials(
-                aws_access_key_id, aws_secret_access_key))
+            if not self.anon:
+                SignerCls = botocore.auth.AUTH_TYPE_MAPS['s3']
+                self._signer = SignerCls(botocore.credentials.Credentials(
+                    aws_access_key_id, aws_secret_access_key))
 
         self._download_http = httpdownloadhandler(settings).download_request
 

--- a/scrapy/core/downloader/handlers/s3.py
+++ b/scrapy/core/downloader/handlers/s3.py
@@ -1,7 +1,9 @@
+import six
 from six.moves.urllib.parse import unquote
 
 from scrapy.exceptions import NotConfigured
 from scrapy.utils.httpobj import urlparse_cached
+from scrapy.utils.python import to_unicode
 from .http import HTTPDownloadHandler
 
 
@@ -37,10 +39,6 @@ class S3DownloadHandler(object):
     def __init__(self, settings, aws_access_key_id=None, aws_secret_access_key=None, \
             httpdownloadhandler=HTTPDownloadHandler, **kw):
 
-        _S3Connection = get_s3_connection()
-        if _S3Connection is None:
-            raise NotConfigured("missing boto library")
-
         if not aws_access_key_id:
             aws_access_key_id = settings['AWS_ACCESS_KEY_ID']
         if not aws_secret_access_key:
@@ -53,10 +51,27 @@ class S3DownloadHandler(object):
         if anon is None and not aws_access_key_id and not aws_secret_access_key:
             kw['anon'] = True
 
+        self._signer = None
         try:
-            self.conn = _S3Connection(aws_access_key_id, aws_secret_access_key, **kw)
-        except Exception as ex:
-            raise NotConfigured(str(ex))
+            import botocore.auth
+            import botocore.credentials
+        except ImportError:
+            if six.PY3:
+                raise NotConfigured("missing botocore library")
+            _S3Connection = get_s3_connection()
+            if _S3Connection is None:
+                raise NotConfigured("missing botocore or boto library")
+            try:
+                self.conn = _S3Connection(
+                    aws_access_key_id, aws_secret_access_key, **kw)
+            except Exception as ex:
+                raise NotConfigured(str(ex))
+        else:
+            SignerCls = botocore.auth.AUTH_TYPE_MAPS['s3']
+            # TODO - anon
+            self._signer = SignerCls(botocore.credentials.Credentials(
+                aws_access_key_id, aws_secret_access_key))
+
         self._download_http = httpdownloadhandler(settings).download_request
 
     def download_request(self, request, spider):
@@ -65,12 +80,28 @@ class S3DownloadHandler(object):
         bucket = p.hostname
         path = p.path + '?' + p.query if p.query else p.path
         url = '%s://%s.s3.amazonaws.com%s' % (scheme, bucket, path)
-        signed_headers = self.conn.make_request(
+        if self._signer is not None:
+            import botocore.awsrequest
+            from botocore.vendored.requests.structures import CaseInsensitiveDict
+            print(url, request.headers)
+            awsrequest = botocore.awsrequest.AWSRequest(
                 method=request.method,
-                bucket=bucket,
-                key=unquote(p.path),
-                query_args=unquote(p.query),
-                headers=request.headers,
+                url='%s://s3.amazonaws.com/%s%s' % (scheme, bucket, path),
+                # TODO - move to a header method
+                headers=CaseInsensitiveDict(
+                    (to_unicode(key), to_unicode(b','.join(value)))
+                    for key, value in request.headers.items()),
                 data=request.body)
-        httpreq = request.replace(url=url, headers=signed_headers)
-        return self._download_http(httpreq, spider)
+            self._signer.add_auth(awsrequest)
+            request = request.replace(
+                url=url, headers=awsrequest.headers.items())
+        else:
+            signed_headers = self.conn.make_request(
+                    method=request.method,
+                    bucket=bucket,
+                    key=unquote(p.path),
+                    query_args=unquote(p.query),
+                    headers=request.headers,
+                    data=request.body)
+            request = request.replace(url=url, headers=signed_headers)
+        return self._download_http(request, spider)

--- a/scrapy/core/downloader/handlers/s3.py
+++ b/scrapy/core/downloader/handlers/s3.py
@@ -82,7 +82,7 @@ class S3DownloadHandler(object):
             awsrequest = botocore.awsrequest.AWSRequest(
                 method=request.method,
                 url='%s://s3.amazonaws.com/%s%s' % (scheme, bucket, path),
-                headers=request.headers.to_native_string_dict(),
+                headers=request.headers.to_unicode_dict(),
                 data=request.body)
             self._signer.add_auth(awsrequest)
             request = request.replace(

--- a/scrapy/core/downloader/handlers/s3.py
+++ b/scrapy/core/downloader/handlers/s3.py
@@ -68,6 +68,9 @@ class S3DownloadHandler(object):
             except Exception as ex:
                 raise NotConfigured(str(ex))
         else:
+            kw.pop('anon', None)
+            if kw:
+                raise TypeError('Unexpected keyword arguments: %s' % kw)
             if not self.anon:
                 SignerCls = botocore.auth.AUTH_TYPE_MAPS['s3']
                 self._signer = SignerCls(botocore.credentials.Credentials(

--- a/scrapy/http/headers.py
+++ b/scrapy/http/headers.py
@@ -79,7 +79,10 @@ class Headers(CaselessDict):
     def to_string(self):
         return headers_dict_to_raw(self)
 
-    def to_native_string_dict(self):
+    def to_unicode_dict(self):
+        """ Return headers as a CaselessDict with unicode keys
+        and unicode values. Multiple values are joined with ','.
+        """
         return CaselessDict(
             (to_unicode(key, encoding=self.encoding),
              to_unicode(b','.join(value), encoding=self.encoding))

--- a/scrapy/http/headers.py
+++ b/scrapy/http/headers.py
@@ -1,6 +1,7 @@
 import six
 from w3lib.http import headers_dict_to_raw
 from scrapy.utils.datatypes import CaselessDict
+from scrapy.utils.python import to_unicode
 
 
 class Headers(CaselessDict):
@@ -77,6 +78,12 @@ class Headers(CaselessDict):
 
     def to_string(self):
         return headers_dict_to_raw(self)
+
+    def to_native_string_dict(self):
+        return CaselessDict(
+            (to_unicode(key, encoding=self.encoding),
+             to_unicode(b','.join(value), encoding=self.encoding))
+            for key, value in self.items())
 
     def __copy__(self):
         return self.__class__(self)

--- a/scrapy/pipelines/files.py
+++ b/scrapy/pipelines/files.py
@@ -28,6 +28,7 @@ from scrapy.utils.misc import md5sum
 from scrapy.utils.log import failure_to_exc_info
 from scrapy.utils.python import to_bytes
 from scrapy.utils.request import referer_str
+from scrapy.utils.boto import is_botocore
 
 logger = logging.getLogger(__name__)
 
@@ -86,20 +87,30 @@ class S3FilesStore(object):
     }
 
     def __init__(self, uri):
-        try:
+        self.is_botocore = is_botocore()
+        if self.is_botocore:
+            import botocore.session
+            session = botocore.session.get_session()
+            self.s3_client = session.create_client(
+                's3', aws_access_key_id=self.AWS_ACCESS_KEY_ID,
+                aws_secret_access_key=self.AWS_SECRET_ACCESS_KEY)
+        else:
             from boto.s3.connection import S3Connection
             self.S3Connection = S3Connection
-        except ImportError:
-            raise NotConfigured("missing boto library")
         assert uri.startswith('s3://')
         self.bucket, self.prefix = uri[5:].split('/', 1)
 
     def stat_file(self, path, info):
         def _onsuccess(boto_key):
-            checksum = boto_key.etag.strip('"')
-            last_modified = boto_key.last_modified
-            modified_tuple = parsedate_tz(last_modified)
-            modified_stamp = int(mktime_tz(modified_tuple))
+            if self.is_botocore:
+                checksum = boto_key['ETag'].strip('"')
+                last_modified = boto_key['LastModified']
+                modified_stamp = time.mktime(last_modified.timetuple())
+            else:
+                checksum = boto_key.etag.strip('"')
+                last_modified = boto_key.last_modified
+                modified_tuple = parsedate_tz(last_modified)
+                modified_stamp = int(mktime_tz(modified_tuple))
             return {'checksum': checksum, 'last_modified': modified_stamp}
 
         return self._get_boto_key(path).addCallback(_onsuccess)
@@ -111,24 +122,40 @@ class S3FilesStore(object):
         return c.get_bucket(self.bucket, validate=False)
 
     def _get_boto_key(self, path):
-        b = self._get_boto_bucket()
         key_name = '%s%s' % (self.prefix, path)
-        return threads.deferToThread(b.get_key, key_name)
+        if self.is_botocore:
+            return threads.deferToThread(
+                self.s3_client.head_object,
+                Bucket=self.bucket,
+                Key=key_name)
+        else:
+            b = self._get_boto_bucket()
+            return threads.deferToThread(b.get_key, key_name)
 
     def persist_file(self, path, buf, info, meta=None, headers=None):
         """Upload file to S3 storage"""
-        b = self._get_boto_bucket()
         key_name = '%s%s' % (self.prefix, path)
-        k = b.new_key(key_name)
-        if meta:
-            for metakey, metavalue in six.iteritems(meta):
-                k.set_metadata(metakey, str(metavalue))
-        h = self.HEADERS.copy()
-        if headers:
-            h.update(headers)
         buf.seek(0)
-        return threads.deferToThread(k.set_contents_from_string, buf.getvalue(),
-                                     headers=h, policy=self.POLICY)
+        if self.is_botocore:
+            return threads.deferToThread(
+                self.s3_client.put_object,
+                Bucket=self.bucket,
+                Key=key_name,
+                Body=buf,
+                Metadata={k: str(v) for k, v in six.iteritems(meta)},
+                ACL=self.POLICY)
+        else:
+            b = self._get_boto_bucket()
+            k = b.new_key(key_name)
+            if meta:
+                for metakey, metavalue in six.iteritems(meta):
+                    k.set_metadata(metakey, str(metavalue))
+            h = self.HEADERS.copy()
+            if headers:
+                h.update(headers)
+            return threads.deferToThread(
+                k.set_contents_from_string, buf.getvalue(),
+                headers=h, policy=self.POLICY)
 
 
 class FilesPipeline(MediaPipeline):

--- a/scrapy/utils/boto.py
+++ b/scrapy/utils/boto.py
@@ -1,5 +1,6 @@
 """Boto/botocore helpers"""
 
+from __future__ import absolute_import
 import six
 
 from scrapy.exceptions import NotConfigured

--- a/scrapy/utils/boto.py
+++ b/scrapy/utils/boto.py
@@ -1,0 +1,20 @@
+"""Boto/botocore helpers"""
+
+import six
+
+from scrapy.exceptions import NotConfigured
+
+
+def is_botocore():
+    try:
+        import botocore
+        return True
+    except ImportError:
+        if six.PY2:
+            try:
+                import boto
+                return False
+            except ImportError:
+                raise NotConfigured('missing botocore or boto library')
+        else:
+            raise NotConfigured('missing botocore library')

--- a/scrapy/utils/test.py
+++ b/scrapy/utils/test.py
@@ -26,7 +26,7 @@ def skip_if_no_boto():
     except NotConfigured as e:
         raise SkipTest(e.message)
 
-def get_s3_content_and_delete(bucket, path):
+def get_s3_content_and_delete(bucket, path, with_key=False):
     """ Get content from s3 key, and delete key afterwards.
     """
     if is_botocore():
@@ -43,7 +43,7 @@ def get_s3_content_and_delete(bucket, path):
         key = bucket.get_key(path)
         content = key.get_contents_as_string()
         bucket.delete_key(path)
-    return content
+    return (content, key) if with_key else content
 
 def get_crawler(spidercls=None, settings_dict=None):
     """Return an unconfigured Crawler object. If settings_dict is given, it

--- a/scrapy/utils/test.py
+++ b/scrapy/utils/test.py
@@ -5,6 +5,7 @@ This module contains some assorted functions used in tests
 import os
 
 from importlib import import_module
+import six
 from twisted.trial.unittest import SkipTest
 
 
@@ -12,13 +13,21 @@ def assert_aws_environ():
     """Asserts the current environment is suitable for running AWS testsi.
     Raises SkipTest with the reason if it's not.
     """
-    try:
-        import boto
-    except ImportError as e:
-        raise SkipTest(str(e))
-
+    skip_if_no_boto()
     if 'AWS_ACCESS_KEY_ID' not in os.environ:
         raise SkipTest("AWS keys not found")
+
+def skip_if_no_boto():
+    try:
+        import botocore
+    except ImportError:
+        if six.PY2:
+            try:
+                import boto
+            except ImportError:
+                raise SkipTest('missing botocore or boto library')
+        else:
+            raise SkipTest('missing botocore library')
 
 def get_crawler(spidercls=None, settings_dict=None):
     """Return an unconfigured Crawler object. If settings_dict is given, it

--- a/scrapy/utils/test.py
+++ b/scrapy/utils/test.py
@@ -5,8 +5,10 @@ This module contains some assorted functions used in tests
 import os
 
 from importlib import import_module
-import six
 from twisted.trial.unittest import SkipTest
+
+from scrapy.exceptions import NotConfigured
+from scrapy.utils.boto import is_botocore
 
 
 def assert_aws_environ():
@@ -19,15 +21,9 @@ def assert_aws_environ():
 
 def skip_if_no_boto():
     try:
-        import botocore
-    except ImportError:
-        if six.PY2:
-            try:
-                import boto
-            except ImportError:
-                raise SkipTest('missing botocore or boto library')
-        else:
-            raise SkipTest('missing botocore library')
+        is_botocore()
+    except NotConfigured as e:
+        raise SkipTest(e.message)
 
 def get_crawler(spidercls=None, settings_dict=None):
     """Return an unconfigured Crawler object. If settings_dict is given, it

--- a/tests/py3-ignores.txt
+++ b/tests/py3-ignores.txt
@@ -7,7 +7,6 @@ scrapy/xlib/tx/endpoints.py
 scrapy/xlib/tx/client.py
 scrapy/xlib/tx/_newclient.py
 scrapy/xlib/tx/__init__.py
-scrapy/core/downloader/handlers/s3.py
 scrapy/core/downloader/handlers/ftp.py
 scrapy/linkextractors/sgml.py
 scrapy/linkextractors/regex.py

--- a/tests/requirements-py3.txt
+++ b/tests/requirements-py3.txt
@@ -4,7 +4,7 @@ pytest-cov
 testfixtures
 jmespath
 leveldb
-boto
+botocore
 # optional for shell wrapper tests
 bpython
 ipython

--- a/tests/test_downloader_handlers.py
+++ b/tests/test_downloader_handlers.py
@@ -458,8 +458,10 @@ class S3AnonTestCase(BaseS3TestCase):
     def test_anon_request(self):
         req = Request('s3://aws-publicdatasets/')
         httpreq = self.download_request(req, self.spider)
-        self.assertEqual(hasattr(self.s3reqh.conn, 'anon'), True)
-        self.assertEqual(self.s3reqh.conn.anon, True)
+        self.assertEqual(hasattr(self.s3reqh, 'anon'), True)
+        self.assertEqual(self.s3reqh.anon, True)
+        self.assertEqual(
+            httpreq.url, 'http://aws-publicdatasets.s3.amazonaws.com/')
 
 
 class S3TestCase(unittest.TestCase):

--- a/tests/test_downloader_handlers.py
+++ b/tests/test_downloader_handlers.py
@@ -546,6 +546,11 @@ class S3TestCase(BaseS3TestCase):
                 b'AWS 0PN5J17HBGZHT7JJ3X82:thdUi9VAkzhkniLj96JIrOPGi0g=')
 
     def test_request_signing5(self):
+        try: import botocore
+        except ImportError: pass
+        else:
+            raise unittest.SkipTest(
+                'botocore does not support overriding date with x-amz-date')
         # deletes an object from the 'johnsmith' bucket using the
         # path-style and Date alternative.
         date = 'Tue, 27 Mar 2007 21:20:27 +0000'
@@ -557,9 +562,8 @@ class S3TestCase(BaseS3TestCase):
         with self._mocked_date(date):
             httpreq = self.download_request(req, self.spider)
         # botocore does not override Date with x-amz-date
-        self.assertIn(httpreq.headers['Authorization'], [
-                b'AWS 0PN5J17HBGZHT7JJ3X82:k3nL7gH3+PadhTEVn5Ip83xlYzk=',
-                b'AWS 0PN5J17HBGZHT7JJ3X82:otYM2krxnuHhAofO4oqIV7wcfdU='])
+        self.assertEqual(httpreq.headers['Authorization'],
+                b'AWS 0PN5J17HBGZHT7JJ3X82:k3nL7gH3+PadhTEVn5Ip83xlYzk=')
 
     def test_request_signing6(self):
         # uploads an object to a CNAME style virtual hosted bucket with metadata.

--- a/tests/test_downloader_handlers.py
+++ b/tests/test_downloader_handlers.py
@@ -490,8 +490,12 @@ class S3TestCase(unittest.TestCase):
                 yield
 
     def test_extra_kw(self):
-        self.assertRaises(
-            TypeError, S3DownloadHandler, Settings(), extra_kw=True)
+        try:
+            S3DownloadHandler(Settings(), extra_kw=True)
+        except Exception as e:
+            self.assertIsInstance(e, (TypeError, NotConfigured))
+        else:
+            assert False
 
     def test_request_signing1(self):
         # gets an object from the johnsmith bucket.

--- a/tests/test_downloader_handlers.py
+++ b/tests/test_downloader_handlers.py
@@ -432,13 +432,20 @@ class HttpDownloadHandlerMock(object):
         return request
 
 
-class S3AnonTestCase(unittest.TestCase):
-    try:
-        import boto
-    except ImportError:
-        skip = 'missing boto library'
+class BaseS3TestCase(unittest.TestCase):
     if six.PY3:
-        skip = 'S3 not supported on Py3'
+        try:
+            import botocore
+        except ImportError:
+            skip = 'missing botocore library'
+    else:
+        try:
+            import boto
+        except ImportError:
+            skip = 'missing boto library'
+
+
+class S3AnonTestCase(BaseS3TestCase):
 
     def setUp(self):
         self.s3reqh = S3DownloadHandler(Settings(),
@@ -457,12 +464,6 @@ class S3AnonTestCase(unittest.TestCase):
 
 class S3TestCase(unittest.TestCase):
     download_handler_cls = S3DownloadHandler
-    try:
-        import boto
-    except ImportError:
-        skip = 'missing boto library'
-    if six.PY3:
-        skip = 'S3 not supported on Py3'
 
     # test use same example keys than amazon developer guide
     # http://s3.amazonaws.com/awsdocs/S3/20060301/s3-dg-20060301.pdf
@@ -484,7 +485,7 @@ class S3TestCase(unittest.TestCase):
                 headers={'Date': 'Tue, 27 Mar 2007 19:36:42 +0000'})
         httpreq = self.download_request(req, self.spider)
         self.assertEqual(httpreq.headers['Authorization'], \
-                'AWS 0PN5J17HBGZHT7JJ3X82:xXjDGYUmKxnwqr5KXNPGldn5LbA=')
+                b'AWS 0PN5J17HBGZHT7JJ3X82:xXjDGYUmKxnwqr5KXNPGldn5LbA=')
 
     def test_request_signing2(self):
         # puts an object into the johnsmith bucket.
@@ -495,7 +496,7 @@ class S3TestCase(unittest.TestCase):
             })
         httpreq = self.download_request(req, self.spider)
         self.assertEqual(httpreq.headers['Authorization'], \
-                'AWS 0PN5J17HBGZHT7JJ3X82:hcicpDDvL9SsO6AkvxqmIWkmOuQ=')
+                b'AWS 0PN5J17HBGZHT7JJ3X82:hcicpDDvL9SsO6AkvxqmIWkmOuQ=')
 
     def test_request_signing3(self):
         # lists the content of the johnsmith bucket.
@@ -506,7 +507,7 @@ class S3TestCase(unittest.TestCase):
                     })
         httpreq = self.download_request(req, self.spider)
         self.assertEqual(httpreq.headers['Authorization'], \
-                'AWS 0PN5J17HBGZHT7JJ3X82:jsRt/rhG+Vtp88HrYL706QhE4w4=')
+                b'AWS 0PN5J17HBGZHT7JJ3X82:jsRt/rhG+Vtp88HrYL706QhE4w4=')
 
     def test_request_signing4(self):
         # fetches the access control policy sub-resource for the 'johnsmith' bucket.
@@ -514,7 +515,7 @@ class S3TestCase(unittest.TestCase):
                 method='GET', headers={'Date': 'Tue, 27 Mar 2007 19:44:46 +0000'})
         httpreq = self.download_request(req, self.spider)
         self.assertEqual(httpreq.headers['Authorization'], \
-                'AWS 0PN5J17HBGZHT7JJ3X82:thdUi9VAkzhkniLj96JIrOPGi0g=')
+                b'AWS 0PN5J17HBGZHT7JJ3X82:thdUi9VAkzhkniLj96JIrOPGi0g=')
 
     def test_request_signing5(self):
         # deletes an object from the 'johnsmith' bucket using the
@@ -526,7 +527,7 @@ class S3TestCase(unittest.TestCase):
                     })
         httpreq = self.download_request(req, self.spider)
         self.assertEqual(httpreq.headers['Authorization'], \
-                'AWS 0PN5J17HBGZHT7JJ3X82:k3nL7gH3+PadhTEVn5Ip83xlYzk=')
+                b'AWS 0PN5J17HBGZHT7JJ3X82:k3nL7gH3+PadhTEVn5Ip83xlYzk=')
 
     def test_request_signing6(self):
         # uploads an object to a CNAME style virtual hosted bucket with metadata.
@@ -547,7 +548,7 @@ class S3TestCase(unittest.TestCase):
                     })
         httpreq = self.download_request(req, self.spider)
         self.assertEqual(httpreq.headers['Authorization'], \
-                'AWS 0PN5J17HBGZHT7JJ3X82:C0FlOtU8Ylb9KDTpZqYkZPX91iI=')
+                b'AWS 0PN5J17HBGZHT7JJ3X82:C0FlOtU8Ylb9KDTpZqYkZPX91iI=')
 
     def test_request_signing7(self):
         # ensure that spaces are quoted properly before signing
@@ -561,7 +562,7 @@ class S3TestCase(unittest.TestCase):
         httpreq = self.download_request(req, self.spider)
         self.assertEqual(
             httpreq.headers['Authorization'],
-            'AWS 0PN5J17HBGZHT7JJ3X82:+CfvG8EZ3YccOrRVMXNaK2eKZmM=')
+            b'AWS 0PN5J17HBGZHT7JJ3X82:+CfvG8EZ3YccOrRVMXNaK2eKZmM=')
 
 
 class FTPTestCase(unittest.TestCase):

--- a/tests/test_downloader_handlers.py
+++ b/tests/test_downloader_handlers.py
@@ -500,6 +500,10 @@ class S3TestCase(BaseS3TestCase):
                 mock_formatdate.return_value = date
                 yield
 
+    def test_extra_kw(self):
+        with self.assertRaises(TypeError):
+            S3DownloadHandler(Settings(), extra_kw=True)
+
     def test_request_signing1(self):
         # gets an object from the johnsmith bucket.
         date ='Tue, 27 Mar 2007 19:36:42 +0000'

--- a/tests/test_downloader_handlers.py
+++ b/tests/test_downloader_handlers.py
@@ -28,7 +28,7 @@ from scrapy.core.downloader.handlers.s3 import S3DownloadHandler
 from scrapy.spiders import Spider
 from scrapy.http import Request
 from scrapy.settings import Settings
-from scrapy.utils.test import get_crawler
+from scrapy.utils.test import get_crawler, skip_if_no_boto
 from scrapy.utils.python import to_bytes
 from scrapy.exceptions import NotConfigured
 
@@ -437,22 +437,10 @@ class HttpDownloadHandlerMock(object):
         return request
 
 
-class BaseS3TestCase(unittest.TestCase):
-    try:
-        import botocore
-    except ImportError:
-        if six.PY2:
-            try:
-                import boto
-            except ImportError:
-                skip = 'missing botocore or boto library'
-        else:
-            skip = 'missing botocore library'
-
-
-class S3AnonTestCase(BaseS3TestCase):
+class S3AnonTestCase(unittest.TestCase):
 
     def setUp(self):
+        skip_if_no_boto()
         self.s3reqh = S3DownloadHandler(Settings(),
                 httpdownloadhandler=HttpDownloadHandlerMock,
                 #anon=True, # is implicit
@@ -469,7 +457,7 @@ class S3AnonTestCase(BaseS3TestCase):
             httpreq.url, 'http://aws-publicdatasets.s3.amazonaws.com/')
 
 
-class S3TestCase(BaseS3TestCase):
+class S3TestCase(unittest.TestCase):
     download_handler_cls = S3DownloadHandler
 
     # test use same example keys than amazon developer guide
@@ -480,6 +468,7 @@ class S3TestCase(BaseS3TestCase):
     AWS_SECRET_ACCESS_KEY = 'uV3F3YluFJax1cknvbcGwgjvx4QpvB+leU8dUj2o'
 
     def setUp(self):
+        skip_if_no_boto()
         s3reqh = S3DownloadHandler(Settings(), self.AWS_ACCESS_KEY_ID,
                 self.AWS_SECRET_ACCESS_KEY,
                 httpdownloadhandler=HttpDownloadHandlerMock)

--- a/tests/test_downloader_handlers.py
+++ b/tests/test_downloader_handlers.py
@@ -490,8 +490,8 @@ class S3TestCase(unittest.TestCase):
                 yield
 
     def test_extra_kw(self):
-        with self.assertRaises(TypeError):
-            S3DownloadHandler(Settings(), extra_kw=True)
+        self.assertRaises(
+            TypeError, S3DownloadHandler, Settings(), extra_kw=True)
 
     def test_request_signing1(self):
         # gets an object from the johnsmith bucket.

--- a/tests/test_feedexport.py
+++ b/tests/test_feedexport.py
@@ -20,7 +20,7 @@ from scrapy.extensions.feedexport import (
     IFeedStorage, FileFeedStorage, FTPFeedStorage,
     S3FeedStorage, StdoutFeedStorage
 )
-from scrapy.utils.test import assert_aws_environ
+from scrapy.utils.test import assert_aws_environ, get_s3_content_and_delete
 from scrapy.utils.python import to_native_str
 from scrapy.utils.boto import is_botocore
 
@@ -93,7 +93,7 @@ class S3FeedStorageTest(unittest.TestCase):
     @defer.inlineCallbacks
     def test_store(self):
         assert_aws_environ()
-        uri = os.environ.get('FEEDTEST_S3_URI')
+        uri = os.environ.get('S3_TEST_FILE_URI')
         if not uri:
             raise unittest.SkipTest("No S3 URI available for testing")
         storage = S3FeedStorage(uri)
@@ -103,24 +103,8 @@ class S3FeedStorageTest(unittest.TestCase):
         file.write(expected_content)
         yield storage.store(file)
         u = urlparse(uri)
-        content = self._get_content_and_delete(u.hostname, u.path[1:])
+        content = get_s3_content_and_delete(u.hostname, u.path[1:])
         self.assertEqual(content, expected_content)
-
-    def _get_content_and_delete(self, bucket, path):
-        if is_botocore():
-            import botocore.session
-            session = botocore.session.get_session()
-            client = session.create_client('s3')
-            key = client.get_object(Bucket=bucket, Key=path)
-            content = key['Body'].read()
-            client.delete_object(Bucket=bucket, Key=path)
-        else:
-            from boto import connect_s3
-            bucket = connect_s3().get_bucket(bucket, validate=False)
-            key = bucket.get_key(path)
-            content = key.get_contents_as_string()
-            bucket.delete_key(path)
-        return content
 
 
 class StdoutFeedStorageTest(unittest.TestCase):

--- a/tests/test_feedexport.py
+++ b/tests/test_feedexport.py
@@ -102,8 +102,10 @@ class S3FeedStorageTest(unittest.TestCase):
         file.write("content")
         yield storage.store(file)
         u = urlparse(uri)
-        key = connect_s3().get_bucket(u.hostname, validate=False).get_key(u.path)
+        bucket = connect_s3().get_bucket(u.hostname, validate=False)
+        key = bucket.get_key(u.path)
         self.assertEqual(key.get_contents_as_string(), "content")
+        bucket.delete_key(u.path)
 
 
 class StdoutFeedStorageTest(unittest.TestCase):

--- a/tests/test_feedexport.py
+++ b/tests/test_feedexport.py
@@ -99,11 +99,12 @@ class S3FeedStorageTest(unittest.TestCase):
         storage = S3FeedStorage(uri)
         verifyObject(IFeedStorage, storage)
         file = storage.open(scrapy.Spider("default"))
-        file.write("content")
+        expected_content = b"content: \xe2\x98\x83"
+        file.write(expected_content)
         yield storage.store(file)
         u = urlparse(uri)
         content = self._get_content_and_delete(u.hostname, u.path[1:])
-        self.assertEqual(content, "content")
+        self.assertEqual(content, expected_content)
 
     def _get_content_and_delete(self, bucket, path):
         if is_botocore():

--- a/tests/test_feedexport.py
+++ b/tests/test_feedexport.py
@@ -22,7 +22,6 @@ from scrapy.extensions.feedexport import (
 )
 from scrapy.utils.test import assert_aws_environ, get_s3_content_and_delete
 from scrapy.utils.python import to_native_str
-from scrapy.utils.boto import is_botocore
 
 
 class FileFeedStorageTest(unittest.TestCase):

--- a/tests/test_pipeline_files.py
+++ b/tests/test_pipeline_files.py
@@ -198,7 +198,7 @@ class TestS3FilesStore(unittest.TestCase):
         s = yield store.stat_file(path, info=None)
         self.assertIn('last_modified', s)
         self.assertIn('checksum', s)
-        self.assertEqual(s['checksum'], b'3187896a9657a28163abb31667df64c8')
+        self.assertEqual(s['checksum'], '3187896a9657a28163abb31667df64c8')
         u = urlparse(uri)
         content = get_s3_content_and_delete(u.hostname, u.path[1:])
         self.assertEqual(content, data)

--- a/tox.ini
+++ b/tox.ini
@@ -14,6 +14,10 @@ deps =
     Pillow != 3.0.0
     leveldb
     -rtests/requirements.txt
+passenv =
+    FEEDTEST_S3_URI
+    AWS_ACCESS_KEY_ID
+    AWS_SECRET_ACCESS_KEY
 commands =
     py.test --cov=scrapy --cov-report= {posargs:scrapy tests}
 

--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,7 @@ envlist = py27
 deps =
     -rrequirements.txt
     # Extras
-    boto
+    botocore
     Pillow != 3.0.0
     leveldb
     -rtests/requirements.txt

--- a/tox.ini
+++ b/tox.ini
@@ -15,7 +15,7 @@ deps =
     leveldb
     -rtests/requirements.txt
 passenv =
-    FEEDTEST_S3_URI
+    S3_TEST_FILE_URI
     AWS_ACCESS_KEY_ID
     AWS_SECRET_ACCESS_KEY
 commands =


### PR DESCRIPTION
The main idea is that we try to use ``botocore`` by default, falling back to ``boto`` on Py2. ``botocore`` is more recent and has better Py3 support. Should fix #1718 (see comments there about some changes in test). boto code path is still tested in ``precise`` environment.