### PR TITLE
Add fallback for upper case attribute names in Images Pipeline (fixes #1985)

### DIFF
--- a/scrapy/pipelines/files.py
+++ b/scrapy/pipelines/files.py
@@ -220,6 +220,12 @@ class FilesPipeline(MediaPipeline):
         's3': S3FilesStore,
     }
 
+    _DEPRECATED_ATTRS = {
+        'FILES_EXPIRES': 'expires',
+        'FILES_URLS_FIELD': 'files_urls_field',
+        'FILES_RESULT_FIELD': 'files_result_field',
+    }
+
     def __init__(self, store_uri, download_func=None, settings=None):
         if not store_uri:
             raise NotConfigured

--- a/scrapy/pipelines/images.py
+++ b/scrapy/pipelines/images.py
@@ -21,7 +21,6 @@ from scrapy.settings import Settings
 from scrapy.exceptions import DropItem
 #TODO: from scrapy.pipelines.media import MediaPipeline
 from scrapy.pipelines.files import FileException, FilesPipeline
-from scrapy.utils import deprecate
 
 
 class NoimagesDrop(DropItem):
@@ -38,6 +37,15 @@ class ImagesPipeline(FilesPipeline):
     """
 
     MEDIA_NAME = 'image'
+
+    _DEPRECATED_ATTRS = {
+        'IMAGES_EXPIRES': 'expires',
+        'IMAGES_URLS_FIELD': 'images_urls_field',
+        'IMAGES_RESULT_FIELD': 'images_result_field',
+        'IMAGES_MIN_WIDTH': 'min_width',
+        'IMAGES_MIN_HEIGHT': 'min_height',
+        'IMAGES_THUMBS': 'thumbs',
+    }
 
     def __init__(self, store_uri, download_func=None, settings=None):
         super(ImagesPipeline, self).__init__(store_uri, settings=settings, download_func=download_func)
@@ -60,22 +68,6 @@ class ImagesPipeline(FilesPipeline):
 
         store_uri = settings['IMAGES_STORE']
         return cls(store_uri, settings=settings)
-
-    def __getattr__(self, name):
-        lower_name = name.lower()
-
-        if name != lower_name and hasattr(self, lower_name):
-            deprecate.attribute(self, name, lower_name, version='1.2')
-            return getattr(self, lower_name)
-
-        if name.startswith('IMAGES_'):
-            alt_name = name[len('IMAGES_'):].lower()
-            if hasattr(self, alt_name):
-                deprecate.attribute(self, name, alt_name, version='1.2')
-                return getattr(self, alt_name)
-
-        msg = '{.__name__!r} object has no attribute {!r}'
-        raise AttributeError(msg.format(self.__class__, name))
 
     def file_downloaded(self, response, request, info):
         return self.image_downloaded(response, request, info)

--- a/tests/test_pipeline_files.py
+++ b/tests/test_pipeline_files.py
@@ -105,6 +105,18 @@ class FilesPipelineTestCase(unittest.TestCase):
         for p in patchers:
             p.stop()
 
+    def test_deprecate_uppercase_attribute_names(self):
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter('always')
+            self.assertEquals(self.pipeline.expires, self.pipeline.FILES_EXPIRES)
+            self.assertEquals(
+                'FilesPipeline.FILES_EXPIRES attribute is deprecated and will'
+                ' be no longer supported in Scrapy 1.2, use FilesPipeline.expires'
+                ' attribute instead', str(w[-1].message))
+
+        with self.assertRaises(AttributeError):
+            self.pipeline.files_EXPIRES
+
 
 class DeprecatedFilesPipeline(FilesPipeline):
     def file_key(self, url):

--- a/tests/test_pipeline_images.py
+++ b/tests/test_pipeline_images.py
@@ -1,4 +1,3 @@
-import os
 import hashlib
 import warnings
 from tempfile import mkdtemp, TemporaryFile
@@ -94,6 +93,34 @@ class ImagesPipelineTestCase(unittest.TestCase):
         converted, _ = self.pipeline.convert_image(im)
         self.assertEquals(converted.mode, 'RGB')
         self.assertEquals(converted.getcolors(), [(10000, (205, 230, 255))])
+
+    def test_derived_pipelines_can_still_use_uppercase_names(self):
+        # given:
+        class CustomImagesPipeline(ImagesPipeline):
+            def item_completed(self, *a, **kw):
+                print('Using result field: %s', self.IMAGES_RESULT_FIELD)
+                return super(CustomImagesPipeline, self).item_completed(*a, **kw)
+
+        # when:
+        pipeline = CustomImagesPipeline(self.tempdir, download_func=_mocked_download_func)
+
+        # then:
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter('always')
+            self.assertEquals(pipeline.images_result_field, pipeline.IMAGES_RESULT_FIELD)
+            self.assertEquals(
+                'CustomImagesPipeline.IMAGES_RESULT_FIELD attribute is deprecated'
+                ' and will be no longer supported in Scrapy 1.2, use'
+                ' CustomImagesPipeline.images_result_field attribute instead', str(w[-1].message))
+
+        # and:
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter('always')
+            self.assertEquals(pipeline.expires, pipeline.IMAGES_EXPIRES)
+            self.assertEquals(
+                'CustomImagesPipeline.IMAGES_EXPIRES attribute is deprecated and will'
+                ' be no longer supported in Scrapy 1.2, use CustomImagesPipeline.expires'
+                ' attribute instead', str(w[-1].message))
 
 
 class DeprecatedImagesPipeline(ImagesPipeline):

--- a/tests/test_pipeline_images.py
+++ b/tests/test_pipeline_images.py
@@ -94,7 +94,7 @@ class ImagesPipelineTestCase(unittest.TestCase):
         self.assertEquals(converted.mode, 'RGB')
         self.assertEquals(converted.getcolors(), [(10000, (205, 230, 255))])
 
-    def test_derived_pipelines_can_still_use_uppercase_names(self):
+    def test_deprecate_uppercase_attribute_names(self):
         # given:
         class CustomImagesPipeline(ImagesPipeline):
             def item_completed(self, *a, **kw):
@@ -105,15 +105,6 @@ class ImagesPipelineTestCase(unittest.TestCase):
         pipeline = CustomImagesPipeline(self.tempdir, download_func=_mocked_download_func)
 
         # then:
-        with warnings.catch_warnings(record=True) as w:
-            warnings.simplefilter('always')
-            self.assertEquals(pipeline.images_result_field, pipeline.IMAGES_RESULT_FIELD)
-            self.assertEquals(
-                'CustomImagesPipeline.IMAGES_RESULT_FIELD attribute is deprecated'
-                ' and will be no longer supported in Scrapy 1.2, use'
-                ' CustomImagesPipeline.images_result_field attribute instead', str(w[-1].message))
-
-        # and:
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter('always')
             self.assertEquals(pipeline.expires, pipeline.IMAGES_EXPIRES)


### PR DESCRIPTION
This adds a fallback for upper case attribute names, with a deprecation notice to deprecate them in Scrapy 1.2 (when we can simply remove the tests and `__getattr__` methods).

Does this look good?