### PR TITLE
[MRG+1] Fix IMAGES_EXPIRES default value

### DIFF
--- a/scrapy/pipelines/images.py
+++ b/scrapy/pipelines/images.py
@@ -42,7 +42,7 @@ class ImagesPipeline(FilesPipeline):
     # ImagesPipeline. They may be overridden by settings.
     MIN_WIDTH = 0
     MIN_HEIGHT = 0
-    EXPIRES = 0
+    EXPIRES = 90
     THUMBS = {}
     DEFAULT_IMAGES_URLS_FIELD = 'image_urls'
     DEFAULT_IMAGES_RESULT_FIELD = 'images'

--- a/tests/test_pipeline_images.py
+++ b/tests/test_pipeline_images.py
@@ -221,7 +221,7 @@ class ImagesPipelineTestCaseCustomSettings(unittest.TestCase):
     default_pipeline_settings = dict(
         MIN_WIDTH=0,
         MIN_HEIGHT=0,
-        EXPIRES=0,
+        EXPIRES=90,
         THUMBS={},
         IMAGES_URLS_FIELD='image_urls',
         IMAGES_RESULT_FIELD='images'


### PR DESCRIPTION
It looks like commit 4cef1a1d0060148716ffec4ad6ce9bf709ad1ea2 introduced a little bug. According to the documentation IMAGES_EXPIRES should be 90.