### PR TITLE
Allow updating dictionary-settings

### DIFF
--- a/docs/topics/settings.rst
+++ b/docs/topics/settings.rst
@@ -100,6 +100,60 @@ class.
 The global defaults are located in the ``scrapy.settings.default_settings``
 module and documented in the :ref:`topics-settings-ref` section.
 
+.. _topics-settings-update-dicts:
+
+Updating dictionary settings
+============================
+
+Scrapy has a few dictionary-valued settings, e.g. for managing middlewares
+and extensions (:setting:`SPIDER_MIDDLEWARES`,
+:setting:`DOWNLOADER_MIDDLEWARES`, :setting:`EXTENSIONS`). Sometimes, it is
+desirable to *update*, not replace, these dictionaries. For these cases, you
+can fill the special ``update`` setting dictionary. This is particularly useful
+when you cannot use Python code to update the setting, e.g. on the command line
+or in a spider's :attr:`~scrapy.spiders.Spider.custom_settings` attribute.
+
+For example if you enabled two spider middlewares in a project,
+
+.. code-block:: python
+
+    # in settings.py
+
+    SPIDER_MIDDLEWARES = {
+        'myproject.spidermw.FirstSMW':  100,
+        'myproject.spidermw.SecondSMW': 200,
+    }
+
+and now wish to enable a third spider middleware for a specific spider only,
+you can achieve this in the spider's
+:attr:`~scrapy.spiders.Spider.custom_settings` attribute without having to
+repeat the above configuration::
+
+    class MySpider(scrapy.Spider):
+        name = 'myspider'
+
+        custom_settings = {
+            'update': {
+                SPIDER_MIDDLEWARES': {'myproject.spidermw.SpecialSMW': 300},
+            }
+        }
+
+Similarly, you can enable an additional spider middleware from the command line
+without repeating the project configuration:
+
+.. code-block:: sh
+
+    scrapy crawl myspider -s 'update={"SPIDER_MIDDLEWARES":{"myproject.spidermw.SpecialSMW": 300}}'
+
+In both cases, the final value of the :setting:`SPIDER_MIDDLEWARES` setting
+would be::
+
+    {
+        'myproject.spidermw.FirstSMW':   100,
+        'myproject.spidermw.SecondSMW':  200,
+        'myproject.spidermw.SpecialSMW': 300,
+    }
+
 How to access settings
 ======================
 

--- a/tests/test_settings/__init__.py
+++ b/tests/test_settings/__init__.py
@@ -103,6 +103,23 @@ class BaseSettingsTest(unittest.TestCase):
                 mock_set.reset_mock()
                 mock_setattr.reset_mock()
 
+    def test_set_merge_with_update(self):
+        self.settings['MYDICT'] = {'one': 1}
+        self.settings['UPDATE'] = {'MYDICT': {'two': 2}}
+        self.assertEqual(self.settings['MYDICT'], {'one': 1, 'two': 2})
+        self.settings['MYDICT'] = {'one': 1}
+        self.settings['update'] = {'MYDICT': {'two': 2}}
+        self.assertEqual(self.settings['MYDICT'], {'one': 1, 'two': 2})
+        self.settings['MYDICT'] = {'three': 3}
+        self.assertEqual(self.settings['MYDICT'], {'three': 3})
+
+        self.settings['MYDICT'] = BaseSettings({'one': 1}, priority=0)
+        self.settings['MYDICT'].set('two', 2, priority=20)
+        self.settings['UPDATE'] = {'MYDICT': BaseSettings({'one': 10, 'two': 20},
+                                                           priority=10)}
+        six.assertCountEqual(self, self.settings['MYDICT'],
+                             {'one': 10, 'two': 2})
+
     def test_setitem(self):
         settings = BaseSettings()
         settings.set('key', 'a', 'default')


### PR DESCRIPTION
This is another proposal for updating settings, without string prefixes. (See #1591 for the other)

It fails the mock tests
`BaseSettingsTest.test_setdict_alias` and
`BaseSettingsTest.test_setmodule_alias`
and probably has other issues at this time.

The idea is that merging two dictionaries (Settings namespace + an 'UPDATE' dict, that shadows the Settings namespace) is more convenient and efficient than string-parsing each setting key for a potential "update:" prefix.
It should also be more versatile (allows `setmodule` with an update flag).

The implementation can perhaps still be improved.
Having an update flag on an update method is also confusing. But both are different "updates".
