### PR TITLE
[WIP] Handle 201 responses in pipelines.files 

### DIFF
--- a/scrapy/pipelines/files.py
+++ b/scrapy/pipelines/files.py
@@ -273,6 +273,14 @@ class FilesPipeline(MediaPipeline):
                     redirect_dfd = DeferredList(redirect_dlist, consumeErrors=1)
                     return redirect_dfd
 
+            logger.warning(
+                'File (code: %(status)s): Error downloading file from '
+                '%(request)s referred in <%(referer)s>',
+                {'status': response.status,
+                 'request': request, 'referer': referer},
+                extra={'spider': info.spider}
+            )
+
             raise FileException('download-error')
 
         if not response.body:


### PR DESCRIPTION
Added a check for `location` field in `201` responses. The `location` field is to have the link for the resource created due to the request.
Fixes #1615 
