### PR TITLE
Fix rules not working on first url

### DIFF
--- a/scrapy/spiders/crawl.py
+++ b/scrapy/spiders/crawl.py
@@ -42,8 +42,13 @@ class CrawlSpider(Spider):
     def parse(self, response):
         return self._parse_response(response, self.parse_start_url, cb_kwargs={}, follow=True)
 
+    def _parse_links(self, response):
+        for extractor in [r.link_extractor for r in self.rules]:
+            for link in extractor.extract_links(response):
+                yield Request(link.url)
+
     def parse_start_url(self, response):
-        return []
+        list(self._parse_links(response))
 
     def process_results(self, response, results):
         return results


### PR DESCRIPTION
For the first urls in `start_urls` the rule will not be applied. This is an issue that seems to be around since 2012.
The proposed changes will make the rules work on the `start_urls`.

See here for the issue from 2012: http://stackoverflow.com/questions/12736257/why-dont-my-scrapy-crawlspider-rules-work