### PR TITLE
#1915: Multiple items through item pipelines

### DIFF
--- a/scrapy/core/scraper.py
+++ b/scrapy/core/scraper.py
@@ -11,7 +11,7 @@ from scrapy.utils.defer import defer_result, defer_succeed, parallel, iter_errba
 from scrapy.utils.spider import iterate_spider_output
 from scrapy.utils.misc import load_object
 from scrapy.utils.log import logformatter_adapter, failure_to_exc_info
-from scrapy.exceptions import CloseSpider, DropItem, IgnoreRequest
+from scrapy.exceptions import CloseSpider, DropItem, SplitItem, IgnoreRequest
 from scrapy import signals
 from scrapy.http import Request, Response
 from scrapy.item import BaseItem
@@ -228,6 +228,8 @@ class Scraper(object):
                 return self.signals.send_catch_log_deferred(
                     signal=signals.item_dropped, item=item, response=response,
                     spider=spider, exception=output.value)
+            elif isinstance(ex, SplitItem):
+                logger.debug('Item Split: {0}'.format(item))
             else:
                 logger.error('Error processing %(item)s', {'item': item},
                              exc_info=failure_to_exc_info(output),

--- a/scrapy/exceptions.py
+++ b/scrapy/exceptions.py
@@ -33,6 +33,10 @@ class DropItem(Exception):
     """Drop item from the item pipeline"""
     pass
 
+class SplitItem(Exception):
+    """Split an item in the item pipeline"""
+    pass
+
 class NotSupported(Exception):
     """Indicates a feature or method is not supported"""
     pass

--- a/scrapy/pipelines/__init__.py
+++ b/scrapy/pipelines/__init__.py
@@ -3,9 +3,15 @@ Item pipeline
 
 See documentation in docs/item-pipeline.rst
 """
+import collections
 
 from scrapy.middleware import MiddlewareManager
 from scrapy.utils.conf import build_component_list
+from scrapy.utils.defer import process_chain, parallel
+from scrapy.item import BaseItem
+from scrapy.exceptions import SplitItem
+
+from twisted.internet.defer import DeferredList
 
 class ItemPipelineManager(MiddlewareManager):
 
@@ -21,4 +27,74 @@ class ItemPipelineManager(MiddlewareManager):
             self.methods['process_item'].append(pipe.process_item)
 
     def process_item(self, item, spider):
-        return self._process_chain('process_item', item, spider)
+        pipelines_list = []
+        scraper = spider.crawler.engine.scraper
+        
+        def buildPipelineHandler(func):
+            if func is not None:
+                def pipelineHandler(output, *args, **kw):
+                    """
+                    Pipeline Handlers: Closures using pipeline functions
+                    item->A->iterable->B->DeferredList->Empty handler->SplitItem
+                    item->A->item->B->item->Empty handler
+                    """
+                    if isinstance(output, (BaseItem, dict)):
+                        return func(output, spider)
+                    elif isinstance(output, collections.Iterable):
+                        if isinstance(output[0], tuple):
+                            raise SplitItem("Item split")
+                        else:
+                            scraper.slot.itemproc_size += len(output) - 1
+                            concurrent_items = scraper.concurrent_items
+                            doneIndex = pipelines_list.index(pipelineHandler)
+                            remainingList = pipelines_list[doneIndex: ]
+                            dfd = parallel(output, concurrent_items, \
+                                self._create_intermediate_chain, remainingList,spider)
+                            return dfd
+            else:
+                def pipelineHandler(output, *args, **kw):
+                    """
+                    Empty Handler
+                    Required to handle the output of the last handler, if it
+                    returns an iterable.
+                    item->A->iterable->Empty handler->Final handler
+                    """
+                    if isinstance(output, (BaseItem, dict)):
+                        return output
+                    elif isinstance(output, collections.Iterable):
+                        if isinstance(output[0], tuple):
+                            raise SplitItem("Item split")
+                        else:
+                            scraper.slot.itemproc_size += len(output) - 1
+                            concurrent_items = scraper.concurrent_items
+                            doneIndex = pipelines_list.index(pipelineHandler)
+                            remainingList = pipelines_list[doneIndex: ]
+                            dfd = parallel(output, concurrent_items, \
+                                self._create_intermediate_chain, remainingList,spider)
+                            return dfd
+            return pipelineHandler
+        
+        def finalHandler(output, *args, **kw):
+            """
+            If the last pipeline returns an iterable, it's handler cannot deal with
+            the result, which is why an Empty handler is uses. This final handler is
+            used to deal with the result of the Empty Handler.
+            """
+            if isinstance(output, (BaseItem, dict)):
+                return output
+            elif isinstance(output, collections.Iterable):
+                raise SplitItem("Item split")
+        
+        pipelines_list = [buildPipelineHandler(method) for method in self.methods['process_item']]
+        pipelines_list.append(buildPipelineHandler(None))
+        pipelines_list.append(finalHandler)
+        return process_chain(pipelines_list, item)
+    
+    def _create_intermediate_chain(self,output, methodList, spider):
+        scraper = spider.crawler.engine.scraper
+        dfd = process_chain(methodList, output, spider)
+        dfd.addBoth(scraper._itemproc_finished, output, None, spider)
+        # Need to add scraper._itemproc_finished here, but not sure how
+        # to source the necessary arguments
+        # Trying with None
+        return dfd


### PR DESCRIPTION
My solution to #1915. Approach:

- All functions in a pipeline are put inside closures and a process chain is made out of them.
- For the n<sup>th</sup> pipeline, it's output is handled by the n+1<sup>th</sup> pipelineHandler.
- When an iterable is encountered, a parallel call is generated and a DeferredList is returned. According to the Twisted docs, if a callback returns a deferred, then the callchain is paused until that deferred completes. So the concurrency limits should be maintained in my approach.
- When the result of a DeferredList is encountered, a SplitItem exception is raised to exit the callchain.

Hiccups:

- I had to add two extra functions at the end of the pipeline just to handle corner cases. Not sure if there's another way around it.
- My plan was to show the split items when the exception is thrown, but I'm not sure how to do that.
- When an item is split, scraper._itemproc_finished should show it like a normal item, as being scraped from the original response. I don't know how to access the response without changing the function signature.
