### PR TITLE
[MRG+1] Fix #396 re-triggered issue

### DIFF
--- a/scrapy/utils/console.py
+++ b/scrapy/utils/console.py
@@ -15,6 +15,9 @@ def _embed_ipython_shell(namespace={}, banner=''):
         config = load_default_config()
         # Always use .instace() to ensure _instance propagation to all parents
         # this is needed for <TAB> completion works well for new imports
+        # and clear the instance to always have the fresh env
+        # on repeated breaks like with inspect_response()
+        InteractiveShellEmbed.clear_instance()
         shell = InteractiveShellEmbed.instance(
             banner1=banner, user_ns=namespace, config=config)
         shell()


### PR DESCRIPTION
The InteractiveShellEmbed class is a singleton
and we need to drop the instance with its clear_instance() method
to rebuild the instance from scratch with fresh environment
for each subsequent Scrapy's shell drop in.