### PR TITLE
[MRG+1] Place brackets on own lines with JsonItemExporter

### DIFF
--- a/scrapy/exporters.py
+++ b/scrapy/exporters.py
@@ -100,10 +100,10 @@ class JsonItemExporter(BaseItemExporter):
         self.first_item = True
 
     def start_exporting(self):
-        self.file.write(b"[")
+        self.file.write(b"[\n")
 
     def finish_exporting(self):
-        self.file.write(b"]")
+        self.file.write(b"\n]")
 
     def export_item(self, item):
         if self.first_item:


### PR DESCRIPTION
Placing the opening and closing brackets on their own lines makes it slightly easier to sort lines after the `spider_closed` signal is fired. (sorting is useful when using scrapy to generate open data sets that should have consistent item order, despite request disorder)