### PR TITLE
Customize linkextractor's _collect_string_content()

### DIFF
--- a/scrapy/linkextractors/lxmlhtml.py
+++ b/scrapy/linkextractors/lxmlhtml.py
@@ -32,7 +32,7 @@ class LxmlParserLinkExtractor(object):
         self.scan_attr = attr if callable(attr) else lambda a: a == attr
         self.process_attr = process if callable(process) else lambda v: v
         self.unique = unique
-        self.text = etree.XPath('string(%s)' % text)
+        self.text = text if callable(text) else etree.XPath('string(%s)' % text)
 
     def _iter_links(self, document):
         for el in document.iter(etree.Element):


### PR DESCRIPTION
I want to customize the linkextractor's _collect_string_content().
My use case is that the anchor (<a>) may enclose lots of elements
(a bad web development practice)
and _collect_string_content() collects some gibberish from them.

I have more expectations from the achor's title attribute
than its text content.

I first thought of moving _collect_string_content() to a method
but I couldn't avoid having to subclass 2 classes
overriding one private and one magic method.
The most straightforward way I see is making it configurable.
##### TLDR

``` html
<a title="I prefer this for link.text">
  <style>instead of this </style>
  <script>or this</script>
</a>
```

So I want to be able to tell the extractor
to use some other xpath for textualization.
(see tests for example)
