### PR TITLE
[MRG+1] Change default S3 ACL to "private" and allow customization via settings

### DIFF
--- a/docs/topics/feed-exports.rst
+++ b/docs/topics/feed-exports.rst
@@ -185,9 +185,6 @@ passed through the following settings:
  * :setting:`AWS_ACCESS_KEY_ID`
  * :setting:`AWS_SECRET_ACCESS_KEY`
 
-Default access policy for uploaded files is ``private``, it can be changed
-(for example, to ``public-read``) via :setting:`S3_STORE_ACL`.
-
 .. _topics-feed-storage-stdout:
 
 Standard output

--- a/docs/topics/feed-exports.rst
+++ b/docs/topics/feed-exports.rst
@@ -185,6 +185,9 @@ passed through the following settings:
  * :setting:`AWS_ACCESS_KEY_ID`
  * :setting:`AWS_SECRET_ACCESS_KEY`
 
+Default access policy for uploaded files is ``private``, it can be changed
+(for example, to ``public-read``) via :setting:`S3_STORE_ACL`.
+
 .. _topics-feed-storage-stdout:
 
 Standard output

--- a/docs/topics/settings.rst
+++ b/docs/topics/settings.rst
@@ -607,6 +607,15 @@ For more information See the :ref:`extensions user guide  <topics-extensions>`
 and the :ref:`list of available extensions <topics-extensions-ref>`.
 
 
+.. setting:: FILES_STORE_S3_ACL
+
+FILES_STORE_S3_ACL
+------------------
+
+Default: ``'private'``
+
+S3-specific access control policy (ACL) for S3 files store.
+
 .. setting:: ITEM_PIPELINES
 
 ITEM_PIPELINES
@@ -925,15 +934,6 @@ If enabled, Scrapy will respect robots.txt policies. For more information see
     While the default value is ``False`` for historical reasons,
     this option is enabled by default in settings.py file generated
     by ``scrapy startproject`` command.
-
-.. setting:: S3_STORE_ACL
-
-S3_STORE_ACL
-------------
-
-Default: ``'private'``
-
-S3-specific access control policy (ACL) for uploaded files.
 
 .. setting:: SCHEDULER
 

--- a/docs/topics/settings.rst
+++ b/docs/topics/settings.rst
@@ -926,6 +926,15 @@ If enabled, Scrapy will respect robots.txt policies. For more information see
     this option is enabled by default in settings.py file generated
     by ``scrapy startproject`` command.
 
+.. setting:: S3_STORE_ACL
+
+S3_STORE_ACL
+------------
+
+Default: ``'private'``
+
+S3-specific access control policy (ACL) for uploaded files.
+
 .. setting:: SCHEDULER
 
 SCHEDULER

--- a/scrapy/pipelines/files.py
+++ b/scrapy/pipelines/files.py
@@ -82,7 +82,7 @@ class S3FilesStore(object):
     AWS_ACCESS_KEY_ID = None
     AWS_SECRET_ACCESS_KEY = None
 
-    POLICY = 'private'  # Overriden from settings.S3_STORE_ACL in
+    POLICY = 'private'  # Overriden from settings.FILES_STORE_S3_ACL in
                         # FilesPipeline.from_settings.
     HEADERS = {
         'Cache-Control': 'max-age=172800',
@@ -233,7 +233,7 @@ class FilesPipeline(MediaPipeline):
         s3store = cls.STORE_SCHEMES['s3']
         s3store.AWS_ACCESS_KEY_ID = settings['AWS_ACCESS_KEY_ID']
         s3store.AWS_SECRET_ACCESS_KEY = settings['AWS_SECRET_ACCESS_KEY']
-        s3store.POLICY = settings['S3_STORE_ACL']
+        s3store.POLICY = settings['FILES_STORE_S3_ACL']
 
         cls.FILES_URLS_FIELD = settings.get('FILES_URLS_FIELD', cls.DEFAULT_FILES_URLS_FIELD)
         cls.FILES_RESULT_FIELD = settings.get('FILES_RESULT_FIELD', cls.DEFAULT_FILES_RESULT_FIELD)

--- a/scrapy/pipelines/files.py
+++ b/scrapy/pipelines/files.py
@@ -82,7 +82,8 @@ class S3FilesStore(object):
     AWS_ACCESS_KEY_ID = None
     AWS_SECRET_ACCESS_KEY = None
 
-    POLICY = 'public-read'
+    POLICY = 'private'  # Overriden from settings.S3_STORE_ACL in
+                        # FilesPipeline.from_settings.
     HEADERS = {
         'Cache-Control': 'max-age=172800',
     }
@@ -232,6 +233,7 @@ class FilesPipeline(MediaPipeline):
         s3store = cls.STORE_SCHEMES['s3']
         s3store.AWS_ACCESS_KEY_ID = settings['AWS_ACCESS_KEY_ID']
         s3store.AWS_SECRET_ACCESS_KEY = settings['AWS_SECRET_ACCESS_KEY']
+        s3store.POLICY = settings['S3_STORE_ACL']
 
         cls.FILES_URLS_FIELD = settings.get('FILES_URLS_FIELD', cls.DEFAULT_FILES_URLS_FIELD)
         cls.FILES_RESULT_FIELD = settings.get('FILES_RESULT_FIELD', cls.DEFAULT_FILES_RESULT_FIELD)

--- a/scrapy/settings/default_settings.py
+++ b/scrapy/settings/default_settings.py
@@ -231,6 +231,8 @@ SCHEDULER = 'scrapy.core.scheduler.Scheduler'
 SCHEDULER_DISK_QUEUE = 'scrapy.squeues.PickleLifoDiskQueue'
 SCHEDULER_MEMORY_QUEUE = 'scrapy.squeues.LifoMemoryQueue'
 
+S3_STORE_ACL = 'private'
+
 SPIDER_LOADER_CLASS = 'scrapy.spiderloader.SpiderLoader'
 
 SPIDER_MIDDLEWARES = {}

--- a/scrapy/settings/default_settings.py
+++ b/scrapy/settings/default_settings.py
@@ -156,6 +156,8 @@ FEED_EXPORTERS_BASE = {
     'pickle': 'scrapy.exporters.PickleItemExporter',
 }
 
+FILES_STORE_S3_ACL = 'private'
+
 HTTPCACHE_ENABLED = False
 HTTPCACHE_DIR = 'httpcache'
 HTTPCACHE_IGNORE_MISSING = False
@@ -230,8 +232,6 @@ ROBOTSTXT_OBEY = False
 SCHEDULER = 'scrapy.core.scheduler.Scheduler'
 SCHEDULER_DISK_QUEUE = 'scrapy.squeues.PickleLifoDiskQueue'
 SCHEDULER_MEMORY_QUEUE = 'scrapy.squeues.LifoMemoryQueue'
-
-S3_STORE_ACL = 'private'
 
 SPIDER_LOADER_CLASS = 'scrapy.spiderloader.SpiderLoader'
 


### PR DESCRIPTION
See #1778 - this will make files uploaded via S3 private by default. If no settings customization is required, I can leave only the ``S3FilesStore.POLICY`` change.