### PR TITLE
[MRG+1] Refactored SpiderLoader class constructor for easier subclassing

### DIFF
--- a/scrapy/spiderloader.py
+++ b/scrapy/spiderloader.py
@@ -17,13 +17,16 @@ class SpiderLoader(object):
     def __init__(self, settings):
         self.spider_modules = settings.getlist('SPIDER_MODULES')
         self._spiders = {}
-        for name in self.spider_modules:
-            for module in walk_modules(name):
-                self._load_spiders(module)
-
+        self._load_all_spiders()
+            
     def _load_spiders(self, module):
         for spcls in iter_spider_classes(module):
             self._spiders[spcls.name] = spcls
+
+    def _load_all_spiders(self):
+        for name in self.spider_modules:
+            for module in walk_modules(name):
+                self._load_spiders(module)
 
     @classmethod
     def from_settings(cls, settings):


### PR DESCRIPTION
As discussed here https://github.com/scrapy/scrapy/issues/1805 I modified the SpiderLoader class making it possible to avoid pre-loading all spiders when subclassing from it without having to copy the constructor's code.