### PR TITLE
[MRG+1] Make FilesPipeline work with S3FilesStore using botocore

### DIFF
--- a/scrapy/pipelines/files.py
+++ b/scrapy/pipelines/files.py
@@ -364,8 +364,9 @@ class FilesPipeline(MediaPipeline):
     def file_downloaded(self, response, request, info):
         path = self.file_path(request, response=response, info=info)
         buf = BytesIO(response.body)
-        self.store.persist_file(path, buf, info)
         checksum = md5sum(buf)
+        buf.seek(0)
+        self.store.persist_file(path, buf, info)
         return checksum
 
     def item_completed(self, results, item, info):

--- a/scrapy/pipelines/files.py
+++ b/scrapy/pipelines/files.py
@@ -147,7 +147,7 @@ class S3FilesStore(object):
                 Bucket=self.bucket,
                 Key=key_name,
                 Body=buf,
-                Metadata={k: str(v) for k, v in six.iteritems(meta)},
+                Metadata={k: str(v) for k, v in six.iteritems(meta or {})},
                 ACL=self.POLICY,
                 **extra)
         else:


### PR DESCRIPTION
It did not work due to two reasons, one silly and one intricate:
- ``meta=None`` was not handled properly
- there was a race condition between persisting file and calculating checksum (explained in the commit message) - this in theory could lead to bugs with other stores as well.