### PR TITLE
Add artwork license, show both licenses in the docs

### DIFF
--- a/artwork/LICENSE
+++ b/artwork/LICENSE
@@ -1,0 +1,11 @@
+Copyright (c) by Scrapy developers.
+Some rights reserved.
+
+This logo or a modified version may be used by anyone to refer to the Scrapy project, but does not indicate endorsement by the project.
+
+Redistribution and use in source (the Gimp file) and binary forms (rendered JPEG files etc.) of the image, with or without modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice and this list of conditions.
+* The names of the contributors to the Scrapy software may not be used to endorse or promote products derived from this software without specific prior written permission.
+
+Note: we would appreciate that you make the image a link to https://scrapy.org if you use it on a web page.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -253,6 +253,7 @@ All the rest
    news
    contributing
    versioning
+   license
 
 :doc:`news`
     See what has changed in recent Scrapy versions.
@@ -262,3 +263,6 @@ All the rest
 
 :doc:`versioning`
     Understand Scrapy versioning and API stability.
+
+:doc:`license`
+    Read licenses of Scrapy software and artwork.

--- a/docs/license.rst
+++ b/docs/license.rst
@@ -1,0 +1,20 @@
+.. _license:
+
+License
+=======
+
+Scrapy is licensed under a three clause BSD License. It basically means: do whatever you want with it as long as the copyright in Scrapy sticks around, the conditions are not modified and the disclaimer is present. Furthermore you must not use the names of the authors to promote derivatives of the software without written consent.
+
+The full license text can be found below (Scrapy License). For the documentation and artwork different licenses apply.
+
+
+Scrapy License
+--------------
+
+.. include::  ../LICENSE
+
+
+Scrapy Artwork License
+----------------------
+
+.. include:: ../artwork/LICENSE


### PR DESCRIPTION
This introduces a license for the artwork (adapted from http://flask.pocoo.org/docs/0.11/license/#flask-artwork-license) and adds a documentation section for both the software and artwork licenses.

Looks good?