### PR TITLE
[Backport][1.1] Re-enable HTTPS tests for download timeouts

### DIFF
--- a/scrapy/core/downloader/webclient.py
+++ b/scrapy/core/downloader/webclient.py
@@ -83,6 +83,11 @@ class ScrapyHTTPPageGetter(HTTPClient):
 
     def timeout(self):
         self.transport.loseConnection()
+
+        # transport cleanup needed for HTTPS connections
+        if self.factory.url.startswith(b'https'):
+            self.transport.stopProducing()
+
         self.factory.noPage(\
                 defer.TimeoutError("Getting %s took longer than %s seconds." % \
                 (self.factory.url, self.factory.timeout)))

--- a/tests/test_downloader_handlers.py
+++ b/tests/test_downloader_handlers.py
@@ -182,17 +182,19 @@ class HttpTestCase(unittest.TestCase):
         return d
 
     @defer.inlineCallbacks
-    def test_timeout_download_from_spider(self):
-        if self.scheme == 'https':
-            raise unittest.SkipTest(
-                'test_timeout_download_from_spider skipped under https')
+    def test_timeout_download_from_spider_nodata_rcvd(self):
+        # client connects but no data is received
         spider = Spider('foo')
         meta = {'download_timeout': 0.2}
-        # client connects but no data is received
         request = Request(self.getURL('wait'), meta=meta)
         d = self.download_request(request, spider)
         yield self.assertFailure(d, defer.TimeoutError, error.TimeoutError)
+
+    @defer.inlineCallbacks
+    def test_timeout_download_from_spider_server_hangs(self):
         # client connects, server send headers and some body bytes but hangs
+        spider = Spider('foo')
+        meta = {'download_timeout': 0.2}
         request = Request(self.getURL('hang-after-headers'), meta=meta)
         d = self.download_request(request, spider)
         yield self.assertFailure(d, defer.TimeoutError, error.TimeoutError)


### PR DESCRIPTION
Backport #1804 into 1.1 branch.