### PR TITLE
[MRG+1] Add flush() method to StreamLogger

### DIFF
--- a/scrapy/utils/log.py
+++ b/scrapy/utils/log.py
@@ -145,6 +145,9 @@ class StreamLogger(object):
         for line in buf.rstrip().splitlines():
             self.logger.log(self.log_level, line.rstrip())
 
+    def flush(self):
+        pass
+
 
 class LogCounterHandler(logging.Handler):
     """Record log levels count into a crawler stats"""

--- a/scrapy/utils/log.py
+++ b/scrapy/utils/log.py
@@ -146,7 +146,8 @@ class StreamLogger(object):
             self.logger.log(self.log_level, line.rstrip())
 
     def flush(self):
-        pass
+        for h in self.logger.handlers:
+            h.flush()
 
 
 class LogCounterHandler(logging.Handler):


### PR DESCRIPTION
Fixes GH-2125

Local tests:

with a pretty simple spider:

```
$ cat stdoutlogging/spiders/example.py 
# -*- coding: utf-8 -*-
import scrapy


class ExampleSpider(scrapy.Spider):
    name = "example"
    allowed_domains = ["example.com"]
    start_urls = (
        'http://www.example.com/',
    )

    def parse(self, response):
        print("hello!")
        return {"somekey": "somevalue"}
```
and Python 3.5:
```
$ scrapy version -v
Scrapy    : 1.2.0dev2
lxml      : 3.6.0.0
libxml2   : 2.9.3
Twisted   : 16.4.0
Python    : 3.5.1+ (default, Mar 30 2016, 22:46:26) - [GCC 5.3.1 20160330]
pyOpenSSL : 16.1.0 (OpenSSL 1.0.2g-fips  1 Mar 2016)
Platform  : Linux-4.4.0-36-generic-x86_64-with-Ubuntu-16.04-xenial
```

Before this change:

```
$ scrapy crawl example -s LOG_STDOUT=1
2016-09-14 12:07:35 [scrapy] INFO: Scrapy 1.2.0dev2 started (bot: stdoutlogging)
2016-09-14 12:07:35 [scrapy] INFO: Overridden settings: {'NEWSPIDER_MODULE': 'stdoutlogging.spiders', 'BOT_NAME': 'stdoutlogging', 'LOG_STDOUT': '1', 'SPIDER_MODULES': ['stdoutlogging.spiders'], 'ROBOTSTXT_OBEY': True}
(...)
2016-09-14 12:07:36 [scrapy] INFO: Spider opened
2016-09-14 12:07:36 [scrapy] INFO: Crawled 0 pages (at 0 pages/min), scraped 0 items (at 0 items/min)
2016-09-14 12:07:36 [scrapy] DEBUG: Telnet console listening on 127.0.0.1:6023
2016-09-14 12:07:36 [scrapy] DEBUG: Crawled (404) <GET http://www.example.com/robots.txt> (referer: None)
2016-09-14 12:07:36 [scrapy] DEBUG: Crawled (200) <GET http://www.example.com/> (referer: None)
2016-09-14 12:07:36 [stdout] INFO: hello!
2016-09-14 12:07:36 [scrapy] DEBUG: Scraped from <200 http://www.example.com/>
{'somekey': 'somevalue'}
2016-09-14 12:07:36 [scrapy] INFO: Closing spider (finished)
(...stats...)
2016-09-14 12:07:36 [scrapy] INFO: Spider closed (finished)
Exception ignored in: <scrapy.utils.log.StreamLogger object at 0x7f298eb66358>
AttributeError: 'StreamLogger' object has no attribute 'flush'
$
```

After the change:

```
$ scrapy crawl example -s LOG_STDOUT=1
2016-09-14 12:11:33 [scrapy] INFO: Scrapy 1.2.0dev2 started (bot: stdoutlogging)
2016-09-14 12:11:33 [scrapy] INFO: Overridden settings: {'NEWSPIDER_MODULE': 'stdoutlogging.spiders', 'SPIDER_MODULES': ['stdoutlogging.spiders'], 'BOT_NAME': 'stdoutlogging', 'ROBOTSTXT_OBEY': True, 'LOG_STDOUT': '1'}
(...)
2016-09-14 12:11:33 [scrapy] INFO: Spider opened
2016-09-14 12:11:33 [scrapy] INFO: Crawled 0 pages (at 0 pages/min), scraped 0 items (at 0 items/min)
2016-09-14 12:11:33 [scrapy] DEBUG: Telnet console listening on 127.0.0.1:6023
2016-09-14 12:11:39 [scrapy] DEBUG: Crawled (404) <GET http://www.example.com/robots.txt> (referer: None)
2016-09-14 12:11:39 [scrapy] DEBUG: Crawled (200) <GET http://www.example.com/> (referer: None)
2016-09-14 12:11:39 [stdout] INFO: hello!
2016-09-14 12:11:39 [scrapy] DEBUG: Scraped from <200 http://www.example.com/>
{'somekey': 'somevalue'}
2016-09-14 12:11:39 [scrapy] INFO: Closing spider (finished)
(...stats...)
2016-09-14 12:11:39 [scrapy] INFO: Spider closed (finished)
$
```

Note: I was not able to write a failing-then-passing test for this change in `test_utils_log.StreamLoggerTest`.
I tried with [`testfixtures.OutputCapture`](https://pythonhosted.org/testfixtures/api.html#testfixtures.OutputCapture) but could not capture the stderr output