### PR TITLE
Fix SkipTest() message for botocore import test

### DIFF
--- a/scrapy/utils/test.py
+++ b/scrapy/utils/test.py
@@ -24,7 +24,7 @@ def skip_if_no_boto():
     try:
         is_botocore()
     except NotConfigured as e:
-        raise SkipTest(str(e))
+        raise SkipTest(e)
 
 def get_s3_content_and_delete(bucket, path, with_key=False):
     """ Get content from s3 key, and delete key afterwards.

--- a/scrapy/utils/test.py
+++ b/scrapy/utils/test.py
@@ -24,7 +24,7 @@ def skip_if_no_boto():
     try:
         is_botocore()
     except NotConfigured as e:
-        raise SkipTest(e.message)
+        raise SkipTest(str(e))
 
 def get_s3_content_and_delete(bucket, path, with_key=False):
     """ Get content from s3 key, and delete key afterwards.


### PR DESCRIPTION
I was getting these errors while running Py3 tests without recreating my local tox virtualenvs (ie. still without botocore)

```
self = <tests.test_downloader_handlers.S3AnonTestCase testMethod=test_anon_request>

    def setUp(self):
>       skip_if_no_boto()

/home/paul/src/scrapy/tests/test_downloader_handlers.py:475: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

    def skip_if_no_boto():
        try:
            is_botocore()
        except NotConfigured as e:
>           raise SkipTest(e.message)
E           AttributeError: 'NotConfigured' object has no attribute 'message'

/home/paul/src/scrapy/scrapy/utils/test.py:27: AttributeError
```

With this patch, the skipped tests in this case (without botocore) do print out fine:

```
~/src/scrapy$ tox -v -e py34 -- -rxs tests/test_downloader_handlers.py
(...)
=============================================================================== test session starts ================================================================================
platform linux -- Python 3.4.3 -- py-1.4.31 -- pytest-2.7.3
rootdir: /home/paul/src/scrapy, inifile: pytest.ini
plugins: cov, twisted
collected 96 items 

tests/test_downloader_handlers.py ........................................s...........................s.s...........ssssssssssssss
============================================================================= short test summary info ==============================================================================
SKIP [1] tests/test_downloader_handlers.py:553: missing botocore library
SKIP [1] tests/test_downloader_handlers.py:596: missing botocore library
SKIP [1] tests/test_downloader_handlers.py:729: Twisted missing ftp support for PY3
SKIP [1] tests/test_downloader_handlers.py:576: missing botocore library
SKIP [1] tests/test_downloader_handlers.py:540: missing botocore library
SKIP [1] tests/test_downloader_handlers.py:705: Twisted missing ftp support for PY3
SKIP [1] tests/test_downloader_handlers.py:566: missing botocore library
SKIP [1] tests/test_downloader_handlers.py:619: missing botocore library
SKIP [1] tests/test_downloader_handlers.py:348: xpayload only enabled for PY2
SKIP [1] tests/test_downloader_handlers.py:523: missing botocore library
SKIP [1] tests/test_downloader_handlers.py:681: Twisted missing ftp support for PY3
SKIP [2] tests/test_downloader_handlers.py:183: test_timeout_download_from_spider skipped under https
SKIP [1] tests/test_downloader_handlers.py:714: Twisted missing ftp support for PY3
SKIP [1] tests/test_downloader_handlers.py:531: missing botocore library
SKIP [1] tests/test_downloader_handlers.py:692: Twisted missing ftp support for PY3
SKIP [1] tests/test_downloader_handlers.py:482: missing botocore library

====================================================================== 79 passed, 17 skipped in 14.73 seconds ======================================================================
_____________________________________________________________________________________ summary ______________________________________________________________________________________
  py34: commands succeeded
  congratulations :)
```