### PR TITLE
Checking if defer gets an error callback while in start_request and killing process

### DIFF
--- a/scrapy/commands/crawl.py
+++ b/scrapy/commands/crawl.py
@@ -1,5 +1,6 @@
 import os
 import logging
+import sys
 from scrapy.commands import ScrapyCommand
 from scrapy.utils.conf import arglist_to_dict
 from scrapy.utils.python import without_none_values
@@ -36,7 +37,8 @@ class Command(ScrapyCommand):
         try:
             opts.spargs = arglist_to_dict(opts.spargs)
         except ValueError:
-            raise UsageError("Invalid -a value, use -a NAME=VALUE", print_help=False)
+            raise UsageError(
+                "Invalid -a value, use -a NAME=VALUE", print_help=False)
         if opts.output:
             if opts.output == '-':
                 self.settings.set('FEED_URI', 'stdout:', priority='cmdline')
@@ -46,19 +48,22 @@ class Command(ScrapyCommand):
                 self.settings.getwithbase('FEED_EXPORTERS'))
             valid_output_formats = feed_exporters.keys()
             if not opts.output_format:
-                opts.output_format = os.path.splitext(opts.output)[1].replace(".", "")
+                opts.output_format = os.path.splitext(
+                    opts.output)[1].replace(".", "")
             if opts.output_format not in valid_output_formats:
                 raise UsageError("Unrecognized output format '%s', set one"
                                  " using the '-t' switch or as a file extension"
                                  " from the supported list %s" % (opts.output_format,
                                                                   tuple(valid_output_formats)))
-            self.settings.set('FEED_FORMAT', opts.output_format, priority='cmdline')
+            self.settings.set(
+                'FEED_FORMAT', opts.output_format, priority='cmdline')
 
     def run(self, args, opts):
         if len(args) < 1:
             raise UsageError()
         elif len(args) > 1:
-            raise UsageError("running 'scrapy crawl' with more than one spider is no longer supported")
+            raise UsageError(
+                "running 'scrapy crawl' with more than one spider is no longer supported")
         spname = args[0]
 
         d = self.crawler_process.crawl(spname, **opts.spargs)
@@ -66,7 +71,7 @@ class Command(ScrapyCommand):
         def _crawl_error(_exc):
             global exception
             exception = _exc
-            
+
         d.addErrback(_crawl_error)
         self.crawler_process.start()
         if exception is not None:

--- a/scrapy/commands/crawl.py
+++ b/scrapy/commands/crawl.py
@@ -37,8 +37,7 @@ class Command(ScrapyCommand):
         try:
             opts.spargs = arglist_to_dict(opts.spargs)
         except ValueError:
-            raise UsageError(
-                "Invalid -a value, use -a NAME=VALUE", print_help=False)
+            raise UsageError("Invalid -a value, use -a NAME=VALUE", print_help=False)
         if opts.output:
             if opts.output == '-':
                 self.settings.set('FEED_URI', 'stdout:', priority='cmdline')
@@ -48,22 +47,19 @@ class Command(ScrapyCommand):
                 self.settings.getwithbase('FEED_EXPORTERS'))
             valid_output_formats = feed_exporters.keys()
             if not opts.output_format:
-                opts.output_format = os.path.splitext(
-                    opts.output)[1].replace(".", "")
+                opts.output_format = os.path.splitext(opts.output)[1].replace(".", "")
             if opts.output_format not in valid_output_formats:
                 raise UsageError("Unrecognized output format '%s', set one"
                                  " using the '-t' switch or as a file extension"
                                  " from the supported list %s" % (opts.output_format,
                                                                   tuple(valid_output_formats)))
-            self.settings.set(
-                'FEED_FORMAT', opts.output_format, priority='cmdline')
+            self.settings.set('FEED_FORMAT', opts.output_format, priority='cmdline')
 
     def run(self, args, opts):
         if len(args) < 1:
             raise UsageError()
         elif len(args) > 1:
-            raise UsageError(
-                "running 'scrapy crawl' with more than one spider is no longer supported")
+            raise UsageError("running 'scrapy crawl' with more than one spider is no longer supported")
         spname = args[0]
 
         d = self.crawler_process.crawl(spname, **opts.spargs)

--- a/scrapy/commands/crawl.py
+++ b/scrapy/commands/crawl.py
@@ -1,8 +1,15 @@
 import os
+import logging
 from scrapy.commands import ScrapyCommand
 from scrapy.utils.conf import arglist_to_dict
 from scrapy.utils.python import without_none_values
 from scrapy.exceptions import UsageError
+
+log = logging.getLogger(__name__)
+log.addHandler(logging.StreamHandler())
+log.setLevel(logging.DEBUG)
+
+exception = None
 
 
 class Command(ScrapyCommand):
@@ -54,5 +61,14 @@ class Command(ScrapyCommand):
             raise UsageError("running 'scrapy crawl' with more than one spider is no longer supported")
         spname = args[0]
 
-        self.crawler_process.crawl(spname, **opts.spargs)
+        d = self.crawler_process.crawl(spname, **opts.spargs)
+
+        def _crawl_error(_exc):
+            global exception
+            exception = _exc
+            
+        d.addErrback(_crawl_error)
         self.crawler_process.start()
+        if exception is not None:
+            log.error(exception)
+            sys.exit(1)

--- a/tests/spiders.py
+++ b/tests/spiders.py
@@ -106,6 +106,14 @@ class ErrorSpider(FollowAllSpider):
             self.raise_exception()
 
 
+class ExceptionStartRequestsSpider(FollowAllSpider):
+
+    name = 'exception_startreq'
+
+    def start_request(self):
+        raise ValueError()
+        
+
 class BrokenStartRequestsSpider(FollowAllSpider):
 
     fail_before_yield = False

--- a/tests/spiders.py
+++ b/tests/spiders.py
@@ -32,7 +32,8 @@ class FollowAllSpider(MetaSpider):
         super(FollowAllSpider, self).__init__(*args, **kwargs)
         self.urls_visited = []
         self.times = []
-        qargs = {'total': total, 'show': show, 'order': order, 'maxlatency': maxlatency}
+        qargs = {'total': total, 'show': show,
+                 'order': order, 'maxlatency': maxlatency}
         url = "http://localhost:8998/follow?%s" % urlencode(qargs, doseq=1)
         self.start_urls = [url]
 
@@ -110,9 +111,9 @@ class ExceptionStartRequestsSpider(FollowAllSpider):
 
     name = 'exception_startreq'
 
-    def start_request(self):
+    def start_requests(self):
         raise ValueError()
-        
+
 
 class BrokenStartRequestsSpider(FollowAllSpider):
 
@@ -135,7 +136,7 @@ class BrokenStartRequestsSpider(FollowAllSpider):
                 2 / 0
 
         assert self.seedsseen, \
-                'All start requests consumed before any download happened'
+            'All start requests consumed before any download happened'
 
     def parse(self, response):
         self.seedsseen.append(response.meta.get('seed'))

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -174,6 +174,12 @@ class GenspiderStandaloneCommandTest(ProjectTest):
         assert exists(join(self.temp_path, 'example.py'))
 
 
+class CrawlCommandTest(CommandTest):
+
+    def test_exit_code(self):
+        self.assertNotEqual(0, self.call('crawl', 'exception_startreq'))
+        
+
 class MiscCommandsTest(CommandTest):
 
     def test_list(self):


### PR DESCRIPTION
This is to account for the case that an exception is being raised in the start_requests method. In `scrapy/crawler.py:Crawler/crawl` the values yielded are left unused. `scrapy/commands/crawl.py:Command.run` does nothing with the deferred that is yielded. This fix checks if an error is raised and calls `sys.exit(1)` if it is. The stack-trace leading to the error is also logged.

This has been tracked in issue [1231](https://github.com/scrapy/scrapy/issues/1231) and [1241](https://github.com/scrapy/scrapy/issues/1241).
