### PR TITLE
[MRG+1] Use "url" variable in the example

### DIFF
--- a/docs/topics/downloader-middleware.rst
+++ b/docs/topics/downloader-middleware.rst
@@ -200,7 +200,7 @@ There is support for keeping multiple cookie sessions per spider by using the
 For example::
 
     for i, url in enumerate(urls):
-        yield scrapy.Request("http://www.example.com", meta={'cookiejar': i},
+        yield scrapy.Request(url, meta={'cookiejar': i},
             callback=self.parse_page)
 
 Keep in mind that the :reqmeta:`cookiejar` meta key is not "sticky". You need to keep


### PR DESCRIPTION
Instead of hardcoded http://www.example.com, as noticed by Andrés Pérez-Albela H.: without it url variable is unused and only one request will make it past dupefilter.