### PR TITLE
[MRG+1] Ignore explicitly compiled python files.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -12,3 +12,4 @@ prune docs/build
 recursive-include extras *
 recursive-include bin *
 recursive-include tests *
+global-exclude __pycache__ *.py[cod]


### PR DESCRIPTION
This avoids to include compiled files in the templates directory.

Without this change, `pyc` files are included in the build:
```
$ find build | grep pyc
build/lib/scrapy/templates/project/module/__init__.pyc
build/lib/scrapy/templates/project/module/spiders/__init__.pyc
```