### PR TITLE
Make crawler.engine available in scrapy's Spider.__init__ method.

### DIFF
--- a/scrapy/crawler.py
+++ b/scrapy/crawler.py
@@ -68,8 +68,8 @@ class Crawler(object):
         self.crawling = True
 
         try:
-            self.spider = self._create_spider(*args, **kwargs)
             self.engine = self._create_engine()
+            self.spider = self._create_spider(*args, **kwargs)
             start_requests = iter(self.spider.start_requests())
             yield self.engine.open_spider(self.spider, start_requests)
             yield defer.maybeDeferred(self.engine.start)

--- a/scrapy/spiders/__init__.py
+++ b/scrapy/spiders/__init__.py
@@ -27,6 +27,11 @@ class Spider(object_ref):
             self.name = name
         elif not getattr(self, 'name', None):
             raise ValueError("%s must have a name" % type(self).__name__)
+
+        crawler = kwargs.pop('crawler', None)
+        if crawler:
+            self._set_crawler(crawler)
+
         self.__dict__.update(kwargs)
         if not hasattr(self, 'start_urls'):
             self.start_urls = []
@@ -47,8 +52,7 @@ class Spider(object_ref):
 
     @classmethod
     def from_crawler(cls, crawler, *args, **kwargs):
-        spider = cls(*args, **kwargs)
-        spider._set_crawler(crawler)
+        spider = cls(*args, crawler=crawler, **kwargs)
         return spider
 
     def set_crawler(self, crawler):

--- a/tests/test_spider.py
+++ b/tests/test_spider.py
@@ -73,9 +73,11 @@ class SpiderTest(unittest.TestCase):
     def test_from_crawler_init_call(self):
         with mock.patch.object(self.spider_class, '__init__',
                                return_value=None) as mock_init:
-            self.spider_class.from_crawler(get_crawler(), 'example.com',
+            crawler = get_crawler()
+            self.spider_class.from_crawler(crawler, 'example.com',
                                            foo='bar')
-            mock_init.assert_called_once_with('example.com', foo='bar')
+            mock_init.assert_called_once_with('example.com', crawler=crawler,
+                                              foo='bar')
 
     def test_closed_signal_call(self):
         class TestSpider(self.spider_class):


### PR DESCRIPTION
Hi,
I've had situation when I needed to extend `Spider.__init__` method and access to low-level http-cache middleware instance methods to manually control scrapy's work with the cache. But in current implementation the engine will be created after spider instance and crawler property will be assigned after spider instance creation, so the next possible point where engine may be accessed is only _start_requests_ method but in my opinion it's irrational place. So in this PR I suggest to change the order of components creation and as result the engine will be available at the end of spider instance `__init__` method just by `self.crawler.engine` reference.
