### PR TITLE
(docs) Fix small typo in practices.rst

### DIFF
--- a/docs/topics/practices.rst
+++ b/docs/topics/practices.rst
@@ -17,7 +17,7 @@ the typical way of running Scrapy via ``scrapy crawl``.
 
 What follows is a working example of how to do that, using the `testspiders`_
 project as example. Remember that Scrapy is built on top of the Twisted
-asynchronous networking library, so you need run it inside the Twisted reactor.
+asynchronous networking library, so you need to run it inside the Twisted reactor.
 
 ::
 


### PR DESCRIPTION
Hello,

I noticed in the practices section there was a missing "to".  I've added it in with this pull request