### PR TITLE
[MRG+1] Fix completion in `scrapy shell` for new imports

### DIFF
--- a/scrapy/utils/console.py
+++ b/scrapy/utils/console.py
@@ -13,7 +13,9 @@ def _embed_ipython_shell(namespace={}, banner=''):
     @wraps(_embed_ipython_shell)
     def wrapper(namespace=namespace, banner=''):
         config = load_default_config()
-        shell = InteractiveShellEmbed(
+        # Always use .instace() to ensure _instance propagation to all parents
+        # this is needed for <TAB> completion works well for new imports
+        shell = InteractiveShellEmbed.instance(
             banner1=banner, user_ns=namespace, config=config)
         shell()
     return wrapper


### PR DESCRIPTION
Hi,
This PR fixes an issue in `scrapy shell` command with IPython shell on attempt to import some new module and complete its name with `<TAB>`, like:
```python
>>> import srap<TAB>
```
The following traceback occurs:
```python
In [1]: import scrException in thread Thread-16:
Traceback (most recent call last):
  File "/home/ahlin/.pyenv/versions/2.7.11/lib/python2.7/threading.py", line 801, in __bootstrap_inner
    self.run()
  File "/home/ahlin/.pyenv/versions/2.7.11/lib/python2.7/threading.py", line 754, in run
    self.__target(*self.__args, **self.__kwargs)
  File "/home/ahlin/.pyenv/versions/2.7.11/envs/scrape27/lib/python2.7/site-packages/prompt_toolkit/interface.py", line 836, in run
    completions = list(buffer.completer.get_completions(document, complete_event))
  File "/home/ahlinc/dev/ipython/IPython/terminal/ptutils.py", line 44, in get_completions
    cursor_pos=document.cursor_position_col
  File "/home/ahlinc/dev/ipython/IPython/core/completer.py", line 84, in comp
    text, matches =  complete(*args, **kwargs)
  File "/home/ahlinc/dev/ipython/IPython/core/completer.py", line 1193, in complete
    custom_res = self.dispatch_custom_completer(text)
  File "/home/ahlinc/dev/ipython/IPython/core/completer.py", line 1117, in dispatch_custom_completer
    res = c(event)
  File "/home/ahlinc/dev/ipython/IPython/core/completerlib.py", line 253, in module_completer
    return module_completion(event.line)
  File "/home/ahlinc/dev/ipython/IPython/core/completerlib.py", line 229, in module_completion
    return get_root_modules()
  File "/home/ahlinc/dev/ipython/IPython/core/completerlib.py", line 119, in get_root_modules
    rootmodules_cache = ip.db.get('rootmodules_cache', {})
AttributeError: 'NoneType' object has no attribute 'db'
```
And after that exception completion doesn't work anymore.