### PR TITLE
[WIP] Change BaseSettings#__getitem__ to behave like a regular dict's one

### DIFF
--- a/scrapy/settings/__init__.py
+++ b/scrapy/settings/__init__.py
@@ -91,8 +91,6 @@ class BaseSettings(MutableMapping):
         self.update(values, priority)
 
     def __getitem__(self, opt_name):
-        if opt_name not in self:
-            return None
         return self.attributes[opt_name].value
 
     def __contains__(self, name):
@@ -108,7 +106,7 @@ class BaseSettings(MutableMapping):
         :param default: the value to return if no setting is found
         :type default: any
         """
-        return self[name] if self[name] is not None else default
+        return self[name] if name in self else default
 
     def getbool(self, name, default=False):
         """
@@ -200,8 +198,8 @@ class BaseSettings(MutableMapping):
         :type name: string
         """
         compbs = BaseSettings()
-        compbs.update(self[name + '_BASE'])
-        compbs.update(self[name])
+        compbs.update(self.get(name + '_BASE'))
+        compbs.update(self.get(name))
         return compbs
 
     def getpriority(self, name):

--- a/scrapy/settings/__init__.py
+++ b/scrapy/settings/__init__.py
@@ -466,6 +466,11 @@ class Settings(BaseSettings):
                 self.set(name, BaseSettings(val, 'default'), 'default')
         self.update(values, priority)
 
+    def __getitem__(self, opt_name):
+        if opt_name not in self:
+            return None
+        return self.attributes[opt_name].value
+
 
 class CrawlerSettings(Settings):
 

--- a/tests/test_settings/__init__.py
+++ b/tests/test_settings/__init__.py
@@ -250,7 +250,6 @@ class BaseSettingsTest(unittest.TestCase):
         self.assertEqual(settings.getlist('TEST_LISTx', ['default']), ['default'])
         self.assertEqual(settings['TEST_STR'], 'value')
         self.assertEqual(settings.get('TEST_STR'), 'value')
-        self.assertEqual(settings['TEST_STRx'], None)
         self.assertEqual(settings.get('TEST_STRx'), None)
         self.assertEqual(settings.get('TEST_STRx', 'default'), 'default')
         self.assertEqual(settings.getdict('TEST_DICT1'), {'key1': 'val1', 'ke2': 3})


### PR DESCRIPTION
The previous implementation broke the MutableMapping contract.
`setdefault`, for one, doesn't work anymore.

`__getitem__` is expected to raise KeyError for non-existing keys, unless
we're trying to emulate a defaultdict, which should be explicit in the
docs and is backwards incompatible.
