### PR TITLE
[WIP] support multipart/form-data form encoding and file upload

### DIFF
--- a/scrapy/__init__.py
+++ b/scrapy/__init__.py
@@ -32,7 +32,7 @@ twisted_version = (_txv.major, _txv.minor, _txv.micro)
 
 # Declare top-level shortcuts
 from scrapy.spiders import Spider
-from scrapy.http import Request, FormRequest
+from scrapy.http import Request, FormRequest, MultipartFormRequest
 from scrapy.selector import Selector
 from scrapy.item import Item, Field
 

--- a/scrapy/http/__init__.py
+++ b/scrapy/http/__init__.py
@@ -9,6 +9,8 @@ from scrapy.http.headers import Headers
 
 from scrapy.http.request import Request
 from scrapy.http.request.form import FormRequest
+from scrapy.http.request.form import MultipartFormRequest
+from scrapy.http.request.form import MultipartFile
 from scrapy.http.request.rpc import XmlRpcRequest
 
 from scrapy.http.response import Response

--- a/tests/test_http_request.py
+++ b/tests/test_http_request.py
@@ -8,8 +8,10 @@ from six.moves import xmlrpc_client as xmlrpclib
 from six.moves.urllib.parse import urlparse, parse_qs, unquote
 if six.PY3:
     from urllib.parse import unquote_to_bytes
+from collections import OrderedDict
 
-from scrapy.http import Request, FormRequest, XmlRpcRequest, Headers, HtmlResponse
+from scrapy.http import Request, FormRequest, MultipartFile, XmlRpcRequest, Headers, \
+                        HtmlResponse, MultipartFormRequest
 from scrapy.utils.python import to_bytes, to_native_str
 
 
@@ -1070,6 +1072,81 @@ class XmlRpcRequestTest(RequestTest):
 
     def test_latin1(self):
         self._test_request(params=(u'pas£',), encoding='latin1')
+
+
+class MultipartFormRequestTest(RequestTest):
+
+    request_class = MultipartFormRequest
+    default_method = 'POST'
+    default_headers = {b'Content-Type': [b'multipart/form-data']}
+
+    def test_multpart_text_body(self):
+        data = {b'field': b'value'}
+        headers = {b'Content-Type': b'multipart/form-data'}
+        r1 = self.request_class("http://www.example.com", formdata=data, headers=headers)
+        boundary1 = r1._boundary
+        body = b'--' + boundary1 + \
+               b'\r\nContent-Disposition: form-data; name="field"' + \
+               b'\r\n' + \
+               b'\r\nvalue' + \
+               b'\r\n--' + boundary1 + b'--'
+        self.assertEqual(r1.body, body)
+
+    def test_multpart_unicode_body(self):
+        data = {u'Price £': u'£ 100'}
+        headers = {b'Content-Type': b'multipart/form-data'}
+        r1 = self.request_class("http://www.example.com", formdata=data, headers=headers)
+        boundary1 = r1._boundary
+        body = b'--' + boundary1 + \
+               b'\r\nContent-Disposition: form-data; name="Price \xc2\xa3"' + \
+               b'\r\n' + \
+               b'\r\n\xc2\xa3 100' + \
+               b'\r\n--' + boundary1 + b'--'
+        self.assertEqual(r1.body, body)
+
+    def test_multipart_file(self):
+        sample_file = MultipartFile(name='sample.txt', content=u'Text file content £ 100')
+
+        data = OrderedDict((
+            (u'Price £', u'£ 100'),
+            ('file', sample_file)
+        ))
+        headers = {b'Content-Type': b'multipart/form-data'}
+        r1 = self.request_class("http://www.example.com", formdata=data, headers=headers)
+        boundary1 = r1._boundary
+        body = b'--' + boundary1 + \
+               b'\r\nContent-Disposition: form-data; name="Price \xc2\xa3"' + \
+               b'\r\n' + \
+               b'\r\n\xc2\xa3 100' + \
+               b'\r\n--' + boundary1 + \
+               b'\r\nContent-Disposition: form-data; name="file"; filename="sample.txt"' + \
+               b'\r\nContent-Type: application/octet-stream' + \
+               b'\r\n' + \
+               b'\r\nText file content \xc2\xa3 100' + \
+               b'\r\n--' + boundary1 + b'--'
+        self.assertEqual(r1.body, body)
+
+    def test_multipart_file_mimetype(self):
+        sample_file = MultipartFile(name='sample.txt', content=u'Text file content £ 100', mimetype='text/plain')
+
+        data = OrderedDict((
+            (u'Price £', u'£ 100'),
+            ('file', sample_file)
+        ))
+        headers = {b'Content-Type': b'multipart/form-data'}
+        r1 = self.request_class("http://www.example.com", formdata=data, headers=headers)
+        boundary1 = r1._boundary
+        body = b'--' + boundary1 + \
+               b'\r\nContent-Disposition: form-data; name="Price \xc2\xa3"' + \
+               b'\r\n' + \
+               b'\r\n\xc2\xa3 100' + \
+               b'\r\n--' + boundary1 + \
+               b'\r\nContent-Disposition: form-data; name="file"; filename="sample.txt"' + \
+               b'\r\nContent-Type: text/plain' + \
+               b'\r\n' + \
+               b'\r\nText file content \xc2\xa3 100' + \
+               b'\r\n--' + boundary1 + b'--'
+        self.assertEqual(r1.body, body)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### PR Overview

This PR add support for multipart/form-data form encoding.

Fixes https://github.com/scrapy/scrapy/issues/1897
- [x] Handle request header
- [x] Encode formdata
- [x] support file upload
- [ ] docs
1. Form fields and form files are present in the `formdata` parameter. To add a file in the `formdata`, it's necessary to use the new `MultipartFile` object (this is not yet documented, because I'd like to confirm if this api design is good first.) From the [multipart/form-data](https://www.w3.org/TR/html401/interact/forms.html#h-17.13.4) spec, files requires a special treatment, thats why we have the `MultipartFile` object. Non-files can be used as usual in the `formdata` parameter, including binary content.
2. Adds the `class MultipartFormRequest(FormRequest)`, designed to work exclusively with multipart requests.
3. A sample Spider using  this feature:
   
   ``` python
   # coding: utf-8
   import scrapy
   from scrapy.http.request.form import MultipartFormRequest, MultipartFile
   
   
   class SampleSpider(scrapy.Spider):
   
       name = 'sample'
       start_urls = ['http://0.0.0.0:5001']
   
       def parse(self, response):
           sample_file = MultipartFile('example £.png', open('/tmp/a.png').read())
           data = {
               'name': 'Test',
               'file': sample_file,
           }
   
           return MultipartFormRequest.from_response(response, formdata=data)
   ```

**updated at Oct 13**
