### PR TITLE
[MRG+1] PY3: Implement some attributes of WrappedRequest required in Python 3

### DIFF
--- a/scrapy/http/cookies.py
+++ b/scrapy/http/cookies.py
@@ -137,13 +137,29 @@ class WrappedRequest(object):
         """
         return self.request.meta.get('is_unverifiable', False)
 
-    # python3 uses request.unverifiable
+    def get_origin_req_host(self):
+        return urlparse_cached(self.request).hostname
+
+    # python3 uses attributes instead of methods
+    @property
+    def full_url(self):
+        return self.get_full_url()
+
+    @property
+    def host(self):
+        return self.get_host()
+
+    @property
+    def type(self):
+        return self.get_type()
+
     @property
     def unverifiable(self):
         return self.is_unverifiable()
 
-    def get_origin_req_host(self):
-        return urlparse_cached(self.request).hostname
+    @property
+    def origin_req_host(self):
+        return self.get_origin_req_host()
 
     def has_header(self, name):
         return name in self.request.headers

--- a/tests/test_http_cookies.py
+++ b/tests/test_http_cookies.py
@@ -14,12 +14,15 @@ class WrappedRequestTest(TestCase):
 
     def test_get_full_url(self):
         self.assertEqual(self.wrapped.get_full_url(), self.request.url)
+        self.assertEqual(self.wrapped.full_url, self.request.url)
 
     def test_get_host(self):
         self.assertEqual(self.wrapped.get_host(), urlparse(self.request.url).netloc)
+        self.assertEqual(self.wrapped.host, urlparse(self.request.url).netloc)
 
     def test_get_type(self):
         self.assertEqual(self.wrapped.get_type(), urlparse(self.request.url).scheme)
+        self.assertEqual(self.wrapped.type, urlparse(self.request.url).scheme)
 
     def test_is_unverifiable(self):
         self.assertFalse(self.wrapped.is_unverifiable())
@@ -32,6 +35,7 @@ class WrappedRequestTest(TestCase):
 
     def test_get_origin_req_host(self):
         self.assertEqual(self.wrapped.get_origin_req_host(), 'www.example.com')
+        self.assertEqual(self.wrapped.origin_req_host, 'www.example.com')
 
     def test_has_header(self):
         self.assertTrue(self.wrapped.has_header('content-type'))


### PR DESCRIPTION
## Purpose

Fix #1770, the failure to download the second or later requests to hosts using secure cookies. The problem is caused by missing `type` attribute of `scrapy.http.WrappedRequest`.

Though [the official document](https://docs.python.org/3/library/http.cookiejar.html#http.cookiejar.CookieJar.add_cookie_header) seems to be outdated, `request` argument of `CookieJar.add_cookie_header()` requires some attributes instead of methods in Python 3. This is because `urllib.request.Request`'s methods `get_hosts()`, `get_type()`, `unverifiable()` and `get_origin_req_host()` were deprecated in Python 3.3 and removed in Python 3.4.

See also:

Issue 15409: Deprecation Warning fix on cookiejar module - Python tracker
http://bugs.python.org/issue15409

cpython: ea8078365d3b
https://hg.python.org/cpython/rev/ea8078365d3b

## Changes

* Implement some attributes of `scrapy.http.cookies.WrappedRequest` required in Python 3.
* Add unit tests.