### PR TITLE
[MRG+1] TST pin pytest-cov to 2.2.1; upgrade pytest

### DIFF
--- a/tests/requirements-py3.txt
+++ b/tests/requirements-py3.txt
@@ -1,6 +1,6 @@
-pytest==2.7.3
+pytest==2.9.2
 pytest-twisted
-pytest-cov
+pytest-cov==2.2.1
 testfixtures
 jmespath
 leveldb

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -2,9 +2,9 @@
 mock
 mitmproxy==0.10.1
 netlib==0.10.1
-pytest==2.7.3
+pytest==2.9.2
 pytest-twisted
-pytest-cov
+pytest-cov==2.2.1
 jmespath
 testfixtures
 # optional for shell wrapper tests


### PR DESCRIPTION
Scrapy testing suite is failing now. I've tried to downgrage/upgrade several dependencies; this looks related to pytest-cov 2.3.0 release. pytest is upgraded just in case; just upgrading pytest didn't help.