### PR TITLE
[MRG+1] Remove dependency on os.environ from default settings

### DIFF
--- a/docs/topics/commands.rst
+++ b/docs/topics/commands.rst
@@ -291,12 +291,12 @@ edit
 * Syntax: ``scrapy edit <spider>``
 * Requires project: *yes*
 
-Edit the given spider using the editor defined in the :setting:`EDITOR`
-setting.
+Edit the given spider using the editor defined in the ``EDITOR`` environment
+variable or (if unset) the :setting:`EDITOR` setting.
 
 This command is provided only as a convenience shortcut for the most common
 case, the developer is of course free to choose any tool or IDE to write and
-debug his spiders.
+debug spiders.
 
 Usage example::
 

--- a/docs/topics/settings.rst
+++ b/docs/topics/settings.rst
@@ -635,11 +635,11 @@ Setting :setting:`DUPEFILTER_DEBUG` to ``True`` will make it log all duplicate r
 EDITOR
 ------
 
-Default: `depends on the environment`
+Default: ``vi`` (on Unix systems) or the IDLE editor (on Windows)
 
-The editor to use for editing spiders with the :command:`edit` command. It
-defaults to the ``EDITOR`` environment variable, if set. Otherwise, it defaults
-to ``vi`` (on Unix systems) or the IDLE editor (on Windows).
+The editor to use for editing spiders with the :command:`edit` command.
+Additionally, if the ``EDITOR`` environment variable is set, the :command:`edit`
+command will prefer it over the default setting.
 
 .. setting:: EXTENSIONS
 

--- a/scrapy/cmdline.py
+++ b/scrapy/cmdline.py
@@ -1,5 +1,5 @@
 from __future__ import print_function
-import sys
+import sys, os
 import optparse
 import cProfile
 import inspect
@@ -106,6 +106,12 @@ def execute(argv=None, settings=None):
 
     if settings is None:
         settings = get_project_settings()
+        # set EDITOR from environment if available
+        try:
+            editor = os.environ['EDITOR']
+        except KeyError: pass
+        else:
+            settings['EDITOR'] = editor
     check_deprecated_settings(settings)
 
     # --- backwards compatibility for scrapy.conf.settings singleton ---

--- a/scrapy/commands/edit.py
+++ b/scrapy/commands/edit.py
@@ -3,6 +3,7 @@ import sys, os
 from scrapy.commands import ScrapyCommand
 from scrapy.exceptions import UsageError
 
+
 class Command(ScrapyCommand):
 
     requires_project = True
@@ -15,7 +16,8 @@ class Command(ScrapyCommand):
         return "Edit spider"
 
     def long_desc(self):
-        return "Edit a spider using the editor defined in EDITOR setting"
+        return ("Edit a spider using the editor defined in the EDITOR environment"
+                " variable or else the EDITOR setting")
 
     def _err(self, msg):
         sys.stderr.write(msg + os.linesep)

--- a/scrapy/settings/default_settings.py
+++ b/scrapy/settings/default_settings.py
@@ -13,7 +13,6 @@ Scrapy developers, if you add a setting here remember to:
 
 """
 
-import os
 import sys
 from importlib import import_module
 from os.path import join, abspath, dirname
@@ -111,13 +110,9 @@ DOWNLOADER_STATS = True
 
 DUPEFILTER_CLASS = 'scrapy.dupefilters.RFPDupeFilter'
 
-try:
-    EDITOR = os.environ['EDITOR']
-except KeyError:
-    if sys.platform == 'win32':
-        EDITOR = '%s -m idlelib.idle'
-    else:
-        EDITOR = 'vi'
+EDITOR = 'vi'
+if sys.platform == 'win32':
+    EDITOR = '%s -m idlelib.idle'
 
 EXTENSIONS = {}
 


### PR DESCRIPTION
Avoid loading settings from Environment in scrapy core.
(Then it's not a _default setting_ but a user-defined one, by definition.)
Instead it's better to populate them from the starting shell or an embedding script.

Plug: noticed this while in the mindset of scrapy as a library (https://github.com/scrapy/scrapy/issues/1777#issuecomment-189419147).
