### PR TITLE
[backport][1.1] Add "Content-Length: 0" for body-less HTTP/1.1 POST requests

### DIFF
--- a/scrapy/core/downloader/handlers/http11.py
+++ b/scrapy/core/downloader/handlers/http11.py
@@ -209,7 +209,21 @@ class ScrapyAgent(object):
         headers = TxHeaders(request.headers)
         if isinstance(agent, self._TunnelingAgent):
             headers.removeHeader(b'Proxy-Authorization')
-        bodyproducer = _RequestBodyProducer(request.body) if request.body else None
+        if request.body:
+            bodyproducer = _RequestBodyProducer(request.body)
+        else:
+            bodyproducer = None
+            # Setting Content-Length: 0 even for POST requests is not a
+            # MUST per HTTP RFCs, but it's common behavior, and some
+            # server require this otherwise returing HTTP 411
+            #
+            # RFC 7230#section-3.3.2:
+            # "a Content-Length header field is normally sent in a POST
+            # request even when the value is 0 (indicating an empty payload body)."
+            #
+            # Twisted Agent will not add "Content-Length: 0" by itself
+            if method == b'POST':
+                headers.addRawHeader(b'Content-Length', b'0')
 
         start_time = time()
         d = agent.request(

--- a/scrapy/core/downloader/handlers/http11.py
+++ b/scrapy/core/downloader/handlers/http11.py
@@ -215,7 +215,7 @@ class ScrapyAgent(object):
             bodyproducer = None
             # Setting Content-Length: 0 even for POST requests is not a
             # MUST per HTTP RFCs, but it's common behavior, and some
-            # server require this otherwise returing HTTP 411
+            # servers require this, otherwise returning HTTP 411 Length required
             #
             # RFC 7230#section-3.3.2:
             # "a Content-Length header field is normally sent in a POST


### PR DESCRIPTION
Commits from https://github.com/scrapy/scrapy/pull/1800