### PR TITLE
[MRG+1] Add set serialization to ScrapyJSONEncoder

### DIFF
--- a/scrapy/utils/serialize.py
+++ b/scrapy/utils/serialize.py
@@ -14,7 +14,9 @@ class ScrapyJSONEncoder(json.JSONEncoder):
     TIME_FORMAT = "%H:%M:%S"
 
     def default(self, o):
-        if isinstance(o, datetime.datetime):
+        if isinstance(o, set):
+            return list(o)
+        elif isinstance(o, datetime.datetime):
             return o.strftime("%s %s" % (self.DATE_FORMAT, self.TIME_FORMAT))
         elif isinstance(o, datetime.date):
             return o.strftime(self.DATE_FORMAT)

--- a/tests/test_utils_serialize.py
+++ b/tests/test_utils_serialize.py
@@ -23,9 +23,14 @@ class JsonEncoderTestCase(unittest.TestCase):
         ts = "10:11:12"
         dec = Decimal("1000.12")
         decs = "1000.12"
+        s = {'foo'}
+        ss = ['foo']
+        dt_set = {dt}
+        dt_sets = [dts]
 
         for input, output in [('foo', 'foo'), (d, ds), (t, ts), (dt, dts),
-                              (dec, decs), (['foo', d], ['foo', ds])]:
+                              (dec, decs), (['foo', d], ['foo', ds]), (s, ss),
+                              (dt_set, dt_sets)]:
             self.assertEqual(self.encoder.encode(input), json.dumps(output))
 
     def test_encode_deferred(self):


### PR DESCRIPTION
Tried using sets a few times as a way to get a list that avoid duplicates in field values. Only to remember that neither Python or Scrapy's encoder can serialize them.