### PR TITLE
Use "tls" extra for Twisted dependency (requires Twisted>=15.1)

### DIFF
--- a/requirements-py3.txt
+++ b/requirements-py3.txt
@@ -1,7 +1,6 @@
-Twisted >= 15.5.0
+Twisted[tls]>=15.5.0
 lxml>=3.2.4
 pyOpenSSL>=0.13.1
 cssselect>=0.9
 queuelib>=1.1.1
 w3lib>=1.14.2
-service_identity

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Twisted>=10.0.0
+Twisted[tls]>=15.1.0
 lxml
 pyOpenSSL
 cssselect>=0.9
@@ -6,5 +6,4 @@ w3lib>=1.15.0
 queuelib
 six>=1.5.2
 PyDispatcher>=2.0.5
-service_identity
 parsel>=0.9.5

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ setup(
         'Topic :: Software Development :: Libraries :: Python Modules',
     ],
     install_requires=[
-        'Twisted>=10.0.0',
+        'Twisted[tls]>=15.1.0',
         'w3lib>=1.15.0',
         'queuelib',
         'lxml',
@@ -50,6 +50,5 @@ setup(
         'six>=1.5.2',
         'parsel>=0.9.3',
         'PyDispatcher>=2.0.5',
-        'service_identity',
     ],
 )


### PR DESCRIPTION
service_identity started being required from Twisted 14,
but was not listed as dependency until Twisted 15.1.
Requiring Twisted>=15.1 removes the need for service_identity dependency
at scrapy level.

Using a more modern Twisted version also solves a few TLS problems.