### PR TITLE
[MRG+1] Better bumpversion config for branch 1.1

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -3,20 +3,5 @@ current_version = 1.1.1
 commit = True
 tag = True
 tag_name = {new_version}
-parse = ^
-	(?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)
-	(?:(?P<prerel>[abc]|rc|dev)(?P<prerelversion>\d+))?
-serialize = 
-	{major}.{minor}.{patch}{prerel}{prerelversion}
-	{major}.{minor}.{patch}
 
 [bumpversion:file:scrapy/VERSION]
-
-[bumpversion:part:prerelversion]
-values = 
-	1
-	2
-	3
-	4
-	5
-

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -12,13 +12,6 @@ serialize =
 
 [bumpversion:file:scrapy/VERSION]
 
-[bumpversion:part:prerel]
-optional_value = gamma
-values = 
-	dev
-	rc
-	gamma
-
 [bumpversion:part:prerelversion]
 values = 
 	1


### PR DESCRIPTION
Having the part:prerel setup as it's right now, it's forcing releases to go through a pre-release cycle dev1, rc1, before the actual release.
That is not desired for older branches, since they will have mostly minor and patch releases.

This disables that behavior, making minor and patch releases for this branch more predictable.