### PR TITLE
[MRG+1] [docs] add note about windows + python3

### DIFF
--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -71,7 +71,10 @@ What Python versions does Scrapy support?
 
 Scrapy is supported under Python 2.7 and Python 3.3+.
 Python 2.6 support was dropped starting at Scrapy 0.20.
-Python 3 support was added in Scrapy 1.1. Python 3 is not yet supported on Windows.
+Python 3 support was added in Scrapy 1.1.
+
+.. note::
+    Python 3 is not yet supported on Windows.
 
 Did Scrapy "steal" X from Django?
 ---------------------------------

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -71,7 +71,7 @@ What Python versions does Scrapy support?
 
 Scrapy is supported under Python 2.7 and Python 3.3+.
 Python 2.6 support was dropped starting at Scrapy 0.20.
-Python 3 support was added in Scrapy 1.1.
+Python 3 support was added in Scrapy 1.1. Python 3 is not yet supported on Windows.
 
 Did Scrapy "steal" X from Django?
 ---------------------------------

--- a/docs/intro/install.rst
+++ b/docs/intro/install.rst
@@ -11,7 +11,7 @@ Installing Scrapy
 
 The installation steps assume that you have the following things installed:
 
-* `Python`_ 2.7
+* `Python`_ 2.7 or above 3.3
 
 * `pip`_ and `setuptools`_ Python packages. Nowadays `pip`_ requires and
   installs `setuptools`_ if not installed. Python 2.7.9 and later include
@@ -84,6 +84,10 @@ Windows
   install Scrapy::
 
       pip install Scrapy
+
+.. note::
+     Python 3 is not supported on Windows. Installation of Scrapy on Windows
+     with Python 3 will fail.
 
 Ubuntu 9.10 or above
 --------------------

--- a/docs/intro/install.rst
+++ b/docs/intro/install.rst
@@ -86,8 +86,8 @@ Windows
       pip install Scrapy
 
 .. note::
-     Python 3 is not supported on Windows. Installation of Scrapy on Windows
-     with Python 3 will fail.
+     Python 3 is not supported on Windows. This is because Scrapy core requirement Twisted does not support
+     Python 3 on Windows.
 
 Ubuntu 9.10 or above
 --------------------

--- a/docs/news.rst
+++ b/docs/news.rst
@@ -72,7 +72,7 @@ features are still missing (and some may never be ported).
 Almost all builtin extensions/middlewares are expected to work.
 However, we are aware of some limitations in Python 3:
 
-- Scrapy has not been tested on Windows with Python 3
+- Scrapy does not work on Windows with Python 3
 - Sending emails is not supported
 - FTP download handler is not supported
 - Telnet console is not supported


### PR DESCRIPTION
#2056 seems like common issue (e.g. user here: http://stackoverflow.com/questions/36857638/can-i-run-scrapy-on-windows-with-python-3/37418422) , should we also update [installation guide](http://doc.scrapy.org/en/1.1/intro/install.html) with note about Python 3? Currently it does not say anything about Python 3 but people assume 3 should be supported.