### PR TITLE
[MRG+1] Use Twisted modules for client and endpoints

### DIFF
--- a/scrapy/xlib/tx/__init__.py
+++ b/scrapy/xlib/tx/__init__.py
@@ -2,13 +2,15 @@ from scrapy import twisted_version
 if twisted_version > (13, 0, 0):
     from twisted.web import client
     from twisted.internet import endpoints
-if twisted_version >= (11, 1, 0):
+elif twisted_version >= (11, 1, 0):
     from . import client, endpoints
 else:
     from scrapy.exceptions import NotSupported
+
     class _Mocked(object):
         def __init__(self, *args, **kw):
             raise NotSupported('HTTP1.1 not supported')
+
     class _Mock(object):
         def __getattr__(self, name):
             return _Mocked


### PR DESCRIPTION
@nyov discovered in https://github.com/scrapy/scrapy/pull/1887#issuecomment-260047541 that Scrapy is using patched Twisted libs shipped under `scrapy.xlib.tx` always. I introduced this bug in https://github.com/scrapy/scrapy/commit/bb806fa0f8f77cba59506153e33cab96f91008ab#diff-e487b2562862226386f811e0659c70c0R6 so this PR is an attempt to address the issue.