### PR TITLE
Re-enable HTTPS tests for download timeouts

### DIFF
--- a/scrapy/core/downloader/handlers/http11.py
+++ b/scrapy/core/downloader/handlers/http11.py
@@ -193,6 +193,7 @@ class ScrapyAgent(object):
         self._pool = pool
         self._maxsize = maxsize
         self._warnsize = warnsize
+        self._txresponse = None
 
     def _get_agent(self, request, timeout):
         bindaddress = request.meta.get('bindaddress') or self._bindAddress
@@ -259,6 +260,11 @@ class ScrapyAgent(object):
         if self._timeout_cl.active():
             self._timeout_cl.cancel()
             return result
+        # needed for HTTPS requests, otherwise _ResponseReader doesn't
+        # receive connectionLost()
+        if self._txresponse:
+            self._txresponse._transport.stopProducing()
+
         raise TimeoutError("Getting %s took longer than %s seconds." % (url, timeout))
 
     def _cb_latency(self, result, request, start_time):
@@ -294,6 +300,10 @@ class ScrapyAgent(object):
 
         d = defer.Deferred(_cancel)
         txresponse.deliverBody(_ResponseReader(d, txresponse, request, maxsize, warnsize))
+
+        # save response for timeouts
+        self._txresponse = txresponse
+
         return d
 
     def _cb_bodydone(self, result, request, url):

--- a/scrapy/core/downloader/webclient.py
+++ b/scrapy/core/downloader/webclient.py
@@ -83,6 +83,11 @@ class ScrapyHTTPPageGetter(HTTPClient):
 
     def timeout(self):
         self.transport.loseConnection()
+
+        # transport cleanup needed for HTTPS connections
+        if self.factory.url.startswith(b'https'):
+            self.transport.stopProducing()
+
         self.factory.noPage(\
                 defer.TimeoutError("Getting %s took longer than %s seconds." % \
                 (self.factory.url, self.factory.timeout)))

--- a/tests/test_downloader_handlers.py
+++ b/tests/test_downloader_handlers.py
@@ -182,17 +182,19 @@ class HttpTestCase(unittest.TestCase):
         return d
 
     @defer.inlineCallbacks
-    def test_timeout_download_from_spider(self):
-        if self.scheme == 'https':
-            raise unittest.SkipTest(
-                'test_timeout_download_from_spider skipped under https')
+    def test_timeout_download_from_spider_nodata_rcvd(self):
+        # client connects but no data is received
         spider = Spider('foo')
         meta = {'download_timeout': 0.2}
-        # client connects but no data is received
         request = Request(self.getURL('wait'), meta=meta)
         d = self.download_request(request, spider)
         yield self.assertFailure(d, defer.TimeoutError, error.TimeoutError)
+
+    @defer.inlineCallbacks
+    def test_timeout_download_from_spider_server_hangs(self):
         # client connects, server send headers and some body bytes but hangs
+        spider = Spider('foo')
+        meta = {'download_timeout': 0.2}
         request = Request(self.getURL('hang-after-headers'), meta=meta)
         d = self.download_request(request, spider)
         yield self.assertFailure(d, defer.TimeoutError, error.TimeoutError)


### PR DESCRIPTION
This PR seperates the original `test_timeout_download_from_spider` into two.

Before the change on `_cb_timeout`:

- HTTP/1.1 failed on `Https11TestCase.test_timeout_download_from_spider_server_hangs` only, `Https11TestCase.test_timeout_download_from_spider_nodata_rcvd` passes
- HTTP/1.0 failed on both `Https10TestCase.test_timeout_download_from_spider_nodata_rcvd` and `Https10TestCase.test_timeout_download_from_spider_server_hangs`

With this change, both HTTP/1.0 and HTTP/1.1 tests pass.
~~HTTP/1.0 are not fixed (yet).~~

The trick is to explicitly call Twisted transport stopProducing()
**If more Twisted-familiar eyes could give their thoughts, I'd be grateful**

This solved dirty reactor errors for me:
```
DirtyReactorAggregateError: Reactor was unclean.
Selectables:
<<class 'twisted.internet.tcp.Client'> to ('localhost', 35640) at 7f649799ff10>
```

It seems that when using HTTPS, `connectionLost()` is not called on the `_ResponseReader` protocol when the server hangs after sending some bytes.

Logs from test sesions on Python 2.7, comparing `Http11TestCase` and `Https11TestCase` for test `test_timeout_download_from_spider_server_hangs` (the tests were using 3 seconds timeouts instead of 0.2, to make debug prints clearer):

```
(scrapydev)paul@paul-SATELLITE-R830:~/src/scrapy$ tox -v -e py27 -- -s tests/test_downloader_handlers.py::Https11TestCase::test_timeout_download_from_spider_server_hangs
(...)
py27 runtests: commands[0] | py.test --cov=scrapy --cov-report= -s tests/test_downloader_handlers.py::Https11TestCase::test_timeout_download_from_spider_server_hangs
  /home/paul/src/scrapy$ /home/paul/src/scrapy/.tox/py27/bin/py.test --cov=scrapy --cov-report= -s tests/test_downloader_handlers.py::Https11TestCase::test_timeout_download_from_spider_server_hangs 
=============================================================================== test session starts ================================================================================
platform linux2 -- Python 2.7.10 -- py-1.4.31 -- pytest-2.7.3
rootdir: /home/paul/src/scrapy, inifile: pytest.ini
plugins: twisted, cov
collected 15 items 

tests/test_downloader_handlers.py [1456157717.16] ScrapyAgent::_cb_bodyready: txresponse=<twisted.web._newclient.Response object at 0x7ff97ffbed90>
[1456157717.16] _ResponseReader::dataReceived: 'some bytes'
[1456157720.15] ScrapyAgent::_cb_timeout: result=<twisted.python.failure.Failure twisted.internet.defer.CancelledError: >; timeout=3
[1456157720.15] ScrapyAgent::_cb_timeout: _txresponse={'_bodyBuffer': None,
 '_bodyProtocol': <scrapy.core.downloader.handlers.http11._ResponseReader instance at 0x7ff97ffc7bd8>,
 '_state': 'CONNECTED',
 '_transport': <twisted.web._newclient.TransportProxyProducer object at 0x7ff97ffbea90>,
 'code': 200,
 'headers': Headers({'date': ['Mon, 22 Feb 2016 16:15:17 GMT'], 'content-type': ['text/html'], 'server': ['TwistedWeb/15.5.0']}),
 'phrase': 'OK',
 'previousResponse': None,
 'request': <twisted.python.components.(Proxy for twisted.web.iweb.IClientRequest) object at 0x7ff97ffdb190>,
 'version': ('HTTP', 1, 1)}
[1456157720.15] ScrapyAgent::_cb_timeout: _transport={'_producer': <<class 'twisted.internet.tcp.Client'> to ('localhost', 38507) at 7ff98083e9d0>}
[1456157720.16] HTTP11DownloadHandler::close()
[1456157720.16] HTTP11DownloadHandler::close ::cancel_delayed_call
/home/paul/src/scrapy/.tox/py27/local/lib/python2.7/site-packages/service_identity/pyopenssl.py:97: SubjectAltNameWarning: Certificate has no `subjectAltName`, falling back to check for a `commonName` for now.  This feature is being removed by major browsers and deprecated by RFC 2818.
  SubjectAltNameWarning
F

===================================================================================== FAILURES =====================================================================================
__________________________________________________________ Https11TestCase.test_timeout_download_from_spider_server_hangs __________________________________________________________
NOTE: Incompatible Exception Representation, displaying natively:

DirtyReactorAggregateError: Reactor was unclean.
Selectables:
<<class 'twisted.internet.tcp.Client'> to ('localhost', 38507) at 7ff98083e9d0>

============================================================================= 1 failed in 4.67 seconds =============================================================================
ERROR: InvocationError: '/home/paul/src/scrapy/.tox/py27/bin/py.test --cov=scrapy --cov-report= -s tests/test_downloader_handlers.py::Https11TestCase::test_timeout_download_from_spider_server_hangs'
_____________________________________________________________________________________ summary ______________________________________________________________________________________
ERROR:   py27: commands failed
(scrapydev)paul@paul-SATELLITE-R830:~/src/scrapy$ tox -v -e py27 -- -s tests/test_downloader_handlers.py::Http11TestCase::test_timeout_download_from_spider_server_hangs
(...)
py27 runtests: commands[0] | py.test --cov=scrapy --cov-report= -s tests/test_downloader_handlers.py::Http11TestCase::test_timeout_download_from_spider_server_hangs
  /home/paul/src/scrapy$ /home/paul/src/scrapy/.tox/py27/bin/py.test --cov=scrapy --cov-report= -s tests/test_downloader_handlers.py::Http11TestCase::test_timeout_download_from_spider_server_hangs 
=============================================================================== test session starts ================================================================================
platform linux2 -- Python 2.7.10 -- py-1.4.31 -- pytest-2.7.3
rootdir: /home/paul/src/scrapy, inifile: pytest.ini
plugins: twisted, cov
collected 15 items 

tests/test_downloader_handlers.py [1456157734.47] ScrapyAgent::_cb_bodyready: txresponse=<twisted.web._newclient.Response object at 0x7fbc6479fed0>
[1456157734.47] _ResponseReader::dataReceived: 'some bytes'
[1456157737.47] ScrapyAgent::_cb_timeout: result=<twisted.python.failure.Failure twisted.internet.defer.CancelledError: >; timeout=3
[1456157737.47] ScrapyAgent::_cb_timeout: _txresponse={'_bodyBuffer': None,
 '_bodyProtocol': <scrapy.core.downloader.handlers.http11._ResponseReader instance at 0x7fbc647a9fc8>,
 '_state': 'CONNECTED',
 '_transport': <twisted.web._newclient.TransportProxyProducer object at 0x7fbc6479fb90>,
 'code': 200,
 'headers': Headers({'content-type': ['text/html'], 'server': ['TwistedWeb/15.5.0'], 'date': ['Mon, 22 Feb 2016 16:15:34 GMT']}),
 'phrase': 'OK',
 'previousResponse': None,
 'request': <twisted.python.components.(Proxy for twisted.web.iweb.IClientRequest) object at 0x7fbc63f382d0>,
 'version': ('HTTP', 1, 1)}
[1456157737.47] ScrapyAgent::_cb_timeout: _transport={'_producer': <<class 'twisted.internet.tcp.Client'> to ('localhost', 44969) at 7fbc6477c710>}
[1456157737.48] _ResponseReader::connectionLost(<twisted.python.failure.Failure twisted.web._newclient.ResponseFailed: [<twisted.python.failure.Failure twisted.internet.error.ConnectionDone: Connection was closed cleanly.>, <twisted.python.failure.Failure twisted.web.http._DataLoss: Chunked decoder in 'CHUNK_LENGTH' state, still expecting more data to get to 'FINISHED' state.>]>)
[1456157737.48] HTTP11DownloadHandler::close()
[1456157737.48] HTTP11DownloadHandler::close ::cancel_delayed_call
.

============================================================================= 1 passed in 4.66 seconds =============================================================================
_____________________________________________________________________________________ summary ______________________________________________________________________________________
  py27: commands succeeded
  congratulations :)
```


Compare with a (Python3.5) test with this change: you can see `_ResponseReader::connectionLost()` being called after `_cb_timeout` fires

```
(scrapydev)paul@paul-SATELLITE-R830:~/src/scrapy$ tox -v -e py35 -- -s tests/test_downloader_handlers.py::Https11TestCase::test_timeout_download_from_spider_server_hangs
(...)
py35 runtests: commands[0] | py.test --cov=scrapy --cov-report= -s tests/test_downloader_handlers.py::Https11TestCase::test_timeout_download_from_spider_server_hangs
  /home/paul/src/scrapy$ /home/paul/src/scrapy/.tox/py35/bin/py.test --cov=scrapy --cov-report= -s tests/test_downloader_handlers.py::Https11TestCase::test_timeout_download_from_spider_server_hangs 
=============================================================================== test session starts ================================================================================
platform linux -- Python 3.5.0 -- py-1.4.31 -- pytest-2.7.3
rootdir: /home/paul/src/scrapy, inifile: pytest.ini
plugins: twisted, cov
collected 15 items 

tests/test_downloader_handlers.py [1456159627.087895] ScrapyAgent::_cb_bodyready: txresponse=<twisted.web._newclient.Response object at 0x7f06c7fe5a20>
[1456159627.088218] _ResponseReader::dataReceived: b'some bytes'
[1456159627.2533302] ScrapyAgent::_cb_timeout: result="{'_rawexcinfo': (<class 'twisted.internet.defer.CancelledError'>,\n                 CancelledError(),\n                 None),\n 'captureVars': None,\n 'count': 6,\n 'frames': [],\n 'parents': ['twisted.internet.defer.CancelledError',\n             'builtins.Exception',\n             'builtins.BaseException',\n             'builtins.object'],\n 'stack': [],\n 'tb': None,\n 'type': <class 'twisted.internet.defer.CancelledError'>,\n 'value': CancelledError()}"; timeout=0.2
[1456159627.2551134] ScrapyAgent::_cb_timeout: _txresponse={'_bodyBuffer': None,
 '_bodyProtocol': <scrapy.core.downloader.handlers.http11._ResponseReader object at 0x7f06c802cdd8>,
 '_state': 'CONNECTED',
 '_transport': <twisted.web._newclient.TransportProxyProducer object at 0x7f06c802cb38>,
 'code': 200,
 'headers': Headers({b'server': [b'TwistedWeb/15.5.0'], b'content-type': [b'text/html'], b'date': [b'Mon, 22 Feb 2016 16:47:07 GMT']}),
 'phrase': b'OK',
 'previousResponse': None,
 'request': <twisted.python.components.(Proxy for twisted.web.iweb.IClientRequest) object at 0x7f06c802c0b8>,
 'version': (b'HTTP', 1, 1)}
[1456159627.256337] ScrapyAgent::_cb_timeout: _transport={'_producer': <twisted.protocols.tls.TLSMemoryBIOProtocol object at 0x7f06c802c630>}
[1456159627.2596357] _ResponseReader::connectionLost(<twisted.python.failure.Failure twisted.web._newclient.ResponseFailed: [<twisted.python.failure.Failure twisted.internet.error.ConnectionLost: Connection to the other side was lost in a non-clean fashion: Connection lost.>, <twisted.python.failure.Failure twisted.web.http._DataLoss: Chunked decoder in 'CHUNK_LENGTH' state, still expecting more data to get to 'FINISHED' state.>]>)
[1456159627.2607982] HTTP11DownloadHandler::close()
[1456159627.2611334] HTTP11DownloadHandler::close ::cancel_delayed_call
/home/paul/src/scrapy/.tox/py35/lib/python3.5/site-packages/service_identity/pyopenssl.py:97: SubjectAltNameWarning: Certificate has no `subjectAltName`, falling back to check for a `commonName` for now.  This feature is being removed by major browsers and deprecated by RFC 2818.
  SubjectAltNameWarning
.

============================================================================= 1 passed in 3.02 seconds =============================================================================
_____________________________________________________________________________________ summary ______________________________________________________________________________________
  py35: commands succeeded
  congratulations :)

```
