### PR TITLE
Add encoding to Link object + re-enable HTML entities links tests

### DIFF
--- a/scrapy/http/request/__init__.py
+++ b/scrapy/http/request/__init__.py
@@ -49,7 +49,7 @@ class Request(object_ref):
         if not isinstance(url, six.string_types):
             raise TypeError('Request url must be str or unicode, got %s:' % type(url).__name__)
 
-        s = safe_url_string(url, self._encoding)
+        s = safe_url_string(url, self.encoding)
         self._url = escape_ajax(s)
 
         if ':' not in self._url:

--- a/scrapy/http/request/__init__.py
+++ b/scrapy/http/request/__init__.py
@@ -5,12 +5,11 @@ requests in Scrapy.
 See documentation in docs/topics/request-response.rst
 """
 import six
-from w3lib.url import safe_url_string
 
 from scrapy.http.headers import Headers
-from scrapy.utils.python import to_native_str, to_bytes
+from scrapy.utils.python import to_bytes
 from scrapy.utils.trackref import object_ref
-from scrapy.utils.url import escape_ajax
+from scrapy.utils.url import escape_ajax, safe_url_string
 from scrapy.http.common import obsolete_setter
 
 
@@ -50,8 +49,8 @@ class Request(object_ref):
         if not isinstance(url, six.string_types):
             raise TypeError('Request url must be str or unicode, got %s:' % type(url).__name__)
 
-        url = to_native_str(url, self.encoding)
-        self._url = escape_ajax(safe_url_string(url))
+        s = safe_url_string(url, self._encoding)
+        self._url = escape_ajax(s)
 
         if ':' not in self._url:
             raise ValueError('Missing scheme in request url: %s' % self._url)

--- a/scrapy/http/request/__init__.py
+++ b/scrapy/http/request/__init__.py
@@ -5,11 +5,12 @@ requests in Scrapy.
 See documentation in docs/topics/request-response.rst
 """
 import six
+from w3lib.url import safe_url_string
 
 from scrapy.http.headers import Headers
 from scrapy.utils.python import to_bytes
 from scrapy.utils.trackref import object_ref
-from scrapy.utils.url import escape_ajax, safe_url_string
+from scrapy.utils.url import escape_ajax
 from scrapy.http.common import obsolete_setter
 
 

--- a/scrapy/http/request/form.py
+++ b/scrapy/http/request/form.py
@@ -10,7 +10,7 @@ import lxml.html
 from parsel.selector import create_root_node
 import six
 from scrapy.http.request import Request
-from scrapy.utils.python import to_bytes, to_unicode, is_listlike
+from scrapy.utils.python import to_bytes, is_listlike
 from scrapy.utils.response import get_base_url
 
 
@@ -120,7 +120,7 @@ def _get_inputs(form, formdata, dont_click, clickdata, response):
                         '  not(re:test(., "^(?:checkbox|radio)$", "i")))]]',
                         namespaces={
                             "re": "http://exslt.org/regular-expressions"})
-    values = [(to_unicode(k), u'' if v is None else v)
+    values = [(k, u'' if v is None else v)
               for k, v in (_value(e) for e in inputs)
               if k and k not in formdata]
 

--- a/scrapy/http/request/form.py
+++ b/scrapy/http/request/form.py
@@ -10,7 +10,7 @@ import lxml.html
 from parsel.selector import create_root_node
 import six
 from scrapy.http.request import Request
-from scrapy.utils.python import to_bytes, is_listlike
+from scrapy.utils.python import to_bytes, to_unicode, is_listlike
 from scrapy.utils.response import get_base_url
 
 
@@ -120,7 +120,7 @@ def _get_inputs(form, formdata, dont_click, clickdata, response):
                         '  not(re:test(., "^(?:checkbox|radio)$", "i")))]]',
                         namespaces={
                             "re": "http://exslt.org/regular-expressions"})
-    values = [(k, u'' if v is None else v)
+    values = [(to_unicode(k), u'' if v is None else v)
               for k, v in (_value(e) for e in inputs)
               if k and k not in formdata]
 

--- a/scrapy/link.py
+++ b/scrapy/link.py
@@ -13,9 +13,9 @@ from scrapy.utils.python import to_bytes
 class Link(object):
     """Link objects represent an extracted link by the LinkExtractor."""
 
-    __slots__ = ['url', 'text', 'fragment', 'nofollow']
+    __slots__ = ['url', 'text', 'fragment', 'nofollow', 'encoding']
 
-    def __init__(self, url, text='', fragment='', nofollow=False):
+    def __init__(self, url, text='', fragment='', nofollow=False, encoding='utf8'):
         if not isinstance(url, str):
             if six.PY2:
                 warnings.warn("Link urls must be str objects. "
@@ -28,6 +28,7 @@ class Link(object):
         self.text = text
         self.fragment = fragment
         self.nofollow = nofollow
+        self.encoding = encoding
 
     def __eq__(self, other):
         return self.url == other.url and self.text == other.text and \

--- a/scrapy/linkextractors/__init__.py
+++ b/scrapy/linkextractors/__init__.py
@@ -100,7 +100,7 @@ class FilteringLinkExtractor(object):
         links = [x for x in links if self._link_allowed(x)]
         if self.canonicalize:
             for link in links:
-                link.url = canonicalize_url(urlparse(link.url))
+                link.url = canonicalize_url(link.url, encoding=link.encoding)
         links = self.link_extractor._process_links(links)
         return links
 

--- a/scrapy/linkextractors/lxmlhtml.py
+++ b/scrapy/linkextractors/lxmlhtml.py
@@ -11,6 +11,7 @@ from scrapy.utils.misc import arg_to_iter, rel_has_nofollow
 from scrapy.utils.python import unique as unique_list, to_native_str
 from scrapy.linkextractors import FilteringLinkExtractor
 from scrapy.utils.response import get_base_url
+from scrapy.utils.url import safe_url_string
 
 
 # from lxml/src/lxml/html/__init__.py
@@ -56,11 +57,12 @@ class LxmlParserLinkExtractor(object):
                 url = self.process_attr(attr_val)
                 if url is None:
                     continue
-            url = to_native_str(url, encoding=response_encoding)
-            # to fix relative links after process_value
-            url = urljoin(response_url, url)
+            url = safe_url_string(url, encoding=response_encoding)
+            url = urljoin(base_url, url)
+
             link = Link(url, _collect_string_content(el) or u'',
-                        nofollow=rel_has_nofollow(el.get('rel')))
+                        nofollow=rel_has_nofollow(el.get('rel')),
+                        encoding=response_encoding)
             links.append(link)
         return self._deduplicate_if_needed(links)
 

--- a/scrapy/linkextractors/lxmlhtml.py
+++ b/scrapy/linkextractors/lxmlhtml.py
@@ -5,13 +5,13 @@ import six
 from six.moves.urllib.parse import urlparse, urljoin
 
 import lxml.etree as etree
+from w3lib.url import safe_url_string
 
 from scrapy.link import Link
 from scrapy.utils.misc import arg_to_iter, rel_has_nofollow
 from scrapy.utils.python import unique as unique_list, to_native_str
 from scrapy.linkextractors import FilteringLinkExtractor
 from scrapy.utils.response import get_base_url
-from scrapy.utils.url import safe_url_string
 
 
 # from lxml/src/lxml/html/__init__.py

--- a/scrapy/utils/url.py
+++ b/scrapy/utils/url.py
@@ -42,26 +42,30 @@ def url_has_any_extension(url, extensions):
 
 
 def safe_url_string(url, encoding='utf8', path_encoding='utf8'):
-    """Convert the given url into a legal URL by escaping unsafe characters
+    """Convert the given URL into a legal URL by escaping unsafe characters
     according to RFC-3986.
-
-    If a unicode url is given, it is first converted to str using the given
-    encoding (which defaults to 'utf-8'). When passing a encoding, you should
-    use the encoding of the original page (the page from which the url was
-    extracted from).
-
-    Calling this function on an already "safe" url will return the url
+    If a bytes URL is given, it is first converted to `str` using the given
+    encoding (which defaults to 'utf-8'). 'utf-8' encoding is used for
+    URL path component (unless overriden by path_encoding), and given
+    encoding is used for query string or form data.
+    When passing a encoding, you should use the encoding of the
+    original page (the page from which the url was extracted from).
+    Calling this function on an already "safe" URL will return the URL
     unmodified.
-
-    Always returns a native str (bytes in Python 2, unicode in Python 3).
+    Always returns a native `str` (bytes in Python2, unicode in Python3).
     """
-    # Python3 chokes on bytes input with non-ASCII chars
-    # This is wrong! encoding only applies to query part, not the whole URL
-    #parts = urlsplit(to_unicode(url, encoding=encoding))
-    # let's consider the string as "correct": if bytes, they should be safe
-    parts = urlsplit(url)
+    # Python3's urlsplit() chokes on bytes input with non-ASCII chars,
+    # so let's decode (to Unicode) using page encoding.
+    #
+    # it is assumed that a raw bytes input comes from the page
+    # corresponding to the encoding
+    #
+    # Note: if this assumption is wrong, this will fail;
+    #       in the general case, users are required to use Unicode
+    #       or safe ASCII bytes input
+    parts = urlsplit(to_unicode(url, encoding=encoding))
 
-    # quote() in Python2 return type follows input type
+    # quote() in Python2 return type follows input type;
     # quote() in Python3 always returns Unicode (native str)
     return urlunsplit((
         to_native_str(parts.scheme),

--- a/scrapy/utils/url.py
+++ b/scrapy/utils/url.py
@@ -7,15 +7,19 @@ to the w3lib.url module. Always import those from there instead.
 """
 import posixpath
 import re
+import six
 from six.moves.urllib.parse import (ParseResult, urlunparse, urldefrag,
                                     urlparse, parse_qsl, urlencode,
                                     unquote)
+from six.moves.urllib.parse import quote, urlsplit, urlunsplit
+if six.PY3:
+    from urllib.parse import unquote_to_bytes
 
 # scrapy.utils.url was moved to w3lib.url and import * ensures this
 # move doesn't break old code
 from w3lib.url import *
 from w3lib.url import _safe_chars
-from scrapy.utils.python import to_native_str
+from scrapy.utils.python import to_bytes, to_native_str, to_unicode
 
 
 def url_is_from_any_domain(url, domains):
@@ -37,42 +41,98 @@ def url_has_any_extension(url, extensions):
     return posixpath.splitext(parse_url(url).path)[1].lower() in extensions
 
 
+def safe_url_string(url, encoding='utf8', path_encoding='utf8'):
+    """Convert the given url into a legal URL by escaping unsafe characters
+    according to RFC-3986.
+
+    If a unicode url is given, it is first converted to str using the given
+    encoding (which defaults to 'utf-8'). When passing a encoding, you should
+    use the encoding of the original page (the page from which the url was
+    extracted from).
+
+    Calling this function on an already "safe" url will return the url
+    unmodified.
+
+    Always returns a native str (bytes in Python 2, unicode in Python 3).
+    """
+    # Python3 chokes on bytes input with non-ASCII chars
+    # This is wrong! encoding only applies to query part, not the whole URL
+    #parts = urlsplit(to_unicode(url, encoding=encoding))
+    # let's consider the string as "correct": if bytes, they should be safe
+    parts = urlsplit(url)
+
+    # quote() in Python2 return type follows input type
+    # quote() in Python3 always returns Unicode (native str)
+    return urlunsplit((
+        to_native_str(parts.scheme),
+        to_native_str(parts.netloc),
+
+        # default encoding for path component SHOULD be UTF-8
+        quote(to_bytes(parts.path, path_encoding), _safe_chars),
+
+        # encoding of query and fragment follows page encoding
+        # or form-charset (if known and passed)
+        quote(to_bytes(parts.query, encoding), _safe_chars),
+        quote(to_bytes(parts.fragment, encoding), _safe_chars),
+    ))
+
+
 def canonicalize_url(url, keep_blank_values=True, keep_fragments=False,
                      encoding=None):
     """Canonicalize the given url by applying the following procedures:
 
     - sort query arguments, first by key, then by value
-    - percent encode paths and query arguments. non-ASCII characters are
-      percent-encoded using UTF-8 (RFC-3986)
+    - percent encode paths ; non-ASCII characters are percent-encoded
+      using UTF-8 (RFC-3986)
+    - percent encode query arguments ; non-ASCII characters are percent-encoded
+      using passed `encoding` (UTF-8 by default)
     - normalize all spaces (in query arguments) '+' (plus symbol)
     - normalize percent encodings case (%2f -> %2F)
-    - remove query arguments with blank values (unless keep_blank_values is True)
-    - remove fragments (unless keep_fragments is True)
+    - remove query arguments with blank values (unless `keep_blank_values` is True)
+    - remove fragments (unless `keep_fragments` is True)
 
-    The url passed can be a str or unicode, while the url returned is always a
-    str.
+    The url passed can be bytes or unicode, while the url returned is
+    always a native str (bytes in Python 2, unicode in Python 3).
 
     For examples see the tests in tests/test_utils_url.py
     """
-
     scheme, netloc, path, params, query, fragment = parse_url(url)
-    keyvals = parse_qsl(query, keep_blank_values)
+
+    # 1. decode query-string using document encoding
+    ekwargs = {}
+    if not six.PY2:
+        # Python3's urllib.parse methods have "encoding" argument
+        # Python2's methods handle non-UTF-8 encoded input just fine
+        ekwargs['encoding'] = encoding
+    keyvals = parse_qsl(query, keep_blank_values, **ekwargs)
     keyvals.sort()
-    query = urlencode(keyvals)
+    query = urlencode(keyvals, **ekwargs)
 
-    # XXX: copied from w3lib.url.safe_url_string to add encoding argument
-    # path = to_native_str(path, encoding)
-    # path = moves.urllib.parse.quote(path, _safe_chars, encoding='latin1') or '/'
+    # 2. decode percent-encoded sequences in path as UTF-8 (or keep raw bytes)
+    #    and percent-encode path again (this normalizes to upper-case %XX)
+    uqp = _unquotepath(path)
+    path = quote(uqp, _safe_chars) or '/'
 
-    path = safe_url_string(_unquotepath(path)) or '/'
     fragment = '' if not keep_fragments else fragment
+
+    # every part should be safe already
     return urlunparse((scheme, netloc.lower(), path, params, query, fragment))
 
 
 def _unquotepath(path):
     for reserved in ('2f', '2F', '3f', '3F'):
         path = path.replace('%' + reserved, '%25' + reserved.upper())
-    return unquote(path)
+
+    if six.PY3:
+        # regular unquote() does not work in Python 3 for non-UTF-8
+        # percent-escaped characters, they get lost.
+        # e.g., '%a3' becomes 'REPLACEMENT CHARACTER' (U+FFFD)
+        #
+        # unquote_to_bytes() returns raw bytes instead
+        return unquote_to_bytes(path)
+    else:
+        # in Python 2, '%a3' becomes '\xa3', which is what we want
+        return unquote(path)
 
 
 def parse_url(url, encoding=None):

--- a/scrapy/utils/url.py
+++ b/scrapy/utils/url.py
@@ -107,7 +107,13 @@ def canonicalize_url(url, keep_blank_values=True, keep_fragments=False,
     # badly encoded percent-encoded sequences are handled below
     # by re-parsing path and query-string (may be sub-optimal)
     if not isinstance(url, ParseResult):
-        url = safe_url_string(url, encoding=encoding)
+        try:
+            url = safe_url_string(url, encoding=encoding)
+
+        # if supplied `encoding` is not able to encode,
+        # fallback to UTF-8 as safety net
+        except UnicodeError as e:
+            url = safe_url_string(url, encoding='utf8')
 
     # parsing does not depend on encoding
     scheme, netloc, path, params, query, fragment = parse_url(url)

--- a/scrapy/utils/url.py
+++ b/scrapy/utils/url.py
@@ -10,8 +10,7 @@ import re
 import six
 from six.moves.urllib.parse import (ParseResult, urlunparse, urldefrag,
                                     urlparse, parse_qsl, urlencode,
-                                    unquote)
-from six.moves.urllib.parse import quote, urlsplit, urlunsplit
+                                    quote, unquote)
 if six.PY3:
     from urllib.parse import unquote_to_bytes
 
@@ -39,49 +38,6 @@ def url_is_from_spider(url, spider):
 
 def url_has_any_extension(url, extensions):
     return posixpath.splitext(parse_url(url).path)[1].lower() in extensions
-
-
-def safe_url_string(url, encoding='utf8', path_encoding='utf8'):
-    """Convert the given URL into a legal URL by escaping unsafe characters
-    according to RFC-3986.
-
-    If a bytes URL is given, it is first converted to `str` using the given
-    encoding (which defaults to 'utf-8'). 'utf-8' encoding is used for
-    URL path component (unless overriden by path_encoding), and given
-    encoding is used for query string or form data.
-    When passing a encoding, you should use the encoding of the
-    original page (the page from which the url was extracted from).
-
-    Calling this function on an already "safe" URL will return the URL
-    unmodified.
-
-    Always returns a native `str` (bytes in Python2, unicode in Python3).
-    """
-    # Python3's urlsplit() chokes on bytes input with non-ASCII chars,
-    # so let's decode (to Unicode) using page encoding.
-    #
-    # it is assumed that a raw bytes input comes from the page
-    # corresponding to the encoding
-    #
-    # Note: if this assumption is wrong, this will fail;
-    #       in the general case, users are required to use Unicode
-    #       or safe ASCII bytes input
-    parts = urlsplit(to_unicode(url, encoding=encoding))
-
-    # quote() in Python2 return type follows input type;
-    # quote() in Python3 always returns Unicode (native str)
-    return urlunsplit((
-        to_native_str(parts.scheme),
-        to_native_str(parts.netloc.encode('idna')),
-
-        # default encoding for path component SHOULD be UTF-8
-        quote(to_bytes(parts.path, path_encoding), _safe_chars),
-
-        # encoding of query and fragment follows page encoding
-        # or form-charset (if known and passed)
-        quote(to_bytes(parts.query, encoding), _safe_chars),
-        quote(to_bytes(parts.fragment, encoding), _safe_chars),
-    ))
 
 
 def _safe_ParseResult(parts, encoding='utf8', path_encoding='utf8'):

--- a/scrapy/utils/url.py
+++ b/scrapy/utils/url.py
@@ -44,14 +44,17 @@ def url_has_any_extension(url, extensions):
 def safe_url_string(url, encoding='utf8', path_encoding='utf8'):
     """Convert the given URL into a legal URL by escaping unsafe characters
     according to RFC-3986.
+
     If a bytes URL is given, it is first converted to `str` using the given
     encoding (which defaults to 'utf-8'). 'utf-8' encoding is used for
     URL path component (unless overriden by path_encoding), and given
     encoding is used for query string or form data.
     When passing a encoding, you should use the encoding of the
     original page (the page from which the url was extracted from).
+
     Calling this function on an already "safe" URL will return the URL
     unmodified.
+
     Always returns a native `str` (bytes in Python2, unicode in Python3).
     """
     # Python3's urlsplit() chokes on bytes input with non-ASCII chars,
@@ -69,7 +72,7 @@ def safe_url_string(url, encoding='utf8', path_encoding='utf8'):
     # quote() in Python3 always returns Unicode (native str)
     return urlunsplit((
         to_native_str(parts.scheme),
-        to_native_str(parts.netloc),
+        to_native_str(parts.netloc.encode('idna')),
 
         # default encoding for path component SHOULD be UTF-8
         quote(to_bytes(parts.path, path_encoding), _safe_chars),

--- a/scrapy/utils/url.py
+++ b/scrapy/utils/url.py
@@ -106,7 +106,8 @@ def canonicalize_url(url, keep_blank_values=True, keep_fragments=False,
     # making the URL safe first handles regular non-ASCII characters ;
     # badly encoded percent-encoded sequences are handled below
     # by re-parsing path and query-string (may be sub-optimal)
-    url = safe_url_string(url, encoding=encoding)
+    if not isinstance(url, ParseResult):
+        url = safe_url_string(url, encoding=encoding)
 
     # parsing does not depend on encoding
     scheme, netloc, path, params, query, fragment = parse_url(url)

--- a/tests/test_http_request.py
+++ b/tests/test_http_request.py
@@ -1,10 +1,13 @@
+# -*- coding: utf-8 -*-
 import cgi
 import unittest
 import re
 
 import six
 from six.moves import xmlrpc_client as xmlrpclib
-from six.moves.urllib.parse import urlparse
+from six.moves.urllib.parse import urlparse, parse_qs, unquote
+if six.PY3:
+    from urllib.parse import unquote_to_bytes
 
 from scrapy.http import Request, FormRequest, XmlRpcRequest, Headers, HtmlResponse
 from scrapy.utils.python import to_bytes, to_native_str
@@ -86,12 +89,60 @@ class RequestTest(unittest.TestCase):
         r = self.request_class(url="http://www.scrapy.org/blank space")
         self.assertEqual(r.url, "http://www.scrapy.org/blank%20space")
 
-    @unittest.skipUnless(six.PY2, "TODO")
     def test_url_encoding(self):
-        r1 = self.request_class(url=u"http://www.scrapy.org/price/\xa3", encoding="utf-8")
-        r2 = self.request_class(url=u"http://www.scrapy.org/price/\xa3", encoding="latin1")
-        self.assertEqual(r1.url, "http://www.scrapy.org/price/%C2%A3")
-        self.assertEqual(r2.url, "http://www.scrapy.org/price/%A3")
+        r = self.request_class(url=u"http://www.scrapy.org/price/£")
+        self.assertEqual(r.url, "http://www.scrapy.org/price/%C2%A3")
+
+    def test_url_encoding_other(self):
+        # encoding affects only query part of URI, not path
+        # path part should always be UTF-8 encoded before percent-escaping
+        r = self.request_class(url=u"http://www.scrapy.org/price/£", encoding="utf-8")
+        self.assertEqual(r.url, "http://www.scrapy.org/price/%C2%A3")
+
+        r = self.request_class(url=u"http://www.scrapy.org/price/£", encoding="latin1")
+        self.assertEqual(r.url, "http://www.scrapy.org/price/%C2%A3")
+
+    def test_url_encoding_query(self):
+        r1 = self.request_class(url=u"http://www.scrapy.org/price/£?unit=µ")
+        self.assertEqual(r1.url, "http://www.scrapy.org/price/%C2%A3?unit=%C2%B5")
+
+        # should be same as above
+        r2 = self.request_class(url=u"http://www.scrapy.org/price/£?unit=µ", encoding="utf-8")
+        self.assertEqual(r2.url, "http://www.scrapy.org/price/%C2%A3?unit=%C2%B5")
+
+    def test_url_encoding_query_latin1(self):
+        # encoding is used for encoding query-string before percent-escaping;
+        # path is still UTF-8 encoded before percent-escaping
+        r3 = self.request_class(url=u"http://www.scrapy.org/price/µ?currency=£", encoding="latin1")
+        self.assertEqual(r3.url, "http://www.scrapy.org/price/%C2%B5?currency=%A3")
+
+    def test_url_encoding_nonutf8_untouched(self):
+        # percent-escaping sequences that do not match valid UTF-8 sequences
+        # should be kept untouched (just upper-cased perhaps)
+        #
+        # See https://tools.ietf.org/html/rfc3987#section-3.2
+        #
+        # "Conversions from URIs to IRIs MUST NOT use any character encoding
+        # other than UTF-8 in steps 3 and 4, even if it might be possible to
+        # guess from the context that another character encoding than UTF-8 was
+        # used in the URI.  For example, the URI
+        # "http://www.example.org/r%E9sum%E9.html" might with some guessing be
+        # interpreted to contain two e-acute characters encoded as iso-8859-1.
+        # It must not be converted to an IRI containing these e-acute
+        # characters.  Otherwise, in the future the IRI will be mapped to
+        # "http://www.example.org/r%C3%A9sum%C3%A9.html", which is a different
+        # URI from "http://www.example.org/r%E9sum%E9.html".
+        r1 = self.request_class(url=u"http://www.scrapy.org/price/%a3")
+        self.assertEqual(r1.url, "http://www.scrapy.org/price/%a3")
+
+        r2 = self.request_class(url=u"http://www.scrapy.org/r%C3%A9sum%C3%A9/%a3")
+        self.assertEqual(r2.url, "http://www.scrapy.org/r%C3%A9sum%C3%A9/%a3")
+
+        r3 = self.request_class(url=u"http://www.scrapy.org/résumé/%a3")
+        self.assertEqual(r3.url, "http://www.scrapy.org/r%C3%A9sum%C3%A9/%a3")
+
+        r4 = self.request_class(url=u"http://www.example.org/r%E9sum%E9.html")
+        self.assertEqual(r4.url, "http://www.example.org/r%E9sum%E9.html")
 
     def test_body(self):
         r1 = self.request_class(url="http://www.example.com/")
@@ -198,10 +249,9 @@ class FormRequestTest(RequestTest):
         r1 = self.request_class("http://www.example.com", formdata={})
         self.assertEqual(r1.body, b'')
 
-    @unittest.skipUnless(six.PY2, "TODO")
     def test_default_encoding(self):
         # using default encoding (utf-8)
-        data = {'one': 'two', 'price': '\xc2\xa3 100'}
+        data = {b'one': b'two', b'price': b'\xc2\xa3 100'}
         r2 = self.request_class("http://www.example.com", formdata=data)
         self.assertEqual(r2.method, 'POST')
         self.assertEqual(r2.encoding, 'utf-8')
@@ -235,8 +285,8 @@ class FormRequestTest(RequestTest):
         self.assertEqual(req.headers[b'Content-type'], b'application/x-www-form-urlencoded')
         self.assertEqual(req.url, "http://www.example.com/this/post.php")
         fs = _qs(req)
-        self.assertEqual(set(fs[b"test"]), {b"val1", b"val2"})
-        self.assertEqual(set(fs[b"one"]), {b"two", b"three"})
+        self.assertEqual(set(fs[b'test']), {b'val1', b'val2'})
+        self.assertEqual(set(fs[b'one']), {b'two', b'three'})
         self.assertEqual(fs[b'test2'], [b'xxx'])
         self.assertEqual(fs[b'six'], [b'seven'])
 
@@ -268,10 +318,10 @@ class FormRequestTest(RequestTest):
         self.assertEqual(urlparse(r1.url).hostname, "www.example.com")
         self.assertEqual(urlparse(r1.url).path, "/this/get.php")
         fs = _qs(r1)
-        self.assertEqual(set(fs['test']), set(['val1', 'val2']))
-        self.assertEqual(set(fs['one']), set(['two', 'three']))
-        self.assertEqual(fs['test2'], ['xxx'])
-        self.assertEqual(fs['six'], ['seven'])
+        self.assertEqual(set(fs[b'test']), set([b'val1', b'val2']))
+        self.assertEqual(set(fs[b'one']), set([b'two', b'three']))
+        self.assertEqual(fs[b'test2'], [b'xxx'])
+        self.assertEqual(fs[b'six'], [b'seven'])
 
     def test_from_response_override_params(self):
         response = _buildresponse(
@@ -315,9 +365,9 @@ class FormRequestTest(RequestTest):
             </form>""")
         req = self.request_class.from_response(response)
         fs = _qs(req)
-        self.assertEqual(fs['clickable1'], ['clicked1'])
-        self.assertFalse('i1' in fs, fs)  # xpath in _get_inputs()
-        self.assertFalse('clickable2' in fs, fs)  # xpath in _get_clickable()
+        self.assertEqual(fs[b'clickable1'], [b'clicked1'])
+        self.assertFalse(b'i1' in fs, fs)  # xpath in _get_inputs()
+        self.assertFalse(b'clickable2' in fs, fs)  # xpath in _get_clickable()
 
     def test_from_response_submit_first_clickable(self):
         response = _buildresponse(
@@ -329,10 +379,10 @@ class FormRequestTest(RequestTest):
             </form>""")
         req = self.request_class.from_response(response, formdata={'two': '2'})
         fs = _qs(req)
-        self.assertEqual(fs['clickable1'], ['clicked1'])
-        self.assertFalse('clickable2' in fs, fs)
-        self.assertEqual(fs['one'], ['1'])
-        self.assertEqual(fs['two'], ['2'])
+        self.assertEqual(fs[b'clickable1'], [b'clicked1'])
+        self.assertFalse(b'clickable2' in fs, fs)
+        self.assertEqual(fs[b'one'], [b'1'])
+        self.assertEqual(fs[b'two'], [b'2'])
 
     def test_from_response_submit_not_first_clickable(self):
         response = _buildresponse(
@@ -345,10 +395,10 @@ class FormRequestTest(RequestTest):
         req = self.request_class.from_response(response, formdata={'two': '2'}, \
                                               clickdata={'name': 'clickable2'})
         fs = _qs(req)
-        self.assertEqual(fs['clickable2'], ['clicked2'])
-        self.assertFalse('clickable1' in fs, fs)
-        self.assertEqual(fs['one'], ['1'])
-        self.assertEqual(fs['two'], ['2'])
+        self.assertEqual(fs[b'clickable2'], [b'clicked2'])
+        self.assertFalse(b'clickable1' in fs, fs)
+        self.assertEqual(fs[b'one'], [b'1'])
+        self.assertEqual(fs[b'two'], [b'2'])
 
     def test_from_response_dont_submit_image_as_input(self):
         response = _buildresponse(
@@ -359,7 +409,7 @@ class FormRequestTest(RequestTest):
             </form>""")
         req = self.request_class.from_response(response, dont_click=True)
         fs = _qs(req)
-        self.assertEqual(fs, {'i1': ['i1v']})
+        self.assertEqual(fs, {b'i1': [b'i1v']})
 
     def test_from_response_dont_submit_reset_as_input(self):
         response = _buildresponse(
@@ -371,7 +421,7 @@ class FormRequestTest(RequestTest):
             </form>""")
         req = self.request_class.from_response(response, dont_click=True)
         fs = _qs(req)
-        self.assertEqual(fs, {'i1': ['i1v'], 'i2': ['i2v']})
+        self.assertEqual(fs, {b'i1': [b'i1v'], b'i2': [b'i2v']})
 
     def test_from_response_multiple_clickdata(self):
         response = _buildresponse(
@@ -382,11 +432,11 @@ class FormRequestTest(RequestTest):
             <input type="hidden" name="two" value="clicked2">
             </form>""")
         req = self.request_class.from_response(response, \
-                clickdata={'name': 'clickable', 'value': 'clicked2'})
+                clickdata={u'name': u'clickable', u'value': u'clicked2'})
         fs = _qs(req)
-        self.assertEqual(fs['clickable'], ['clicked2'])
-        self.assertEqual(fs['one'], ['clicked1'])
-        self.assertEqual(fs['two'], ['clicked2'])
+        self.assertEqual(fs[b'clickable'], [b'clicked2'])
+        self.assertEqual(fs[b'one'], [b'clicked1'])
+        self.assertEqual(fs[b'two'], [b'clicked2'])
 
     def test_from_response_unicode_clickdata(self):
         response = _buildresponse(
@@ -397,9 +447,24 @@ class FormRequestTest(RequestTest):
             <input type="hidden" name="eurosign" value="\u20ac">
             </form>""")
         req = self.request_class.from_response(response, \
-                clickdata={'name': u'price in \u00a3'})
-        fs = _qs(req)
-        self.assertTrue(fs[to_native_str(u'price in \u00a3')])
+                clickdata={u'name': u'price in \u00a3'})
+        fs = _qs(req, to_unicode=True)
+        self.assertTrue(fs[u'price in \u00a3'])
+
+    def test_from_response_unicode_clickdata_latin1(self):
+        response = _buildresponse(
+            u"""<form action="get.php" method="GET">
+            <input type="submit" name="price in \u00a3" value="\u00a3 1000">
+            <input type="submit" name="price in \u00a5" value="\u00a5 2000">
+            <input type="hidden" name="poundsign" value="\u00a3">
+            <input type="hidden" name="yensign" value="\u00a5">
+            </form>""",
+            encoding='latin1')
+        req = self.request_class.from_response(response, \
+                clickdata={u'name': u'price in \u00a5'})
+        fs = _qs(req, to_unicode=True, encoding='latin1')
+        self.assertTrue(fs[u'price in \u00a5'])
+
 
     def test_from_response_multiple_forms_clickdata(self):
         response = _buildresponse(
@@ -413,18 +478,18 @@ class FormRequestTest(RequestTest):
             </form>
             """)
         req = self.request_class.from_response(response, formname='form2', \
-                clickdata={'name': 'clickable'})
+                clickdata={u'name': u'clickable'})
         fs = _qs(req)
-        self.assertEqual(fs['clickable'], ['clicked2'])
-        self.assertEqual(fs['field2'], ['value2'])
-        self.assertFalse('field1' in fs, fs)
+        self.assertEqual(fs[b'clickable'], [b'clicked2'])
+        self.assertEqual(fs[b'field2'], [b'value2'])
+        self.assertFalse(b'field1' in fs, fs)
 
     def test_from_response_override_clickable(self):
         response = _buildresponse('''<form><input type="submit" name="clickme" value="one"> </form>''')
         req = self.request_class.from_response(response, \
                 formdata={'clickme': 'two'}, clickdata={'name': 'clickme'})
         fs = _qs(req)
-        self.assertEqual(fs['clickme'], ['two'])
+        self.assertEqual(fs[b'clickme'], [b'two'])
 
     def test_from_response_dont_click(self):
         response = _buildresponse(
@@ -436,8 +501,8 @@ class FormRequestTest(RequestTest):
             </form>""")
         r1 = self.request_class.from_response(response, dont_click=True)
         fs = _qs(r1)
-        self.assertFalse('clickable1' in fs, fs)
-        self.assertFalse('clickable2' in fs, fs)
+        self.assertFalse(b'clickable1' in fs, fs)
+        self.assertFalse(b'clickable2' in fs, fs)
 
     def test_from_response_ambiguous_clickdata(self):
         response = _buildresponse(
@@ -468,8 +533,8 @@ class FormRequestTest(RequestTest):
             """)
         req = self.request_class.from_response(response, clickdata={'nr': 1})
         fs = _qs(req)
-        self.assertIn('clickable2', fs)
-        self.assertNotIn('clickable1', fs)
+        self.assertIn(b'clickable2', fs)
+        self.assertNotIn(b'clickable1', fs)
 
     def test_from_response_invalid_nr_index_clickdata(self):
         response = _buildresponse(
@@ -490,7 +555,7 @@ class FormRequestTest(RequestTest):
                                   """</form></body></html>""")
         req = self.request_class.from_response(response, formdata={'bar': 'buz'})
         fs = _qs(req)
-        self.assertEqual(fs, {'foo': ['xxx'], 'bar': ['buz']})
+        self.assertEqual(fs, {b'foo': [b'xxx'], b'bar': [b'buz']})
 
     def test_from_response_errors_formnumber(self):
         response = _buildresponse(
@@ -634,7 +699,7 @@ class FormRequestTest(RequestTest):
             <select name="i7"/>
             </form>''')
         req = self.request_class.from_response(res)
-        fs = _qs(req)
+        fs = _qs(req, to_unicode=True)
         self.assertEqual(fs, {'i1': ['i1v2'], 'i2': ['i2v1'], 'i4': ['i4v2', 'i4v3']})
 
     def test_from_response_radio(self):
@@ -651,7 +716,7 @@ class FormRequestTest(RequestTest):
             </form>''')
         req = self.request_class.from_response(res)
         fs = _qs(req)
-        self.assertEqual(fs, {'i1': ['iv2'], 'i2': ['on']})
+        self.assertEqual(fs, {b'i1': [b'iv2'], b'i2': [b'on']})
 
     def test_from_response_checkbox(self):
         res = _buildresponse(
@@ -667,7 +732,7 @@ class FormRequestTest(RequestTest):
             </form>''')
         req = self.request_class.from_response(res)
         fs = _qs(req)
-        self.assertEqual(fs, {'i1': ['iv2'], 'i2': ['on']})
+        self.assertEqual(fs, {b'i1': [b'iv2'], b'i2': [b'on']})
 
     def test_from_response_input_text(self):
         res = _buildresponse(
@@ -680,7 +745,7 @@ class FormRequestTest(RequestTest):
             </form>''')
         req = self.request_class.from_response(res)
         fs = _qs(req)
-        self.assertEqual(fs, {'i1': ['i1v1'], 'i2': [''], 'i4': ['i4v1']})
+        self.assertEqual(fs, {b'i1': [b'i1v1'], b'i2': [b''], b'i4': [b'i4v1']})
 
     def test_from_response_input_hidden(self):
         res = _buildresponse(
@@ -692,7 +757,7 @@ class FormRequestTest(RequestTest):
             </form>''')
         req = self.request_class.from_response(res)
         fs = _qs(req)
-        self.assertEqual(fs, {'i1': ['i1v1'], 'i2': ['']})
+        self.assertEqual(fs, {b'i1': [b'i1v1'], b'i2': [b'']})
 
     def test_from_response_input_textarea(self):
         res = _buildresponse(
@@ -704,7 +769,7 @@ class FormRequestTest(RequestTest):
             </form>''')
         req = self.request_class.from_response(res)
         fs = _qs(req)
-        self.assertEqual(fs, {'i1': ['i1v'], 'i2': [''], 'i3': ['']})
+        self.assertEqual(fs, {b'i1': [b'i1v'], b'i2': [b''], b'i3': [b'']})
 
     def test_from_response_descendants(self):
         res = _buildresponse(
@@ -725,7 +790,7 @@ class FormRequestTest(RequestTest):
             </form>''')
         req = self.request_class.from_response(res)
         fs = _qs(req)
-        self.assertEqual(set(fs), set(['h2', 'i2', 'i1', 'i3', 'h1', 'i5', 'i4']))
+        self.assertEqual(set(fs), set([b'h2', b'i2', b'i1', b'i3', b'h1', b'i5', b'i4']))
 
     def test_from_response_xpath(self):
         response = _buildresponse(
@@ -806,10 +871,10 @@ class FormRequestTest(RequestTest):
         self.assertEqual(req.method, 'POST')
         self.assertEqual(req.headers['Content-type'], b'application/x-www-form-urlencoded')
         self.assertEqual(req.url, "http://www.example.com/this/post.php")
-        fs = _qs(req)
-        self.assertEqual(fs[b'test1'], [b'val1'])
-        self.assertEqual(fs[b'test2'], [b'val2'])
-        self.assertEqual(fs[b'button1'], [b''])
+        fs = _qs(req, to_unicode=True)
+        self.assertEqual(fs[u'test1'], [u'val1'])
+        self.assertEqual(fs[u'test2'], [u'val2'])
+        self.assertEqual(fs[u'button1'], [u''])
 
     def test_from_response_button_novalue(self):
         response = _buildresponse(
@@ -873,12 +938,18 @@ def _buildresponse(body, **kwargs):
     kwargs.setdefault('encoding', 'utf-8')
     return HtmlResponse(**kwargs)
 
-def _qs(req):
+def _qs(req, encoding='utf-8', to_unicode=False):
     if req.method == 'POST':
         qs = req.body
     else:
         qs = req.url.partition('?')[2]
-    return cgi.parse_qs(qs, True)
+    if six.PY2:
+        uqs = unquote(to_native_str(qs, encoding))
+    elif six.PY3:
+        uqs = unquote_to_bytes(qs)
+    if to_unicode:
+        uqs = uqs.decode(encoding)
+    return parse_qs(uqs, True)
 
 
 class XmlRpcRequestTest(RequestTest):
@@ -890,7 +961,9 @@ class XmlRpcRequestTest(RequestTest):
     def _test_request(self, **kwargs):
         r = self.request_class('http://scrapytest.org/rpc2', **kwargs)
         self.assertEqual(r.headers[b'Content-Type'], b'text/xml')
-        self.assertEqual(r.body, to_bytes(xmlrpclib.dumps(**kwargs)))
+        self.assertEqual(r.body,
+                         to_bytes(xmlrpclib.dumps(**kwargs),
+                                  encoding=kwargs.get('encoding', 'utf-8')))
         self.assertEqual(r.method, 'POST')
         self.assertEqual(r.encoding, kwargs.get('encoding', 'utf-8'))
         self.assertTrue(r.dont_filter, True)
@@ -899,14 +972,13 @@ class XmlRpcRequestTest(RequestTest):
         self._test_request(params=('value',))
         self._test_request(params=('username', 'password'), methodname='login')
         self._test_request(params=('response', ), methodresponse='login')
-        self._test_request(params=(u'pas\xa3',), encoding='utf-8')
+        self._test_request(params=(u'pas£',), encoding='utf-8')
         self._test_request(params=(None,), allow_none=1)
         self.assertRaises(TypeError, self._test_request)
         self.assertRaises(TypeError, self._test_request, params=(None,))
 
-    @unittest.skipUnless(six.PY2, "TODO")
     def test_latin1(self):
-        self._test_request(params=(u'pas\xa3',), encoding='latin')
+        self._test_request(params=(u'pas£',), encoding='latin1')
 
 
 if __name__ == "__main__":

--- a/tests/test_linkextractors_deprecated.py
+++ b/tests/test_linkextractors_deprecated.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 import unittest
 from scrapy.linkextractors.regex import RegexLinkExtractor
 from scrapy.http import HtmlResponse
@@ -81,9 +82,14 @@ class BaseSgmlLinkExtractorTestCase(unittest.TestCase):
             Link(url='http://example.com/sample_%E2%82%AC.html', text='sample \xe2\x82\xac text'.decode('utf-8')),
         ])
 
+        # document encoding does not affect URL path component, only query part
+        # >>> u'sample_ñ.html'.encode('utf8')
+        # 'sample_\xc3\xb1.html'
+        # >>> u"sample_á.html".encode('utf8')
+        # 'sample_\xc3\xa1.html'
         self.assertEqual(lx.extract_links(response_latin1), [
-            Link(url='http://example.com/sample_%F1.html', text=''),
-            Link(url='http://example.com/sample_%E1.html', text='sample \xe1 text'.decode('latin1')),
+            Link(url='http://example.com/sample_%C3%B1.html', text=''),
+            Link(url='http://example.com/sample_%C3%A1.html', text='sample \xe1 text'.decode('latin1')),
         ])
 
     def test_matches(self):

--- a/tests/test_linkextractors_deprecated.py
+++ b/tests/test_linkextractors_deprecated.py
@@ -1,5 +1,8 @@
 # -*- coding: utf-8 -*-
 import unittest
+
+import pytest
+
 from scrapy.linkextractors.regex import RegexLinkExtractor
 from scrapy.http import HtmlResponse
 from scrapy.link import Link
@@ -164,6 +167,10 @@ class SgmlLinkExtractorTestCase(Base.LinkExtractorTestCase):
             Link(url='http://example.org/about.html', text=u'About us', nofollow=False),
             Link(url='http://google.com/something', text=u'Something', nofollow=True),
         ])
+
+    @pytest.mark.xfail
+    def test_restrict_xpaths_with_html_entities(self):
+        super(SgmlLinkExtractorTestCase, self).test_restrict_xpaths_with_html_entities()
 
 
 class RegexLinkExtractorTestCase(unittest.TestCase):

--- a/tests/test_utils_url.py
+++ b/tests/test_utils_url.py
@@ -123,14 +123,12 @@ class CanonicalizeUrlTest(unittest.TestCase):
         self.assertEqual(canonicalize_url("http://www.example.com/do?q=a%20space&a=1"),
                                           "http://www.example.com/do?a=1&q=a+space")
 
-    @unittest.skipUnless(six.PY2, "TODO")
     def test_normalize_percent_encoding_in_paths(self):
         self.assertEqual(canonicalize_url("http://www.example.com/a%a3do"),
-                                          "http://www.example.com/a%A3do"),
+                                          "http://www.example.com/a%A3do")
 
-    @unittest.skipUnless(six.PY2, "TODO")
     def test_normalize_percent_encoding_in_query_arguments(self):
-        self.assertEqual(canonicalize_url("http://www.example.com/do?k=b%a3"),
+        self.assertEqual(canonicalize_url("http://www.example.com/do?k=b%a3", encoding='latin1'),
                                           "http://www.example.com/do?k=b%A3")
 
     def test_non_ascii_percent_encoding_in_paths(self):
@@ -167,7 +165,6 @@ class CanonicalizeUrlTest(unittest.TestCase):
             "http://www.simplybedrooms.com/White-Bedroom-Furniture/Bedroom-Mirror:-Josephine-Cheval-Mirror.html"),
             "http://www.simplybedrooms.com/White-Bedroom-Furniture/Bedroom-Mirror:-Josephine-Cheval-Mirror.html")
 
-    @unittest.skipUnless(six.PY2, "TODO")
     def test_safe_characters_unicode(self):
         # urllib.quote uses a mapping cache of encoded characters. when parsing
         # an already percent-encoded url, it will fail if that url was not

--- a/tests/test_utils_url.py
+++ b/tests/test_utils_url.py
@@ -141,9 +141,12 @@ class CanonicalizeUrlTest(unittest.TestCase):
 
     def test_canonicalize_url_unicode_query_string_wrong_encoding(self):
         # trying to encode with wrong encoding
-        self.assertRaises(UnicodeEncodeError, canonicalize_url,
-                            u"http://www.example.com/résumé?currency=€",
-                            encoding='latin1')
+        # fallback to UTF-8
+        self.assertEqual(canonicalize_url(u"http://www.example.com/résumé?currency=€", encoding='latin1'),
+                                          "http://www.example.com/r%C3%A9sum%C3%A9?currency=%E2%82%AC")
+
+        self.assertEqual(canonicalize_url(u"http://www.example.com/résumé?country=Россия", encoding='latin1'),
+                                          "http://www.example.com/r%C3%A9sum%C3%A9?country=%D0%A0%D0%BE%D1%81%D1%81%D0%B8%D1%8F")
 
     def test_normalize_percent_encoding_in_paths(self):
         self.assertEqual(canonicalize_url("http://www.example.com/r%c3%a9sum%c3%a9"),
@@ -180,7 +183,7 @@ class CanonicalizeUrlTest(unittest.TestCase):
                                           "http://www.example.com/a%20do%C2%A3.html?a=1")
 
     def test_non_ascii_percent_encoding_in_query_arguments(self):
-        self.assertEqual(canonicalize_url(u"http://www.example.com/do?price=\xa3500&a=5&z=3"),
+        self.assertEqual(canonicalize_url(u"http://www.example.com/do?price=£500&a=5&z=3"),
                                           u"http://www.example.com/do?a=5&price=%C2%A3500&z=3")
         self.assertEqual(canonicalize_url(b"http://www.example.com/do?price=\xc2\xa3500&a=5&z=3"),
                                           "http://www.example.com/do?a=5&price=%C2%A3500&z=3")

--- a/tests/test_utils_url.py
+++ b/tests/test_utils_url.py
@@ -139,6 +139,12 @@ class CanonicalizeUrlTest(unittest.TestCase):
         self.assertEqual(canonicalize_url(u"http://www.example.com/résumé?country=Россия", encoding='cp1251'),
                                           "http://www.example.com/r%C3%A9sum%C3%A9?country=%D0%EE%F1%F1%E8%FF")
 
+    def test_canonicalize_url_unicode_query_string_wrong_encoding(self):
+        # trying to encode with wrong encoding
+        self.assertRaises(UnicodeEncodeError, canonicalize_url,
+                            u"http://www.example.com/résumé?currency=€",
+                            encoding='latin1')
+
     def test_normalize_percent_encoding_in_paths(self):
         self.assertEqual(canonicalize_url("http://www.example.com/r%c3%a9sum%c3%a9"),
                                           "http://www.example.com/r%C3%A9sum%C3%A9")


### PR DESCRIPTION
Built on top of https://github.com/scrapy/scrapy/pull/1874

Should fix #1403.

I had to add a `encoding` attribute for the `Link` objects to build proper URLs.

[`url = urljoin(response_url, url)`](https://github.com/scrapy/scrapy/blob/master/scrapy/linkextractors/lxmlhtml.py#L61) after processing the base_URL-joined attribute looks wrong to me. I'm not even sure we should pass attributes to `process_value` after this baseURL joining.