### PR TITLE
Changed sel. to response. for clarity

### DIFF
--- a/docs/topics/selectors.rst
+++ b/docs/topics/selectors.rst
@@ -151,7 +151,7 @@ It returns ``None`` if no element was found:
 
 A default return value can be provided as an argument, to be used instead of ``None``:
 
-    >>> sel.xpath('//div[@id="not-exists"]/text()').extract_first(default='not-found')
+    >>> response.xpath('//div[@id="not-exists"]/text()').extract_first(default='not-found')
     'not-found'
 
 Notice that CSS selectors can select text or attribute nodes using CSS3


### PR DESCRIPTION
Changed sel. to response. to comply with the rest of the examples in the same section, to avoid confusion.