### PR TITLE
Added DeltaLeveldbCacheStorage class

### DIFF
--- a/docs/topics/downloader-middleware.rst
+++ b/docs/topics/downloader-middleware.rst
@@ -467,6 +467,28 @@ In order to use this storage backend:
 .. _LevelDB: http://code.google.com/p/leveldb/
 .. _leveldb python bindings: https://pypi.python.org/pypi/leveldb
 
+Delta storage backend
+~~~~~~~~~~~~~~~~~~~~~~~
+
+.. versionadded:: 1.2.0dev2 
+
+A Delta encoding storage backend is also available for the HTTP cache middleware.
+
+This backend is based on the LevelDB storage backend, but uses BSDiff4's 
+delta encoding to gain additional performance in terms of storage space. The 
+algorithm works best when crawling domains that have self-similar pages because 
+it is storing a diff of most 'target' pages off of a 'source' page. 
+
+In order to use this storage backend:
+
+* set :setting:`HTTPCACHE_STORAGE` to ``scrapy.extensions.httpcache.DeltaLeveldbCacheStorage``
+* install `LevelDB python bindings`_ like ``pip install leveldb``
+* install `BSDiff4`_ like ``pip install bsdiff4``
+
+.. _LevelDB: http://code.google.com/p/leveldb/
+.. _leveldb python bindings: https://pypi.python.org/pypi/leveldb
+.. _BSDiff4: https://github.com/ilanschnell/bsdiff4
+.. _bsdiff4 python bindings: https://pypi.python.org/pypi/bsdiff4/1.1.4  
 
 HTTPCache middleware settings
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/tests/test_downloadermiddleware_httpcache.py
+++ b/tests/test_downloadermiddleware_httpcache.py
@@ -159,6 +159,11 @@ class LeveldbStorageTest(DefaultStorageTest):
     pytest.importorskip('leveldb')
     storage_class = 'scrapy.extensions.httpcache.LeveldbCacheStorage'
 
+class DeltaLeveldbStorageTest(DefaultStorageTest):
+
+    pytest.importorskip('leveldb')
+    pytest.importorskip('bsdiff4')
+    storage_class = 'scrapy.extensions.httpcache.DeltaLeveldbCacheStorage'
 
 class DummyPolicyTest(_BaseTest):
 

--- a/tox.ini
+++ b/tox.ini
@@ -13,6 +13,7 @@ deps =
     boto
     Pillow != 3.0.0
     leveldb
+    bsdiff4
     -rtests/requirements.txt
 commands =
     py.test --cov=scrapy --cov-report= {posargs:scrapy tests}


### PR DESCRIPTION
Our computer science capstone team decided to create a storage backend for scrapy to solve our sponsor's specific problem. We decided to build a backend that uses delta encoding as a means to save space when storing lots of web pages that are self similar, so we built a backend using bsdiff4 to do the encoding and built our class based on the existing leveldb backend. 

The backend will decompress data that is sent compressed by the server, serialize all the header data and body together in order to get better performance when calculating the diff, which it stores in LevelDB. On retrieval, it reconstructs the response from this form. 

We will have some more formal test data available, but as an example we took a crawl from a popular web comic and were able to take a 39M (FilesystemStorageCache, without accounting for block size) or 5.7M (LeveldbCacheStorage) to a 1.6M cache size, so we think this may be a pretty useful tool for other Scrapy users.
