### PR TITLE
Test Slot's heartbeat state before stopping it

### DIFF
--- a/scrapy/core/engine.py
+++ b/scrapy/core/engine.py
@@ -48,7 +48,8 @@ class Slot(object):
         if self.closing and not self.inprogress:
             if self.nextcall:
                 self.nextcall.cancel()
-                self.heartbeat.stop()
+                if self.heartbeat.running:
+                    self.heartbeat.stop()
             self.closing.callback(None)
 
 

--- a/scrapy/extensions/logstats.py
+++ b/scrapy/extensions/logstats.py
@@ -15,6 +15,7 @@ class LogStats(object):
         self.stats = stats
         self.interval = interval
         self.multiplier = 60.0 / self.interval
+        self.task = None
 
     @classmethod
     def from_crawler(cls, crawler):
@@ -47,5 +48,5 @@ class LogStats(object):
         logger.info(msg, log_args, extra={'spider': spider})
 
     def spider_closed(self, spider, reason):
-        if self.task.running:
+        if self.task and self.task.running:
             self.task.stop()

--- a/tests/pipelines.py
+++ b/tests/pipelines.py
@@ -1,0 +1,11 @@
+"""
+Some pipelines used for testing and benchmarking
+"""
+
+class ZeroDivisionErrorPipeline(object):
+
+    def open_spider(self, spider):
+        a = 1/0
+
+    def process_item(self, item, spider):
+        return item

--- a/tests/pipelines.py
+++ b/tests/pipelines.py
@@ -1,5 +1,5 @@
 """
-Some pipelines used for testing and benchmarking
+Some pipelines used for testing
 """
 
 class ZeroDivisionErrorPipeline(object):

--- a/tests/test_crawl.py
+++ b/tests/test_crawl.py
@@ -261,6 +261,7 @@ with multiples lines
         yield self.assertFailure(
             self.runner.crawl(crawler, "http://localhost:8998/status?n=200"),
             ZeroDivisionError)
+        self.assertFalse(crawler.crawling)
 
     @defer.inlineCallbacks
     def test_crawlerrunner_accepts_crawler(self):

--- a/tests/test_crawl.py
+++ b/tests/test_crawl.py
@@ -251,6 +251,18 @@ with multiples lines
         self.assertFalse(crawler.crawling)
 
     @defer.inlineCallbacks
+    def test_open_spider_error_on_faulty_pipeline(self):
+        settings = {
+            "ITEM_PIPELINES": {
+                "tests.pipelines.ZeroDivisionErrorPipeline": 300,
+            }
+        }
+        crawler = CrawlerRunner(settings).create_crawler(SimpleSpider)
+        yield self.assertFailure(
+            self.runner.crawl(crawler, "http://localhost:8998/status?n=200"),
+            ZeroDivisionError)
+
+    @defer.inlineCallbacks
     def test_crawlerrunner_accepts_crawler(self):
         crawler = self.runner.create_crawler(SimpleSpider)
         with LogCapture() as log:


### PR DESCRIPTION
Also add a test on state of looping task in LogStats extension.

Fixes #2011 and #2362

Before (scrapy 1.2.1 Python 2.7.12):

(with my test bogus pipeline from https://github.com/scrapy/scrapy/issues/2362#issuecomment-258451020
```
class CryptictracebacksPipeline(object):

    def open_spider(self, spider):
        a = int(spider)/0

    def process_item(self, item, spider):
        return item
```
)

```
$ scrapy crawl example
2016-11-07 16:51:52 [scrapy] INFO: Scrapy 1.2.1 started (bot: cryptictracebacks)
(...)
2016-11-07 16:51:52 [scrapy] INFO: Enabled item pipelines:
['cryptictracebacks.pipelines.CryptictracebacksPipeline']
2016-11-07 16:51:52 [scrapy] INFO: Spider opened
2016-11-07 16:51:52 [scrapy] INFO: Closing spider (shutdown)
Unhandled error in Deferred:
2016-11-07 16:51:52 [twisted] CRITICAL: Unhandled error in Deferred:

2016-11-07 16:51:52 [twisted] CRITICAL: 
Traceback (most recent call last):
  File "/home/paul/.virtualenvs/scrapy12/local/lib/python2.7/site-packages/twisted/internet/defer.py", line 1258, in _inlineCallbacks
    result = result.throwExceptionIntoGenerator(g)
  File "/home/paul/.virtualenvs/scrapy12/local/lib/python2.7/site-packages/twisted/python/failure.py", line 389, in throwExceptionIntoGenerator
    return g.throw(self.type, self.value, self.tb)
  File "/home/paul/.virtualenvs/scrapy12/local/lib/python2.7/site-packages/scrapy/crawler.py", line 87, in crawl
    yield self.engine.close()
  File "/home/paul/.virtualenvs/scrapy12/local/lib/python2.7/site-packages/scrapy/core/engine.py", line 100, in close
    return self._close_all_spiders()
  File "/home/paul/.virtualenvs/scrapy12/local/lib/python2.7/site-packages/scrapy/core/engine.py", line 340, in _close_all_spiders
    dfds = [self.close_spider(s, reason='shutdown') for s in self.open_spiders]
  File "/home/paul/.virtualenvs/scrapy12/local/lib/python2.7/site-packages/scrapy/core/engine.py", line 298, in close_spider
    dfd = slot.close()
  File "/home/paul/.virtualenvs/scrapy12/local/lib/python2.7/site-packages/scrapy/core/engine.py", line 44, in close
    self._maybe_fire_closing()
  File "/home/paul/.virtualenvs/scrapy12/local/lib/python2.7/site-packages/scrapy/core/engine.py", line 51, in _maybe_fire_closing
    self.heartbeat.stop()
  File "/home/paul/.virtualenvs/scrapy12/local/lib/python2.7/site-packages/twisted/internet/task.py", line 202, in stop
    assert self.running, ("Tried to stop a LoopingCall that was "
AssertionError: Tried to stop a LoopingCall that was not running.
```

After (still Python 2):

```
$ scrapy crawl example
2016-11-07 16:52:58 [scrapy] INFO: Scrapy 1.2.1 started (bot: cryptictracebacks)
(...)
2016-11-07 16:52:58 [scrapy] INFO: Enabled item pipelines:
['cryptictracebacks.pipelines.CryptictracebacksPipeline']
2016-11-07 16:52:58 [scrapy] INFO: Spider opened
2016-11-07 16:52:58 [scrapy] INFO: Closing spider (shutdown)
2016-11-07 16:52:58 [scrapy] INFO: Dumping Scrapy stats:
{'finish_reason': 'shutdown',
 'finish_time': datetime.datetime(2016, 11, 7, 15, 52, 58, 180288),
 'log_count/INFO': 6}
2016-11-07 16:52:58 [scrapy] INFO: Spider closed (shutdown)
Unhandled error in Deferred:
2016-11-07 16:52:58 [twisted] CRITICAL: Unhandled error in Deferred:


Traceback (most recent call last):
  File "/home/paul/src/scrapy/scrapy/commands/crawl.py", line 57, in run
    self.crawler_process.crawl(spname, **opts.spargs)
  File "/home/paul/src/scrapy/scrapy/crawler.py", line 163, in crawl
    return self._crawl(crawler, *args, **kwargs)
  File "/home/paul/src/scrapy/scrapy/crawler.py", line 167, in _crawl
    d = crawler.crawl(*args, **kwargs)
  File "/home/paul/.virtualenvs/scrapydev/local/lib/python2.7/site-packages/twisted/internet/defer.py", line 1331, in unwindGenerator
    return _inlineCallbacks(None, gen, Deferred())
--- <exception caught here> ---
  File "/home/paul/.virtualenvs/scrapydev/local/lib/python2.7/site-packages/twisted/internet/defer.py", line 1185, in _inlineCallbacks
    result = g.send(result)
  File "/home/paul/src/scrapy/scrapy/crawler.py", line 90, in crawl
    six.reraise(*exc_info)
  File "/home/paul/src/scrapy/scrapy/crawler.py", line 74, in crawl
    yield self.engine.open_spider(self.spider, start_requests)
exceptions.TypeError: int() argument must be a string or a number, not 'ExampleSpider'
2016-11-07 16:52:58 [twisted] CRITICAL: 
Traceback (most recent call last):
  File "/home/paul/.virtualenvs/scrapydev/local/lib/python2.7/site-packages/twisted/internet/defer.py", line 1185, in _inlineCallbacks
    result = g.send(result)
  File "/home/paul/src/scrapy/scrapy/crawler.py", line 90, in crawl
    six.reraise(*exc_info)
  File "/home/paul/src/scrapy/scrapy/crawler.py", line 74, in crawl
    yield self.engine.open_spider(self.spider, start_requests)
TypeError: int() argument must be a string or a number, not 'ExampleSpider'
```