### PR TITLE
[MRG+1] [image & file pipeline] loading setting for user classes

### DIFF
--- a/scrapy/pipelines/files.py
+++ b/scrapy/pipelines/files.py
@@ -233,7 +233,8 @@ class FilesPipeline(MediaPipeline):
         cls_name = "FilesPipeline"
         self.store = self._get_store(store_uri)
         resolve = functools.partial(self._key_for_pipe,
-                                    base_class_name=cls_name)
+                                    base_class_name=cls_name,
+                                    settings=settings)
         self.expires = settings.getint(
             resolve('FILES_EXPIRES'), self.EXPIRES
         )

--- a/scrapy/pipelines/images.py
+++ b/scrapy/pipelines/images.py
@@ -55,7 +55,8 @@ class ImagesPipeline(FilesPipeline):
             settings = Settings(settings)
 
         resolve = functools.partial(self._key_for_pipe,
-                                    base_class_name="ImagesPipeline")
+                                    base_class_name="ImagesPipeline",
+                                    settings=settings)
         self.expires = settings.getint(
             resolve("IMAGES_EXPIRES"), self.EXPIRES
         )

--- a/scrapy/pipelines/media.py
+++ b/scrapy/pipelines/media.py
@@ -28,7 +28,8 @@ class MediaPipeline(object):
         self.download_func = download_func
 
 
-    def _key_for_pipe(self, key, base_class_name=None):
+    def _key_for_pipe(self, key, base_class_name=None,
+                      settings=None):
         """
         >>> MediaPipeline()._key_for_pipe("IMAGES")
         'IMAGES'
@@ -38,9 +39,11 @@ class MediaPipeline(object):
         'MYPIPE_IMAGES'
         """
         class_name = self.__class__.__name__
-        if class_name == base_class_name or not base_class_name:
+        formatted_key = "{}_{}".format(class_name.upper(), key)
+        if class_name == base_class_name or not base_class_name \
+            or (settings and not settings.get(formatted_key)):
             return key
-        return "{}_{}".format(class_name.upper(), key)
+        return formatted_key
 
     @classmethod
     def from_crawler(cls, crawler):

--- a/tests/test_pipeline_files.py
+++ b/tests/test_pipeline_files.py
@@ -255,16 +255,17 @@ class FilesPipelineTestCaseCustomSettings(unittest.TestCase):
 
     def test_subclass_attrs_preserved_custom_settings(self):
         """
-        If file settings are defined but they are not defined for subclass class attributes
-        should be preserved.
+        If file settings are defined but they are not defined for subclass
+        settings should be preserved.
         """
         pipeline_cls = self._generate_fake_pipeline()
         settings = self._generate_fake_settings()
         pipeline = pipeline_cls.from_settings(Settings(settings))
         for pipe_attr, settings_attr, pipe_ins_attr in self.file_cls_attr_settings_map:
             value = getattr(pipeline, pipe_ins_attr)
+            setting_value = settings.get(settings_attr)
             self.assertNotEqual(value, self.default_cls_settings[pipe_attr])
-            self.assertEqual(value, getattr(pipeline, pipe_attr))
+            self.assertEqual(value, setting_value)
 
     def test_no_custom_settings_for_subclasses(self):
         """
@@ -319,6 +320,24 @@ class FilesPipelineTestCaseCustomSettings(unittest.TestCase):
         pipeline = UserDefinedFilesPipeline.from_settings(Settings({"FILES_STORE": self.tempdir}))
         self.assertEqual(pipeline.files_result_field, "this")
         self.assertEqual(pipeline.files_urls_field, "that")
+
+
+    def test_user_defined_subclass_default_key_names(self):
+        """Test situation when user defines subclass of FilesPipeline,
+        but uses attribute names for default pipeline (without prefixing
+        them with pipeline class name).
+        """
+        settings = self._generate_fake_settings()
+
+        class UserPipe(FilesPipeline):
+            pass
+
+        pipeline_cls = UserPipe.from_settings(Settings(settings))
+
+        for pipe_attr, settings_attr, pipe_inst_attr in self.file_cls_attr_settings_map:
+            expected_value = settings.get(settings_attr)
+            self.assertEqual(getattr(pipeline_cls, pipe_inst_attr),
+                             expected_value)
 
 
 class TestS3FilesStore(unittest.TestCase):


### PR DESCRIPTION
if user has some custom subclass of Image pipeline and no setting for
this pipeline, he should get default settings defined for Image Pipeline.

Fixes #2198