### PR TITLE
Update __init__.py

### DIFF
--- a/scrapy/spiders/__init__.py
+++ b/scrapy/spiders/__init__.py
@@ -70,7 +70,7 @@ class Spider(object_ref):
             yield self.make_requests_from_url(url)
 
     def make_requests_from_url(self, url):
-        return Request(url, dont_filter=True)
+        return Request(url,dont_filter=False)
 
     def parse(self, response):
         raise NotImplementedError


### PR DESCRIPTION
dont_filter (boolean) – indicates that this request should not be filtered by the scheduler. This is used when you want to perform an identical request multiple times, to ignore the duplicates filter. Use it with care, or you will get into crawling loops. Default to False