### PR TITLE
[MRG+1] Temporarily deprecate official Ubuntu packages

### DIFF
--- a/docs/intro/install.rst
+++ b/docs/intro/install.rst
@@ -89,15 +89,14 @@ Windows
      Python 3 is not supported on Windows. This is because Scrapy core requirement Twisted does not support
      Python 3 on Windows.
 
-Ubuntu 9.10 or above
---------------------
+Ubuntu 12.04 or above
+---------------------
 
 **Don't** use the ``python-scrapy`` package provided by Ubuntu, they are
-typically too old and slow to catch up with latest Scrapy.
+typically too old and slow to catch up with latest Scrapy. You will need
+to install the following system packages::
 
-Instead, use the official :ref:`Ubuntu Packages <topics-ubuntu>`, which already
-solve all dependencies for you and are continuously updated with the latest bug
-fixes.
+    sudo apt-get install python-pip python-twisted python-openssl python-lxml
 
 If you prefer to build the python dependencies locally instead of relying on
 system packages you'll need to install their required non-python dependencies

--- a/docs/topics/ubuntu.rst
+++ b/docs/topics/ubuntu.rst
@@ -11,6 +11,9 @@ those in Ubuntu, and more stable too since they're continuously built from
 `GitHub repo`_ (master & stable branches) and so they contain the latest bug
 fixes.
 
+.. caution:: These packages are currently not updated and may not work on
+   Ubuntu 16.04 and above, see :issue:`2076` and :issue:`2137`.
+
 To use the packages:
 
 1. Import the GPG key used to sign Scrapy packages into APT keyring::


### PR DESCRIPTION
They are not currently updated and fail to install on Ubuntu 16.04

fixes #2137 and closes #2076