### PR TITLE
[MRG+1] response_status_message should not fail on non-standard HTTP codes

### DIFF
--- a/scrapy/utils/response.py
+++ b/scrapy/utils/response.py
@@ -47,14 +47,8 @@ def get_meta_refresh(response):
 
 def response_status_message(status):
     """Return status code plus status text descriptive message
-
-    >>> response_status_message(200)
-    '200 OK'
-
-    >>> response_status_message(404)
-    '404 Not Found'
     """
-    return '%s %s' % (status, to_native_str(http.RESPONSES.get(int(status))))
+    return '%s %s' % (status, to_native_str(http.RESPONSES.get(int(status), "Unknown Status")))
 
 
 def response_httprepr(response):

--- a/tests/test_utils_response.py
+++ b/tests/test_utils_response.py
@@ -5,7 +5,7 @@ from six.moves.urllib.parse import urlparse
 from scrapy.http import Response, TextResponse, HtmlResponse
 from scrapy.utils.python import to_bytes
 from scrapy.utils.response import (response_httprepr, open_in_browser,
-                                   get_meta_refresh, get_base_url)
+                                   get_meta_refresh, get_base_url, response_status_message)
 
 __doctests__ = ['scrapy.utils.response']
 
@@ -78,3 +78,8 @@ class ResponseUtilsTest(unittest.TestCase):
         resp2 = HtmlResponse("http://www.example.com", body=b"""
         <html><body>blahablsdfsal&amp;</body></html>""")
         self.assertEqual(get_base_url(resp2), "http://www.example.com")
+
+    def test_response_status_message(self):
+        self.assertEqual(response_status_message(200), '200 OK')
+        self.assertEqual(response_status_message(404), '404 Not Found')
+        self.assertEqual(response_status_message(573), "573 Unknown Status")


### PR DESCRIPTION
utility is used in retry middleware and it was failing to handle non-standard HTTP codes. Instead of raising exceptions when passing through `to_native_str` it should return "Unknown status" message.