### PR TITLE
[MRG+1] Add fallback and deprecation warning for pydispatch (fixes #1762)

### DIFF
--- a/docs/news.rst
+++ b/docs/news.rst
@@ -124,6 +124,9 @@ Deprecations and Removals
   + ``scrapy.utils.datatypes.MultiValueDict``
   + ``scrapy.utils.datatypes.SiteNode``
 
+- The previously bundled ``scrapy.xlib.pydispatch`` library was deprecated and
+  replaced by `pydispatcher <https://pypi.python.org/pypi/PyDispatcher>`_.
+
 
 Relocations
 ~~~~~~~~~~~

--- a/scrapy/xlib/pydispatch.py
+++ b/scrapy/xlib/pydispatch.py
@@ -1,0 +1,19 @@
+from __future__ import absolute_import
+
+import warnings
+from scrapy.exceptions import ScrapyDeprecationWarning
+
+from pydispatch import (
+    dispatcher,
+    errors,
+    robust,
+    robustapply,
+    saferef,
+)
+
+warnings.warn("Importing from scrapy.xlib.pydispatch is deprecated and will"
+              " no longer be supported in future Scrapy versions."
+              " If you just want to connect signals use the from_crawler class method,"
+              " otherwise import pydispatch directly if needed."
+              " See: https://github.com/scrapy/scrapy/issues/1762",
+              ScrapyDeprecationWarning, stacklevel=2)

--- a/tests/test_pydispatch_deprecated.py
+++ b/tests/test_pydispatch_deprecated.py
@@ -1,0 +1,12 @@
+import unittest
+import warnings
+from six.moves import reload_module
+
+
+class DeprecatedPydispatchTest(unittest.TestCase):
+    def test_import_xlib_pydispatch_show_warning(self):
+        with warnings.catch_warnings(record=True) as w:
+            from scrapy.xlib import pydispatch
+            reload_module(pydispatch)
+        self.assertIn('Importing from scrapy.xlib.pydispatch is deprecated',
+                      str(w[0].message))


### PR DESCRIPTION
Hey folks!

This adds fallback imports and a deprecation warning when importing from scrapy.xlib.pydispatch and adds a note it in the release notes.

Does this look good?