### PR TITLE
PY3 optimize ChunkedTransferMiddleware and port it to Python 3

### DIFF
--- a/scrapy/downloadermiddlewares/chunked.py
+++ b/scrapy/downloadermiddlewares/chunked.py
@@ -7,7 +7,7 @@ class ChunkedTransferMiddleware(object):
     """
 
     def process_response(self, request, response, spider):
-        if response.headers.get('Transfer-Encoding') == 'chunked':
+        if response.headers.get(b'Transfer-Encoding') == b'chunked':
             body = decode_chunked_transfer(response.body)
             return response.replace(body=body)
         return response

--- a/scrapy/utils/http.py
+++ b/scrapy/utils/http.py
@@ -14,10 +14,10 @@ def decode_chunked_transfer(chunked_body):
     http://en.wikipedia.org/wiki/Chunked_transfer_encoding
 
     """
-    body, h, t = '', '', chunked_body
+    body, h, t = b'', b'', chunked_body
     while t:
-        h, t = t.split('\r\n', 1)
-        if h == '0':
+        h, t = t.split(b'\r\n', 1)
+        if h == b'0':
             break
         size = int(h, 16)
         body += t[:size]

--- a/scrapy/utils/http.py
+++ b/scrapy/utils/http.py
@@ -14,13 +14,13 @@ def decode_chunked_transfer(chunked_body):
     http://en.wikipedia.org/wiki/Chunked_transfer_encoding
 
     """
-    body, h, t = b'', b'', chunked_body
+    body_parts, h, t = [], b'', chunked_body
     while t:
         h, t = t.split(b'\r\n', 1)
         if h == b'0':
             break
         size = int(h, 16)
-        body += t[:size]
+        body_parts.append(t[:size])
         t = t[size+2:]
-    return body
+    return b''.join(body_parts)
 

--- a/scrapy/utils/http.py
+++ b/scrapy/utils/http.py
@@ -14,13 +14,20 @@ def decode_chunked_transfer(chunked_body):
     http://en.wikipedia.org/wiki/Chunked_transfer_encoding
 
     """
-    body_parts, h, t = [], b'', chunked_body
-    while t:
-        h, t = t.split(b'\r\n', 1)
-        if h == b'0':
-            break
-        size = int(h, 16)
-        body_parts.append(t[:size])
-        t = t[size+2:]
-    return b''.join(body_parts)
+    body_parts = []
+    pos = 0
+    while pos < len(chunked_body):
+        separator_pos = chunked_body.find(b'\r\n', pos)
+        if separator_pos == -1:
+            separator_pos = len(chunked_body)
 
+        chunk_size = chunked_body[pos:separator_pos]
+        if chunk_size == b'0':
+            break
+        size = int(chunk_size, 16)
+        pos = separator_pos + 2
+        chunk_data = chunked_body[pos:pos+size]
+        body_parts.append(chunk_data)
+        pos += size + 2
+
+    return b''.join(body_parts)

--- a/tests/test_utils_http.py
+++ b/tests/test_utils_http.py
@@ -6,15 +6,15 @@ class ChunkedTest(unittest.TestCase):
 
     def test_decode_chunked_transfer(self):
         """Example taken from: http://en.wikipedia.org/wiki/Chunked_transfer_encoding"""
-        chunked_body = "25\r\n" + "This is the data in the first chunk\r\n\r\n"
-        chunked_body += "1C\r\n" + "and this is the second one\r\n\r\n"
-        chunked_body += "3\r\n" + "con\r\n"
-        chunked_body += "8\r\n" + "sequence\r\n"
-        chunked_body += "0\r\n\r\n"
+        chunked_body = b"25\r\n" + b"This is the data in the first chunk\r\n\r\n"
+        chunked_body += b"1C\r\n" + b"and this is the second one\r\n\r\n"
+        chunked_body += b"3\r\n" + b"con\r\n"
+        chunked_body += b"8\r\n" + b"sequence\r\n"
+        chunked_body += b"0\r\n\r\n"
         body = decode_chunked_transfer(chunked_body)
-        self.assertEqual(body, \
-            "This is the data in the first chunk\r\n" +
-            "and this is the second one\r\n" +
-            "consequence")
+        self.assertEqual(body,
+            b"This is the data in the first chunk\r\n"
+            b"and this is the second one\r\n"
+            b"consequence")
 
 


### PR DESCRIPTION
- port ChunkedTransferMiddleware to Python 3;
- fixed O(N^2) body building in decode_chunked_transfer;
- fixed O(N^2) string splitting in decode_chunked_transfer.

I also noticed that `decode_chunked_transfer` is not standard compliant. Twisted version should be compliant, but it has the same O(N^2) worst case complexity, and it uses a private `_ChunkedTransferDecoder`:

``` py
from twisted.web.http import _ChunkedTransferDecoder
def decode_chunked_transfer_twisted(chunked_body):
    parts = []
    dec = _ChunkedTransferDecoder(parts.append, lambda _:None)
    dec.dataReceived(chunked_body)
    return b''.join(parts)
```

Benchmark (using an adapted example from our test case):

``` py
chunked_body = b"25\r\n" + b"This is the data in the first chunk\r\n\r\n"
chunked_body += b"1C\r\n" + b"and this is the second one\r\n\r\n"
chunked_body += b"3\r\n" + b"con\r\n"
chunked_body += b"8\r\n" + b"sequence\r\n"

chunked_body = chunked_body * 10000

chunked_body += b"0\r\n\r\n"
```

`chunked_body` size is about 1MB; 
- new version: 48.1 ms
- old version: 2.81 s
- Twisted version: 4.48 s

for 2MB body:
- new version: 111 ms
- old version: 12.3 s
- Twisted version: 21.3 s

It looks like Scrapy http11 handler handles chunked transfer encoding itself (via Twisted) and this change has no effect on it. 

Also, Twisted passes body in chunks. So Twisted version can be modified - this one works much better, it parses 2MB body in 418 ms (not in 21s):

``` py
def decode_chunked_transfer_twisted(chunked_body):
    parts = []
    dec = _ChunkedTransferDecoder(parts.append, lambda _:None)
    size = 10000
    pos = 0
    while pos < len(chunked_body):
        dec.dataReceived(chunked_body[pos:pos+size])
        pos += size
    return b''.join(parts)
```
