### PR TITLE
Add encoding to Link object + re-enable HTML entities links tests

### DIFF
--- a/scrapy/commands/bench.py
+++ b/scrapy/commands/bench.py
@@ -56,4 +56,5 @@ class _BenchSpider(scrapy.Spider):
 
     def parse(self, response):
         for link in self.link_extractor.extract_links(response):
-            yield scrapy.Request(link.url, callback=self.parse)
+            yield scrapy.Request(link.url, encoding=link.encoding,
+                                 callback=self.parse)

--- a/scrapy/link.py
+++ b/scrapy/link.py
@@ -13,9 +13,9 @@ from scrapy.utils.python import to_bytes
 class Link(object):
     """Link objects represent an extracted link by the LinkExtractor."""
 
-    __slots__ = ['url', 'text', 'fragment', 'nofollow']
+    __slots__ = ['url', 'text', 'fragment', 'nofollow', 'encoding']
 
-    def __init__(self, url, text='', fragment='', nofollow=False):
+    def __init__(self, url, text='', fragment='', nofollow=False, encoding='utf8'):
         if not isinstance(url, str):
             if six.PY2:
                 warnings.warn("Link urls must be str objects. "
@@ -28,6 +28,7 @@ class Link(object):
         self.text = text
         self.fragment = fragment
         self.nofollow = nofollow
+        self.encoding = encoding
 
     def __eq__(self, other):
         return self.url == other.url and self.text == other.text and \

--- a/scrapy/linkextractors/__init__.py
+++ b/scrapy/linkextractors/__init__.py
@@ -100,7 +100,7 @@ class FilteringLinkExtractor(object):
         links = [x for x in links if self._link_allowed(x)]
         if self.canonicalize:
             for link in links:
-                link.url = canonicalize_url(urlparse(link.url))
+                link.url = canonicalize_url(link.url, encoding=link.encoding)
         links = self.link_extractor._process_links(links)
         return links
 

--- a/scrapy/linkextractors/lxmlhtml.py
+++ b/scrapy/linkextractors/lxmlhtml.py
@@ -5,6 +5,7 @@ import six
 from six.moves.urllib.parse import urlparse, urljoin
 
 import lxml.etree as etree
+from w3lib.url import safe_url_string
 
 from scrapy.link import Link
 from scrapy.utils.misc import arg_to_iter, rel_has_nofollow
@@ -56,11 +57,12 @@ class LxmlParserLinkExtractor(object):
                 url = self.process_attr(attr_val)
                 if url is None:
                     continue
-            url = to_native_str(url, encoding=response_encoding)
-            # to fix relative links after process_value
-            url = urljoin(response_url, url)
+            url = safe_url_string(url, encoding=response_encoding)
+            url = urljoin(base_url, url)
+
             link = Link(url, _collect_string_content(el) or u'',
-                        nofollow=rel_has_nofollow(el.get('rel')))
+                        nofollow=rel_has_nofollow(el.get('rel')),
+                        encoding=response_encoding)
             links.append(link)
         return self._deduplicate_if_needed(links)
 

--- a/scrapy/linkextractors/lxmlhtml.py
+++ b/scrapy/linkextractors/lxmlhtml.py
@@ -5,7 +5,6 @@ import six
 from six.moves.urllib.parse import urlparse, urljoin
 
 import lxml.etree as etree
-from w3lib.url import safe_url_string
 
 from scrapy.link import Link
 from scrapy.utils.misc import arg_to_iter, rel_has_nofollow
@@ -57,7 +56,6 @@ class LxmlParserLinkExtractor(object):
                 url = self.process_attr(attr_val)
                 if url is None:
                     continue
-            url = safe_url_string(url, encoding=response_encoding)
             url = urljoin(base_url, url)
 
             link = Link(url, _collect_string_content(el) or u'',

--- a/scrapy/spiders/crawl.py
+++ b/scrapy/spiders/crawl.py
@@ -59,7 +59,8 @@ class CrawlSpider(Spider):
                 links = rule.process_links(links)
             for link in links:
                 seen.add(link)
-                r = Request(url=link.url, callback=self._response_downloaded)
+                r = Request(url=link.url, encoding=link.encoding,
+                        callback=self._response_downloaded)
                 r.meta.update(rule=n, link_text=link.text)
                 yield rule.process_request(r)
 

--- a/tests/test_linkextractors_deprecated.py
+++ b/tests/test_linkextractors_deprecated.py
@@ -1,5 +1,8 @@
 # -*- coding: utf-8 -*-
 import unittest
+
+import pytest
+
 from scrapy.linkextractors.regex import RegexLinkExtractor
 from scrapy.http import HtmlResponse
 from scrapy.link import Link
@@ -171,6 +174,10 @@ class SgmlLinkExtractorTestCase(Base.LinkExtractorTestCase):
             Link(url='http://example.org/about.html', text=u'About us', nofollow=False),
             Link(url='http://google.com/something', text=u'Something', nofollow=True),
         ])
+
+    @pytest.mark.xfail
+    def test_restrict_xpaths_with_html_entities(self):
+        super(SgmlLinkExtractorTestCase, self).test_restrict_xpaths_with_html_entities()
 
 
 class RegexLinkExtractorTestCase(unittest.TestCase):


### PR DESCRIPTION
Add `encoding` parameter and attribute to `Link` object.
That's the only way I found to properly account for encoding information when building requests from link extractors.

Supersedes #1880 
Should fix #1403
