### PR TITLE
[MRG+1] Added: Making it case-insensitive when extracting sitemap URLs from a robots.txt

### DIFF
--- a/scrapy/utils/sitemap.py
+++ b/scrapy/utils/sitemap.py
@@ -39,5 +39,5 @@ def sitemap_urls_from_robots(robots_text):
     robots.txt file
     """
     for line in robots_text.splitlines():
-        if line.lstrip().startswith('Sitemap:'):
+        if line.lstrip().lower().startswith('sitemap:'):
             yield line.split(':', 1)[1].strip()


### PR DESCRIPTION
Reasons:
- The proposal on robots.txt is never standardized.
- The field "Sitemap:" is also merely a de facto standard since [the original robots.txt draft](http://www.robotstxt.org/norobots-rfc.txt) did not mention it at all.
- Many websites are currently using all-lowercase fields, e.g. "disallow" and "user-agent".
- Some big companies treat the field names as case-insensitive, like [Google](https://developers.google.com/webmasters/control-crawl-index/docs/robots_txt)