### PR TITLE
[MRG] Add "Host" header in CONNECT requests to HTTPS proxies

### DIFF
--- a/scrapy/core/downloader/handlers/http11.py
+++ b/scrapy/core/downloader/handlers/http11.py
@@ -93,7 +93,7 @@ class TunnelingTCP4ClientEndpoint(TCP4ClientEndpoint):
     for it.
     """
 
-    _responseMatcher = re.compile(b'HTTP/1\.. 200')
+    _responseMatcher = re.compile(b'HTTP/1\.. (?P<status>\d{3})(?P<reason>.{,32})')
 
     def __init__(self, reactor, host, port, proxyConf, contextFactory,
                  timeout=30, bindAddress=None):
@@ -115,13 +115,14 @@ class TunnelingTCP4ClientEndpoint(TCP4ClientEndpoint):
         self._protocol = protocol
         return protocol
 
-    def processProxyResponse(self, bytes):
+    def processProxyResponse(self, rcvd_bytes):
         """Processes the response from the proxy. If the tunnel is successfully
         created, notifies the client that we are ready to send requests. If not
         raises a TunnelError.
         """
         self._protocol.dataReceived = self._protocolDataReceived
-        if  TunnelingTCP4ClientEndpoint._responseMatcher.match(bytes):
+        respm = TunnelingTCP4ClientEndpoint._responseMatcher.match(rcvd_bytes)
+        if respm and int(respm.group('status')) == 200:
             try:
                 # this sets proper Server Name Indication extension
                 # but is only available for Twisted>=14.0
@@ -134,9 +135,14 @@ class TunnelingTCP4ClientEndpoint(TCP4ClientEndpoint):
                                               self._protocolFactory)
             self._tunnelReadyDeferred.callback(self._protocol)
         else:
+            if respm:
+                extra = {'status': int(respm.group('status')),
+                         'reason': respm.group('reason').strip()}
+            else:
+                extra = rcvd_bytes[:32]
             self._tunnelReadyDeferred.errback(
-                TunnelError('Could not open CONNECT tunnel with proxy %s:%s' % (
-                    self._host, self._port)))
+                TunnelError('Could not open CONNECT tunnel with proxy %s:%s [%r]' % (
+                    self._host, self._port, extra)))
 
     def connectFailed(self, reason):
         """Propagates the errback to the appropriate deferred."""
@@ -151,23 +157,22 @@ class TunnelingTCP4ClientEndpoint(TCP4ClientEndpoint):
         return self._tunnelReadyDeferred
 
 
-def tunnel_request_data(host, port, proxy_auth_header=None):
+def tunnel_request_data(host, port, proxy_auth_header=None, host_header=True):
     r"""
     Return binary content of a CONNECT request.
 
     >>> from scrapy.utils.python import to_native_str as s
     >>> s(tunnel_request_data("example.com", 8080))
-    'CONNECT example.com:8080 HTTP/1.1\r\n\r\n'
+    'CONNECT example.com:8080 HTTP/1.1\r\nHost: example.com:8080\r\n\r\n'
     >>> s(tunnel_request_data("example.com", 8080, b"123"))
-    'CONNECT example.com:8080 HTTP/1.1\r\nProxy-Authorization: 123\r\n\r\n'
+    'CONNECT example.com:8080 HTTP/1.1\r\nHost: example.com:8080\r\nProxy-Authorization: 123\r\n\r\n'
     >>> s(tunnel_request_data(b"example.com", "8090"))
-    'CONNECT example.com:8090 HTTP/1.1\r\n\r\n'
+    'CONNECT example.com:8090 HTTP/1.1\r\nHost: example.com:8090\r\n\r\n'
     """
-    tunnel_req = (
-        b'CONNECT ' +
-        to_bytes(host, encoding='ascii') + b':' +
-        to_bytes(str(port)) +
-        b' HTTP/1.1\r\n')
+    host_value = to_bytes(host, encoding='ascii') + b':' + to_bytes(str(port))
+    tunnel_req = b'CONNECT ' + host_value + b' HTTP/1.1\r\n'
+    if host_header:
+        tunnel_req += b'Host: ' + host_value + b'\r\n'
     if proxy_auth_header:
         tunnel_req += b'Proxy-Authorization: ' + proxy_auth_header + b'\r\n'
     tunnel_req += b'\r\n'

--- a/scrapy/core/downloader/handlers/http11.py
+++ b/scrapy/core/downloader/handlers/http11.py
@@ -157,7 +157,7 @@ class TunnelingTCP4ClientEndpoint(TCP4ClientEndpoint):
         return self._tunnelReadyDeferred
 
 
-def tunnel_request_data(host, port, proxy_auth_header=None, host_header=True):
+def tunnel_request_data(host, port, proxy_auth_header=None):
     r"""
     Return binary content of a CONNECT request.
 
@@ -171,8 +171,7 @@ def tunnel_request_data(host, port, proxy_auth_header=None, host_header=True):
     """
     host_value = to_bytes(host, encoding='ascii') + b':' + to_bytes(str(port))
     tunnel_req = b'CONNECT ' + host_value + b' HTTP/1.1\r\n'
-    if host_header:
-        tunnel_req += b'Host: ' + host_value + b'\r\n'
+    tunnel_req += b'Host: ' + host_value + b'\r\n'
     if proxy_auth_header:
         tunnel_req += b'Proxy-Authorization: ' + proxy_auth_header + b'\r\n'
     tunnel_req += b'\r\n'

--- a/tests/test_downloader_handlers.py
+++ b/tests/test_downloader_handlers.py
@@ -401,7 +401,13 @@ class UriResource(resource.Resource):
         return self
 
     def render(self, request):
-        return request.uri
+        # Note: this is an ugly hack for CONNECT request timeout test.
+        #       Returning some data here fail SSL/TLS handshake
+        # ToDo: implement proper HTTPS proxy tests, not faking them.
+        if request.method != b'CONNECT':
+            return request.uri
+        else:
+            return b''
 
 
 class HttpProxyTestCase(unittest.TestCase):


### PR DESCRIPTION
"Host" request header is a MUST according to [RFC 2616](https://tools.ietf.org/html/rfc2616#page-128)

> A client MUST include a Host header field in all HTTP/1.1 request
>    messages . If the requested URI does not include an Internet host
>    name for the service being requested, then the Host header field MUST
>    be given with an empty value. An HTTP/1.1 proxy MUST ensure that any
>    request message it forwards does contain an appropriate Host header
>    field that identifies the service being requested by the proxy. All
>    Internet-based HTTP/1.1 servers MUST respond with a 400 (Bad Request)
>    status code to any HTTP/1.1 request message which lacks a Host header
>    field.

so it must also be sent for CONNECT requests.

Fixes issue raised in https://github.com/scrapy/scrapy/issues/1434#issuecomment-227393544

Note:
HTTPS proxy tests need some love.
We could perhaps reuse https://github.com/fmoo/twisted-connect-proxy

It seems that currently the only test using CONNECT is `tests/test_downloader_handlers.py::Http11ProxyTestCase::test_download_with_proxy_https_timeout`,
which sends this over the wire (with this "Host" header fix):

```
CONNECT no-such-domain.nosuch:443 HTTP/1.1
Host: no-such-domain.nosuch:443
```
And test server returns
```
HTTP/1.1 200 OK
Server: TwistedWeb/16.2.0
Date: Tue, 21 Jun 2016 11:33:19 GMT
Content-Type: text/html
Content-Length: 25

no-such-domain.nosuch:443
```
I don't know where that `no-such-domain.nosuch:443` line at the end comes from.