### PR TITLE
MediaPipeline redirect fix #2004

### DIFF
--- a/docs/topics/media-pipeline.rst
+++ b/docs/topics/media-pipeline.rst
@@ -308,11 +308,11 @@ By default media pipelines ignore redirects. To allow redirecting(all 300 codes)
 
     MEDIA_ALLOW_REDIRECTS = True
 
-To only allow specific codes through set:
+To only allow handling only specific codes set (default: any code):
 
-    MEDIA_HTTpSTATUS_LIST = <LIST>
+    MEDIA_HTTPSTATUS_LIST = <LIST>
     # example:
-    MEDIA_HTTPSTATUS_LIST = [303, 404]
+    MEDIA_HTTPSTATUS_LIST = [303, 404]  # will not go through pipelines
 
 Extending the Media Pipelines
 =============================

--- a/docs/topics/media-pipeline.rst
+++ b/docs/topics/media-pipeline.rst
@@ -298,6 +298,22 @@ By default, there are no size constraints, so all images are processed.
 
 .. _topics-media-pipeline-override:
 
+Allowing redirection and handling various http statuses
+-------------------------------------------------------
+
+.. setting:: MEDIA_ALLOW_REDIRECTS
+.. setting:: MEDIA_HTTPSTATUS_LIST
+
+By default media pipelines ignore redirects. To allow redirecting(all 300 codes) set:
+
+    MEDIA_ALLOW_REDIRECTS = True
+
+To only allow specific codes through set:
+
+    MEDIA_HTTpSTATUS_LIST = <LIST>
+    # example:
+    MEDIA_HTTPSTATUS_LIST = [303, 404]
+
 Extending the Media Pipelines
 =============================
 

--- a/scrapy/downloadermiddlewares/redirect.py
+++ b/scrapy/downloadermiddlewares/redirect.py
@@ -53,6 +53,7 @@ class BaseRedirectMiddleware(object):
 
 class RedirectMiddleware(BaseRedirectMiddleware):
     """Handle redirection of requests based on response status and meta-refresh html tag"""
+    allowed_status = (301, 302, 303, 307)
 
     def process_response(self, request, response, spider):
         if (request.meta.get('dont_redirect', False) or
@@ -61,8 +62,7 @@ class RedirectMiddleware(BaseRedirectMiddleware):
                 request.meta.get('handle_httpstatus_all', False)):
             return response
 
-        allowed_status = (301, 302, 303, 307)
-        if 'Location' not in response.headers or response.status not in allowed_status:
+        if 'Location' not in response.headers or response.status not in self.allowed_status:
             return response
 
         # HTTP header is ascii or latin1, redirected url will be percent-encoded utf-8

--- a/scrapy/pipelines/files.py
+++ b/scrapy/pipelines/files.py
@@ -248,7 +248,7 @@ class FilesPipeline(MediaPipeline):
             resolve('FILES_RESULT_FIELD'), self.FILES_RESULT_FIELD
         )
 
-        super(FilesPipeline, self).__init__(download_func=download_func)
+        super(FilesPipeline, self).__init__(download_func=download_func, settings=settings)
 
     @classmethod
     def from_settings(cls, settings):

--- a/scrapy/pipelines/media.py
+++ b/scrapy/pipelines/media.py
@@ -6,6 +6,7 @@ from collections import defaultdict
 from twisted.internet.defer import Deferred, DeferredList
 from twisted.python.failure import Failure
 
+from scrapy.settings import Settings
 from scrapy.utils.defer import mustbe_deferred, defer_result
 from scrapy.utils.request import request_fingerprint
 from scrapy.utils.misc import arg_to_iter
@@ -28,6 +29,8 @@ class MediaPipeline(object):
 
     def __init__(self, download_func=None, settings=None):
         self.download_func = download_func
+        if isinstance(settings, dict) or settings is None:
+            settings = Settings(settings)
         resolve = functools.partial(self._key_for_pipe,
                                     base_class_name="MediaPipeline")
         self.allow_redirects = settings.getbool(

--- a/scrapy/pipelines/media.py
+++ b/scrapy/pipelines/media.py
@@ -6,6 +6,7 @@ from collections import defaultdict
 from twisted.internet.defer import Deferred, DeferredList
 from twisted.python.failure import Failure
 
+from scrapy.downloadermiddlewares.redirect import RedirectMiddleware
 from scrapy.settings import Settings
 from scrapy.utils.defer import mustbe_deferred, defer_result
 from scrapy.utils.request import request_fingerprint
@@ -36,7 +37,7 @@ class MediaPipeline(object):
         self.allow_redirects = settings.getbool(
             resolve('MEDIA_ALLOW_REDIRECTS'), self.ALLOW_REDIRECTS
         )
-        self.allow_httpstatus_list = settings.getlist(
+        self.handle_httpstatus_list = settings.getlist(
             resolve('MEDIA_HTTPSTATUS_LIST'), []
         )
 
@@ -104,17 +105,15 @@ class MediaPipeline(object):
 
     def _modify_media_request(self, request):
         httpstatus_list = []
-        if self.allow_httpstatus_list:
-            httpstatus_list = self.allow_httpstatus_list
-        elif self.allow_redirects:
+        if self.handle_httpstatus_list:
+            httpstatus_list = self.handle_httpstatus_list
+        if self.allow_redirects:
             if not httpstatus_list:
-                httpstatus_list = list(range(0, 300)) + list(range(400, 1000))
+                httpstatus_list = [i for i in range(1000)
+                                   if i not in RedirectMiddleware.allowed_status]
             else:
-                for i in range(300, 400):
-                    try:
-                        httpstatus_list.remove(i)
-                    except ValueError:
-                        pass
+                httpstatus_list = [i for i in httpstatus_list
+                                   if i not in RedirectMiddleware.allowed_status]
         if httpstatus_list:
             request.meta['handle_httpstatus_list'] = httpstatus_list
         else:

--- a/scrapy/pipelines/media.py
+++ b/scrapy/pipelines/media.py
@@ -1,5 +1,6 @@
 from __future__ import print_function
 
+import functools
 import logging
 from collections import defaultdict
 from twisted.internet.defer import Deferred, DeferredList
@@ -16,6 +17,7 @@ logger = logging.getLogger(__name__)
 class MediaPipeline(object):
 
     LOG_FAILED_RESULTS = True
+    ALLOW_REDIRECTS = False
 
     class SpiderInfo(object):
         def __init__(self, spider):
@@ -24,9 +26,16 @@ class MediaPipeline(object):
             self.downloaded = {}
             self.waiting = defaultdict(list)
 
-    def __init__(self, download_func=None):
+    def __init__(self, download_func=None, settings=None):
         self.download_func = download_func
-
+        resolve = functools.partial(self._key_for_pipe,
+                                    base_class_name="MediaPipeline")
+        self.allow_redirects = settings.getbool(
+            resolve('MEDIA_ALLOW_REDIRECTS'), self.ALLOW_REDIRECTS
+        )
+        self.allow_httpstatus_list = settings.getlist(
+            resolve('MEDIA_HTTPSTATUS_LIST'), []
+        )
 
     def _key_for_pipe(self, key, base_class_name=None):
         """
@@ -90,6 +99,25 @@ class MediaPipeline(object):
         )
         return dfd.addBoth(lambda _: wad)  # it must return wad at last
 
+    def _modify_media_request(self, request):
+        httpstatus_list = []
+        if self.allow_httpstatus_list:
+            httpstatus_list = self.allow_httpstatus_list
+        elif self.allow_redirects:
+            if not httpstatus_list:
+                httpstatus_list = list(range(0, 300)) + list(range(400, 1000))
+            else:
+                for i in range(300, 400):
+                    try:
+                        httpstatus_list.remove(i)
+                    except ValueError:
+                        pass
+        if httpstatus_list:
+            request.meta['handle_httpstatus_list'] = httpstatus_list
+        else:
+            request.meta['handle_httpstatus_all'] = True
+        return request
+
     def _check_media_to_download(self, result, request, info):
         if result is not None:
             return result
@@ -100,7 +128,7 @@ class MediaPipeline(object):
                 callback=self.media_downloaded, callbackArgs=(request, info),
                 errback=self.media_failed, errbackArgs=(request, info))
         else:
-            request.meta['handle_httpstatus_all'] = True
+            request = self._modify_media_request(request)
             dfd = self.crawler.engine.download(request, info.spider)
             dfd.addCallbacks(
                 callback=self.media_downloaded, callbackArgs=(request, info),

--- a/tests/test_pipeline_media.py
+++ b/tests/test_pipeline_media.py
@@ -89,9 +89,9 @@ class BaseMediaPipelineTestCase(unittest.TestCase):
         assert self.pipe._modify_media_request(request).meta == {'handle_httpstatus_all': True}
 
         request = Request('http://url')
-        self.pipe.allow_httpstatus_list = list(range(100))
+        self.pipe.handle_httpstatus_list = list(range(100))
         assert self.pipe._modify_media_request(request).meta == {'handle_httpstatus_list': list(range(100))}
-        self.pipe.allow_httpstatus_list = None
+        self.pipe.handle_httpstatus_list = None
 
         request = Request('http://url')
         self.pipe.allow_redirects = True

--- a/tests/test_pipeline_media.py
+++ b/tests/test_pipeline_media.py
@@ -5,6 +5,7 @@ from twisted.python.failure import Failure
 from twisted.internet import reactor
 from twisted.internet.defer import Deferred, inlineCallbacks
 
+from scrapy.downloadermiddlewares.redirect import RedirectMiddleware
 from scrapy.http import Request, Response
 from scrapy.settings import Settings
 from scrapy.spiders import Spider
@@ -95,7 +96,8 @@ class BaseMediaPipelineTestCase(unittest.TestCase):
 
         request = Request('http://url')
         self.pipe.allow_redirects = True
-        correct = {'handle_httpstatus_list': list(range(300)) + list(range(400,1000))}
+        correct = {'handle_httpstatus_list': [i for i in range(1000)
+                                              if i not in RedirectMiddleware.allowed_status]}
         assert self.pipe._modify_media_request(request).meta == correct
         self.pipe.allow_redirects = False
 


### PR DESCRIPTION
Fixes https://github.com/scrapy/scrapy/issues/2004

Right now this approach offers two settings:

`MEDIA_ALLOW_REDIRECTS` - Disables handling of all 300 codes (the ones Redirect Middleware uses)
`MEDIA_HTTPSTATUS_LIST` - Only handles codes in this setting

Also added tests and a doc entry(though this might need adjusting)
