### PR TITLE
Catch and ignore certification verification exception for IP-address hosts

### DIFF
--- a/scrapy/core/downloader/tls.py
+++ b/scrapy/core/downloader/tls.py
@@ -34,9 +34,15 @@ try:
                                              VerificationError)
 
     class ScrapyClientTLSOptions(ClientTLSOptions):
-        # same as Twisted's ClientTLSOptions,
-        # except that VerificationError is caught
-        # and doesn't close the connection
+        """
+        SSL Client connection creator ignoring certificate verification errors
+        (for genuinely invalid certificates or bugs in verification code).
+
+        Same as Twisted's private _sslverify.ClientTLSOptions,
+        except that VerificationError and ValueError exceptions are caught,
+        so that the connection is not closed, only logging warnings.
+        """
+
         def _identityVerifyingInfoCallback(self, connection, where, ret):
             if where & SSL_CB_HANDSHAKE_START:
                 _maybeSetHostNameIndication(connection, self._hostnameBytes)
@@ -50,8 +56,9 @@ try:
 
                 except ValueError as e:
                     logger.warning(
-                        'Ignoring remote certificate verification failure for hostname "{}"; {}'.format(
-                            self._hostnameASCII, e))
+                        'Ignoring error while verifying certificate '
+                        'from host "{}" (exception: {})'.format(
+                            self._hostnameASCII, repr(e)))
 
 except ImportError:
     # ImportError should not matter for older Twisted versions

--- a/scrapy/core/downloader/tls.py
+++ b/scrapy/core/downloader/tls.py
@@ -50,7 +50,7 @@ try:
 
                 except ValueError as e:
                     logger.warning(
-                        'SSL/TLS verification failed for hostname "{}"; {}'.format(
+                        'Ignoring remote certificate verification failure for hostname "{}"; {}'.format(
                             self._hostnameASCII, e))
 
 except ImportError:

--- a/scrapy/core/downloader/tls.py
+++ b/scrapy/core/downloader/tls.py
@@ -48,6 +48,11 @@ try:
                         'Remote certificate is not valid for hostname "{}"; {}'.format(
                             self._hostnameASCII, e))
 
+                except ValueError as e:
+                    logger.warning(
+                        'SSL/TLS verification failed for hostname "{}"; {}'.format(
+                            self._hostnameASCII, e))
+
 except ImportError:
     # ImportError should not matter for older Twisted versions
     # as the above is not used in the fallback ScrapyClientContextFactory

--- a/tests/test_downloader_handlers.py
+++ b/tests/test_downloader_handlers.py
@@ -335,6 +335,14 @@ class Https11WrongHostnameTestCase(Http11TestCase):
     certfile = 'keys/example-com.cert.pem'
 
 
+class Https11InvalidDNSId(Https11TestCase):
+    """Connect to HTTPS hosts with IP while certificate uses domain names IDs."""
+
+    def setUp(self):
+        super(Https11InvalidDNSId, self).setUp()
+        self.host = '127.0.0.1'
+
+
 class Http11MockServerTestCase(unittest.TestCase):
     """HTTP 1.1 test case with MockServer"""
     if twisted_version < (11, 1, 0):


### PR DESCRIPTION
Fixes GH-2092

FTR, this is what Twisted 16.3.0 gives with default `Agent` (for www.google.com at 216.58.208.132)

```
$ python
Python 2.7.9 (default, Apr  2 2015, 15:33:21) 
[GCC 4.9.2] on linux2
Type "help", "copyright", "credits" or "license" for more information.
>>> from twisted.internet import reactor
>>> from twisted.web.client import Agent
>>> from twisted.web.http_headers import Headers
>>> 
>>> agent = Agent(reactor)
>>> 
>>> d = agent.request(
...     'GET',
...     'https://216.58.208.132:443/',
...     Headers({'User-Agent': ['Twisted Web Client Example']}),
...     None)
>>> 
>>> 
>>> def cbResponse(ignored):
...     print('Response received')
... 
>>> 
>>> d.addCallback(cbResponse)
<Deferred at 0x7fc71fd89e18>
>>> 
>>> def cbShutdown(ignored):
...     reactor.stop()
... 
>>> 
>>> d.addBoth(cbShutdown)
<Deferred at 0x7fc71fd89e18>
>>> 
>>> reactor.run()
Error during info_callback
Traceback (most recent call last):
  File "/home/paul/.virtualenvs/scrapy10/local/lib/python2.7/site-packages/twisted/protocols/tls.py", line 423, in dataReceived
    self._write(bytes)
  File "/home/paul/.virtualenvs/scrapy10/local/lib/python2.7/site-packages/twisted/protocols/tls.py", line 571, in _write
    sent = self._tlsConnection.send(toSend)
  File "/home/paul/.virtualenvs/scrapy10/local/lib/python2.7/site-packages/OpenSSL/SSL.py", line 1270, in send
    result = _lib.SSL_write(self._ssl, buf, len(buf))
  File "/home/paul/.virtualenvs/scrapy10/local/lib/python2.7/site-packages/OpenSSL/SSL.py", line 933, in wrapper
    callback(Connection._reverse_mapping[ssl], where, return_code)
--- <exception caught here> ---
  File "/home/paul/.virtualenvs/scrapy10/local/lib/python2.7/site-packages/twisted/internet/_sslverify.py", line 1154, in infoCallback
    return wrapped(connection, where, ret)
  File "/home/paul/.virtualenvs/scrapy10/local/lib/python2.7/site-packages/twisted/internet/_sslverify.py", line 1253, in _identityVerifyingInfoCallback
    verifyHostname(connection, self._hostnameASCII)
  File "/home/paul/.virtualenvs/scrapy10/local/lib/python2.7/site-packages/service_identity/pyopenssl.py", line 45, in verify_hostname
    obligatory_ids=[DNS_ID(hostname)],
  File "/home/paul/.virtualenvs/scrapy10/local/lib/python2.7/site-packages/service_identity/_common.py", line 245, in __init__
    raise ValueError("Invalid DNS-ID.")
exceptions.ValueError: Invalid DNS-ID.

>>> 
```

And `curl`'s default (secure, i.e. without `-k`):

```
$ curl -v https://216.58.208.132:443
* Rebuilt URL to: https://216.58.208.132:443/
*   Trying 216.58.208.132...
* Connected to 216.58.208.132 (216.58.208.132) port 443 (#0)
* found 174 certificates in /etc/ssl/certs/ca-certificates.crt
* found 708 certificates in /etc/ssl/certs
* ALPN, offering http/1.1
* SSL connection using TLS1.2 / ECDHE_RSA_AES_128_GCM_SHA256
* 	 server certificate verification OK
* 	 server certificate status verification SKIPPED
* SSL: certificate subject name (www.google.com) does not match target host name '216.58.208.132'
* Closing connection 0
curl: (51) SSL: certificate subject name (www.google.com) does not match target host name '216.58.208.132'
```