### PR TITLE
Use functions from w3lib.url if they are present

### DIFF
--- a/scrapy/utils/url.py
+++ b/scrapy/utils/url.py
@@ -9,10 +9,7 @@ import posixpath
 import re
 from six.moves.urllib.parse import (ParseResult, urldefrag, urlparse)
 
-# scrapy.utils.url was moved to w3lib.url and import * ensures this
-# move doesn't break old code
-from w3lib.url import *
-from w3lib.url import _safe_chars, _unquotepath
+from w3lib.url import any_to_uri, add_or_replace_parameter
 from scrapy.utils.python import to_unicode
 
 
@@ -103,3 +100,9 @@ def guess_scheme(url):
         return any_to_uri(url)
     else:
         return add_http_if_no_scheme(url)
+
+
+# scrapy.utils.url was moved to w3lib.url and import * ensures this
+# move doesn't break old code
+from w3lib.url import *
+from w3lib.url import _safe_chars, _unquotepath


### PR DESCRIPTION
Move `from w3lib.url import *` to the end of the file, so that w3lib.url functions are defined later. The only imports left on top are imports that are actually used in this module.

Without this change, old functions defined in `scrapy.utils.url` are used even with new w3lib (for example, `canonicalize_url`), so changes bugfixes in w3lib.url are not picked up. And we can not yet change internal scrapy imports to use functions from w3lib, because we do not require newer w3lib (we can't require it yet, right?)