### PR TITLE
[MRG+1] Remove bumpversion prerelease configuration

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -3,27 +3,5 @@ current_version = 1.2.0dev2
 commit = True
 tag = True
 tag_name = {new_version}
-parse = ^
-	(?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)
-	(?:(?P<prerel>[abc]|rc|dev)(?P<prerelversion>\d+))?
-serialize = 
-	{major}.{minor}.{patch}{prerel}{prerelversion}
-	{major}.{minor}.{patch}
 
 [bumpversion:file:scrapy/VERSION]
-
-[bumpversion:part:prerel]
-optional_value = gamma
-values = 
-	dev
-	rc
-	gamma
-
-[bumpversion:part:prerelversion]
-values = 
-	1
-	2
-	3
-	4
-	5
-


### PR DESCRIPTION
I propose to remove the prerelease configuration from bumpversion, because I think its behavior is just too confusing.

The rationale for this is that making the release procedure predictable is more important than facilitating making pre-releases, which are sort of the exception in the workflow.

The current configuration makes most common cases confusing:
- bug fix releases require you have to remember to use `--serialize "{major}.{minor}.{patch}"`
- to start a pre-release cycle, you actually use `minor` or `patch`
- to do the actual minor or patch release, you use `prerel`

Also, `prerel` breaks if you run it on a branch with a final release, because it can't parse the prerelease information.

Therefore, I propose keeping the bumpversion defaults, and do the prereleases (dev1, dev2, rc1, etc) manually (with `--new-version`), which makes for a more predictable and intuitive behavior.
- `bumpversion minor` and `bumpversion patch` will work as expected
- pre-releases will be manually handled, but this seems a small overhead
  than remembering the details I mention above.

If you're happy with this, I'll also update [the wiki](https://github.com/scrapy/scrapy/wiki/Scrapy-release-procedure) with new instructions.

What do you think?
