### PR TITLE
[MRG+1] Fix JsonWriterPipeline example in docs

### DIFF
--- a/docs/topics/item-pipeline.rst
+++ b/docs/topics/item-pipeline.rst
@@ -106,8 +106,11 @@ format::
 
    class JsonWriterPipeline(object):
 
-       def __init__(self):
+       def open_spider(self, spider):
            self.file = open('items.jl', 'wb')
+
+       def close_spider(self, spider):
+           self.file.close()
 
        def process_item(self, item, spider):
            line = json.dumps(dict(item)) + "\n"

--- a/docs/topics/item-pipeline.rst
+++ b/docs/topics/item-pipeline.rst
@@ -129,14 +129,7 @@ MongoDB address and database name are specified in Scrapy settings;
 MongoDB collection is named after item class.
 
 The main point of this example is to show how to use :meth:`from_crawler`
-method and how to clean up the resources properly.
-
-.. note::
-
-    Previous example (JsonWriterPipeline) doesn't clean up resources properly.
-    Fixing it is left as an exercise for the reader.
-
-::
+method and how to clean up the resources properly.::
 
     import pymongo
 


### PR DESCRIPTION
The current example does not save the file properly if crawler is called from within a script since file object is never closed. 

related stackoverflow question: http://stackoverflow.com/questions/39821693/scrapy-print-pipeline-data-in-a-scripts-context