### PR TITLE
Issue #1915: Allow multiple items through pipelines experiment

### DIFF
--- a/scrapy/pipelines/__init__.py
+++ b/scrapy/pipelines/__init__.py
@@ -23,13 +23,38 @@ class ItemPipelineManager(MiddlewareManager):
             self.methods['process_item'].append(pipe.process_item)
 
     def process_item(self, item, spider):
+        pipelines_list = []
+        scraper = spider.crawler.engine.scraper
         def buildPipelineHandler(func):
             def pipelineHandler(output):
                 print pipelines_list.index(pipelineHandler)
                 if isinstance(output, (BaseItem, dict)):
                     return func(output, spider)
                 elif isinstance(output, collections.Iterable):
-                    pass
+                    if isinstance(output[0],tuple):
+                        '''
+                            Returned from a DeferredList, so raise a SplitItemError 
+                            & end callchain
+                        '''
+                        pass
+                    else:
+                        '''
+                            Process iterable of items
+                        '''
+                        scraper.slot.itemproc_size += len(output) - 1
+                        concurrent_items = scraper.concurrent_items
+                        doneIndex = pipelines_list.index(pipelineHandler)
+                        remainingList = pipelines_list[doneIndex: ]
+                        dfd = parallel(output, self.concurrent_items,
+            self._create_intermediate_chain, remainingList, errback, spider)
+                        return dfd
             return pipelineHandler
         pipelines_list = [buildPipelineHandler(method) for method in self.methods['process_item']]
         return process_chain(pipelines_list, item)
+    
+    def _create_intermediate_chain(self,output, methodList, errback, spider)
+        dfd = process_chain(methodList, output, spider)
+        dfd.addBoth(errback)
+        # Need to add scraper._itemproc_finished here, but not sure how
+        # to source the necessary arguments
+        return dfd

--- a/scrapy/pipelines/__init__.py
+++ b/scrapy/pipelines/__init__.py
@@ -3,7 +3,7 @@ Item pipeline
 
 See documentation in docs/item-pipeline.rst
 """
-
+import collections
 from scrapy.middleware import MiddlewareManager
 from scrapy.utils.conf import build_component_list
 from scrapy.utils.defer import process_chain
@@ -27,6 +27,8 @@ class ItemPipelineManager(MiddlewareManager):
             def pipelineHandler(output):
                 if isinstance(output, (BaseItem, dict)):
                     return func(output, spider)
+                if isinstance(output, collections.Iterable):
+                    pass
             return pipelineHandler
         pipelines_list = [buildPipelineHandler(method) for method in self.methods['process_item']]
         return process_chain(pipelines_list, item)

--- a/scrapy/pipelines/__init__.py
+++ b/scrapy/pipelines/__init__.py
@@ -25,5 +25,6 @@ class ItemPipelineManager(MiddlewareManager):
         def buildPipelineHandler(func):
             def pipelineHandler(output):
                 return func(output, spider)
+            return pipelineHandler
         pipelines_list = [buildPipelineHandler(method) for method in self.methods['process_item']]
         return process_chain(pipelines_list, item)

--- a/scrapy/pipelines/__init__.py
+++ b/scrapy/pipelines/__init__.py
@@ -6,6 +6,7 @@ See documentation in docs/item-pipeline.rst
 
 from scrapy.middleware import MiddlewareManager
 from scrapy.utils.conf import build_component_list
+from scrapy.utils.defer import process_chain
 
 class ItemPipelineManager(MiddlewareManager):
 
@@ -21,4 +22,8 @@ class ItemPipelineManager(MiddlewareManager):
             self.methods['process_item'].append(pipe.process_item)
 
     def process_item(self, item, spider):
-        return self._process_chain('process_item', item, spider)
+        def buildPipelineHandler(func):
+            def pipelineHandler(output):
+                return func(output, spider)
+        pipelines_list = [buildPipelineHandler(method) for method in self.methods['process_item']]
+        return process_chain(pipelines_list, item)

--- a/scrapy/pipelines/__init__.py
+++ b/scrapy/pipelines/__init__.py
@@ -27,7 +27,7 @@ class ItemPipelineManager(MiddlewareManager):
             def pipelineHandler(output):
                 if isinstance(output, (BaseItem, dict)):
                     return func(output, spider)
-                if isinstance(output, collections.Iterable):
+                elif isinstance(output, collections.Iterable):
                     pass
             return pipelineHandler
         pipelines_list = [buildPipelineHandler(method) for method in self.methods['process_item']]

--- a/scrapy/pipelines/__init__.py
+++ b/scrapy/pipelines/__init__.py
@@ -7,6 +7,7 @@ See documentation in docs/item-pipeline.rst
 from scrapy.middleware import MiddlewareManager
 from scrapy.utils.conf import build_component_list
 from scrapy.utils.defer import process_chain
+from scrapy.item import BaseItem
 
 class ItemPipelineManager(MiddlewareManager):
 
@@ -24,7 +25,8 @@ class ItemPipelineManager(MiddlewareManager):
     def process_item(self, item, spider):
         def buildPipelineHandler(func):
             def pipelineHandler(output):
-                return func(output, spider)
+                if isinstance(output, (BaseItem, dict)):
+                    return func(output, spider)
             return pipelineHandler
         pipelines_list = [buildPipelineHandler(method) for method in self.methods['process_item']]
         return process_chain(pipelines_list, item)

--- a/scrapy/pipelines/__init__.py
+++ b/scrapy/pipelines/__init__.py
@@ -25,6 +25,7 @@ class ItemPipelineManager(MiddlewareManager):
     def process_item(self, item, spider):
         def buildPipelineHandler(func):
             def pipelineHandler(output):
+                print pipelines_list.index(pipelineHandler)
                 if isinstance(output, (BaseItem, dict)):
                     return func(output, spider)
                 elif isinstance(output, collections.Iterable):


### PR DESCRIPTION
PR as a possible solution to #1915. Not functional yet.

My plan is to change the ItemPipelineManager to handle multiple items, rather than doing it in the Scraper. 

According to the Twisted documentation, if a callback returns a Deferred, then the outer Deferred pauses until the inner Deferred has finished it's callbacks. Thus what I'm planning is to create a new set of parallel calls when an iterable is returned, which will pause the processing of the original item ( and the cooperative scheduler running the original items returned from the spider). In this way, the concurrency limits should be respected.

The pipeline handler method is needed to inspect the output of a pipeline and act accordingly.