### PR TITLE
[MRG+1] PY3: Fix TypeError when outputting to stdout

### DIFF
--- a/scrapy/extensions/feedexport.py
+++ b/scrapy/extensions/feedexport.py
@@ -10,6 +10,7 @@ import logging
 import posixpath
 from tempfile import TemporaryFile
 from datetime import datetime
+import six
 from six.moves.urllib.parse import urlparse
 from ftplib import FTP
 
@@ -57,7 +58,9 @@ class BlockingFeedStorage(object):
 @implementer(IFeedStorage)
 class StdoutFeedStorage(object):
 
-    def __init__(self, uri, _stdout=sys.stdout):
+    def __init__(self, uri, _stdout=None):
+        if not _stdout:
+            _stdout = sys.stdout if six.PY2 else sys.stdout.buffer
         self._stdout = _stdout
 
     def open(self, spider):


### PR DESCRIPTION
## Purpose

Fix #1768, the failure to output to stdout in Python 3.

## Changes

* Use `sys.stdout.buffer` instead of `sys.stdout` in Python 3.

## Note

Buffering behavior seems to be different between Python 2 and 3, though I don't think it's a matter.

### In Python 2

The exporeted item is shown at the line immediately after the scraped log, i.e. it seems to be unbuffered.

```
$ scrapy runspider myspider.py -o - -t jl
2016-02-07 08:06:55 [scrapy] INFO: Scrapy 1.1.0rc1 started (bot: scrapybot)
2016-02-07 08:06:55 [scrapy] INFO: Overridden settings: {'FEED_FORMAT': 'jl', 'FEED_URI': 'stdout:'}
2016-02-07 08:06:55 [scrapy] INFO: Enabled extensions:
['scrapy.extensions.feedexport.FeedExporter',
 'scrapy.extensions.logstats.LogStats',
 'scrapy.extensions.telnet.TelnetConsole',
 'scrapy.extensions.corestats.CoreStats']
2016-02-07 08:06:55 [scrapy] INFO: Enabled downloader middlewares:
['scrapy.downloadermiddlewares.httpauth.HttpAuthMiddleware',
 'scrapy.downloadermiddlewares.downloadtimeout.DownloadTimeoutMiddleware',
 'scrapy.downloadermiddlewares.useragent.UserAgentMiddleware',
 'scrapy.downloadermiddlewares.retry.RetryMiddleware',
 'scrapy.downloadermiddlewares.defaultheaders.DefaultHeadersMiddleware',
 'scrapy.downloadermiddlewares.redirect.MetaRefreshMiddleware',
 'scrapy.downloadermiddlewares.httpcompression.HttpCompressionMiddleware',
 'scrapy.downloadermiddlewares.redirect.RedirectMiddleware',
 'scrapy.downloadermiddlewares.cookies.CookiesMiddleware',
 'scrapy.downloadermiddlewares.chunked.ChunkedTransferMiddleware',
 'scrapy.downloadermiddlewares.stats.DownloaderStats']
2016-02-07 08:06:55 [scrapy] INFO: Enabled spider middlewares:
['scrapy.spidermiddlewares.httperror.HttpErrorMiddleware',
 'scrapy.spidermiddlewares.offsite.OffsiteMiddleware',
 'scrapy.spidermiddlewares.referer.RefererMiddleware',
 'scrapy.spidermiddlewares.urllength.UrlLengthMiddleware',
 'scrapy.spidermiddlewares.depth.DepthMiddleware']
2016-02-07 08:06:55 [scrapy] INFO: Enabled item pipelines:
[]
2016-02-07 08:06:55 [scrapy] INFO: Spider opened
2016-02-07 08:06:55 [scrapy] INFO: Crawled 0 pages (at 0 pages/min), scraped 0 items (at 0 items/min)
2016-02-07 08:06:55 [scrapy] DEBUG: Telnet console listening on 127.0.0.1:6023
2016-02-07 08:06:56 [scrapy] DEBUG: Crawled (200) <GET https://blog.scrapinghub.com> (referer: None)
2016-02-07 08:06:56 [scrapy] DEBUG: Scraped from <200 https://blog.scrapinghub.com>
{'title': u'The Scrapinghub Blog'}
{"title": "The Scrapinghub Blog"}
2016-02-07 08:06:56 [scrapy] INFO: Closing spider (finished)
2016-02-07 08:06:56 [scrapy] INFO: Stored jl feed (1 items) in: stdout:
2016-02-07 08:06:56 [scrapy] INFO: Dumping Scrapy stats:
{'downloader/request_bytes': 221,
 'downloader/request_count': 1,
 'downloader/request_method_count/GET': 1,
 'downloader/response_bytes': 37889,
 'downloader/response_count': 1,
 'downloader/response_status_count/200': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2016, 2, 6, 23, 6, 56, 340778),
 'item_scraped_count': 1,
 'log_count/DEBUG': 3,
 'log_count/INFO': 8,
 'response_received_count': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2016, 2, 6, 23, 6, 55, 491594)}
2016-02-07 08:06:56 [scrapy] INFO: Spider closed (finished)
```

### In Python 3

The exporeted item is shown at the last, i.e. it seems to be buffered.

```
$ scrapy runspider myspider.py -o - -t jl
2016-02-07 10:05:52 [scrapy] INFO: Scrapy 1.2.0dev2 started (bot: scrapybot)
2016-02-07 10:05:52 [scrapy] INFO: Overridden settings: {'FEED_FORMAT': 'jl', 'FEED_URI': 'stdout:'}
2016-02-07 10:05:52 [scrapy] INFO: Enabled extensions:
['scrapy.extensions.corestats.CoreStats',
 'scrapy.extensions.feedexport.FeedExporter',
 'scrapy.extensions.logstats.LogStats']
2016-02-07 10:05:53 [scrapy] INFO: Enabled downloader middlewares:
['scrapy.downloadermiddlewares.httpauth.HttpAuthMiddleware',
 'scrapy.downloadermiddlewares.downloadtimeout.DownloadTimeoutMiddleware',
 'scrapy.downloadermiddlewares.useragent.UserAgentMiddleware',
 'scrapy.downloadermiddlewares.retry.RetryMiddleware',
 'scrapy.downloadermiddlewares.defaultheaders.DefaultHeadersMiddleware',
 'scrapy.downloadermiddlewares.redirect.MetaRefreshMiddleware',
 'scrapy.downloadermiddlewares.httpcompression.HttpCompressionMiddleware',
 'scrapy.downloadermiddlewares.redirect.RedirectMiddleware',
 'scrapy.downloadermiddlewares.cookies.CookiesMiddleware',
 'scrapy.downloadermiddlewares.chunked.ChunkedTransferMiddleware',
 'scrapy.downloadermiddlewares.stats.DownloaderStats']
2016-02-07 10:05:53 [scrapy] INFO: Enabled spider middlewares:
['scrapy.spidermiddlewares.httperror.HttpErrorMiddleware',
 'scrapy.spidermiddlewares.offsite.OffsiteMiddleware',
 'scrapy.spidermiddlewares.referer.RefererMiddleware',
 'scrapy.spidermiddlewares.urllength.UrlLengthMiddleware',
 'scrapy.spidermiddlewares.depth.DepthMiddleware']
2016-02-07 10:05:53 [scrapy] INFO: Enabled item pipelines:
[]
2016-02-07 10:05:53 [scrapy] INFO: Spider opened
2016-02-07 10:05:53 [scrapy] INFO: Crawled 0 pages (at 0 pages/min), scraped 0 items (at 0 items/min)
2016-02-07 10:05:53 [scrapy] DEBUG: Crawled (200) <GET https://blog.scrapinghub.com> (referer: None)
2016-02-07 10:05:53 [scrapy] DEBUG: Scraped from <200 https://blog.scrapinghub.com>
{'title': 'The Scrapinghub Blog'}
2016-02-07 10:05:53 [scrapy] INFO: Closing spider (finished)
2016-02-07 10:05:53 [scrapy] INFO: Stored jl feed (1 items) in: stdout:
2016-02-07 10:05:53 [scrapy] INFO: Dumping Scrapy stats:
{'downloader/request_bytes': 222,
 'downloader/request_count': 1,
 'downloader/request_method_count/GET': 1,
 'downloader/response_bytes': 37890,
 'downloader/response_count': 1,
 'downloader/response_status_count/200': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2016, 2, 7, 1, 5, 53, 804361),
 'item_scraped_count': 1,
 'log_count/DEBUG': 2,
 'log_count/INFO': 8,
 'response_received_count': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2016, 2, 7, 1, 5, 53, 40263)}
2016-02-07 10:05:53 [scrapy] INFO: Spider closed (finished)
{"title": "The Scrapinghub Blog"}
```