### PR TITLE
[MRG+1] Prevent empty warnings in case of certificate verification failures

### DIFF
--- a/scrapy/core/downloader/tls.py
+++ b/scrapy/core/downloader/tls.py
@@ -44,7 +44,9 @@ try:
                 try:
                     verifyHostname(connection, self._hostnameASCII)
                 except VerificationError as e:
-                    logger.warning(e)
+                    logger.warning(
+                        'Remote certificate is not valid for hostname "{}"; {}'.format(
+                            self._hostnameASCII, e))
 
 except ImportError:
     # ImportError should not matter for older Twisted versions


### PR DESCRIPTION
Fixes #1976

`VerificationError` exception can have an empty string representation ([e.g. for `service-identity<16`](https://github.com/scrapy/scrapy/issues/1976#issuecomment-218422811))

This patch adds a (more) meaningful message before the exception message just in case.