### PR TITLE
[MRG] Always decompress Content-Encoding: gzip at HttpCompression stage

### DIFF
--- a/scrapy/downloadermiddlewares/httpcompression.py
+++ b/scrapy/downloadermiddlewares/httpcompression.py
@@ -1,6 +1,6 @@
 import zlib
 
-from scrapy.utils.gz import gunzip, is_gzipped
+from scrapy.utils.gz import gunzip
 from scrapy.http import Response, TextResponse
 from scrapy.responsetypes import responsetypes
 from scrapy.exceptions import NotConfigured

--- a/scrapy/downloadermiddlewares/httpcompression.py
+++ b/scrapy/downloadermiddlewares/httpcompression.py
@@ -34,7 +34,7 @@ class HttpCompressionMiddleware(object):
             return response
         if isinstance(response, Response):
             content_encoding = response.headers.getlist('Content-Encoding')
-            if content_encoding and not is_gzipped(response):
+            if content_encoding:
                 encoding = content_encoding.pop()
                 decoded_body = self._decode(response.body, encoding.lower())
                 respcls = responsetypes.from_args(headers=response.headers, \

--- a/scrapy/spiders/sitemap.py
+++ b/scrapy/spiders/sitemap.py
@@ -61,10 +61,7 @@ class SitemapSpider(Spider):
         if isinstance(response, XmlResponse):
             return response.body
         elif gzip_magic_number(response):
-            try:
-                return gunzip(response.body)
-            except:
-                pass
+            return gunzip(response.body)
         # actual gzipped sitemap files are decompressed above ;
         # if we are here (response body is not gzipped)
         # and have a response for .xml.gz,

--- a/scrapy/spiders/sitemap.py
+++ b/scrapy/spiders/sitemap.py
@@ -5,7 +5,8 @@ import six
 from scrapy.spiders import Spider
 from scrapy.http import Request, XmlResponse
 from scrapy.utils.sitemap import Sitemap, sitemap_urls_from_robots
-from scrapy.utils.gz import gunzip, is_gzipped
+from scrapy.utils.gz import gunzip, gzip_magic_number
+
 
 logger = logging.getLogger(__name__)
 
@@ -59,12 +60,22 @@ class SitemapSpider(Spider):
         """
         if isinstance(response, XmlResponse):
             return response.body
-        elif is_gzipped(response):
-            return gunzip(response.body)
-        elif response.url.endswith('.xml'):
+        elif gzip_magic_number(response):
+            try:
+                return gunzip(response.body)
+            except:
+                pass
+        # actual gzipped sitemap files are decompressed above ;
+        # if we are here (response body is not gzipped)
+        # and have a response for .xml.gz,
+        # it usually means that it was already gunzipped
+        # by HttpCompression middleware,
+        # the HTTP response being sent with "Content-Encoding: gzip"
+        # without actually being a .xml.gz file in the first place,
+        # merely XML gzip-compressed on the fly,
+        # in other word, here, we have plain XML
+        elif response.url.endswith('.xml') or response.url.endswith('.xml.gz'):
             return response.body
-        elif response.url.endswith('.xml.gz'):
-            return gunzip(response.body)
 
 
 def regex(x):

--- a/scrapy/utils/gz.py
+++ b/scrapy/utils/gz.py
@@ -59,3 +59,7 @@ def is_gzipped(response):
     cenc = response.headers.get('Content-Encoding', b'').lower()
     return (_is_gzipped(ctype) or
             (_is_octetstream(ctype) and cenc in (b'gzip', b'x-gzip')))
+
+
+def gzip_magic_number(response):
+    return response.body[:2] == b'\x1f\x8b'

--- a/scrapy/utils/gz.py
+++ b/scrapy/utils/gz.py
@@ -62,4 +62,4 @@ def is_gzipped(response):
 
 
 def gzip_magic_number(response):
-    return response.body[:2] == b'\x1f\x8b'
+    return response.body[:3] == b'\x1f\x8b\x08'

--- a/tests/test_downloadermiddleware_httpcompression.py
+++ b/tests/test_downloadermiddleware_httpcompression.py
@@ -174,9 +174,9 @@ class HttpCompressionTest(TestCase):
         request = response.request
 
         newresponse = self.mw.process_response(request, response, self.spider)
-        assert newresponse is not response
-        assert newresponse.body.startswith(b'<!DOCTYPE')
-        assert 'Content-Encoding' not in newresponse.headers
+        self.assertIsNot(newresponse, response)
+        self.assertTrue(newresponse.body.startswith(b'<!DOCTYPE'))
+        self.assertNotIn('Content-Encoding', newresponse.headers)
 
     def test_process_response_gzip_app_octetstream_contenttype(self):
         response = self._getresponse('gzip')
@@ -184,9 +184,9 @@ class HttpCompressionTest(TestCase):
         request = response.request
 
         newresponse = self.mw.process_response(request, response, self.spider)
-        assert newresponse is not response
-        assert newresponse.body.startswith(b'<!DOCTYPE')
-        assert 'Content-Encoding' not in newresponse.headers
+        self.assertIsNot(newresponse, response)
+        self.assertTrue(newresponse.body.startswith(b'<!DOCTYPE'))
+        self.assertNotIn('Content-Encoding', newresponse.headers)
 
     def test_process_response_gzip_binary_octetstream_contenttype(self):
         response = self._getresponse('x-gzip')
@@ -194,9 +194,9 @@ class HttpCompressionTest(TestCase):
         request = response.request
 
         newresponse = self.mw.process_response(request, response, self.spider)
-        assert newresponse is not response
-        assert newresponse.body.startswith(b'<!DOCTYPE')
-        assert 'Content-Encoding' not in newresponse.headers
+        self.assertIsNot(newresponse, response)
+        self.assertTrue(newresponse.body.startswith(b'<!DOCTYPE'))
+        self.assertNotIn('Content-Encoding', newresponse.headers)
 
     def test_process_response_gzipped_gzip_file(self):
         """Test that a gzip Content-Encoded .gz file is gunzipped

--- a/tests/test_spider.py
+++ b/tests/test_spider.py
@@ -328,6 +328,10 @@ class SitemapSpiderTest(SpiderTest):
         r = Response(url="http://www.example.com/sitemap.xml.gz", body=self.GZBODY)
         self.assertSitemapBody(r, self.BODY)
 
+        # .xml.gz but body decoded by HttpCompression middleware already
+        r = Response(url="http://www.example.com/sitemap.xml.gz", body=self.BODY)
+        self.assertSitemapBody(r, self.BODY)
+
     def test_get_sitemap_urls_from_robotstxt(self):
         robots = b"""# Sitemap files
 Sitemap: http://example.com/sitemap.xml


### PR DESCRIPTION
Let SitemapSpider handle decoding of .xml.gz files if necessary.

Fixes #2389

The change here is to always decompress responses with `Content-Encoding: gzip`, whatever `Content-Type` says, and contrary to https://github.com/scrapy/scrapy/issues/193#issuecomment-12844809, #660, #2065

Therefore, SitemapSpider still has to decode "real" .gz files/content if the HTTP response was not "Content-Encoded", relying on gzip magic number instead of response headers.

I believe it follows [RFC 7231](https://tools.ietf.org/html/rfc7231#section-3.1.2.2) better:

> The "Content-Encoding" header field indicates what content codings
>    have been applied to the representation, beyond those inherent in the
>    media type, and thus **what decoding mechanisms have to be applied in
>    order to obtain data in the media type referenced by the Content-Type
>    header field.**  Content-Encoding is primarily used to allow a
>    representation's data to be compressed without losing the identity of
>    its underlying media type.

https://github.com/scrapy/scrapy/issues/951#issuecomment-180249747 also hinted at something like this.

I think it can also fix #2162 though I need to test that.