### PR TITLE
[MRG+1] Fix HTTP Pool key for HTTPS proxy tunneled connections (CONNECT method)

### DIFF
--- a/scrapy/core/downloader/handlers/http11.py
+++ b/scrapy/core/downloader/handlers/http11.py
@@ -127,7 +127,8 @@ class TunnelingTCP4ClientEndpoint(TCP4ClientEndpoint):
             self._tunnelReadyDeferred.callback(self._protocol)
         else:
             self._tunnelReadyDeferred.errback(
-                TunnelError('Could not open CONNECT tunnel.'))
+                TunnelError('Could not open CONNECT tunnel with proxy %s:%s' % (
+                    self._host, self._port)))
 
     def connectFailed(self, reason):
         """Propagates the errback to the appropriate deferred."""
@@ -193,6 +194,14 @@ class TunnelingAgent(Agent):
                 self._contextFactory, self._connectTimeout,
                 self._bindAddress)
 
+    def _requestWithEndpoint(self, key, endpoint, method, parsedURI,
+            headers, bodyProducer, requestPath):
+        # proxy host and port are required for HTTP pool `key`
+        # otherwise, same remote host connection request could reuse
+        # a cached tunneled connection to a different proxy
+        key = key + self._proxyConf
+        return super(TunnelingAgent, self)._requestWithEndpoint(key, endpoint, method, parsedURI,
+            headers, bodyProducer, requestPath)
 
 
 class ScrapyAgent(object):


### PR DESCRIPTION
Should fix https://github.com/scrapy/scrapy/issues/1807

It adds the proxy host and port to the key used to cache HTTP connections, instead of just the remote host and port.

I have no concrete proposal for unittesting this though.
I only was able to debug-print HTTP pool keys and testing with https://httpbin.org/ip with a few open HTTPS proxies.
With current code, before this patch, connections do get mixed with current default Twisted `Agent` [`key = (parsedURI.scheme, parsedURI.host, parsedURI.port)`](http://twistedmatrix.com/trac/browser/tags/releases/twisted-16.0.0/twisted/web/client.py#L1597)