### PR TITLE
[MRG+1] Typo fix for error in parse command 

### DIFF
--- a/scrapy/commands/parse.py
+++ b/scrapy/commands/parse.py
@@ -175,7 +175,7 @@ class Command(ScrapyCommand):
                     cb = cb_method
                 else:
                     logger.error('Cannot find callback %(callback)r in spider: %(spider)s',
-                                 {'callback': callback, 'spider': spider.name})
+                                 {'callback': cb, 'spider': spider.name})
                     return
 
             # parse items and requests


### PR DESCRIPTION
Fixed typo in error message when selecting a callback method for the parse command.

Example:
```
scrapy parse http://www.example.com -c humpty
...
2016-08-08 13:20:27 [scrapy] ERROR: Cannot find callback <function Command.prepare_request.<locals>.callback at 0x7f61273ff730> in spider: <spider_name>
```

After:
```
scrapy parse http://www.example.com -c humpty
...
2016-08-08 14:32:11 [scrapy] ERROR: Cannot find callback 'humpty' in spider: <spider_name>
```