### PR TITLE
(docs) Fix small grammar issue in practices.rst (Supersedes #2119)

### DIFF
--- a/docs/topics/practices.rst
+++ b/docs/topics/practices.rst
@@ -18,7 +18,7 @@ the typical way of running Scrapy via ``scrapy crawl``.
 Remember that Scrapy is built on top of the Twisted
 asynchronous networking library, so you need to run it inside the Twisted reactor.
 
-First utility you can use to run your spiders is
+The first utility you can use to run your spiders is
 :class:`scrapy.crawler.CrawlerProcess`. This class will start a Twisted reactor
 for you, configuring the logging and setting shutdown handlers. This class is
 the one used by all Scrapy commands.


### PR DESCRIPTION
Hello,

As I was reading the (current 😂) docs I noticed a small grammar error. I've fixed it in this pull request

I've made this PR target the master branch instead of the 1.1 branch as requested