### PR TITLE
[MRG+1] Use newer w3lib.url.safe_url_string() and re-enable HTTP request tests

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ Twisted>=10.0.0
 lxml
 pyOpenSSL
 cssselect>=0.9
-w3lib>=1.14.1
+w3lib>=1.14.2
 queuelib
 six>=1.5.2
 PyDispatcher>=2.0.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ Twisted>=10.0.0
 lxml
 pyOpenSSL
 cssselect>=0.9
-w3lib>=1.13.0
+w3lib>=1.14.1
 queuelib
 six>=1.5.2
 PyDispatcher>=2.0.5

--- a/scrapy/http/request/__init__.py
+++ b/scrapy/http/request/__init__.py
@@ -8,7 +8,7 @@ import six
 from w3lib.url import safe_url_string
 
 from scrapy.http.headers import Headers
-from scrapy.utils.python import to_native_str, to_bytes
+from scrapy.utils.python import to_bytes
 from scrapy.utils.trackref import object_ref
 from scrapy.utils.url import escape_ajax
 from scrapy.http.common import obsolete_setter
@@ -50,8 +50,8 @@ class Request(object_ref):
         if not isinstance(url, six.string_types):
             raise TypeError('Request url must be str or unicode, got %s:' % type(url).__name__)
 
-        url = to_native_str(url, self.encoding)
-        self._url = escape_ajax(safe_url_string(url))
+        s = safe_url_string(url, self.encoding)
+        self._url = escape_ajax(s)
 
         if ':' not in self._url:
             raise ValueError('Missing scheme in request url: %s' % self._url)


### PR DESCRIPTION
Starting from w3lib 1.14.1, `safe_url_string` implementation follows browsers' behavior better.
Let's use it from now on.

These changes were originally part of https://github.com/scrapy/scrapy/pull/1874, split here so as to seperate topics.
