### PR TITLE
[MRG+1] Make scrapy available in shell without explicit import statement

### DIFF
--- a/scrapy/shell.py
+++ b/scrapy/shell.py
@@ -139,6 +139,7 @@ class Shell(object):
     def get_help(self):
         b = []
         b.append("Available Scrapy objects:")
+        b.append("  scrapy     scrapy module (contains scrapy.Request, scrapy.Selector, etc)")
         for k, v in sorted(self.vars.items()):
             if self._is_relevant(v):
                 b.append("  %-10s %s" % (k, v))

--- a/scrapy/shell.py
+++ b/scrapy/shell.py
@@ -115,6 +115,9 @@ class Shell(object):
         self.populate_vars(response, request, spider)
 
     def populate_vars(self, response=None, request=None, spider=None):
+        import scrapy
+
+        self.vars['scrapy'] = scrapy
         self.vars['crawler'] = self.crawler
         self.vars['item'] = self.item_class()
         self.vars['settings'] = self.crawler.settings

--- a/tests/test_command_shell.py
+++ b/tests/test_command_shell.py
@@ -57,6 +57,13 @@ class ShellTest(ProcessTest, SiteTest, unittest.TestCase):
         self.assertEqual(errcode, 0, out)
 
     @defer.inlineCallbacks
+    def test_scrapy_import(self):
+        url = self.url('/text')
+        code = "fetch(scrapy.Request('{0}'))"
+        errcode, out, _ = yield self.execute(['-c', code.format(url)])
+        self.assertEqual(errcode, 0, out)
+
+    @defer.inlineCallbacks
     def test_local_file(self):
         filepath = join(tests_datadir, 'test_site/index.html')
         _, out, _ = yield self.execute([filepath, '-c', 'item'])


### PR DESCRIPTION
Maybe it's just me but I'm always a bit annoyed to have to do `import scrapy` in the shell.
Thoughts?