### PR TITLE
[MRG+1] Update exceptions.rst

### DIFF
--- a/docs/topics/exceptions.rst
+++ b/docs/topics/exceptions.rst
@@ -60,7 +60,7 @@ remain disabled. Those components include:
  * Downloader middlewares
  * Spider middlewares
 
-The exception must be raised in the component constructor.
+The exception must be raised in the component's ``__init__`` method
 
 NotSupported
 ------------

--- a/docs/topics/exceptions.rst
+++ b/docs/topics/exceptions.rst
@@ -60,7 +60,7 @@ remain disabled. Those components include:
  * Downloader middlewares
  * Spider middlewares
 
-The exception must be raised in the component's ``__init__`` method
+The exception must be raised in the component's ``__init__`` method.
 
 NotSupported
 ------------


### PR DESCRIPTION
There are namely no constructors in classes in Python but an ``__init__`` method instead.