### PR TITLE
Now "ROBOTSTXT_OBEY" is enabled by default

### DIFF
--- a/docs/topics/settings.rst
+++ b/docs/topics/settings.rst
@@ -993,7 +993,7 @@ Adjust retry request priority relative to original request:
 ROBOTSTXT_OBEY
 --------------
 
-Default: ``False``
+Default: ``True``
 
 Scope: ``scrapy.downloadermiddlewares.robotstxt``
 


### PR DESCRIPTION
Updating Docs to show that, In a newer version of scrapy ``ROBOTSTXT_OBEY`` is ``True`` by default when project is created with ``scrapy startproject``

[PR#187 - change the default value for ROBOTSTXT_OBEY to True ](https://github.com/scrapy/scrapy/pull/1867)