### PR TITLE
sorted imports using isort and enabled isort check on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,9 @@ env:
  - TOXENV=py35
  - TOXENV=docs
  - TOXENV=isort
+matrix:
+  allow_failures:
+    - env: TOXENV=isort
 install:
  - pip install -U tox twine wheel codecov
 script: tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ env:
  - TOXENV=py33
  - TOXENV=py35
  - TOXENV=docs
+ - TOXENV=isort
 install:
  - pip install -U tox twine wheel codecov
 script: tox

--- a/scrapy/__init__.py
+++ b/scrapy/__init__.py
@@ -6,34 +6,34 @@ __all__ = ['__version__', 'version_info', 'twisted_version',
            'Spider', 'Request', 'FormRequest', 'Selector', 'Item', 'Field']
 
 # Scrapy version
-import pkgutil
+import pkgutil  # isort:skip
 __version__ = pkgutil.get_data(__package__, 'VERSION').decode('ascii').strip()
 version_info = tuple(int(v) if v.isdigit() else v
                      for v in __version__.split('.'))
 del pkgutil
 
 # Check minimum required Python version
-import sys
+import sys  # isort:skip
 if sys.version_info < (2, 7):
     print("Scrapy %s requires Python 2.7" % __version__)
     sys.exit(1)
 
 # Ignore noisy twisted deprecation warnings
-import warnings
+import warnings  # isort:skip
 warnings.filterwarnings('ignore', category=DeprecationWarning, module='twisted')
 del warnings
 
 # Apply monkey patches to fix issues in external libraries
-from . import _monkeypatches
+from . import _monkeypatches  # isort:skip
 del _monkeypatches
 
-from twisted import version as _txv
+from twisted import version as _txv  # isort:skip
 twisted_version = (_txv.major, _txv.minor, _txv.micro)
 
 # Declare top-level shortcuts
-from scrapy.spiders import Spider
-from scrapy.http import Request, FormRequest
+from scrapy.http import FormRequest, Request
+from scrapy.item import Field, Item
 from scrapy.selector import Selector
-from scrapy.item import Item, Field
+from scrapy.spiders import Spider
 
 del sys

--- a/scrapy/_monkeypatches.py
+++ b/scrapy/_monkeypatches.py
@@ -17,7 +17,7 @@ if sys.version_info[0] == 2:
 
 # Undo what Twisted's perspective broker adds to pickle register
 # to prevent bugs like Twisted#7989 while serializing requests
-import twisted.persisted.styles  # NOQA
+import twisted.persisted.styles  # NOQA isort:skip
 # Remove only entries with twisted serializers for non-twisted types.
 for k, v in frozenset(copyreg.dispatch_table.items()):
     if not str(getattr(k, '__module__', '')).startswith('twisted') \

--- a/scrapy/cmdline.py
+++ b/scrapy/cmdline.py
@@ -1,17 +1,20 @@
 from __future__ import print_function
-import sys
-import optparse
+
 import cProfile
 import inspect
+import optparse
+import sys
+
 import pkg_resources
 
 import scrapy
-from scrapy.crawler import CrawlerProcess
 from scrapy.commands import ScrapyCommand
+from scrapy.crawler import CrawlerProcess
 from scrapy.exceptions import UsageError
-from scrapy.utils.misc import walk_modules
-from scrapy.utils.project import inside_project, get_project_settings
 from scrapy.settings.deprecated import check_deprecated_settings
+from scrapy.utils.misc import walk_modules
+from scrapy.utils.project import get_project_settings, inside_project
+
 
 def _iter_command_classes(module_name):
     # TODO: add `name` attribute to commands and and merge this function with

--- a/scrapy/command.py
+++ b/scrapy/command.py
@@ -1,7 +1,9 @@
 import warnings
+
 from scrapy.exceptions import ScrapyDeprecationWarning
+
 warnings.warn("Module `scrapy.command` is deprecated, "
               "use `scrapy.commands` instead",
               ScrapyDeprecationWarning, stacklevel=2)
 
-from scrapy.commands import *
+from scrapy.commands import *  # isort:skip

--- a/scrapy/commands/__init__.py
+++ b/scrapy/commands/__init__.py
@@ -3,10 +3,11 @@ Base class for Scrapy commands
 """
 import os
 from optparse import OptionGroup
+
 from twisted.python import failure
 
-from scrapy.utils.conf import arglist_to_dict
 from scrapy.exceptions import UsageError
+from scrapy.utils.conf import arglist_to_dict
 
 
 class ScrapyCommand(object):

--- a/scrapy/commands/bench.py
+++ b/scrapy/commands/bench.py
@@ -1,6 +1,6 @@
+import subprocess
 import sys
 import time
-import subprocess
 
 from six.moves.urllib.parse import urlencode
 

--- a/scrapy/commands/check.py
+++ b/scrapy/commands/check.py
@@ -1,13 +1,14 @@
 from __future__ import print_function
-import time
+
 import sys
+import time
 from collections import defaultdict
-from unittest import TextTestRunner, TextTestResult as _TextTestResult
+from unittest import TextTestResult as _TextTestResult, TextTestRunner
 
 from scrapy.commands import ScrapyCommand
 from scrapy.contracts import ContractsManager
-from scrapy.utils.misc import load_object
 from scrapy.utils.conf import build_component_list
+from scrapy.utils.misc import load_object
 
 
 class TextTestResult(_TextTestResult):
@@ -95,4 +96,3 @@ class Command(ScrapyCommand):
             result.printErrors()
             result.printSummary(start, stop)
             self.exitcode = int(not result.wasSuccessful())
-

--- a/scrapy/commands/crawl.py
+++ b/scrapy/commands/crawl.py
@@ -1,8 +1,9 @@
 import os
+
 from scrapy.commands import ScrapyCommand
+from scrapy.exceptions import UsageError
 from scrapy.utils.conf import arglist_to_dict
 from scrapy.utils.python import without_none_values
-from scrapy.exceptions import UsageError
 
 
 class Command(ScrapyCommand):

--- a/scrapy/commands/edit.py
+++ b/scrapy/commands/edit.py
@@ -1,7 +1,9 @@
-import sys, os
+import os
+import sys
 
 from scrapy.commands import ScrapyCommand
 from scrapy.exceptions import UsageError
+
 
 class Command(ScrapyCommand):
 

--- a/scrapy/commands/fetch.py
+++ b/scrapy/commands/fetch.py
@@ -1,11 +1,15 @@
 from __future__ import print_function
-import sys, six
+
+import sys
+
+import six
 from w3lib.url import is_url
 
 from scrapy.commands import ScrapyCommand
-from scrapy.http import Request
 from scrapy.exceptions import UsageError
-from scrapy.utils.spider import spidercls_for_request, DefaultSpider
+from scrapy.http import Request
+from scrapy.utils.spider import DefaultSpider, spidercls_for_request
+
 
 class Command(ScrapyCommand):
 

--- a/scrapy/commands/genspider.py
+++ b/scrapy/commands/genspider.py
@@ -1,15 +1,15 @@
 from __future__ import print_function
+
 import os
 import shutil
 import string
-
 from importlib import import_module
-from os.path import join, dirname, abspath, exists, splitext
+from os.path import abspath, dirname, exists, join, splitext
 
 import scrapy
 from scrapy.commands import ScrapyCommand
-from scrapy.utils.template import render_templatefile, string_camelcase
 from scrapy.exceptions import UsageError
+from scrapy.utils.template import render_templatefile, string_camelcase
 
 
 def sanitize_module_name(module_name):

--- a/scrapy/commands/list.py
+++ b/scrapy/commands/list.py
@@ -1,5 +1,7 @@
 from __future__ import print_function
+
 from scrapy.commands import ScrapyCommand
+
 
 class Command(ScrapyCommand):
 

--- a/scrapy/commands/parse.py
+++ b/scrapy/commands/parse.py
@@ -1,15 +1,16 @@
 from __future__ import print_function
+
 import logging
 
 from w3lib.url import is_url
 
 from scrapy.commands import ScrapyCommand
+from scrapy.exceptions import UsageError
 from scrapy.http import Request
 from scrapy.item import BaseItem
 from scrapy.utils import display
 from scrapy.utils.conf import arglist_to_dict
 from scrapy.utils.spider import iterate_spider_output, spidercls_for_request
-from scrapy.exceptions import UsageError
 
 logger = logging.getLogger(__name__)
 

--- a/scrapy/commands/runspider.py
+++ b/scrapy/commands/runspider.py
@@ -1,12 +1,12 @@
-import sys
 import os
+import sys
 from importlib import import_module
 
-from scrapy.utils.spider import iter_spider_classes
 from scrapy.commands import ScrapyCommand
 from scrapy.exceptions import UsageError
 from scrapy.utils.conf import arglist_to_dict
 from scrapy.utils.python import without_none_values
+from scrapy.utils.spider import iter_spider_classes
 
 
 def _import_file(filepath):

--- a/scrapy/commands/settings.py
+++ b/scrapy/commands/settings.py
@@ -1,8 +1,10 @@
 from __future__ import print_function
+
 import json
 
 from scrapy.commands import ScrapyCommand
 from scrapy.settings import BaseSettings
+
 
 class Command(ScrapyCommand):
 

--- a/scrapy/commands/shell.py
+++ b/scrapy/commands/shell.py
@@ -6,9 +6,9 @@ See documentation in docs/topics/shell.rst
 from threading import Thread
 
 from scrapy.commands import ScrapyCommand
-from scrapy.shell import Shell
 from scrapy.http import Request
-from scrapy.utils.spider import spidercls_for_request, DefaultSpider
+from scrapy.shell import Shell
+from scrapy.utils.spider import DefaultSpider, spidercls_for_request
 from scrapy.utils.url import guess_scheme
 
 

--- a/scrapy/commands/startproject.py
+++ b/scrapy/commands/startproject.py
@@ -1,16 +1,16 @@
 from __future__ import print_function
-import re
+
 import os
+import re
 import string
 from importlib import import_module
-from os.path import join, exists, abspath
-from shutil import ignore_patterns, move, copy2, copystat
+from os.path import abspath, exists, join
+from shutil import copy2, copystat, ignore_patterns, move
 
 import scrapy
 from scrapy.commands import ScrapyCommand
-from scrapy.utils.template import render_templatefile, string_camelcase
 from scrapy.exceptions import UsageError
-
+from scrapy.utils.template import render_templatefile, string_camelcase
 
 TEMPLATES_TO_RENDER = (
     ('scrapy.cfg',),
@@ -118,4 +118,3 @@ class Command(ScrapyCommand):
         _templates_base_dir = self.settings['TEMPLATES_DIR'] or \
             join(scrapy.__path__[0], 'templates')
         return join(_templates_base_dir, 'project')
-    

--- a/scrapy/commands/version.py
+++ b/scrapy/commands/version.py
@@ -1,9 +1,10 @@
 from __future__ import print_function
-import sys
-import platform
 
-import twisted
+import platform
+import sys
+
 import OpenSSL
+import twisted
 
 import scrapy
 from scrapy.commands import ScrapyCommand

--- a/scrapy/commands/view.py
+++ b/scrapy/commands/view.py
@@ -1,5 +1,6 @@
-from scrapy.commands import fetch, ScrapyCommand
+from scrapy.commands import ScrapyCommand, fetch
 from scrapy.utils.response import open_in_browser
+
 
 class Command(fetch.Command):
 

--- a/scrapy/conf.py
+++ b/scrapy/conf.py
@@ -2,12 +2,13 @@
 # scrapy.conf.settings and get the settings they expect
 
 import sys
+import warnings
+
+from scrapy.exceptions import ScrapyDeprecationWarning
 
 if 'scrapy.cmdline' not in sys.modules:
     from scrapy.utils.project import get_project_settings
     settings = get_project_settings()
 
-import warnings
-from scrapy.exceptions import ScrapyDeprecationWarning
 warnings.warn("Module `scrapy.conf` is deprecated, use `crawler.settings` attribute instead",
     ScrapyDeprecationWarning, stacklevel=2)

--- a/scrapy/contracts/__init__.py
+++ b/scrapy/contracts/__init__.py
@@ -1,11 +1,11 @@
-import sys
 import re
+import sys
 from functools import wraps
 from unittest import TestCase
 
 from scrapy.http import Request
-from scrapy.utils.spider import iterate_spider_output
 from scrapy.utils.python import get_spec
+from scrapy.utils.spider import iterate_spider_output
 
 
 class ContractsManager(object):

--- a/scrapy/contracts/default.py
+++ b/scrapy/contracts/default.py
@@ -1,6 +1,6 @@
-from scrapy.item import BaseItem
-from scrapy.http import Request
 from scrapy.exceptions import ContractFail
+from scrapy.http import Request
+from scrapy.item import BaseItem
 
 from . import Contract
 

--- a/scrapy/contrib/closespider.py
+++ b/scrapy/contrib/closespider.py
@@ -1,7 +1,9 @@
 import warnings
+
 from scrapy.exceptions import ScrapyDeprecationWarning
+
 warnings.warn("Module `scrapy.contrib.closespider` is deprecated, "
               "use `scrapy.extensions.closespider` instead",
               ScrapyDeprecationWarning, stacklevel=2)
 
-from scrapy.extensions.closespider import *
+from scrapy.extensions.closespider import *  # isort:skip

--- a/scrapy/contrib/corestats.py
+++ b/scrapy/contrib/corestats.py
@@ -1,7 +1,9 @@
 import warnings
+
 from scrapy.exceptions import ScrapyDeprecationWarning
+
 warnings.warn("Module `scrapy.contrib.corestats` is deprecated, "
               "use `scrapy.extensions.corestats` instead",
               ScrapyDeprecationWarning, stacklevel=2)
 
-from scrapy.extensions.corestats import *
+from scrapy.extensions.corestats import *  # isort:skip

--- a/scrapy/contrib/debug.py
+++ b/scrapy/contrib/debug.py
@@ -1,7 +1,9 @@
 import warnings
+
 from scrapy.exceptions import ScrapyDeprecationWarning
+
 warnings.warn("Module `scrapy.contrib.debug` is deprecated, "
               "use `scrapy.extensions.debug` instead",
               ScrapyDeprecationWarning, stacklevel=2)
 
-from scrapy.extensions.debug import *
+from scrapy.extensions.debug import *  # isort:skip

--- a/scrapy/contrib/downloadermiddleware/ajaxcrawl.py
+++ b/scrapy/contrib/downloadermiddleware/ajaxcrawl.py
@@ -1,7 +1,9 @@
 import warnings
+
 from scrapy.exceptions import ScrapyDeprecationWarning
+
 warnings.warn("Module `scrapy.contrib.downloadermiddleware.ajaxcrawl` is deprecated, "
               "use `scrapy.downloadermiddlewares.ajaxcrawl` instead",
               ScrapyDeprecationWarning, stacklevel=2)
 
-from scrapy.downloadermiddlewares.ajaxcrawl import *
+from scrapy.downloadermiddlewares.ajaxcrawl import *  # isort:skip

--- a/scrapy/contrib/downloadermiddleware/chunked.py
+++ b/scrapy/contrib/downloadermiddleware/chunked.py
@@ -1,7 +1,9 @@
 import warnings
+
 from scrapy.exceptions import ScrapyDeprecationWarning
+
 warnings.warn("Module `scrapy.contrib.downloadermiddleware.chunked` is deprecated, "
               "use `scrapy.downloadermiddlewares.chunked` instead",
               ScrapyDeprecationWarning, stacklevel=2)
 
-from scrapy.downloadermiddlewares.chunked import *
+from scrapy.downloadermiddlewares.chunked import *  # isort:skip

--- a/scrapy/contrib/downloadermiddleware/cookies.py
+++ b/scrapy/contrib/downloadermiddleware/cookies.py
@@ -1,7 +1,9 @@
 import warnings
+
 from scrapy.exceptions import ScrapyDeprecationWarning
+
 warnings.warn("Module `scrapy.contrib.downloadermiddleware.cookies` is deprecated, "
               "use `scrapy.downloadermiddlewares.cookies` instead",
               ScrapyDeprecationWarning, stacklevel=2)
 
-from scrapy.downloadermiddlewares.cookies import *
+from scrapy.downloadermiddlewares.cookies import *  # isort:skip

--- a/scrapy/contrib/downloadermiddleware/decompression.py
+++ b/scrapy/contrib/downloadermiddleware/decompression.py
@@ -1,7 +1,9 @@
 import warnings
+
 from scrapy.exceptions import ScrapyDeprecationWarning
+
 warnings.warn("Module `scrapy.contrib.downloadermiddleware.decompression` is deprecated, "
               "use `scrapy.downloadermiddlewares.decompression` instead",
               ScrapyDeprecationWarning, stacklevel=2)
 
-from scrapy.downloadermiddlewares.decompression import *
+from scrapy.downloadermiddlewares.decompression import *  # isort:skip

--- a/scrapy/contrib/downloadermiddleware/defaultheaders.py
+++ b/scrapy/contrib/downloadermiddleware/defaultheaders.py
@@ -1,7 +1,9 @@
 import warnings
+
 from scrapy.exceptions import ScrapyDeprecationWarning
+
 warnings.warn("Module `scrapy.contrib.downloadermiddleware.defaultheaders` is deprecated, "
               "use `scrapy.downloadermiddlewares.defaultheaders` instead",
               ScrapyDeprecationWarning, stacklevel=2)
 
-from scrapy.downloadermiddlewares.defaultheaders import *
+from scrapy.downloadermiddlewares.defaultheaders import *  # isort:skip

--- a/scrapy/contrib/downloadermiddleware/downloadtimeout.py
+++ b/scrapy/contrib/downloadermiddleware/downloadtimeout.py
@@ -1,7 +1,9 @@
 import warnings
+
 from scrapy.exceptions import ScrapyDeprecationWarning
+
 warnings.warn("Module `scrapy.contrib.downloadermiddleware.downloadtimeout` is deprecated, "
               "use `scrapy.downloadermiddlewares.downloadtimeout` instead",
               ScrapyDeprecationWarning, stacklevel=2)
 
-from scrapy.downloadermiddlewares.downloadtimeout import *
+from scrapy.downloadermiddlewares.downloadtimeout import *  # isort:skip

--- a/scrapy/contrib/downloadermiddleware/httpauth.py
+++ b/scrapy/contrib/downloadermiddleware/httpauth.py
@@ -1,7 +1,9 @@
 import warnings
+
 from scrapy.exceptions import ScrapyDeprecationWarning
+
 warnings.warn("Module `scrapy.contrib.downloadermiddleware.httpauth` is deprecated, "
               "use `scrapy.downloadermiddlewares.httpauth` instead",
               ScrapyDeprecationWarning, stacklevel=2)
 
-from scrapy.downloadermiddlewares.httpauth import *
+from scrapy.downloadermiddlewares.httpauth import *  # isort:skip

--- a/scrapy/contrib/downloadermiddleware/httpcache.py
+++ b/scrapy/contrib/downloadermiddleware/httpcache.py
@@ -1,7 +1,9 @@
 import warnings
+
 from scrapy.exceptions import ScrapyDeprecationWarning
+
 warnings.warn("Module `scrapy.contrib.downloadermiddleware.httpcache` is deprecated, "
               "use `scrapy.downloadermiddlewares.httpcache` instead",
               ScrapyDeprecationWarning, stacklevel=2)
 
-from scrapy.downloadermiddlewares.httpcache import *
+from scrapy.downloadermiddlewares.httpcache import *  # isort:skip

--- a/scrapy/contrib/downloadermiddleware/httpcompression.py
+++ b/scrapy/contrib/downloadermiddleware/httpcompression.py
@@ -1,7 +1,9 @@
 import warnings
+
 from scrapy.exceptions import ScrapyDeprecationWarning
+
 warnings.warn("Module `scrapy.contrib.downloadermiddleware.httpcompression` is deprecated, "
               "use `scrapy.downloadermiddlewares.httpcompression` instead",
               ScrapyDeprecationWarning, stacklevel=2)
 
-from scrapy.downloadermiddlewares.httpcompression import *
+from scrapy.downloadermiddlewares.httpcompression import *  # isort:skip

--- a/scrapy/contrib/downloadermiddleware/httpproxy.py
+++ b/scrapy/contrib/downloadermiddleware/httpproxy.py
@@ -1,7 +1,9 @@
 import warnings
+
 from scrapy.exceptions import ScrapyDeprecationWarning
+
 warnings.warn("Module `scrapy.contrib.downloadermiddleware.httpproxy` is deprecated, "
               "use `scrapy.downloadermiddlewares.httpproxy` instead",
               ScrapyDeprecationWarning, stacklevel=2)
 
-from scrapy.downloadermiddlewares.httpproxy import *
+from scrapy.downloadermiddlewares.httpproxy import *  # isort:skip

--- a/scrapy/contrib/downloadermiddleware/redirect.py
+++ b/scrapy/contrib/downloadermiddleware/redirect.py
@@ -1,7 +1,9 @@
 import warnings
+
 from scrapy.exceptions import ScrapyDeprecationWarning
+
 warnings.warn("Module `scrapy.contrib.downloadermiddleware.redirect` is deprecated, "
               "use `scrapy.downloadermiddlewares.redirect` instead",
               ScrapyDeprecationWarning, stacklevel=2)
 
-from scrapy.downloadermiddlewares.redirect import *
+from scrapy.downloadermiddlewares.redirect import *  # isort:skip

--- a/scrapy/contrib/downloadermiddleware/retry.py
+++ b/scrapy/contrib/downloadermiddleware/retry.py
@@ -1,7 +1,9 @@
 import warnings
+
 from scrapy.exceptions import ScrapyDeprecationWarning
+
 warnings.warn("Module `scrapy.contrib.downloadermiddleware.retry` is deprecated, "
               "use `scrapy.downloadermiddlewares.retry` instead",
               ScrapyDeprecationWarning, stacklevel=2)
 
-from scrapy.downloadermiddlewares.retry import *
+from scrapy.downloadermiddlewares.retry import *  # isort:skip

--- a/scrapy/contrib/downloadermiddleware/robotstxt.py
+++ b/scrapy/contrib/downloadermiddleware/robotstxt.py
@@ -1,7 +1,9 @@
 import warnings
+
 from scrapy.exceptions import ScrapyDeprecationWarning
+
 warnings.warn("Module `scrapy.contrib.downloadermiddleware.robotstxt` is deprecated, "
               "use `scrapy.downloadermiddlewares.robotstxt` instead",
               ScrapyDeprecationWarning, stacklevel=2)
 
-from scrapy.downloadermiddlewares.robotstxt import *
+from scrapy.downloadermiddlewares.robotstxt import *  # isort:skip

--- a/scrapy/contrib/downloadermiddleware/stats.py
+++ b/scrapy/contrib/downloadermiddleware/stats.py
@@ -1,7 +1,9 @@
 import warnings
+
 from scrapy.exceptions import ScrapyDeprecationWarning
+
 warnings.warn("Module `scrapy.contrib.downloadermiddleware.stats` is deprecated, "
               "use `scrapy.downloadermiddlewares.stats` instead",
               ScrapyDeprecationWarning, stacklevel=2)
 
-from scrapy.downloadermiddlewares.stats import *
+from scrapy.downloadermiddlewares.stats import *  # isort:skip

--- a/scrapy/contrib/downloadermiddleware/useragent.py
+++ b/scrapy/contrib/downloadermiddleware/useragent.py
@@ -1,7 +1,9 @@
 import warnings
+
 from scrapy.exceptions import ScrapyDeprecationWarning
+
 warnings.warn("Module `scrapy.contrib.downloadermiddleware.useragent` is deprecated, "
               "use `scrapy.downloadermiddlewares.useragent` instead",
               ScrapyDeprecationWarning, stacklevel=2)
 
-from scrapy.downloadermiddlewares.useragent import *
+from scrapy.downloadermiddlewares.useragent import *  # isort:skip

--- a/scrapy/contrib/exporter/__init__.py
+++ b/scrapy/contrib/exporter/__init__.py
@@ -1,8 +1,10 @@
 import warnings
+
 from scrapy.exceptions import ScrapyDeprecationWarning
+
 warnings.warn("Module `scrapy.contrib.exporter` is deprecated, "
               "use `scrapy.exporters` instead",
               ScrapyDeprecationWarning, stacklevel=2)
 
-from scrapy.exporters import *
-from scrapy.exporters import PythonItemExporter
+from scrapy.exporters import *  # isort:skip
+from scrapy.exporters import PythonItemExporter  # isort:skip

--- a/scrapy/contrib/feedexport.py
+++ b/scrapy/contrib/feedexport.py
@@ -1,7 +1,9 @@
 import warnings
+
 from scrapy.exceptions import ScrapyDeprecationWarning
+
 warnings.warn("Module `scrapy.contrib.feedexport` is deprecated, "
               "use `scrapy.extensions.feedexport` instead",
               ScrapyDeprecationWarning, stacklevel=2)
 
-from scrapy.extensions.feedexport import *
+from scrapy.extensions.feedexport import *  # isort:skip

--- a/scrapy/contrib/httpcache.py
+++ b/scrapy/contrib/httpcache.py
@@ -1,7 +1,9 @@
 import warnings
+
 from scrapy.exceptions import ScrapyDeprecationWarning
+
 warnings.warn("Module `scrapy.contrib.httpcache` is deprecated, "
               "use `scrapy.extensions.httpcache` instead",
               ScrapyDeprecationWarning, stacklevel=2)
 
-from scrapy.extensions.httpcache import *
+from scrapy.extensions.httpcache import *  # isort:skip

--- a/scrapy/contrib/linkextractors/__init__.py
+++ b/scrapy/contrib/linkextractors/__init__.py
@@ -1,7 +1,9 @@
 import warnings
+
 from scrapy.exceptions import ScrapyDeprecationWarning
+
 warnings.warn("Module `scrapy.contrib.linkextractors` is deprecated, "
               "use `scrapy.linkextractors` instead",
               ScrapyDeprecationWarning, stacklevel=2)
 
-from scrapy.linkextractors import *
+from scrapy.linkextractors import *  # isort:skip

--- a/scrapy/contrib/linkextractors/htmlparser.py
+++ b/scrapy/contrib/linkextractors/htmlparser.py
@@ -1,7 +1,9 @@
 import warnings
+
 from scrapy.exceptions import ScrapyDeprecationWarning
+
 warnings.warn("Module `scrapy.contrib.linkextractors.htmlparser` is deprecated, "
               "use `scrapy.linkextractors.htmlparser` instead",
               ScrapyDeprecationWarning, stacklevel=2)
 
-from scrapy.linkextractors.htmlparser import *
+from scrapy.linkextractors.htmlparser import *  # isort:skip

--- a/scrapy/contrib/linkextractors/lxmlhtml.py
+++ b/scrapy/contrib/linkextractors/lxmlhtml.py
@@ -1,7 +1,9 @@
 import warnings
+
 from scrapy.exceptions import ScrapyDeprecationWarning
+
 warnings.warn("Module `scrapy.contrib.linkextractors.lxmlhtml` is deprecated, "
               "use `scrapy.linkextractors.lxmlhtml` instead",
               ScrapyDeprecationWarning, stacklevel=2)
 
-from scrapy.linkextractors.lxmlhtml import *
+from scrapy.linkextractors.lxmlhtml import *  # isort:skip

--- a/scrapy/contrib/linkextractors/regex.py
+++ b/scrapy/contrib/linkextractors/regex.py
@@ -1,7 +1,9 @@
 import warnings
+
 from scrapy.exceptions import ScrapyDeprecationWarning
+
 warnings.warn("Module `scrapy.contrib.linkextractors.regex` is deprecated, "
               "use `scrapy.linkextractors.regex` instead",
               ScrapyDeprecationWarning, stacklevel=2)
 
-from scrapy.linkextractors.regex import *
+from scrapy.linkextractors.regex import *  # isort:skip

--- a/scrapy/contrib/linkextractors/sgml.py
+++ b/scrapy/contrib/linkextractors/sgml.py
@@ -1,7 +1,9 @@
 import warnings
+
 from scrapy.exceptions import ScrapyDeprecationWarning
+
 warnings.warn("Module `scrapy.contrib.linkextractors.sgml` is deprecated, "
               "use `scrapy.linkextractors.sgml` instead",
               ScrapyDeprecationWarning, stacklevel=2)
 
-from scrapy.linkextractors.sgml import *
+from scrapy.linkextractors.sgml import *  # isort:skip

--- a/scrapy/contrib/loader/__init__.py
+++ b/scrapy/contrib/loader/__init__.py
@@ -1,7 +1,9 @@
 import warnings
+
 from scrapy.exceptions import ScrapyDeprecationWarning
+
 warnings.warn("Module `scrapy.contrib.loader` is deprecated, "
               "use `scrapy.loader` instead",
               ScrapyDeprecationWarning, stacklevel=2)
 
-from scrapy.loader import *
+from scrapy.loader import *  # isort:skip

--- a/scrapy/contrib/loader/common.py
+++ b/scrapy/contrib/loader/common.py
@@ -1,7 +1,9 @@
 import warnings
+
 from scrapy.exceptions import ScrapyDeprecationWarning
+
 warnings.warn("Module `scrapy.contrib.loader.common` is deprecated, "
               "use `scrapy.loader.common` instead",
               ScrapyDeprecationWarning, stacklevel=2)
 
-from scrapy.loader.common import *
+from scrapy.loader.common import *  # isort:skip

--- a/scrapy/contrib/loader/processor.py
+++ b/scrapy/contrib/loader/processor.py
@@ -1,7 +1,9 @@
 import warnings
+
 from scrapy.exceptions import ScrapyDeprecationWarning
+
 warnings.warn("Module `scrapy.contrib.loader.processor` is deprecated, "
               "use `scrapy.loader.processors` instead",
               ScrapyDeprecationWarning, stacklevel=2)
 
-from scrapy.loader.processors import *
+from scrapy.loader.processors import *  # isort:skip

--- a/scrapy/contrib/logstats.py
+++ b/scrapy/contrib/logstats.py
@@ -1,7 +1,9 @@
 import warnings
+
 from scrapy.exceptions import ScrapyDeprecationWarning
+
 warnings.warn("Module `scrapy.contrib.logstats` is deprecated, "
               "use `scrapy.extensions.logstats` instead",
               ScrapyDeprecationWarning, stacklevel=2)
 
-from scrapy.extensions.logstats import *
+from scrapy.extensions.logstats import *  # isort:skip

--- a/scrapy/contrib/memdebug.py
+++ b/scrapy/contrib/memdebug.py
@@ -1,7 +1,9 @@
 import warnings
+
 from scrapy.exceptions import ScrapyDeprecationWarning
+
 warnings.warn("Module `scrapy.contrib.memdebug` is deprecated, "
               "use `scrapy.extensions.memdebug` instead",
               ScrapyDeprecationWarning, stacklevel=2)
 
-from scrapy.extensions.memdebug import *
+from scrapy.extensions.memdebug import *  # isort:skip

--- a/scrapy/contrib/memusage.py
+++ b/scrapy/contrib/memusage.py
@@ -1,7 +1,9 @@
 import warnings
+
 from scrapy.exceptions import ScrapyDeprecationWarning
+
 warnings.warn("Module `scrapy.contrib.memusage` is deprecated, "
               "use `scrapy.extensions.memusage` instead",
               ScrapyDeprecationWarning, stacklevel=2)
 
-from scrapy.extensions.memusage import *
+from scrapy.extensions.memusage import *  # isort:skip

--- a/scrapy/contrib/pipeline/__init__.py
+++ b/scrapy/contrib/pipeline/__init__.py
@@ -1,7 +1,9 @@
 import warnings
+
 from scrapy.exceptions import ScrapyDeprecationWarning
+
 warnings.warn("Module `scrapy.contrib.pipeline` is deprecated, "
               "use `scrapy.pipelines` instead",
               ScrapyDeprecationWarning, stacklevel=2)
 
-from scrapy.pipelines import *
+from scrapy.pipelines import *  # isort:skip

--- a/scrapy/contrib/pipeline/files.py
+++ b/scrapy/contrib/pipeline/files.py
@@ -1,7 +1,9 @@
 import warnings
+
 from scrapy.exceptions import ScrapyDeprecationWarning
+
 warnings.warn("Module `scrapy.contrib.pipeline.files` is deprecated, "
               "use `scrapy.pipelines.files` instead",
               ScrapyDeprecationWarning, stacklevel=2)
 
-from scrapy.pipelines.files import *
+from scrapy.pipelines.files import *  # isort:skip

--- a/scrapy/contrib/pipeline/images.py
+++ b/scrapy/contrib/pipeline/images.py
@@ -1,7 +1,9 @@
 import warnings
+
 from scrapy.exceptions import ScrapyDeprecationWarning
+
 warnings.warn("Module `scrapy.contrib.pipeline.images` is deprecated, "
               "use `scrapy.pipelines.images` instead",
               ScrapyDeprecationWarning, stacklevel=2)
 
-from scrapy.pipelines.images import *
+from scrapy.pipelines.images import *  # isort:skip

--- a/scrapy/contrib/pipeline/media.py
+++ b/scrapy/contrib/pipeline/media.py
@@ -1,7 +1,9 @@
 import warnings
+
 from scrapy.exceptions import ScrapyDeprecationWarning
+
 warnings.warn("Module `scrapy.contrib.pipeline.media` is deprecated, "
               "use `scrapy.pipelines.media` instead",
               ScrapyDeprecationWarning, stacklevel=2)
 
-from scrapy.pipelines.media import *
+from scrapy.pipelines.media import *  # isort:skip

--- a/scrapy/contrib/spidermiddleware/depth.py
+++ b/scrapy/contrib/spidermiddleware/depth.py
@@ -1,7 +1,9 @@
 import warnings
+
 from scrapy.exceptions import ScrapyDeprecationWarning
+
 warnings.warn("Module `scrapy.contrib.spidermiddleware.depth` is deprecated, "
               "use `scrapy.spidermiddlewares.depth` instead",
               ScrapyDeprecationWarning, stacklevel=2)
 
-from scrapy.spidermiddlewares.depth import *
+from scrapy.spidermiddlewares.depth import *  # isort:skip

--- a/scrapy/contrib/spidermiddleware/httperror.py
+++ b/scrapy/contrib/spidermiddleware/httperror.py
@@ -1,7 +1,9 @@
 import warnings
+
 from scrapy.exceptions import ScrapyDeprecationWarning
+
 warnings.warn("Module `scrapy.contrib.spidermiddleware.httperror` is deprecated, "
               "use `scrapy.spidermiddlewares.httperror` instead",
               ScrapyDeprecationWarning, stacklevel=2)
 
-from scrapy.spidermiddlewares.httperror import *
+from scrapy.spidermiddlewares.httperror import *  # isort:skip

--- a/scrapy/contrib/spidermiddleware/offsite.py
+++ b/scrapy/contrib/spidermiddleware/offsite.py
@@ -1,7 +1,9 @@
 import warnings
+
 from scrapy.exceptions import ScrapyDeprecationWarning
+
 warnings.warn("Module `scrapy.contrib.spidermiddleware.offsite` is deprecated, "
               "use `scrapy.spidermiddlewares.offsite` instead",
               ScrapyDeprecationWarning, stacklevel=2)
 
-from scrapy.spidermiddlewares.offsite import *
+from scrapy.spidermiddlewares.offsite import *  # isort:skip

--- a/scrapy/contrib/spidermiddleware/referer.py
+++ b/scrapy/contrib/spidermiddleware/referer.py
@@ -1,7 +1,9 @@
 import warnings
+
 from scrapy.exceptions import ScrapyDeprecationWarning
+
 warnings.warn("Module `scrapy.contrib.spidermiddleware.referer` is deprecated, "
               "use `scrapy.spidermiddlewares.referer` instead",
               ScrapyDeprecationWarning, stacklevel=2)
 
-from scrapy.spidermiddlewares.referer import *
+from scrapy.spidermiddlewares.referer import *  # isort:skip

--- a/scrapy/contrib/spidermiddleware/urllength.py
+++ b/scrapy/contrib/spidermiddleware/urllength.py
@@ -1,7 +1,9 @@
 import warnings
+
 from scrapy.exceptions import ScrapyDeprecationWarning
+
 warnings.warn("Module `scrapy.contrib.spidermiddleware.urllength` is deprecated, "
               "use `scrapy.spidermiddlewares.urllength` instead",
               ScrapyDeprecationWarning, stacklevel=2)
 
-from scrapy.spidermiddlewares.urllength import *
+from scrapy.spidermiddlewares.urllength import *  # isort:skip

--- a/scrapy/contrib/spiders/__init__.py
+++ b/scrapy/contrib/spiders/__init__.py
@@ -1,7 +1,9 @@
 import warnings
+
 from scrapy.exceptions import ScrapyDeprecationWarning
+
 warnings.warn("Module `scrapy.contrib.spiders` is deprecated, "
               "use `scrapy.spiders` instead",
               ScrapyDeprecationWarning, stacklevel=2)
 
-from scrapy.spiders import *
+from scrapy.spiders import *  # isort:skip

--- a/scrapy/contrib/spiders/crawl.py
+++ b/scrapy/contrib/spiders/crawl.py
@@ -1,7 +1,9 @@
 import warnings
+
 from scrapy.exceptions import ScrapyDeprecationWarning
+
 warnings.warn("Module `scrapy.contrib.spiders.crawl` is deprecated, "
               "use `scrapy.spiders.crawl` instead",
               ScrapyDeprecationWarning, stacklevel=2)
 
-from scrapy.spiders.crawl import *
+from scrapy.spiders.crawl import *  # isort:skip

--- a/scrapy/contrib/spiders/feed.py
+++ b/scrapy/contrib/spiders/feed.py
@@ -1,7 +1,9 @@
 import warnings
+
 from scrapy.exceptions import ScrapyDeprecationWarning
+
 warnings.warn("Module `scrapy.contrib.spiders.feed` is deprecated, "
               "use `scrapy.spiders.feed` instead",
               ScrapyDeprecationWarning, stacklevel=2)
 
-from scrapy.spiders.feed import *
+from scrapy.spiders.feed import *  # isort:skip

--- a/scrapy/contrib/spiders/init.py
+++ b/scrapy/contrib/spiders/init.py
@@ -1,7 +1,9 @@
 import warnings
+
 from scrapy.exceptions import ScrapyDeprecationWarning
+
 warnings.warn("Module `scrapy.contrib.spiders.init` is deprecated, "
               "use `scrapy.spiders.init` instead",
               ScrapyDeprecationWarning, stacklevel=2)
 
-from scrapy.spiders.init import *
+from scrapy.spiders.init import *  # isort:skip

--- a/scrapy/contrib/spiders/sitemap.py
+++ b/scrapy/contrib/spiders/sitemap.py
@@ -1,7 +1,9 @@
 import warnings
+
 from scrapy.exceptions import ScrapyDeprecationWarning
+
 warnings.warn("Module `scrapy.contrib.spiders.sitemap` is deprecated, "
               "use `scrapy.spiders.sitemap` instead",
               ScrapyDeprecationWarning, stacklevel=2)
 
-from scrapy.spiders.sitemap import *
+from scrapy.spiders.sitemap import *  # isort:skip

--- a/scrapy/contrib/spiderstate.py
+++ b/scrapy/contrib/spiderstate.py
@@ -1,7 +1,9 @@
 import warnings
+
 from scrapy.exceptions import ScrapyDeprecationWarning
+
 warnings.warn("Module `scrapy.contrib.spiderstate` is deprecated, "
               "use `scrapy.extensions.spiderstate` instead",
               ScrapyDeprecationWarning, stacklevel=2)
 
-from scrapy.extensions.spiderstate import *
+from scrapy.extensions.spiderstate import *  # isort:skip

--- a/scrapy/contrib/statsmailer.py
+++ b/scrapy/contrib/statsmailer.py
@@ -1,7 +1,9 @@
 import warnings
+
 from scrapy.exceptions import ScrapyDeprecationWarning
+
 warnings.warn("Module `scrapy.contrib.statsmailer` is deprecated, "
               "use `scrapy.extensions.statsmailer` instead",
               ScrapyDeprecationWarning, stacklevel=2)
 
-from scrapy.extensions.statsmailer import *
+from scrapy.extensions.statsmailer import *  # isort:skip

--- a/scrapy/contrib/throttle.py
+++ b/scrapy/contrib/throttle.py
@@ -1,7 +1,9 @@
 import warnings
+
 from scrapy.exceptions import ScrapyDeprecationWarning
+
 warnings.warn("Module `scrapy.contrib.throttle` is deprecated, "
               "use `scrapy.extensions.throttle` instead",
               ScrapyDeprecationWarning, stacklevel=2)
 
-from scrapy.extensions.throttle import *
+from scrapy.extensions.throttle import *  # isort:skip

--- a/scrapy/contrib_exp/downloadermiddleware/decompression.py
+++ b/scrapy/contrib_exp/downloadermiddleware/decompression.py
@@ -1,7 +1,9 @@
 import warnings
+
 from scrapy.exceptions import ScrapyDeprecationWarning
+
 warnings.warn("Module `scrapy.contrib_exp.downloadermiddleware.decompression` is deprecated, "
               "use `scrapy.downloadermiddlewares.decompression` instead",
     ScrapyDeprecationWarning, stacklevel=2)
 
-from scrapy.downloadermiddlewares.decompression import DecompressionMiddleware
+from scrapy.downloadermiddlewares.decompression import DecompressionMiddleware  # isort:skip

--- a/scrapy/contrib_exp/iterators.py
+++ b/scrapy/contrib_exp/iterators.py
@@ -1,6 +1,8 @@
 import warnings
+
 from scrapy.exceptions import ScrapyDeprecationWarning
+
 warnings.warn("Module `scrapy.contrib_exp.iterators` is deprecated, use `scrapy.utils.iterators` instead",
     ScrapyDeprecationWarning, stacklevel=2)
 
-from scrapy.utils.iterators import xmliter_lxml
+from scrapy.utils.iterators import xmliter_lxml  # isort:skip

--- a/scrapy/core/downloader/__init__.py
+++ b/scrapy/core/downloader/__init__.py
@@ -1,19 +1,21 @@
 from __future__ import absolute_import
+
 import random
 import warnings
-from time import time
-from datetime import datetime
 from collections import deque
+from datetime import datetime
+from time import time
 
 import six
-from twisted.internet import reactor, defer, task
+from twisted.internet import defer, reactor, task
 
+from scrapy import signals
+from scrapy.resolver import dnscache
 from scrapy.utils.defer import mustbe_deferred
 from scrapy.utils.httpobj import urlparse_cached
-from scrapy.resolver import dnscache
-from scrapy import signals
-from .middleware import DownloaderMiddlewareManager
+
 from .handlers import DownloadHandlers
+from .middleware import DownloaderMiddlewareManager
 
 
 class Slot(object):

--- a/scrapy/core/downloader/handlers/__init__.py
+++ b/scrapy/core/downloader/handlers/__init__.py
@@ -1,14 +1,15 @@
 """Download handlers for different schemes"""
 
 import logging
-from twisted.internet import defer
+
 import six
-from scrapy.exceptions import NotSupported, NotConfigured
+from twisted.internet import defer
+
+from scrapy import signals
+from scrapy.exceptions import NotConfigured, NotSupported
 from scrapy.utils.httpobj import urlparse_cached
 from scrapy.utils.misc import load_object
 from scrapy.utils.python import without_none_values
-from scrapy import signals
-
 
 logger = logging.getLogger(__name__)
 

--- a/scrapy/core/downloader/handlers/file.py
+++ b/scrapy/core/downloader/handlers/file.py
@@ -1,6 +1,8 @@
 from w3lib.url import file_uri_to_path
+
 from scrapy.responsetypes import responsetypes
 from scrapy.utils.decorators import defers
+
 
 class FileDownloadHandler(object):
 

--- a/scrapy/core/downloader/handlers/ftp.py
+++ b/scrapy/core/downloader/handlers/ftp.py
@@ -30,14 +30,15 @@ In case of status 200 request, response.headers will come with two keys:
 
 import re
 from io import BytesIO
-from six.moves.urllib.parse import urlparse, unquote
 
+from six.moves.urllib.parse import unquote, urlparse
 from twisted.internet import reactor
-from twisted.protocols.ftp import FTPClient, CommandFailed
-from twisted.internet.protocol import Protocol, ClientCreator
+from twisted.internet.protocol import ClientCreator, Protocol
+from twisted.protocols.ftp import CommandFailed, FTPClient
 
 from scrapy.http import Response
 from scrapy.responsetypes import responsetypes
+
 
 class ReceivedDataProtocol(Protocol):
     def __init__(self, filename=None):
@@ -101,4 +102,3 @@ class FTPDownloadHandler(object):
                 httpcode = self.CODE_MAPPING.get(ftpcode, self.CODE_MAPPING["default"])
                 return Response(url=request.url, status=httpcode, body=message)
         raise result.type(result.value)
-

--- a/scrapy/core/downloader/handlers/http.py
+++ b/scrapy/core/downloader/handlers/http.py
@@ -1,4 +1,5 @@
 from scrapy import twisted_version
+
 from .http10 import HTTP10DownloadHandler
 
 if twisted_version >= (11, 1, 0):

--- a/scrapy/core/downloader/handlers/http10.py
+++ b/scrapy/core/downloader/handlers/http10.py
@@ -1,6 +1,7 @@
 """Download handlers for http and https schemes
 """
 from twisted.internet import reactor
+
 from scrapy.utils.misc import load_object
 from scrapy.utils.python import to_unicode
 

--- a/scrapy/core/downloader/handlers/http11.py
+++ b/scrapy/core/downloader/handlers/http11.py
@@ -1,28 +1,27 @@
 """Download handlers for http and https schemes"""
 
-import re
 import logging
+import re
+import warnings
 from io import BytesIO
 from time import time
-import warnings
-from six.moves.urllib.parse import urldefrag
 
-from zope.interface import implementer
-from twisted.internet import defer, reactor, protocol
-from twisted.web.http_headers import Headers as TxHeaders
-from twisted.web.iweb import IBodyProducer, UNKNOWN_LENGTH
+from six.moves.urllib.parse import urldefrag
+from twisted.internet import defer, protocol, reactor
 from twisted.internet.error import TimeoutError
 from twisted.web.http import PotentialDataLoss
-from scrapy.xlib.tx import Agent, ProxyAgent, ResponseDone, \
-    HTTPConnectionPool, TCP4ClientEndpoint
+from twisted.web.http_headers import Headers as TxHeaders
+from twisted.web.iweb import UNKNOWN_LENGTH, IBodyProducer
+from zope.interface import implementer
 
+from scrapy import twisted_version
+from scrapy.core.downloader.tls import openssl_methods
+from scrapy.core.downloader.webclient import _parse
 from scrapy.http import Headers
 from scrapy.responsetypes import responsetypes
-from scrapy.core.downloader.webclient import _parse
-from scrapy.core.downloader.tls import openssl_methods
 from scrapy.utils.misc import load_object
 from scrapy.utils.python import to_bytes, to_unicode
-from scrapy import twisted_version
+from scrapy.xlib.tx import Agent, HTTPConnectionPool, ProxyAgent, ResponseDone, TCP4ClientEndpoint
 
 logger = logging.getLogger(__name__)
 

--- a/scrapy/core/downloader/handlers/s3.py
+++ b/scrapy/core/downloader/handlers/s3.py
@@ -1,8 +1,9 @@
 from six.moves.urllib.parse import unquote
 
 from scrapy.exceptions import NotConfigured
-from scrapy.utils.httpobj import urlparse_cached
 from scrapy.utils.boto import is_botocore
+from scrapy.utils.httpobj import urlparse_cached
+
 from .http import HTTPDownloadHandler
 
 

--- a/scrapy/core/downloader/middleware.py
+++ b/scrapy/core/downloader/middleware.py
@@ -4,13 +4,12 @@ Downloader Middleware manager
 See documentation in docs/topics/downloader-middleware.rst
 """
 import six
-
 from twisted.internet import defer
 
 from scrapy.http import Request, Response
 from scrapy.middleware import MiddlewareManager
-from scrapy.utils.defer import mustbe_deferred
 from scrapy.utils.conf import build_component_list
+from scrapy.utils.defer import mustbe_deferred
 
 
 class DownloaderMiddlewareManager(MiddlewareManager):

--- a/scrapy/core/downloader/tls.py
+++ b/scrapy/core/downloader/tls.py
@@ -1,6 +1,6 @@
 import logging
-from OpenSSL import SSL
 
+from OpenSSL import SSL
 
 logger = logging.getLogger(__name__)
 

--- a/scrapy/core/downloader/webclient.py
+++ b/scrapy/core/downloader/webclient.py
@@ -1,14 +1,14 @@
 from time import time
-from six.moves.urllib.parse import urlparse, urlunparse, urldefrag
 
+from six.moves.urllib.parse import urldefrag, urlparse, urlunparse
+from twisted.internet import defer
 from twisted.web.client import HTTPClientFactory
 from twisted.web.http import HTTPClient
-from twisted.internet import defer
 
 from scrapy.http import Headers
+from scrapy.responsetypes import responsetypes
 from scrapy.utils.httpobj import urlparse_cached
 from scrapy.utils.python import to_bytes
-from scrapy.responsetypes import responsetypes
 
 
 def _parsed_url_args(parsed):
@@ -157,4 +157,3 @@ class ScrapyHTTPClientFactory(HTTPClientFactory):
     def gotHeaders(self, headers):
         self.headers_time = time()
         self.response_headers = headers
-

--- a/scrapy/core/engine.py
+++ b/scrapy/core/engine.py
@@ -13,10 +13,10 @@ from twisted.python.failure import Failure
 from scrapy import signals
 from scrapy.core.scraper import Scraper
 from scrapy.exceptions import DontCloseSpider
-from scrapy.http import Response, Request
+from scrapy.http import Request, Response
+from scrapy.utils.log import failure_to_exc_info, logformatter_adapter
 from scrapy.utils.misc import load_object
 from scrapy.utils.reactor import CallLaterOnce
-from scrapy.utils.log import logformatter_adapter, failure_to_exc_info
 
 logger = logging.getLogger(__name__)
 

--- a/scrapy/core/scheduler.py
+++ b/scrapy/core/scheduler.py
@@ -1,11 +1,11 @@
-import os
 import json
 import logging
-from os.path import join, exists
+import os
+from os.path import exists, join
 
-from scrapy.utils.reqser import request_to_dict, request_from_dict
-from scrapy.utils.misc import load_object
 from scrapy.utils.job import job_dir
+from scrapy.utils.misc import load_object
+from scrapy.utils.reqser import request_from_dict, request_to_dict
 
 logger = logging.getLogger(__name__)
 

--- a/scrapy/core/scraper.py
+++ b/scrapy/core/scraper.py
@@ -4,19 +4,19 @@ extracts information from them"""
 import logging
 from collections import deque
 
-from twisted.python.failure import Failure
 from twisted.internet import defer
+from twisted.python.failure import Failure
 
-from scrapy.utils.defer import defer_result, defer_succeed, parallel, iter_errback
-from scrapy.utils.spider import iterate_spider_output
-from scrapy.utils.misc import load_object
-from scrapy.utils.log import logformatter_adapter, failure_to_exc_info
-from scrapy.exceptions import CloseSpider, DropItem, IgnoreRequest
 from scrapy import signals
+from scrapy.core.spidermw import SpiderMiddlewareManager
+from scrapy.exceptions import CloseSpider, DropItem, IgnoreRequest
 from scrapy.http import Request, Response
 from scrapy.item import BaseItem
-from scrapy.core.spidermw import SpiderMiddlewareManager
+from scrapy.utils.defer import defer_result, defer_succeed, iter_errback, parallel
+from scrapy.utils.log import failure_to_exc_info, logformatter_adapter
+from scrapy.utils.misc import load_object
 from scrapy.utils.request import referer_str
+from scrapy.utils.spider import iterate_spider_output
 
 logger = logging.getLogger(__name__)
 
@@ -238,4 +238,3 @@ class Scraper(object):
             return self.signals.send_catch_log_deferred(
                 signal=signals.item_scraped, item=output, response=response,
                 spider=spider)
-

--- a/scrapy/core/spidermw.py
+++ b/scrapy/core/spidermw.py
@@ -5,9 +5,11 @@ See documentation in docs/topics/spider-middleware.rst
 """
 import six
 from twisted.python.failure import Failure
+
 from scrapy.middleware import MiddlewareManager
-from scrapy.utils.defer import mustbe_deferred
 from scrapy.utils.conf import build_component_list
+from scrapy.utils.defer import mustbe_deferred
+
 
 def _isiterable(possible_iterator):
     return hasattr(possible_iterator, '__iter__')

--- a/scrapy/crawler.py
+++ b/scrapy/crawler.py
@@ -1,23 +1,23 @@
-import six
-import signal
 import logging
+import signal
+import sys
 import warnings
 
-import sys
-from twisted.internet import reactor, defer
-from zope.interface.verify import verifyClass, DoesNotImplement
+import six
+from twisted.internet import defer, reactor
+from zope.interface.verify import DoesNotImplement, verifyClass
 
+from scrapy import signals
 from scrapy.core.engine import ExecutionEngine
-from scrapy.resolver import CachingThreadedResolver
-from scrapy.interfaces import ISpiderLoader
+from scrapy.exceptions import ScrapyDeprecationWarning
 from scrapy.extension import ExtensionManager
+from scrapy.interfaces import ISpiderLoader
+from scrapy.resolver import CachingThreadedResolver
 from scrapy.settings import Settings
 from scrapy.signalmanager import SignalManager
-from scrapy.exceptions import ScrapyDeprecationWarning
-from scrapy.utils.ossignal import install_shutdown_handlers, signal_names
-from scrapy.utils.misc import load_object
 from scrapy.utils.log import LogCounterHandler, configure_logging, log_scrapy_info
-from scrapy import signals
+from scrapy.utils.misc import load_object
+from scrapy.utils.ossignal import install_shutdown_handlers, signal_names
 
 logger = logging.getLogger(__name__)
 

--- a/scrapy/downloadermiddlewares/ajaxcrawl.py
+++ b/scrapy/downloadermiddlewares/ajaxcrawl.py
@@ -1,14 +1,14 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import
-import re
+
 import logging
+import re
 
 import six
 from w3lib import html
 
 from scrapy.exceptions import NotConfigured
 from scrapy.http import HtmlResponse
-
 
 logger = logging.getLogger(__name__)
 

--- a/scrapy/downloadermiddlewares/cookies.py
+++ b/scrapy/downloadermiddlewares/cookies.py
@@ -1,7 +1,8 @@
-import os
-import six
 import logging
+import os
 from collections import defaultdict
+
+import six
 
 from scrapy.exceptions import NotConfigured
 from scrapy.http import Response

--- a/scrapy/downloadermiddlewares/decompression.py
+++ b/scrapy/downloadermiddlewares/decompression.py
@@ -4,19 +4,20 @@ and extract the potentially compressed responses that may arrive.
 
 import bz2
 import gzip
-import zipfile
-import tarfile
 import logging
+import tarfile
+import zipfile
 from tempfile import mktemp
 
 import six
+
+from scrapy.responsetypes import responsetypes
 
 try:
     from cStringIO import StringIO as BytesIO
 except ImportError:
     from io import BytesIO
 
-from scrapy.responsetypes import responsetypes
 
 logger = logging.getLogger(__name__)
 

--- a/scrapy/downloadermiddlewares/httpcache.py
+++ b/scrapy/downloadermiddlewares/httpcache.py
@@ -1,10 +1,13 @@
 from email.utils import formatdate
+
 from twisted.internet import defer
-from twisted.internet.error import TimeoutError, DNSLookupError, \
-        ConnectionRefusedError, ConnectionDone, ConnectError, \
-        ConnectionLost, TCPTimedOutError
+from twisted.internet.error import (
+    ConnectError, ConnectionDone, ConnectionLost, ConnectionRefusedError, DNSLookupError, TCPTimedOutError,
+    TimeoutError,
+)
+
 from scrapy import signals
-from scrapy.exceptions import NotConfigured, IgnoreRequest
+from scrapy.exceptions import IgnoreRequest, NotConfigured
 from scrapy.utils.misc import load_object
 from scrapy.xlib.tx import ResponseFailed
 

--- a/scrapy/downloadermiddlewares/httpcompression.py
+++ b/scrapy/downloadermiddlewares/httpcompression.py
@@ -1,9 +1,9 @@
 import zlib
 
-from scrapy.utils.gz import gunzip, is_gzipped
+from scrapy.exceptions import NotConfigured
 from scrapy.http import Response, TextResponse
 from scrapy.responsetypes import responsetypes
-from scrapy.exceptions import NotConfigured
+from scrapy.utils.gz import gunzip, is_gzipped
 
 
 class HttpCompressionMiddleware(object):
@@ -56,4 +56,3 @@ class HttpCompressionMiddleware(object):
                 # http://www.gzip.org/zlib/zlib_faq.html#faq38
                 body = zlib.decompress(body, -15)
         return body
-

--- a/scrapy/downloadermiddlewares/httpproxy.py
+++ b/scrapy/downloadermiddlewares/httpproxy.py
@@ -1,15 +1,17 @@
 import base64
+
+from six.moves.urllib.parse import unquote, urlunparse
 from six.moves.urllib.request import getproxies, proxy_bypass
-from six.moves.urllib.parse import unquote
+
+from scrapy.exceptions import NotConfigured
+from scrapy.utils.httpobj import urlparse_cached
+from scrapy.utils.python import to_bytes
+
 try:
     from urllib2 import _parse_proxy
 except ImportError:
     from urllib.request import _parse_proxy
-from six.moves.urllib.parse import urlunparse
 
-from scrapy.utils.httpobj import urlparse_cached
-from scrapy.exceptions import NotConfigured
-from scrapy.utils.python import to_bytes
 
 
 class HttpProxyMiddleware(object):

--- a/scrapy/downloadermiddlewares/redirect.py
+++ b/scrapy/downloadermiddlewares/redirect.py
@@ -1,11 +1,11 @@
 import logging
-from six.moves.urllib.parse import urljoin
 
+from six.moves.urllib.parse import urljoin
 from w3lib.url import safe_url_string
 
+from scrapy.exceptions import IgnoreRequest, NotConfigured
 from scrapy.http import HtmlResponse
 from scrapy.utils.response import get_meta_refresh
-from scrapy.exceptions import IgnoreRequest, NotConfigured
 
 logger = logging.getLogger(__name__)
 

--- a/scrapy/downloadermiddlewares/retry.py
+++ b/scrapy/downloadermiddlewares/retry.py
@@ -14,14 +14,15 @@ there is no more failed pages to retry this middleware sends a signal
 import logging
 
 from twisted.internet import defer
-from twisted.internet.error import TimeoutError, DNSLookupError, \
-        ConnectionRefusedError, ConnectionDone, ConnectError, \
-        ConnectionLost, TCPTimedOutError
+from twisted.internet.error import (
+    ConnectError, ConnectionDone, ConnectionLost, ConnectionRefusedError, DNSLookupError, TCPTimedOutError,
+    TimeoutError,
+)
 
+from scrapy.core.downloader.handlers.http11 import TunnelError
 from scrapy.exceptions import NotConfigured
 from scrapy.utils.response import response_status_message
 from scrapy.xlib.tx import ResponseFailed
-from scrapy.core.downloader.handlers.http11 import TunnelError
 
 logger = logging.getLogger(__name__)
 

--- a/scrapy/downloadermiddlewares/robotstxt.py
+++ b/scrapy/downloadermiddlewares/robotstxt.py
@@ -7,9 +7,9 @@ enable this middleware and enable the ROBOTSTXT_OBEY setting.
 import logging
 
 from six.moves.urllib import robotparser
-
 from twisted.internet.defer import Deferred, maybeDeferred
-from scrapy.exceptions import NotConfigured, IgnoreRequest
+
+from scrapy.exceptions import IgnoreRequest, NotConfigured
 from scrapy.http import Request
 from scrapy.utils.httpobj import urlparse_cached
 from scrapy.utils.log import failure_to_exc_info

--- a/scrapy/downloadermiddlewares/stats.py
+++ b/scrapy/downloadermiddlewares/stats.py
@@ -2,6 +2,7 @@ from scrapy.exceptions import NotConfigured
 from scrapy.utils.request import request_httprepr
 from scrapy.utils.response import response_httprepr
 
+
 class DownloaderStats(object):
 
     def __init__(self, stats):

--- a/scrapy/dupefilter.py
+++ b/scrapy/dupefilter.py
@@ -1,7 +1,9 @@
 import warnings
+
 from scrapy.exceptions import ScrapyDeprecationWarning
+
 warnings.warn("Module `scrapy.dupefilter` is deprecated, "
               "use `scrapy.dupefilters` instead",
               ScrapyDeprecationWarning, stacklevel=2)
 
-from scrapy.dupefilters import *
+from scrapy.dupefilters import *  # isort:skip

--- a/scrapy/dupefilters.py
+++ b/scrapy/dupefilters.py
@@ -1,6 +1,7 @@
 from __future__ import print_function
-import os
+
 import logging
+import os
 
 from scrapy.utils.job import job_dir
 from scrapy.utils.request import request_fingerprint

--- a/scrapy/exporters.py
+++ b/scrapy/exporters.py
@@ -4,19 +4,19 @@ Item Exporters are used to export/serialize items into different formats.
 
 import csv
 import io
-import sys
 import pprint
+import sys
+import warnings
+from xml.sax.saxutils import XMLGenerator
+
 import marshal
 import six
 from six.moves import cPickle as pickle
-from xml.sax.saxutils import XMLGenerator
 
-from scrapy.utils.serialize import ScrapyJSONEncoder
-from scrapy.utils.python import to_bytes, to_unicode, to_native_str, is_listlike
-from scrapy.item import BaseItem
 from scrapy.exceptions import ScrapyDeprecationWarning
-import warnings
-
+from scrapy.item import BaseItem
+from scrapy.utils.python import is_listlike, to_bytes, to_native_str, to_unicode
+from scrapy.utils.serialize import ScrapyJSONEncoder
 
 __all__ = ['BaseItemExporter', 'PprintItemExporter', 'PickleItemExporter',
            'CsvItemExporter', 'XmlItemExporter', 'JsonLinesItemExporter',

--- a/scrapy/extension.py
+++ b/scrapy/extension.py
@@ -6,6 +6,7 @@ See documentation in docs/topics/extensions.rst
 from scrapy.middleware import MiddlewareManager
 from scrapy.utils.conf import build_component_list
 
+
 class ExtensionManager(MiddlewareManager):
 
     component_name = 'extension'

--- a/scrapy/extensions/corestats.py
+++ b/scrapy/extensions/corestats.py
@@ -5,6 +5,7 @@ import datetime
 
 from scrapy import signals
 
+
 class CoreStats(object):
 
     def __init__(self, stats):

--- a/scrapy/extensions/debug.py
+++ b/scrapy/extensions/debug.py
@@ -4,11 +4,11 @@ Extensions for debugging Scrapy
 See documentation in docs/topics/extensions.rst
 """
 
-import sys
-import signal
 import logging
-import traceback
+import signal
+import sys
 import threading
+import traceback
 from pdb import Pdb
 
 from scrapy.utils.engine import format_engine_status

--- a/scrapy/extensions/feedexport.py
+++ b/scrapy/extensions/feedexport.py
@@ -4,27 +4,27 @@ Feed Exports extension
 See documentation in docs/topics/feed-exports.rst
 """
 
-import os
-import sys
 import logging
+import os
 import posixpath
-from tempfile import NamedTemporaryFile
+import sys
 from datetime import datetime
+from ftplib import FTP
+from tempfile import NamedTemporaryFile
+
 import six
 from six.moves.urllib.parse import urlparse
-from ftplib import FTP
-
-from zope.interface import Interface, implementer
 from twisted.internet import defer, threads
 from w3lib.url import file_uri_to_path
+from zope.interface import Interface, implementer
 
 from scrapy import signals
-from scrapy.utils.ftp import ftp_makedirs_cwd
 from scrapy.exceptions import NotConfigured
-from scrapy.utils.misc import load_object
-from scrapy.utils.log import failure_to_exc_info
-from scrapy.utils.python import without_none_values
 from scrapy.utils.boto import is_botocore
+from scrapy.utils.ftp import ftp_makedirs_cwd
+from scrapy.utils.log import failure_to_exc_info
+from scrapy.utils.misc import load_object
+from scrapy.utils.python import without_none_values
 
 logger = logging.getLogger(__name__)
 

--- a/scrapy/extensions/httpcache.py
+++ b/scrapy/extensions/httpcache.py
@@ -1,18 +1,21 @@
 from __future__ import print_function
-import os
+
 import gzip
-from six.moves import cPickle as pickle
+import os
+from email.utils import mktime_tz, parsedate_tz
 from importlib import import_module
 from time import time
 from weakref import WeakKeyDictionary
-from email.utils import mktime_tz, parsedate_tz
-from w3lib.http import headers_raw_to_dict, headers_dict_to_raw
+
+from six.moves import cPickle as pickle
+from w3lib.http import headers_dict_to_raw, headers_raw_to_dict
+
 from scrapy.http import Headers, Response
 from scrapy.responsetypes import responsetypes
-from scrapy.utils.request import request_fingerprint
-from scrapy.utils.project import data_path
 from scrapy.utils.httpobj import urlparse_cached
+from scrapy.utils.project import data_path
 from scrapy.utils.python import to_bytes, to_unicode
+from scrapy.utils.request import request_fingerprint
 
 
 class DummyPolicy(object):

--- a/scrapy/extensions/logstats.py
+++ b/scrapy/extensions/logstats.py
@@ -2,8 +2,8 @@ import logging
 
 from twisted.internet import task
 
-from scrapy.exceptions import NotConfigured
 from scrapy import signals
+from scrapy.exceptions import NotConfigured
 
 logger = logging.getLogger(__name__)
 

--- a/scrapy/extensions/memdebug.py
+++ b/scrapy/extensions/memdebug.py
@@ -5,6 +5,7 @@ See documentation in docs/topics/extensions.rst
 """
 
 import gc
+
 import six
 
 from scrapy import signals

--- a/scrapy/extensions/memusage.py
+++ b/scrapy/extensions/memusage.py
@@ -3,11 +3,11 @@ MemoryUsage extension
 
 See documentation in docs/topics/extensions.rst
 """
-import sys
-import socket
 import logging
-from pprint import pformat
+import socket
+import sys
 from importlib import import_module
+from pprint import pformat
 
 from twisted.internet import task
 

--- a/scrapy/extensions/spiderstate.py
+++ b/scrapy/extensions/spiderstate.py
@@ -1,9 +1,11 @@
 import os
+
 from six.moves import cPickle as pickle
 
 from scrapy import signals
 from scrapy.exceptions import NotConfigured
 from scrapy.utils.job import job_dir
+
 
 class SpiderState(object):
     """Store and load spider state during a scraping job"""

--- a/scrapy/extensions/statsmailer.py
+++ b/scrapy/extensions/statsmailer.py
@@ -5,8 +5,9 @@ Use STATSMAILER_RCPTS setting to enable and give the recipient mail address
 """
 
 from scrapy import signals
-from scrapy.mail import MailSender
 from scrapy.exceptions import NotConfigured
+from scrapy.mail import MailSender
+
 
 class StatsMailer(object):
 

--- a/scrapy/extensions/telnet.py
+++ b/scrapy/extensions/telnet.py
@@ -4,10 +4,17 @@ Scrapy Telnet Console extension
 See documentation in docs/topics/telnetconsole.rst
 """
 
-import pprint
 import logging
+import pprint
 
 from twisted.internet import protocol
+
+from scrapy import signals
+from scrapy.exceptions import NotConfigured
+from scrapy.utils.engine import print_engine_status
+from scrapy.utils.reactor import listen_tcp
+from scrapy.utils.trackref import print_live_refs
+
 try:
     from twisted.conch import manhole, telnet
     from twisted.conch.insults import insults
@@ -15,11 +22,6 @@ try:
 except ImportError:
     TWISTED_CONCH_AVAILABLE = False
 
-from scrapy.exceptions import NotConfigured
-from scrapy import signals
-from scrapy.utils.trackref import print_live_refs
-from scrapy.utils.engine import print_engine_status
-from scrapy.utils.reactor import listen_tcp
 
 try:
     import guppy

--- a/scrapy/extensions/throttle.py
+++ b/scrapy/extensions/throttle.py
@@ -1,7 +1,7 @@
 import logging
 
-from scrapy.exceptions import NotConfigured
 from scrapy import signals
+from scrapy.exceptions import NotConfigured
 
 logger = logging.getLogger(__name__)
 

--- a/scrapy/http/__init__.py
+++ b/scrapy/http/__init__.py
@@ -6,12 +6,10 @@ Request and Response outside this module.
 """
 
 from scrapy.http.headers import Headers
-
 from scrapy.http.request import Request
 from scrapy.http.request.form import FormRequest
 from scrapy.http.request.rpc import XmlRpcRequest
-
 from scrapy.http.response import Response
 from scrapy.http.response.html import HtmlResponse
-from scrapy.http.response.xml import XmlResponse
 from scrapy.http.response.text import TextResponse
+from scrapy.http.response.xml import XmlResponse

--- a/scrapy/http/cookies.py
+++ b/scrapy/http/cookies.py
@@ -1,7 +1,7 @@
 import time
-from six.moves.http_cookiejar import (
-    CookieJar as _CookieJar, DefaultCookiePolicy, IPV4_RE
-)
+
+from six.moves.http_cookiejar import IPV4_RE, CookieJar as _CookieJar, DefaultCookiePolicy
+
 from scrapy.utils.httpobj import urlparse_cached
 from scrapy.utils.python import to_native_str
 

--- a/scrapy/http/headers.py
+++ b/scrapy/http/headers.py
@@ -1,5 +1,6 @@
 import six
 from w3lib.http import headers_dict_to_raw
+
 from scrapy.utils.datatypes import CaselessDict
 from scrapy.utils.python import to_unicode
 
@@ -91,5 +92,3 @@ class Headers(CaselessDict):
     def __copy__(self):
         return self.__class__(self)
     copy = __copy__
-
-

--- a/scrapy/http/request/__init__.py
+++ b/scrapy/http/request/__init__.py
@@ -7,11 +7,11 @@ See documentation in docs/topics/request-response.rst
 import six
 from w3lib.url import safe_url_string
 
+from scrapy.http.common import obsolete_setter
 from scrapy.http.headers import Headers
 from scrapy.utils.python import to_bytes
 from scrapy.utils.trackref import object_ref
 from scrapy.utils.url import escape_ajax
-from scrapy.http.common import obsolete_setter
 
 
 class Request(object_ref):

--- a/scrapy/http/request/form.py
+++ b/scrapy/http/request/form.py
@@ -5,12 +5,13 @@ This module implements the FormRequest class which is a more convenient class
 See documentation in docs/topics/request-response.rst
 """
 
-from six.moves.urllib.parse import urljoin, urlencode
 import lxml.html
-from parsel.selector import create_root_node
 import six
+from parsel.selector import create_root_node
+from six.moves.urllib.parse import urlencode, urljoin
+
 from scrapy.http.request import Request
-from scrapy.utils.python import to_bytes, is_listlike
+from scrapy.utils.python import is_listlike, to_bytes
 from scrapy.utils.response import get_base_url
 
 

--- a/scrapy/http/request/rpc.py
+++ b/scrapy/http/request/rpc.py
@@ -9,7 +9,6 @@ from six.moves import xmlrpc_client as xmlrpclib
 from scrapy.http.request import Request
 from scrapy.utils.python import get_func_args
 
-
 DUMPS_ARGS = get_func_args(xmlrpclib.dumps)
 
 

--- a/scrapy/http/response/__init__.py
+++ b/scrapy/http/response/__init__.py
@@ -6,10 +6,10 @@ See documentation in docs/topics/request-response.rst
 """
 from six.moves.urllib.parse import urljoin
 
+from scrapy.exceptions import NotSupported
+from scrapy.http.common import obsolete_setter
 from scrapy.http.headers import Headers
 from scrapy.utils.trackref import object_ref
-from scrapy.http.common import obsolete_setter
-from scrapy.exceptions import NotSupported
 
 
 class Response(object_ref):

--- a/scrapy/http/response/html.py
+++ b/scrapy/http/response/html.py
@@ -7,5 +7,6 @@ See documentation in docs/topics/request-response.rst
 
 from scrapy.http.response.text import TextResponse
 
+
 class HtmlResponse(TextResponse):
     pass

--- a/scrapy/http/response/text.py
+++ b/scrapy/http/response/text.py
@@ -7,12 +7,11 @@ See documentation in docs/topics/request-response.rst
 
 import six
 from six.moves.urllib.parse import urljoin
+from w3lib.encoding import html_body_declared_encoding, html_to_unicode, http_content_type_encoding, resolve_encoding
 
-from w3lib.encoding import html_to_unicode, resolve_encoding, \
-    html_body_declared_encoding, http_content_type_encoding
 from scrapy.http.response import Response
-from scrapy.utils.response import get_base_url
 from scrapy.utils.python import memoizemethod_noargs, to_native_str
+from scrapy.utils.response import get_base_url
 
 
 class TextResponse(Response):

--- a/scrapy/http/response/xml.py
+++ b/scrapy/http/response/xml.py
@@ -7,5 +7,6 @@ See documentation in docs/topics/request-response.rst
 
 from scrapy.http.response.text import TextResponse
 
+
 class XmlResponse(TextResponse):
     pass

--- a/scrapy/interfaces.py
+++ b/scrapy/interfaces.py
@@ -1,5 +1,6 @@
 from zope.interface import Interface
 
+
 class ISpiderLoader(Interface):
 
     def from_settings(settings):

--- a/scrapy/item.py
+++ b/scrapy/item.py
@@ -4,10 +4,10 @@ Scrapy Item
 See documentation in docs/topics/item.rst
 """
 
-from pprint import pformat
-from collections import MutableMapping
-
 from abc import ABCMeta
+from collections import MutableMapping
+from pprint import pformat
+
 import six
 
 from scrapy.utils.trackref import object_ref

--- a/scrapy/link.py
+++ b/scrapy/link.py
@@ -5,6 +5,7 @@ For actual link extractors implementation see scrapy.linkextractors, or
 its documentation in: docs/topics/link-extractors.rst
 """
 import warnings
+
 import six
 
 from scrapy.utils.python import to_bytes
@@ -39,4 +40,3 @@ class Link(object):
     def __repr__(self):
         return 'Link(url=%r, text=%r, fragment=%r, nofollow=%r)' % \
             (self.url, self.text, self.fragment, self.nofollow)
-

--- a/scrapy/linkextractor.py
+++ b/scrapy/linkextractor.py
@@ -1,7 +1,9 @@
 import warnings
+
 from scrapy.exceptions import ScrapyDeprecationWarning
+
 warnings.warn("Module `scrapy.linkextractor` is deprecated, "
               "use `scrapy.linkextractors` instead",
               ScrapyDeprecationWarning, stacklevel=2)
 
-from scrapy.linkextractors import *
+from scrapy.linkextractors import *  # isort:skip

--- a/scrapy/linkextractors/__init__.py
+++ b/scrapy/linkextractors/__init__.py
@@ -7,15 +7,12 @@ For more info see docs/topics/link-extractors.rst
 """
 import re
 
-from six.moves.urllib.parse import urlparse
 from parsel.csstranslator import HTMLTranslator
+from six.moves.urllib.parse import urlparse
 from w3lib.url import canonicalize_url
 
 from scrapy.utils.misc import arg_to_iter
-from scrapy.utils.url import (
-    url_is_from_any_domain, url_has_any_extension,
-)
-
+from scrapy.utils.url import url_has_any_extension, url_is_from_any_domain
 
 # common file extensions that are not followed if they occur in links
 IGNORED_EXTENSIONS = [
@@ -110,4 +107,4 @@ class FilteringLinkExtractor(object):
 
 
 # Top-level imports
-from .lxmlhtml import LxmlLinkExtractor as LinkExtractor
+from .lxmlhtml import LxmlLinkExtractor as LinkExtractor  # isort:skip

--- a/scrapy/linkextractors/htmlparser.py
+++ b/scrapy/linkextractors/htmlparser.py
@@ -3,15 +3,15 @@ HTMLParser-based link extractor
 """
 
 import warnings
+
 import six
 from six.moves.html_parser import HTMLParser
 from six.moves.urllib.parse import urljoin
-
 from w3lib.url import safe_url_string
 
+from scrapy.exceptions import ScrapyDeprecationWarning
 from scrapy.link import Link
 from scrapy.utils.python import unique as unique_list
-from scrapy.exceptions import ScrapyDeprecationWarning
 
 
 class HtmlParserLinkExtractor(HTMLParser):

--- a/scrapy/linkextractors/lxmlhtml.py
+++ b/scrapy/linkextractors/lxmlhtml.py
@@ -1,17 +1,15 @@
 """
 Link extractor based on lxml.html
 """
-import six
-from six.moves.urllib.parse import urlparse, urljoin
-
 import lxml.etree as etree
+import six
+from six.moves.urllib.parse import urljoin, urlparse
 
 from scrapy.link import Link
-from scrapy.utils.misc import arg_to_iter, rel_has_nofollow
-from scrapy.utils.python import unique as unique_list, to_native_str
 from scrapy.linkextractors import FilteringLinkExtractor
+from scrapy.utils.misc import arg_to_iter, rel_has_nofollow
+from scrapy.utils.python import to_native_str, unique as unique_list
 from scrapy.utils.response import get_base_url
-
 
 # from lxml/src/lxml/html/__init__.py
 XHTML_NAMESPACE = "http://www.w3.org/1999/xhtml"

--- a/scrapy/linkextractors/regex.py
+++ b/scrapy/linkextractors/regex.py
@@ -1,9 +1,10 @@
 import re
-from six.moves.urllib.parse import urljoin
 
-from w3lib.html import remove_tags, replace_entities, replace_escape_chars, get_base_url
+from six.moves.urllib.parse import urljoin
+from w3lib.html import get_base_url, remove_tags, replace_entities, replace_escape_chars
 
 from scrapy.link import Link
+
 from .sgml import SgmlLinkExtractor
 
 linkre = re.compile(

--- a/scrapy/linkextractors/sgml.py
+++ b/scrapy/linkextractors/sgml.py
@@ -1,19 +1,20 @@
 """
 SGMLParser-based Link extractors
 """
-import six
-from six.moves.urllib.parse import urljoin
 import warnings
-from sgmllib import SGMLParser
 
+import six
+from sgmllib import SGMLParser
+from six.moves.urllib.parse import urljoin
 from w3lib.url import safe_url_string
-from scrapy.selector import Selector
+
+from scrapy.exceptions import ScrapyDeprecationWarning
 from scrapy.link import Link
 from scrapy.linkextractors import FilteringLinkExtractor
+from scrapy.selector import Selector
 from scrapy.utils.misc import arg_to_iter, rel_has_nofollow
-from scrapy.utils.python import unique as unique_list, to_unicode
+from scrapy.utils.python import to_unicode, unique as unique_list
 from scrapy.utils.response import get_base_url
-from scrapy.exceptions import ScrapyDeprecationWarning
 
 
 class BaseSgmlLinkExtractor(SGMLParser):

--- a/scrapy/loader/__init__.py
+++ b/scrapy/loader/__init__.py
@@ -4,6 +4,7 @@ See documentation in docs/topics/loaders.rst
 
 """
 from collections import defaultdict
+
 import six
 
 from scrapy.item import Item

--- a/scrapy/loader/common.py
+++ b/scrapy/loader/common.py
@@ -1,7 +1,9 @@
 """Common functions used in Item Loaders code"""
 
 from functools import partial
+
 from scrapy.utils.python import get_func_args
+
 
 def wrap_loader_context(function, context):
     """Wrap functions that receive loader_context to contain the context

--- a/scrapy/loader/processors.py
+++ b/scrapy/loader/processors.py
@@ -4,8 +4,9 @@ This module provides some commonly used processors for Item Loaders.
 See documentation in docs/topics/loaders.rst
 """
 
-from scrapy.utils.misc import arg_to_iter
 from scrapy.utils.datatypes import MergeDict
+from scrapy.utils.misc import arg_to_iter
+
 from .common import wrap_loader_context
 
 

--- a/scrapy/logformatter.py
+++ b/scrapy/logformatter.py
@@ -1,5 +1,5 @@
-import os
 import logging
+import os
 
 from twisted.python.failure import Failure
 

--- a/scrapy/mail.py
+++ b/scrapy/mail.py
@@ -4,14 +4,15 @@ Mail sending helpers
 See documentation in docs/topics/email.rst
 """
 import logging
-
-from six.moves import cStringIO as StringIO
-import six
-
 from email.utils import COMMASPACE, formatdate
+
+import six
+from six.moves import cStringIO as StringIO
+from six.moves.email_mime_base import MIMEBase
 from six.moves.email_mime_multipart import MIMEMultipart
 from six.moves.email_mime_text import MIMEText
-from six.moves.email_mime_base import MIMEBase
+from twisted.internet import defer, reactor, ssl
+
 if six.PY2:
     from email.MIMENonMultipart import MIMENonMultipart
     from email import Encoders
@@ -19,7 +20,6 @@ else:
     from email.mime.nonmultipart import MIMENonMultipart
     from email import encoders as Encoders
 
-from twisted.internet import defer, reactor, ssl
 
 logger = logging.getLogger(__name__)
 

--- a/scrapy/middleware.py
+++ b/scrapy/middleware.py
@@ -1,10 +1,10 @@
-from collections import defaultdict
 import logging
 import pprint
+from collections import defaultdict
 
 from scrapy.exceptions import NotConfigured
+from scrapy.utils.defer import process_chain, process_chain_both, process_parallel
 from scrapy.utils.misc import load_object
-from scrapy.utils.defer import process_parallel, process_chain, process_chain_both
 
 logger = logging.getLogger(__name__)
 

--- a/scrapy/pipelines/__init__.py
+++ b/scrapy/pipelines/__init__.py
@@ -7,6 +7,7 @@ See documentation in docs/item-pipeline.rst
 from scrapy.middleware import MiddlewareManager
 from scrapy.utils.conf import build_component_list
 
+
 class ItemPipelineManager(MiddlewareManager):
 
     component_name = 'item pipeline'

--- a/scrapy/pipelines/files.py
+++ b/scrapy/pipelines/files.py
@@ -5,32 +5,34 @@ See documentation in topics/media-pipeline.rst
 """
 import functools
 import hashlib
+import logging
 import os
 import os.path
 import time
-import logging
-from email.utils import parsedate_tz, mktime_tz
-from six.moves.urllib.parse import urlparse
 from collections import defaultdict
+from email.utils import mktime_tz, parsedate_tz
+
 import six
+from six.moves.urllib.parse import urlparse
+from twisted.internet import defer, threads
+
+from scrapy.exceptions import IgnoreRequest, NotConfigured
+from scrapy.http import Request
+from scrapy.pipelines.media import MediaPipeline
+from scrapy.settings import Settings
+from scrapy.utils.boto import is_botocore
+from scrapy.utils.datatypes import CaselessDict
+from scrapy.utils.log import failure_to_exc_info
+from scrapy.utils.misc import md5sum
+from scrapy.utils.python import to_bytes
+from scrapy.utils.request import referer_str
 
 try:
     from cStringIO import StringIO as BytesIO
 except ImportError:
     from io import BytesIO
 
-from twisted.internet import defer, threads
 
-from scrapy.pipelines.media import MediaPipeline
-from scrapy.settings import Settings
-from scrapy.exceptions import NotConfigured, IgnoreRequest
-from scrapy.http import Request
-from scrapy.utils.misc import md5sum
-from scrapy.utils.log import failure_to_exc_info
-from scrapy.utils.python import to_bytes
-from scrapy.utils.request import referer_str
-from scrapy.utils.boto import is_botocore
-from scrapy.utils.datatypes import CaselessDict
 
 logger = logging.getLogger(__name__)
 

--- a/scrapy/pipelines/images.py
+++ b/scrapy/pipelines/images.py
@@ -5,22 +5,24 @@ See documentation in topics/media-pipeline.rst
 """
 import functools
 import hashlib
+
 import six
+from PIL import Image
+
+from scrapy.exceptions import DropItem
+from scrapy.http import Request
+#TODO: from scrapy.pipelines.media import MediaPipeline
+from scrapy.pipelines.files import FileException, FilesPipeline
+from scrapy.settings import Settings
+from scrapy.utils.misc import md5sum
+from scrapy.utils.python import to_bytes
 
 try:
     from cStringIO import StringIO as BytesIO
 except ImportError:
     from io import BytesIO
 
-from PIL import Image
 
-from scrapy.utils.misc import md5sum
-from scrapy.utils.python import to_bytes
-from scrapy.http import Request
-from scrapy.settings import Settings
-from scrapy.exceptions import DropItem
-#TODO: from scrapy.pipelines.media import MediaPipeline
-from scrapy.pipelines.files import FileException, FilesPipeline
 
 
 class NoimagesDrop(DropItem):

--- a/scrapy/pipelines/media.py
+++ b/scrapy/pipelines/media.py
@@ -2,13 +2,14 @@ from __future__ import print_function
 
 import logging
 from collections import defaultdict
+
 from twisted.internet.defer import Deferred, DeferredList
 from twisted.python.failure import Failure
 
-from scrapy.utils.defer import mustbe_deferred, defer_result
-from scrapy.utils.request import request_fingerprint
-from scrapy.utils.misc import arg_to_iter
+from scrapy.utils.defer import defer_result, mustbe_deferred
 from scrapy.utils.log import failure_to_exc_info
+from scrapy.utils.misc import arg_to_iter
+from scrapy.utils.request import request_fingerprint
 
 logger = logging.getLogger(__name__)
 

--- a/scrapy/responsetypes.py
+++ b/scrapy/responsetypes.py
@@ -3,9 +3,11 @@ This module implements a class which returns the appropriate Response class
 based on different criteria.
 """
 from __future__ import absolute_import
+
+from io import StringIO
 from mimetypes import MimeTypes
 from pkgutil import get_data
-from io import StringIO
+
 import six
 
 from scrapy.http import Response

--- a/scrapy/selector/__init__.py
+++ b/scrapy/selector/__init__.py
@@ -1,5 +1,5 @@
 """
 Selectors
 """
-from scrapy.selector.unified import *
 from scrapy.selector.lxmlsel import *
+from scrapy.selector.unified import *

--- a/scrapy/selector/csstranslator.py
+++ b/scrapy/selector/csstranslator.py
@@ -1,6 +1,6 @@
-from parsel.csstranslator import XPathExpr, GenericTranslator, HTMLTranslator
-from scrapy.utils.deprecate import create_deprecated_class
+from parsel.csstranslator import GenericTranslator, HTMLTranslator, XPathExpr
 
+from scrapy.utils.deprecate import create_deprecated_class
 
 ScrapyXPathExpr = create_deprecated_class(
     'ScrapyXPathExpr', XPathExpr,

--- a/scrapy/selector/lxmlsel.py
+++ b/scrapy/selector/lxmlsel.py
@@ -2,8 +2,8 @@
 XPath selectors based on lxml
 """
 from scrapy.utils.deprecate import create_deprecated_class
-from .unified import Selector, SelectorList
 
+from .unified import Selector, SelectorList
 
 __all__ = ['HtmlXPathSelector', 'XmlXPathSelector', 'XPathSelector',
            'XPathSelectorList']

--- a/scrapy/selector/unified.py
+++ b/scrapy/selector/unified.py
@@ -3,13 +3,14 @@ XPath selectors based on lxml
 """
 
 import warnings
+
 from parsel import Selector as _ParselSelector
-from scrapy.utils.trackref import object_ref
-from scrapy.utils.python import to_bytes
+
+from scrapy.exceptions import ScrapyDeprecationWarning
 from scrapy.http import HtmlResponse, XmlResponse
 from scrapy.utils.decorators import deprecated
-from scrapy.exceptions import ScrapyDeprecationWarning
-
+from scrapy.utils.python import to_bytes
+from scrapy.utils.trackref import object_ref
 
 __all__ = ['Selector', 'SelectorList']
 

--- a/scrapy/settings/__init__.py
+++ b/scrapy/settings/__init__.py
@@ -1,16 +1,16 @@
-import six
-import json
 import copy
+import json
 import warnings
 from collections import MutableMapping
 from importlib import import_module
 from pprint import pformat
 
-from scrapy.utils.deprecate import create_deprecated_class
+import six
+
 from scrapy.exceptions import ScrapyDeprecationWarning
+from scrapy.utils.deprecate import create_deprecated_class
 
 from . import default_settings
-
 
 SETTINGS_PRIORITIES = {
     'default': 0,

--- a/scrapy/settings/default_settings.py
+++ b/scrapy/settings/default_settings.py
@@ -16,7 +16,7 @@ Scrapy developers, if you add a setting here remember to:
 import os
 import sys
 from importlib import import_module
-from os.path import join, abspath, dirname
+from os.path import abspath, dirname, join
 
 import six
 

--- a/scrapy/settings/deprecated.py
+++ b/scrapy/settings/deprecated.py
@@ -1,4 +1,5 @@
 import warnings
+
 from scrapy.exceptions import ScrapyDeprecationWarning
 
 DEPRECATED_SETTINGS = [

--- a/scrapy/shell.py
+++ b/scrapy/shell.py
@@ -9,7 +9,7 @@ import os
 import signal
 import warnings
 
-from twisted.internet import reactor, threads, defer
+from twisted.internet import defer, reactor, threads
 from twisted.python import threadable
 from w3lib.url import any_to_uri
 
@@ -19,11 +19,10 @@ from scrapy.http import Request, Response
 from scrapy.item import BaseItem
 from scrapy.settings import Settings
 from scrapy.spiders import Spider
-from scrapy.utils.console import start_python_console
+from scrapy.utils.conf import get_config
+from scrapy.utils.console import DEFAULT_PYTHON_SHELLS, start_python_console
 from scrapy.utils.misc import load_object
 from scrapy.utils.response import open_in_browser
-from scrapy.utils.conf import get_config
-from scrapy.utils.console import DEFAULT_PYTHON_SHELLS
 
 
 class Shell(object):

--- a/scrapy/signalmanager.py
+++ b/scrapy/signalmanager.py
@@ -1,5 +1,7 @@
 from __future__ import absolute_import
+
 from pydispatch import dispatcher
+
 from scrapy.utils import signal as _signal
 
 

--- a/scrapy/spider.py
+++ b/scrapy/spider.py
@@ -1,7 +1,9 @@
 import warnings
+
 from scrapy.exceptions import ScrapyDeprecationWarning
+
 warnings.warn("Module `scrapy.spider` is deprecated, "
               "use `scrapy.spiders` instead",
               ScrapyDeprecationWarning, stacklevel=2)
 
-from scrapy.spiders import *
+from scrapy.spiders import *  # isort:skip

--- a/scrapy/spidermiddlewares/offsite.py
+++ b/scrapy/spidermiddlewares/offsite.py
@@ -4,8 +4,8 @@ Offsite Spider Middleware
 See documentation in docs/topics/spider-middleware.rst
 """
 
-import re
 import logging
+import re
 
 from scrapy import signals
 from scrapy.http import Request

--- a/scrapy/spidermiddlewares/referer.py
+++ b/scrapy/spidermiddlewares/referer.py
@@ -3,8 +3,9 @@ RefererMiddleware: populates Request referer field, based on the Response which
 originated it.
 """
 
-from scrapy.http import Request
 from scrapy.exceptions import NotConfigured
+from scrapy.http import Request
+
 
 class RefererMiddleware(object):
 
@@ -20,4 +21,3 @@ class RefererMiddleware(object):
                 r.headers.setdefault('Referer', response.url)
             return r
         return (_set_referer(r) for r in result or ())
-

--- a/scrapy/spidermiddlewares/urllength.py
+++ b/scrapy/spidermiddlewares/urllength.py
@@ -6,8 +6,8 @@ See documentation in docs/topics/spider-middleware.rst
 
 import logging
 
-from scrapy.http import Request
 from scrapy.exceptions import NotConfigured
+from scrapy.http import Request
 
 logger = logging.getLogger(__name__)
 

--- a/scrapy/spiders/__init__.py
+++ b/scrapy/spiders/__init__.py
@@ -7,11 +7,11 @@ import logging
 import warnings
 
 from scrapy import signals
+from scrapy.exceptions import ScrapyDeprecationWarning
 from scrapy.http import Request
+from scrapy.utils.deprecate import create_deprecated_class
 from scrapy.utils.trackref import object_ref
 from scrapy.utils.url import url_is_from_spider
-from scrapy.utils.deprecate import create_deprecated_class
-from scrapy.exceptions import ScrapyDeprecationWarning
 
 
 class Spider(object_ref):
@@ -112,6 +112,6 @@ spiders = ObsoleteClass(
 )
 
 # Top-level imports
-from scrapy.spiders.crawl import CrawlSpider, Rule
-from scrapy.spiders.feed import XMLFeedSpider, CSVFeedSpider
-from scrapy.spiders.sitemap import SitemapSpider
+from scrapy.spiders.crawl import CrawlSpider, Rule  # isort:skip
+from scrapy.spiders.feed import CSVFeedSpider, XMLFeedSpider  # isort:skip
+from scrapy.spiders.sitemap import SitemapSpider  # isort:skip

--- a/scrapy/spiders/crawl.py
+++ b/scrapy/spiders/crawl.py
@@ -6,11 +6,12 @@ See documentation in docs/topics/spiders.rst
 """
 
 import copy
+
 import six
 
-from scrapy.http import Request, HtmlResponse
-from scrapy.utils.spider import iterate_spider_output
+from scrapy.http import HtmlResponse, Request
 from scrapy.spiders import Spider
+from scrapy.utils.spider import iterate_spider_output
 
 
 def identity(x):

--- a/scrapy/spiders/feed.py
+++ b/scrapy/spiders/feed.py
@@ -4,11 +4,11 @@ for scraping from an XML feed.
 
 See documentation in docs/topics/spiders.rst
 """
-from scrapy.spiders import Spider
-from scrapy.utils.iterators import xmliter, csviter
-from scrapy.utils.spider import iterate_spider_output
-from scrapy.selector import Selector
 from scrapy.exceptions import NotConfigured, NotSupported
+from scrapy.selector import Selector
+from scrapy.spiders import Spider
+from scrapy.utils.iterators import csviter, xmliter
+from scrapy.utils.spider import iterate_spider_output
 
 
 class XMLFeedSpider(Spider):
@@ -133,4 +133,3 @@ class CSVFeedSpider(Spider):
             raise NotConfigured('You must define parse_row method in order to scrape this CSV feed')
         response = self.adapt_response(response)
         return self.parse_rows(response)
-

--- a/scrapy/spiders/init.py
+++ b/scrapy/spiders/init.py
@@ -29,4 +29,3 @@ class InitSpider(Spider):
         spider
         """
         return self.initialized()
-

--- a/scrapy/spiders/sitemap.py
+++ b/scrapy/spiders/sitemap.py
@@ -1,11 +1,12 @@
-import re
 import logging
+import re
+
 import six
 
-from scrapy.spiders import Spider
 from scrapy.http import Request, XmlResponse
-from scrapy.utils.sitemap import Sitemap, sitemap_urls_from_robots
+from scrapy.spiders import Spider
 from scrapy.utils.gz import gunzip, is_gzipped
+from scrapy.utils.sitemap import Sitemap, sitemap_urls_from_robots
 
 logger = logging.getLogger(__name__)
 

--- a/scrapy/squeue.py
+++ b/scrapy/squeue.py
@@ -1,7 +1,9 @@
 import warnings
+
 from scrapy.exceptions import ScrapyDeprecationWarning
+
 warnings.warn("Module `scrapy.squeue` is deprecated, "
               "use `scrapy.squeues` instead",
               ScrapyDeprecationWarning, stacklevel=2)
 
-from scrapy.squeues import *
+from scrapy.squeues import *  # isort:skip

--- a/scrapy/squeues.py
+++ b/scrapy/squeues.py
@@ -3,9 +3,9 @@ Scheduler queues
 """
 
 import marshal
+from queuelib import queue
 from six.moves import cPickle as pickle
 
-from queuelib import queue
 
 def _serializable_queue(queue_class, serialize, deserialize):
 

--- a/scrapy/statscol.py
+++ b/scrapy/statscol.py
@@ -1,7 +1,9 @@
 import warnings
+
 from scrapy.exceptions import ScrapyDeprecationWarning
+
 warnings.warn("Module `scrapy.statscol` is deprecated, "
               "use `scrapy.statscollectors` instead",
               ScrapyDeprecationWarning, stacklevel=2)
 
-from scrapy.statscollectors import *
+from scrapy.statscollectors import *  # isort:skip

--- a/scrapy/statscollectors.py
+++ b/scrapy/statscollectors.py
@@ -1,8 +1,8 @@
 """
 Scrapy extension for collecting scraping stats
 """
-import pprint
 import logging
+import pprint
 
 logger = logging.getLogger(__name__)
 
@@ -80,5 +80,3 @@ class DummyStatsCollector(StatsCollector):
 
     def min_value(self, key, value, spider=None):
         pass
-
-

--- a/scrapy/telnet.py
+++ b/scrapy/telnet.py
@@ -1,7 +1,9 @@
 import warnings
+
 from scrapy.exceptions import ScrapyDeprecationWarning
+
 warnings.warn("Module `scrapy.telnet` is deprecated, "
               "use `scrapy.extensions.telnet` instead",
               ScrapyDeprecationWarning, stacklevel=2)
 
-from scrapy.extensions.telnet import *
+from scrapy.extensions.telnet import *  # isort:skip

--- a/scrapy/utils/benchserver.py
+++ b/scrapy/utils/benchserver.py
@@ -1,8 +1,9 @@
 import random
+
 from six.moves.urllib.parse import urlencode
-from twisted.web.server import Site
-from twisted.web.resource import Resource
 from twisted.internet import reactor
+from twisted.web.resource import Resource
+from twisted.web.server import Site
 
 
 class Root(Resource):

--- a/scrapy/utils/boto.py
+++ b/scrapy/utils/boto.py
@@ -1,6 +1,7 @@
 """Boto/botocore helpers"""
 
 from __future__ import absolute_import
+
 import six
 
 from scrapy.exceptions import NotConfigured

--- a/scrapy/utils/console.py
+++ b/scrapy/utils/console.py
@@ -1,5 +1,6 @@
-from functools import wraps
 from collections import OrderedDict
+from functools import wraps
+
 
 def _embed_ipython_shell(namespace={}, banner=''):
     """Start an IPython Shell"""

--- a/scrapy/utils/datatypes.py
+++ b/scrapy/utils/datatypes.py
@@ -6,9 +6,10 @@ This module must not depend on any module outside the Standard Library.
 """
 
 import copy
-import six
 import warnings
 from collections import OrderedDict
+
+import six
 
 from scrapy.exceptions import ScrapyDeprecationWarning
 

--- a/scrapy/utils/decorator.py
+++ b/scrapy/utils/decorator.py
@@ -1,7 +1,9 @@
 import warnings
+
 from scrapy.exceptions import ScrapyDeprecationWarning
+
 warnings.warn("Module `scrapy.utils.decorator` is deprecated, "
               "use `scrapy.utils.decorators` instead",
               ScrapyDeprecationWarning, stacklevel=2)
 
-from scrapy.utils.decorators import *
+from scrapy.utils.decorators import *  # isort:skip

--- a/scrapy/utils/defer.py
+++ b/scrapy/utils/defer.py
@@ -7,6 +7,7 @@ from twisted.python import failure
 
 from scrapy.exceptions import IgnoreRequest
 
+
 def defer_fail(_failure):
     """Same as twisted.internet.defer.fail but delay calling errback until
     next reactor loop

--- a/scrapy/utils/deprecate.py
+++ b/scrapy/utils/deprecate.py
@@ -1,7 +1,8 @@
 """Some helpers for deprecation messages"""
 
-import warnings
 import inspect
+import warnings
+
 from scrapy.exceptions import ScrapyDeprecationWarning
 
 

--- a/scrapy/utils/display.py
+++ b/scrapy/utils/display.py
@@ -3,8 +3,10 @@ pprint and pformat wrappers with colorization support
 """
 
 from __future__ import print_function
+
 import sys
 from pprint import pformat as pformat_
+
 
 def _colorize(text, colorize=True):
     if not colorize or not sys.stdout.isatty():

--- a/scrapy/utils/engine.py
+++ b/scrapy/utils/engine.py
@@ -1,7 +1,9 @@
 """Some debugging functions for working with the Scrapy engine"""
 
 from __future__ import print_function
-from time import time # used in global tests code
+
+from time import time  # used in global tests code
+
 
 def get_engine_status(engine):
     """Return a report of the current engine status"""

--- a/scrapy/utils/ftp.py
+++ b/scrapy/utils/ftp.py
@@ -1,6 +1,7 @@
 from ftplib import error_perm
 from posixpath import dirname
 
+
 def ftp_makedirs_cwd(ftp, path, first_call=True):
     """Set the current directory of the FTP connection given in the `ftp`
     argument (as a ftplib.FTP object), creating all parent directories if they

--- a/scrapy/utils/gz.py
+++ b/scrapy/utils/gz.py
@@ -1,13 +1,14 @@
+import re
 import struct
+from gzip import GzipFile
+
+import six
 
 try:
     from cStringIO import StringIO as BytesIO
 except ImportError:
     from io import BytesIO
-from gzip import GzipFile
 
-import six
-import re
 
 # - Python>=3.5 GzipFile's read() has issues returning leftover
 #   uncompressed data when input is corrupted

--- a/scrapy/utils/http.py
+++ b/scrapy/utils/http.py
@@ -6,6 +6,7 @@ For new code, always import from w3lib.http instead of this module
 
 from w3lib.http import *
 
+
 def decode_chunked_transfer(chunked_body):
     """Parsed body received with chunked transfer encoding, and return the
     decoded body.
@@ -23,4 +24,3 @@ def decode_chunked_transfer(chunked_body):
         body += t[:size]
         t = t[size+2:]
     return body
-

--- a/scrapy/utils/iterators.py
+++ b/scrapy/utils/iterators.py
@@ -1,16 +1,19 @@
-import re
 import csv
 import logging
+import re
+from io import StringIO
+
+import six
+
+from scrapy.http import Response, TextResponse
+from scrapy.selector import Selector
+from scrapy.utils.python import re_rsearch, to_unicode
+
 try:
     from cStringIO import StringIO as BytesIO
 except ImportError:
     from io import BytesIO
-from io import StringIO
-import six
 
-from scrapy.http import TextResponse, Response
-from scrapy.selector import Selector
-from scrapy.utils.python import re_rsearch, to_unicode
 
 logger = logging.getLogger(__name__)
 

--- a/scrapy/utils/job.py
+++ b/scrapy/utils/job.py
@@ -1,5 +1,6 @@
 import os
 
+
 def job_dir(settings):
     path = settings['JOBDIR']
     if path and not os.path.exists(path):

--- a/scrapy/utils/log.py
+++ b/scrapy/utils/log.py
@@ -1,16 +1,16 @@
 # -*- coding: utf-8 -*-
 
-import sys
 import logging
+import sys
 import warnings
 from logging.config import dictConfig
 
-from twisted.python.failure import Failure
 from twisted.python import log as twisted_log
+from twisted.python.failure import Failure
 
 import scrapy
-from scrapy.settings import overridden_settings, Settings
 from scrapy.exceptions import ScrapyDeprecationWarning
+from scrapy.settings import Settings, overridden_settings
 
 logger = logging.getLogger(__name__)
 

--- a/scrapy/utils/misc.py
+++ b/scrapy/utils/misc.py
@@ -1,15 +1,14 @@
 """Helper functions which don't fit anywhere else"""
-import re
 import hashlib
+import re
 from importlib import import_module
 from pkgutil import iter_modules
 
 import six
 from w3lib.html import replace_entities
 
-from scrapy.utils.python import flatten, to_unicode
 from scrapy.item import BaseItem
-
+from scrapy.utils.python import flatten, to_unicode
 
 _ITERABLE_SINGLE_VALUES = dict, BaseItem, six.text_type, bytes
 
@@ -116,4 +115,3 @@ def md5sum(file):
 def rel_has_nofollow(rel):
     """Return True if link rel attribute has nofollow type"""
     return True if rel is not None and 'nofollow' in rel.split() else False
-    

--- a/scrapy/utils/ossignal.py
+++ b/scrapy/utils/ossignal.py
@@ -1,9 +1,9 @@
 
 from __future__ import absolute_import
 
-from twisted.internet import reactor
-
 import signal
+
+from twisted.internet import reactor
 
 signal_names = {}
 for signame in dir(signal):

--- a/scrapy/utils/project.py
+++ b/scrapy/utils/project.py
@@ -1,13 +1,13 @@
 import os
-from six.moves import cPickle as pickle
 import warnings
-
 from importlib import import_module
-from os.path import join, dirname, abspath, isabs, exists
+from os.path import abspath, dirname, exists, isabs, join
 
-from scrapy.utils.conf import closest_scrapy_cfg, get_config, init_env
-from scrapy.settings import Settings
+from six.moves import cPickle as pickle
+
 from scrapy.exceptions import NotConfigured
+from scrapy.settings import Settings
+from scrapy.utils.conf import closest_scrapy_cfg, get_config, init_env
 
 ENVVAR = 'SCRAPY_SETTINGS_MODULE'
 DATADIR_CFG_SECTION = 'datadir'

--- a/scrapy/utils/python.py
+++ b/scrapy/utils/python.py
@@ -1,13 +1,14 @@
 """
 This module contains essential stuff that should've come with Python itself ;)
 """
+import errno
+import inspect
 import os
 import re
-import inspect
 import weakref
-import errno
-import six
 from functools import partial, wraps
+
+import six
 
 from scrapy.utils.decorators import deprecated
 

--- a/scrapy/utils/reactor.py
+++ b/scrapy/utils/reactor.py
@@ -1,4 +1,5 @@
-from twisted.internet import reactor, error
+from twisted.internet import error, reactor
+
 
 def listen_tcp(portrange, host, factory):
     """Like reactor.listenTCP but tries different ports in a range."""

--- a/scrapy/utils/reqser.py
+++ b/scrapy/utils/reqser.py
@@ -4,7 +4,7 @@ Helper functions for serializing (and deserializing) requests.
 import six
 
 from scrapy.http import Request
-from scrapy.utils.python import to_unicode, to_native_str
+from scrapy.utils.python import to_native_str, to_unicode
 
 
 def request_to_dict(request, spider=None):

--- a/scrapy/utils/request.py
+++ b/scrapy/utils/request.py
@@ -4,16 +4,16 @@ scrapy.http.Request objects
 """
 
 from __future__ import print_function
+
 import hashlib
 import weakref
+
 from six.moves.urllib.parse import urlunparse
-
 from w3lib.http import basic_auth_header
-from scrapy.utils.python import to_bytes, to_native_str
-
 from w3lib.url import canonicalize_url
-from scrapy.utils.httpobj import urlparse_cached
 
+from scrapy.utils.httpobj import urlparse_cached
+from scrapy.utils.python import to_bytes, to_native_str
 
 _fingerprint_cache = weakref.WeakKeyDictionary()
 def request_fingerprint(request, include_headers=None):

--- a/scrapy/utils/response.py
+++ b/scrapy/utils/response.py
@@ -3,15 +3,15 @@ This module provides some useful functions for working with
 scrapy.http.Response objects
 """
 import os
+import tempfile
 import weakref
 import webbrowser
-import tempfile
 
 from twisted.web import http
-from scrapy.utils.python import to_bytes, to_native_str
 from w3lib import html
 
 from scrapy.utils.decorators import deprecated
+from scrapy.utils.python import to_bytes, to_native_str
 
 
 @deprecated

--- a/scrapy/utils/serialize.py
+++ b/scrapy/utils/serialize.py
@@ -1,6 +1,6 @@
-import json
 import datetime
 import decimal
+import json
 
 from twisted.internet import defer
 

--- a/scrapy/utils/signal.py
+++ b/scrapy/utils/signal.py
@@ -2,12 +2,11 @@
 
 import logging
 
-from twisted.internet.defer import maybeDeferred, DeferredList, Deferred
+from pydispatch.dispatcher import Anonymous, Any, disconnect, getAllReceivers, liveReceivers
+from pydispatch.robustapply import robustApply
+from twisted.internet.defer import Deferred, DeferredList, maybeDeferred
 from twisted.python.failure import Failure
 
-from pydispatch.dispatcher import Any, Anonymous, liveReceivers, \
-    getAllReceivers, disconnect
-from pydispatch.robustapply import robustApply
 from scrapy.utils.log import failure_to_exc_info
 
 logger = logging.getLogger(__name__)

--- a/scrapy/utils/spider.py
+++ b/scrapy/utils/spider.py
@@ -1,10 +1,10 @@
-import logging
 import inspect
+import logging
 
 import six
 
 from scrapy.spiders import Spider
-from scrapy.utils.misc import  arg_to_iter
+from scrapy.utils.misc import arg_to_iter
 
 logger = logging.getLogger(__name__)
 

--- a/scrapy/utils/test.py
+++ b/scrapy/utils/test.py
@@ -3,9 +3,10 @@ This module contains some assorted functions used in tests
 """
 
 from __future__ import absolute_import
-import os
 
+import os
 from importlib import import_module
+
 from twisted.trial.unittest import SkipTest
 
 from scrapy.exceptions import NotConfigured

--- a/scrapy/utils/testproc.py
+++ b/scrapy/utils/testproc.py
@@ -1,8 +1,9 @@
 from __future__ import absolute_import
-import sys
-import os
 
-from twisted.internet import reactor, defer, protocol
+import os
+import sys
+
+from twisted.internet import defer, protocol, reactor
 
 
 class ProcessTest(object):

--- a/scrapy/utils/testsite.py
+++ b/scrapy/utils/testsite.py
@@ -1,8 +1,8 @@
 from __future__ import print_function
-from six.moves.urllib.parse import urljoin
 
+from six.moves.urllib.parse import urljoin
 from twisted.internet import reactor
-from twisted.web import server, resource, static, util
+from twisted.web import resource, server, static, util
 
 
 class SiteTest(object):

--- a/scrapy/utils/trackref.py
+++ b/scrapy/utils/trackref.py
@@ -10,12 +10,13 @@ alias to object in that case).
 """
 
 from __future__ import print_function
-import weakref
-from time import time
-from operator import itemgetter
-from collections import defaultdict
-import six
 
+import weakref
+from collections import defaultdict
+from operator import itemgetter
+from time import time
+
+import six
 
 NoneType = type(None)
 live_refs = defaultdict(weakref.WeakKeyDictionary)

--- a/scrapy/utils/url.py
+++ b/scrapy/utils/url.py
@@ -7,12 +7,13 @@ to the w3lib.url module. Always import those from there instead.
 """
 import posixpath
 import re
-from six.moves.urllib.parse import (ParseResult, urldefrag, urlparse)
 
+from six.moves.urllib.parse import ParseResult, urldefrag, urlparse
+from w3lib.url import *
 # scrapy.utils.url was moved to w3lib.url and import * ensures this
 # move doesn't break old code
-from w3lib.url import *
 from w3lib.url import _safe_chars, _unquotepath
+
 from scrapy.utils.python import to_unicode
 
 

--- a/scrapy/xlib/pydispatch.py
+++ b/scrapy/xlib/pydispatch.py
@@ -1,15 +1,10 @@
 from __future__ import absolute_import
 
 import warnings
-from scrapy.exceptions import ScrapyDeprecationWarning
 
-from pydispatch import (
-    dispatcher,
-    errors,
-    robust,
-    robustapply,
-    saferef,
-)
+from pydispatch import dispatcher, errors, robust, robustapply, saferef
+
+from scrapy.exceptions import ScrapyDeprecationWarning
 
 warnings.warn("Importing from scrapy.xlib.pydispatch is deprecated and will"
               " no longer be supported in future Scrapy versions."

--- a/scrapy/xlib/tx/__init__.py
+++ b/scrapy/xlib/tx/__init__.py
@@ -1,4 +1,5 @@
 from scrapy import twisted_version
+
 if twisted_version > (13, 0, 0):
     from twisted.web import client
     from twisted.internet import endpoints

--- a/scrapy/xlib/tx/_newclient.py
+++ b/scrapy/xlib/tx/_newclient.py
@@ -28,23 +28,21 @@ Various other classes in this module support this usage:
 
 __metaclass__ = type
 
-from zope.interface import implements
-
-from twisted.python import log
-from twisted.python.reflect import fullyQualifiedName
-from twisted.python.failure import Failure
-from twisted.internet.interfaces import IConsumer, IPushProducer
+from twisted.internet.defer import CancelledError, Deferred, fail, maybeDeferred, succeed
 from twisted.internet.error import ConnectionDone
-from twisted.internet.defer import Deferred, succeed, fail, maybeDeferred
-from twisted.internet.defer import CancelledError
+from twisted.internet.interfaces import IConsumer, IPushProducer
 from twisted.internet.protocol import Protocol
 from twisted.protocols.basic import LineReceiver
+from twisted.python import log
+from twisted.python.failure import Failure
+from twisted.python.reflect import fullyQualifiedName
+from twisted.web.http import (
+    NO_CONTENT, NOT_MODIFIED, PotentialDataLoss, _ChunkedTransferDecoder, _DataLoss, _IdentityTransferDecoder,
+)
 from twisted.web.http_headers import Headers
-from twisted.web.http import NO_CONTENT, NOT_MODIFIED
-from twisted.web.http import _DataLoss, PotentialDataLoss
-from twisted.web.http import _IdentityTransferDecoder, _ChunkedTransferDecoder
+from zope.interface import implements
 
-from .iweb import IResponse, UNKNOWN_LENGTH
+from .iweb import UNKNOWN_LENGTH, IResponse
 
 # States HTTPParser can be in
 STATUS = 'STATUS'

--- a/scrapy/xlib/tx/client.py
+++ b/scrapy/xlib/tx/client.py
@@ -6,9 +6,27 @@
 HTTP client.
 """
 
-from __future__ import division, absolute_import
+from __future__ import absolute_import, division
 
 import os
+import zlib
+
+from twisted.internet import defer, protocol, reactor, task
+from twisted.internet.interfaces import IProtocol
+from twisted.python import failure, log
+from twisted.python.components import proxyForInterface
+from twisted.python.failure import Failure
+from twisted.web import error, http
+from twisted.web.error import SchemeNotSupported
+from twisted.web.http_headers import Headers
+from zope.interface import implementer
+
+from ._newclient import (
+    HTTP11ClientProtocol, PotentialDataLoss, Request, RequestNotSent, RequestTransmissionFailed, Response,
+    ResponseDone, ResponseFailed, ResponseNeverReceived, _WrapperException,
+)
+from .endpoints import SSL4ClientEndpoint, TCP4ClientEndpoint
+from .iweb import UNKNOWN_LENGTH, IBodyProducer, IResponse
 
 try:
     from urlparse import urlunparse
@@ -20,22 +38,9 @@ except ImportError:
     def urlunparse(parts):
         result = _urlunparse(tuple([p.decode("charmap") for p in parts]))
         return result.encode("charmap")
-import zlib
 
-from zope.interface import implementer
 
-from twisted.python import log
-from twisted.python.failure import Failure
-from twisted.web import http
-from twisted.internet import defer, protocol, task, reactor
-from twisted.internet.interfaces import IProtocol
-from twisted.python import failure
-from twisted.python.components import proxyForInterface
-from twisted.web import error
-from twisted.web.http_headers import Headers
 
-from .endpoints import TCP4ClientEndpoint, SSL4ClientEndpoint
-from .iweb import IResponse, UNKNOWN_LENGTH, IBodyProducer
 
 
 class PartialDownloadError(error.Error):
@@ -134,12 +139,6 @@ def _makeGetterFactory(url, factoryFactory, contextFactory=None,
 # should be significantly better than anything above, though it is not yet
 # feature equivalent.
 
-from twisted.web.error import SchemeNotSupported
-from ._newclient import Request, Response, HTTP11ClientProtocol
-from ._newclient import ResponseDone, ResponseFailed
-from ._newclient import RequestNotSent, RequestTransmissionFailed
-from ._newclient import (
-    ResponseNeverReceived, PotentialDataLoss, _WrapperException)
 
 try:
     from twisted.internet.ssl import ClientContextFactory

--- a/scrapy/xlib/tx/endpoints.py
+++ b/scrapy/xlib/tx/endpoints.py
@@ -12,29 +12,23 @@ parsed by the L{clientFromString} and L{serverFromString} functions.
 @since: 10.1
 """
 
-from __future__ import division, absolute_import
+from __future__ import absolute_import, division
 
 import os
 import socket
-
-from zope.interface import implementer, directlyProvides
 import warnings
 
-from twisted.internet import interfaces, defer, error, fdesc, threads
-from twisted.internet.protocol import (
-        ClientFactory, Protocol, ProcessProtocol, Factory)
-from twisted.internet.interfaces import IStreamServerEndpointStringParser
-from twisted.internet.interfaces import IStreamClientEndpointStringParser
-from twisted.python.filepath import FilePath
-from twisted.python.failure import Failure
+from twisted.internet import defer, error, fdesc, interfaces, stdio, threads
+from twisted.internet.interfaces import IStreamClientEndpointStringParser, IStreamServerEndpointStringParser
+from twisted.internet.protocol import ClientFactory, Factory, ProcessProtocol, Protocol
+from twisted.plugin import IPlugin, getPlugins
 from twisted.python import log
 from twisted.python.components import proxyForInterface
-
-from twisted.plugin import IPlugin, getPlugins
-from twisted.internet import stdio
+from twisted.python.failure import Failure
+from twisted.python.filepath import FilePath
+from zope.interface import directlyProvides, implementer
 
 from .interfaces import IFileDescriptorReceiver
-
 
 __all__ = ["TCP4ClientEndpoint", "SSL4ServerEndpoint"]
 
@@ -1266,4 +1260,3 @@ def connectProtocol(endpoint, protocol):
         def buildProtocol(self, addr):
             return protocol
     return endpoint.connect(OneShotFactory())
-

--- a/scrapy/xlib/tx/interfaces.py
+++ b/scrapy/xlib/tx/interfaces.py
@@ -7,9 +7,9 @@ Interface documentation.
 Maintainer: Itamar Shtull-Trauring
 """
 
-from __future__ import division, absolute_import
+from __future__ import absolute_import, division
 
-from zope.interface import Interface, Attribute
+from zope.interface import Attribute, Interface
 
 
 class IAddress(Interface):

--- a/scrapy/xlib/tx/iweb.py
+++ b/scrapy/xlib/tx/iweb.py
@@ -10,9 +10,8 @@ Interface definitions for L{twisted.web}.
     body is not known in advance.
 """
 
-from zope.interface import Interface, Attribute
-
 from twisted.internet.interfaces import IPushProducer
+from zope.interface import Attribute, Interface
 
 
 class IRequest(Interface):

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,3 +3,12 @@ doc_files = docs AUTHORS INSTALL LICENSE README.rst
 
 [bdist_wheel]
 universal=1
+
+[isort]
+combine_as_imports = true
+default_section = THIRDPARTY
+include_trailing_comma = true
+known_first_party = scrapy,tests
+multi_line_output = 5
+not_skip = __init__.py
+line_length = 119

--- a/tests/mockserver.py
+++ b/tests/mockserver.py
@@ -1,13 +1,19 @@
 from __future__ import print_function
-import sys, time, random, os, json
+
+import json
+import os
+import random
+import sys
+import time
+from subprocess import PIPE, Popen
+
 from six.moves.urllib.parse import urlencode
-from subprocess import Popen, PIPE
-from twisted.web.server import Site, NOT_DONE_YET
+from twisted.internet import defer, reactor, ssl
 from twisted.web.resource import Resource
-from twisted.internet import reactor, defer, ssl
+from twisted.web.server import NOT_DONE_YET, Site
+
 from scrapy import twisted_version
 from scrapy.utils.python import to_bytes, to_unicode
-
 
 if twisted_version < (11, 0, 0):
     def deferLater(clock, delay, func, *args, **kw):

--- a/tests/spiders.py
+++ b/tests/spiders.py
@@ -3,12 +3,13 @@ Some spiders used for testing and benchmarking
 """
 
 import time
+
 from six.moves.urllib.parse import urlencode
 
-from scrapy.spiders import Spider
 from scrapy.http import Request
 from scrapy.item import Item
 from scrapy.linkextractors import LinkExtractor
+from scrapy.spiders import Spider
 
 
 class MetaSpider(Spider):

--- a/tests/test_closespider.py
+++ b/tests/test_closespider.py
@@ -1,8 +1,9 @@
 from twisted.internet import defer
 from twisted.trial.unittest import TestCase
+
 from scrapy.utils.test import get_crawler
-from tests.spiders import FollowAllSpider, ItemSpider, ErrorSpider
 from tests.mockserver import MockServer
+from tests.spiders import ErrorSpider, FollowAllSpider, ItemSpider
 
 
 class TestCloseSpider(TestCase):

--- a/tests/test_cmdline/__init__.py
+++ b/tests/test_cmdline/__init__.py
@@ -2,17 +2,20 @@ import json
 import os
 import pstats
 import shutil
-import six
-from subprocess import Popen, PIPE
 import sys
 import tempfile
 import unittest
+from subprocess import PIPE, Popen
+
+import six
+
+from scrapy.utils.test import get_testenv
+
 try:
     from cStringIO import StringIO
 except ImportError:
     from io import StringIO
 
-from scrapy.utils.test import get_testenv
 
 
 class CmdlineTest(unittest.TestCase):

--- a/tests/test_cmdline/extensions.py
+++ b/tests/test_cmdline/extensions.py
@@ -12,4 +12,3 @@ class TestExtension(object):
 
 class DummyExtension(object):
     pass
-

--- a/tests/test_command_fetch.py
+++ b/tests/test_command_fetch.py
@@ -1,8 +1,8 @@
-from twisted.trial import unittest
 from twisted.internet import defer
+from twisted.trial import unittest
 
-from scrapy.utils.testsite import SiteTest
 from scrapy.utils.testproc import ProcessTest
+from scrapy.utils.testsite import SiteTest
 
 
 class FetchTest(ProcessTest, SiteTest, unittest.TestCase):

--- a/tests/test_command_parse.py
+++ b/tests/test_command_parse.py
@@ -1,9 +1,11 @@
-from os.path import join, abspath
-from twisted.trial import unittest
+from os.path import abspath, join
+
 from twisted.internet import defer
-from scrapy.utils.testsite import SiteTest
-from scrapy.utils.testproc import ProcessTest
+from twisted.trial import unittest
+
 from scrapy.utils.python import to_native_str
+from scrapy.utils.testproc import ProcessTest
+from scrapy.utils.testsite import SiteTest
 from tests.test_commands import CommandTest
 
 

--- a/tests/test_command_shell.py
+++ b/tests/test_command_shell.py
@@ -1,11 +1,10 @@
 from os.path import join
 
-from twisted.trial import unittest
 from twisted.internet import defer
+from twisted.trial import unittest
 
-from scrapy.utils.testsite import SiteTest
 from scrapy.utils.testproc import ProcessTest
-
+from scrapy.utils.testsite import SiteTest
 from tests import tests_datadir
 
 

--- a/tests/test_command_version.py
+++ b/tests/test_command_version.py
@@ -1,6 +1,7 @@
 import sys
-from twisted.trial import unittest
+
 from twisted.internet import defer
+from twisted.trial import unittest
 
 import scrapy
 from scrapy.utils.testproc import ProcessTest

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -1,22 +1,21 @@
 import os
-import sys
 import subprocess
+import sys
 import tempfile
-from time import sleep
-from os.path import exists, join, abspath
-from shutil import rmtree, copytree
-from tempfile import mkdtemp
 from contextlib import contextmanager
+from os.path import abspath, exists, join
+from shutil import copytree, rmtree
+from tempfile import mkdtemp
+from time import sleep
 
-from twisted.trial import unittest
 from twisted.internet import defer
+from twisted.trial import unittest
 
 import scrapy
-from scrapy.utils.python import to_native_str
-from scrapy.utils.python import retry_on_eintr
+from scrapy.utils.python import retry_on_eintr, to_native_str
 from scrapy.utils.test import get_testenv
-from scrapy.utils.testsite import SiteTest
 from scrapy.utils.testproc import ProcessTest
+from scrapy.utils.testsite import SiteTest
 
 
 class ProjectTest(unittest.TestCase):

--- a/tests/test_contracts.py
+++ b/tests/test_contracts.py
@@ -2,15 +2,11 @@ from unittest import TextTestResult
 
 from twisted.trial import unittest
 
-from scrapy.spiders import Spider
-from scrapy.http import Request
-from scrapy.item import Item, Field
 from scrapy.contracts import ContractsManager
-from scrapy.contracts.default import (
-    UrlContract,
-    ReturnsContract,
-    ScrapesContract,
-)
+from scrapy.contracts.default import ReturnsContract, ScrapesContract, UrlContract
+from scrapy.http import Request
+from scrapy.item import Field, Item
+from scrapy.spiders import Spider
 
 
 class TestItem(Item):

--- a/tests/test_crawl.py
+++ b/tests/test_crawl.py
@@ -1,18 +1,20 @@
 import json
-import socket
 import logging
+import socket
 
 from testfixtures import LogCapture
 from twisted.internet import defer
 from twisted.trial.unittest import TestCase
 
-from scrapy.http import Request
 from scrapy.crawler import CrawlerRunner
+from scrapy.http import Request
 from scrapy.utils.python import to_unicode
 from tests import mock
-from tests.spiders import FollowAllSpider, DelaySpider, SimpleSpider, \
-    BrokenStartRequestsSpider, SingleRequestSpider, DuplicateStartRequestsSpider
 from tests.mockserver import MockServer
+from tests.spiders import (
+    BrokenStartRequestsSpider, DelaySpider, DuplicateStartRequestsSpider, FollowAllSpider, SimpleSpider,
+    SingleRequestSpider,
+)
 
 
 class CrawlTestCase(TestCase):

--- a/tests/test_crawler.py
+++ b/tests/test_crawler.py
@@ -1,13 +1,13 @@
-import warnings
 import unittest
+import warnings
 
 import scrapy
-from scrapy.crawler import Crawler, CrawlerRunner, CrawlerProcess
+from scrapy.crawler import Crawler, CrawlerProcess, CrawlerRunner
+from scrapy.extensions.throttle import AutoThrottle
 from scrapy.settings import Settings, default_settings
 from scrapy.spiderloader import SpiderLoader
-from scrapy.utils.spider import DefaultSpider
 from scrapy.utils.misc import load_object
-from scrapy.extensions.throttle import AutoThrottle
+from scrapy.utils.spider import DefaultSpider
 
 
 class BaseCrawlerTest(unittest.TestCase):

--- a/tests/test_dependencies.py
+++ b/tests/test_dependencies.py
@@ -1,5 +1,7 @@
 from importlib import import_module
+
 from twisted.trial import unittest
+
 
 class ScrapyUtilsTest(unittest.TestCase):
     def test_required_openssl_version(self):

--- a/tests/test_downloader_handlers.py
+++ b/tests/test_downloader_handlers.py
@@ -1,40 +1,44 @@
-import os
-import six
 import contextlib
-try:
-    from unittest import mock
-except ImportError:
-    import mock
+import os
 
-from twisted.trial import unittest
+import six
+from twisted.cred import checkers, credentials, portal
+from twisted.internet import defer, error, reactor
 from twisted.protocols.policies import WrappingFactory
 from twisted.python.filepath import FilePath
-from twisted.internet import reactor, defer, error
-from twisted.web import server, static, util, resource
-from twisted.web.test.test_webclient import ForeverTakingResource, \
-        NoLengthResource, HostHeaderResource, \
-        PayloadResource, BrokenDownloadResource
-from twisted.cred import portal, checkers, credentials
+from twisted.trial import unittest
+from twisted.web import resource, server, static, util
+from twisted.web.test.test_webclient import (
+    BrokenDownloadResource, ForeverTakingResource, HostHeaderResource, NoLengthResource, PayloadResource,
+)
 from w3lib.url import path_to_file_uri
 
 from scrapy import twisted_version
 from scrapy.core.downloader.handlers import DownloadHandlers
 from scrapy.core.downloader.handlers.file import FileDownloadHandler
-from scrapy.core.downloader.handlers.http import HTTPDownloadHandler, HttpDownloadHandler
 from scrapy.core.downloader.handlers.http10 import HTTP10DownloadHandler
 from scrapy.core.downloader.handlers.http11 import HTTP11DownloadHandler
 from scrapy.core.downloader.handlers.s3 import S3DownloadHandler
-
-from scrapy.spiders import Spider
+from scrapy.exceptions import NotConfigured
 from scrapy.http import Request
 from scrapy.http.response.text import TextResponse
 from scrapy.settings import Settings
-from scrapy.utils.test import get_crawler, skip_if_no_boto
+from scrapy.spiders import Spider
 from scrapy.utils.python import to_bytes
-from scrapy.exceptions import NotConfigured
-
+from scrapy.utils.test import get_crawler, skip_if_no_boto
 from tests.mockserver import MockServer, ssl_context_factory
 from tests.spiders import SingleRequestSpider
+
+from scrapy.core.downloader.handlers.http import HttpDownloadHandler, HTTPDownloadHandler  # isort:skip bug isort#484
+
+try:
+    from unittest import mock
+except ImportError:
+    import mock
+
+
+
+
 
 class DummyDH(object):
 

--- a/tests/test_downloadermiddleware.py
+++ b/tests/test_downloadermiddleware.py
@@ -1,11 +1,11 @@
-from twisted.trial.unittest import TestCase
 from twisted.python.failure import Failure
+from twisted.trial.unittest import TestCase
 
+from scrapy.core.downloader.middleware import DownloaderMiddlewareManager
 from scrapy.http import Request, Response
 from scrapy.spiders import Spider
-from scrapy.core.downloader.middleware import DownloaderMiddlewareManager
-from scrapy.utils.test import get_crawler
 from scrapy.utils.python import to_bytes
+from scrapy.utils.test import get_crawler
 from tests import mock
 
 

--- a/tests/test_downloadermiddleware_ajaxcrawlable.py
+++ b/tests/test_downloadermiddleware_ajaxcrawlable.py
@@ -1,8 +1,8 @@
 import unittest
 
 from scrapy.downloadermiddlewares.ajaxcrawl import AjaxCrawlMiddleware
+from scrapy.http import HtmlResponse, Request, Response
 from scrapy.spiders import Spider
-from scrapy.http import Request, HtmlResponse, Response
 from scrapy.utils.test import get_crawler
 
 __doctests__ = ['scrapy.downloadermiddlewares.ajaxcrawl']

--- a/tests/test_downloadermiddleware_cookies.py
+++ b/tests/test_downloadermiddleware_cookies.py
@@ -1,13 +1,14 @@
-import re
 import logging
+import re
 from unittest import TestCase
+
 from testfixtures import LogCapture
 
-from scrapy.http import Response, Request
+from scrapy.downloadermiddlewares.cookies import CookiesMiddleware
+from scrapy.exceptions import NotConfigured
+from scrapy.http import Request, Response
 from scrapy.spiders import Spider
 from scrapy.utils.test import get_crawler
-from scrapy.exceptions import NotConfigured
-from scrapy.downloadermiddlewares.cookies import CookiesMiddleware
 
 
 class CookiesMiddlewareTest(TestCase):

--- a/tests/test_downloadermiddleware_decompression.py
+++ b/tests/test_downloadermiddleware_decompression.py
@@ -1,9 +1,10 @@
 from unittest import TestCase, main
-from scrapy.http import Response, XmlResponse
+
 from scrapy.downloadermiddlewares.decompression import DecompressionMiddleware
+from scrapy.http import Response, XmlResponse
 from scrapy.spiders import Spider
-from tests import get_testdata
 from scrapy.utils.test import assert_samelines
+from tests import get_testdata
 
 
 def _test_data(formats):

--- a/tests/test_downloadermiddleware_defaultheaders.py
+++ b/tests/test_downloadermiddleware_defaultheaders.py
@@ -3,8 +3,8 @@ from unittest import TestCase
 from scrapy.downloadermiddlewares.defaultheaders import DefaultHeadersMiddleware
 from scrapy.http import Request
 from scrapy.spiders import Spider
-from scrapy.utils.test import get_crawler
 from scrapy.utils.python import to_bytes
+from scrapy.utils.test import get_crawler
 
 
 class TestDefaultHeadersMiddleware(TestCase):

--- a/tests/test_downloadermiddleware_downloadtimeout.py
+++ b/tests/test_downloadermiddleware_downloadtimeout.py
@@ -1,8 +1,8 @@
 import unittest
 
 from scrapy.downloadermiddlewares.downloadtimeout import DownloadTimeoutMiddleware
-from scrapy.spiders import Spider
 from scrapy.http import Request
+from scrapy.spiders import Spider
 from scrapy.utils.test import get_crawler
 
 

--- a/tests/test_downloadermiddleware_httpauth.py
+++ b/tests/test_downloadermiddleware_httpauth.py
@@ -1,7 +1,7 @@
 import unittest
 
-from scrapy.http import Request
 from scrapy.downloadermiddlewares.httpauth import HttpAuthMiddleware
+from scrapy.http import Request
 from scrapy.spiders import Spider
 
 

--- a/tests/test_downloadermiddleware_httpcache.py
+++ b/tests/test_downloadermiddleware_httpcache.py
@@ -1,18 +1,20 @@
 from __future__ import print_function
-import time
-import tempfile
-import shutil
-import unittest
+
 import email.utils
+import shutil
+import tempfile
+import time
+import unittest
 from contextlib import contextmanager
+
 import pytest
 
-from scrapy.http import Response, HtmlResponse, Request
-from scrapy.spiders import Spider
-from scrapy.settings import Settings
-from scrapy.exceptions import IgnoreRequest
-from scrapy.utils.test import get_crawler
 from scrapy.downloadermiddlewares.httpcache import HttpCacheMiddleware
+from scrapy.exceptions import IgnoreRequest
+from scrapy.http import HtmlResponse, Request, Response
+from scrapy.settings import Settings
+from scrapy.spiders import Spider
+from scrapy.utils.test import get_crawler
 
 
 class _BaseTest(unittest.TestCase):

--- a/tests/test_downloadermiddleware_httpcompression.py
+++ b/tests/test_downloadermiddleware_httpcompression.py
@@ -1,14 +1,14 @@
-from io import BytesIO
-from unittest import TestCase
-from os.path import join, abspath, dirname
 from gzip import GzipFile
+from io import BytesIO
+from os.path import abspath, dirname, join
+from unittest import TestCase
 
-from scrapy.spiders import Spider
-from scrapy.http import Response, Request, HtmlResponse
-from scrapy.downloadermiddlewares.httpcompression import HttpCompressionMiddleware
-from tests import tests_datadir
 from w3lib.encoding import resolve_encoding
 
+from scrapy.downloadermiddlewares.httpcompression import HttpCompressionMiddleware
+from scrapy.http import HtmlResponse, Request, Response
+from scrapy.spiders import Spider
+from tests import tests_datadir
 
 SAMPLEDIR = join(tests_datadir, 'compressed')
 

--- a/tests/test_downloadermiddleware_httpproxy.py
+++ b/tests/test_downloadermiddleware_httpproxy.py
@@ -1,10 +1,11 @@
 import os
 import sys
-from twisted.trial.unittest import TestCase, SkipTest
+
+from twisted.trial.unittest import SkipTest, TestCase
 
 from scrapy.downloadermiddlewares.httpproxy import HttpProxyMiddleware
 from scrapy.exceptions import NotConfigured
-from scrapy.http import Response, Request
+from scrapy.http import Request, Response
 from scrapy.spiders import Spider
 
 spider = Spider('foo')

--- a/tests/test_downloadermiddleware_redirect.py
+++ b/tests/test_downloadermiddleware_redirect.py
@@ -2,10 +2,10 @@
 
 import unittest
 
-from scrapy.downloadermiddlewares.redirect import RedirectMiddleware, MetaRefreshMiddleware
-from scrapy.spiders import Spider
+from scrapy.downloadermiddlewares.redirect import MetaRefreshMiddleware, RedirectMiddleware
 from scrapy.exceptions import IgnoreRequest
-from scrapy.http import Request, Response, HtmlResponse
+from scrapy.http import HtmlResponse, Request, Response
+from scrapy.spiders import Spider
 from scrapy.utils.test import get_crawler
 
 

--- a/tests/test_downloadermiddleware_retry.py
+++ b/tests/test_downloadermiddleware_retry.py
@@ -1,15 +1,17 @@
 import unittest
+
 from twisted.internet import defer
-from twisted.internet.error import TimeoutError, DNSLookupError, \
-        ConnectionRefusedError, ConnectionDone, ConnectError, \
-        ConnectionLost, TCPTimedOutError
+from twisted.internet.error import (
+    ConnectError, ConnectionDone, ConnectionLost, ConnectionRefusedError, DNSLookupError, TCPTimedOutError,
+    TimeoutError,
+)
 
 from scrapy import twisted_version
 from scrapy.downloadermiddlewares.retry import RetryMiddleware
-from scrapy.xlib.tx import ResponseFailed
-from scrapy.spiders import Spider
 from scrapy.http import Request, Response
+from scrapy.spiders import Spider
 from scrapy.utils.test import get_crawler
+from scrapy.xlib.tx import ResponseFailed
 
 
 class RetryTest(unittest.TestCase):

--- a/tests/test_downloadermiddleware_robotstxt.py
+++ b/tests/test_downloadermiddleware_robotstxt.py
@@ -1,11 +1,13 @@
 from __future__ import absolute_import
+
 import re
-from twisted.internet import reactor, error
+
+from twisted.internet import error, reactor
 from twisted.internet.defer import Deferred, DeferredList, maybeDeferred
 from twisted.python import failure
 from twisted.trial import unittest
-from scrapy.downloadermiddlewares.robotstxt import (RobotsTxtMiddleware,
-                                                    logger as mw_module_logger)
+
+from scrapy.downloadermiddlewares.robotstxt import RobotsTxtMiddleware, logger as mw_module_logger
 from scrapy.exceptions import IgnoreRequest, NotConfigured
 from scrapy.http import Request, Response, TextResponse
 from scrapy.settings import Settings

--- a/tests/test_downloadermiddleware_useragent.py
+++ b/tests/test_downloadermiddleware_useragent.py
@@ -1,8 +1,8 @@
 from unittest import TestCase
 
-from scrapy.spiders import Spider
-from scrapy.http import Request
 from scrapy.downloadermiddlewares.useragent import UserAgentMiddleware
+from scrapy.http import Request
+from scrapy.spiders import Spider
 from scrapy.utils.test import get_crawler
 
 

--- a/tests/test_dupefilters.py
+++ b/tests/test_dupefilters.py
@@ -1,7 +1,7 @@
 import hashlib
+import shutil
 import tempfile
 import unittest
-import shutil
 
 from scrapy.dupefilters import RFPDupeFilter
 from scrapy.http import Request

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -11,23 +11,26 @@ module with the ``runserver`` argument::
 """
 
 from __future__ import print_function
-import sys, os, re
-from six.moves.urllib.parse import urlparse
 
-from twisted.internet import reactor, defer
-from twisted.web import server, static, util
+import os
+import re
+import sys
+
+from pydispatch import dispatcher
+from six.moves.urllib.parse import urlparse
+from twisted.internet import defer, reactor
 from twisted.trial import unittest
+from twisted.web import server, static, util
 
 from scrapy import signals
 from scrapy.core.engine import ExecutionEngine
-from scrapy.utils.test import get_crawler
-from pydispatch import dispatcher
-from tests import tests_datadir
-from scrapy.spiders import Spider
-from scrapy.item import Item, Field
-from scrapy.linkextractors import LinkExtractor
 from scrapy.http import Request
+from scrapy.item import Field, Item
+from scrapy.linkextractors import LinkExtractor
+from scrapy.spiders import Spider
 from scrapy.utils.signal import disconnect_all
+from scrapy.utils.test import get_crawler
+from tests import tests_datadir
 
 
 class TestItem(Item):

--- a/tests/test_exporters.py
+++ b/tests/test_exporters.py
@@ -1,23 +1,23 @@
 from __future__ import absolute_import
-import re
+
 import json
-import marshal
+import re
 import tempfile
 import unittest
-from io import BytesIO
 from datetime import datetime
-from six.moves import cPickle as pickle
+from io import BytesIO
 
 import lxml.etree
+import marshal
 import six
+from six.moves import cPickle as pickle
 
-from scrapy.item import Item, Field
-from scrapy.utils.python import to_unicode
 from scrapy.exporters import (
-    BaseItemExporter, PprintItemExporter, PickleItemExporter, CsvItemExporter,
-    XmlItemExporter, JsonLinesItemExporter, JsonItemExporter,
-    PythonItemExporter, MarshalItemExporter
+    BaseItemExporter, CsvItemExporter, JsonItemExporter, JsonLinesItemExporter, MarshalItemExporter,
+    PickleItemExporter, PprintItemExporter, PythonItemExporter, XmlItemExporter,
 )
+from scrapy.item import Field, Item
+from scrapy.utils.python import to_unicode
 
 
 class TestItem(Item):

--- a/tests/test_feedexport.py
+++ b/tests/test_feedexport.py
@@ -1,27 +1,27 @@
 from __future__ import absolute_import
-import os
+
 import csv
 import json
-from io import BytesIO
-import tempfile
+import os
 import shutil
-from six.moves.urllib.parse import urlparse
+import tempfile
+from io import BytesIO
 
-from zope.interface.verify import verifyObject
-from twisted.trial import unittest
+from six.moves.urllib.parse import urlparse
 from twisted.internet import defer
-from scrapy.crawler import CrawlerRunner
-from scrapy.settings import Settings
-from tests.mockserver import MockServer
+from twisted.trial import unittest
 from w3lib.url import path_to_file_uri
+from zope.interface.verify import verifyObject
 
 import scrapy
+from scrapy.crawler import CrawlerRunner
 from scrapy.extensions.feedexport import (
-    IFeedStorage, FileFeedStorage, FTPFeedStorage,
-    S3FeedStorage, StdoutFeedStorage,
-    BlockingFeedStorage)
-from scrapy.utils.test import assert_aws_environ, get_s3_content_and_delete, get_crawler
+    BlockingFeedStorage, FileFeedStorage, FTPFeedStorage, IFeedStorage, S3FeedStorage, StdoutFeedStorage,
+)
+from scrapy.settings import Settings
 from scrapy.utils.python import to_native_str
+from scrapy.utils.test import assert_aws_environ, get_crawler, get_s3_content_and_delete
+from tests.mockserver import MockServer
 
 
 class FileFeedStorageTest(unittest.TestCase):

--- a/tests/test_http_cookies.py
+++ b/tests/test_http_cookies.py
@@ -1,5 +1,6 @@
-from six.moves.urllib.parse import urlparse
 from unittest import TestCase
+
+from six.moves.urllib.parse import urlparse
 
 from scrapy.http import Request, Response
 from scrapy.http.cookies import WrappedRequest, WrappedResponse

--- a/tests/test_http_headers.py
+++ b/tests/test_http_headers.py
@@ -1,7 +1,8 @@
-import unittest
 import copy
+import unittest
 
 from scrapy.http import Headers
+
 
 class HeadersTest(unittest.TestCase):
 

--- a/tests/test_http_request.py
+++ b/tests/test_http_request.py
@@ -1,16 +1,18 @@
 # -*- coding: utf-8 -*-
 import cgi
-import unittest
 import re
+import unittest
 
 import six
 from six.moves import xmlrpc_client as xmlrpclib
-from six.moves.urllib.parse import urlparse, parse_qs, unquote
+from six.moves.urllib.parse import parse_qs, unquote, urlparse
+
+from scrapy.http import FormRequest, Headers, HtmlResponse, Request, XmlRpcRequest
+from scrapy.utils.python import to_bytes, to_native_str
+
 if six.PY3:
     from urllib.parse import unquote_to_bytes
 
-from scrapy.http import Request, FormRequest, XmlRpcRequest, Headers, HtmlResponse
-from scrapy.utils.python import to_bytes, to_native_str
 
 
 class RequestTest(unittest.TestCase):

--- a/tests/test_http_response.py
+++ b/tests/test_http_response.py
@@ -3,11 +3,10 @@ import unittest
 import six
 from w3lib.encoding import resolve_encoding
 
-from scrapy.http import (Request, Response, TextResponse, HtmlResponse,
-                         XmlResponse, Headers)
+from scrapy.exceptions import NotSupported
+from scrapy.http import Headers, HtmlResponse, Request, Response, TextResponse, XmlResponse
 from scrapy.selector import Selector
 from scrapy.utils.python import to_native_str
-from scrapy.exceptions import NotSupported
 
 
 class BaseResponseTest(unittest.TestCase):

--- a/tests/test_item.py
+++ b/tests/test_item.py
@@ -1,7 +1,8 @@
 import unittest
 
-from scrapy.item import Item, Field
 import six
+
+from scrapy.item import Field, Item
 
 
 class ItemTest(unittest.TestCase):

--- a/tests/test_link.py
+++ b/tests/test_link.py
@@ -1,5 +1,6 @@
 import unittest
 import warnings
+
 import six
 
 from scrapy.link import Link

--- a/tests/test_linkextractors.py
+++ b/tests/test_linkextractors.py
@@ -430,4 +430,3 @@ class LxmlLinkExtractorTestCase(Base.LinkExtractorTestCase):
     @pytest.mark.xfail
     def test_restrict_xpaths_with_html_entities(self):
         super(LxmlLinkExtractorTestCase, self).test_restrict_xpaths_with_html_entities()
-

--- a/tests/test_linkextractors_deprecated.py
+++ b/tests/test_linkextractors_deprecated.py
@@ -1,12 +1,12 @@
 # -*- coding: utf-8 -*-
 import unittest
-from scrapy.linkextractors.regex import RegexLinkExtractor
+
 from scrapy.http import HtmlResponse
 from scrapy.link import Link
 from scrapy.linkextractors.htmlparser import HtmlParserLinkExtractor
-from scrapy.linkextractors.sgml import SgmlLinkExtractor, BaseSgmlLinkExtractor
+from scrapy.linkextractors.regex import RegexLinkExtractor
+from scrapy.linkextractors.sgml import BaseSgmlLinkExtractor, SgmlLinkExtractor
 from tests import get_testdata
-
 from tests.test_linkextractors import Base
 
 

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -1,13 +1,14 @@
 import unittest
-import six
 from functools import partial
 
-from scrapy.loader import ItemLoader
-from scrapy.loader.processors import Join, Identity, TakeFirst, \
-    Compose, MapCompose, SelectJmes
-from scrapy.item import Item, Field
-from scrapy.selector import Selector
+import six
+
 from scrapy.http import HtmlResponse
+from scrapy.item import Field, Item
+from scrapy.loader import ItemLoader
+from scrapy.loader.processors import Compose, Identity, Join, MapCompose, SelectJmes, TakeFirst
+from scrapy.selector import Selector
+
 
 # test items
 class NameItem(Item):

--- a/tests/test_logformatter.py
+++ b/tests/test_logformatter.py
@@ -1,10 +1,11 @@
 import unittest
+
 import six
 
-from scrapy.spiders import Spider
 from scrapy.http import Request, Response
-from scrapy.item import Item, Field
+from scrapy.item import Field, Item
 from scrapy.logformatter import LogFormatter
+from scrapy.spiders import Spider
 
 
 class CustomItem(Item):

--- a/tests/test_mail.py
+++ b/tests/test_mail.py
@@ -1,10 +1,11 @@
 # coding=utf-8
 
 import unittest
-from io import BytesIO
 from email.charset import Charset
+from io import BytesIO
 
 from scrapy.mail import MailSender
+
 
 class MailSenderTest(unittest.TestCase):
 

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -1,9 +1,10 @@
+import six
 from twisted.trial import unittest
 
-from scrapy.settings import Settings
 from scrapy.exceptions import NotConfigured
 from scrapy.middleware import MiddlewareManager
-import six
+from scrapy.settings import Settings
+
 
 class M1(object):
 

--- a/tests/test_pipeline_files.py
+++ b/tests/test_pipeline_files.py
@@ -1,24 +1,23 @@
+import hashlib
 import os
 import random
 import time
-import hashlib
 import warnings
-from tempfile import mkdtemp
 from shutil import rmtree
-from six.moves.urllib.parse import urlparse
+from tempfile import mkdtemp
+
 from six import BytesIO
-
-from twisted.trial import unittest
+from six.moves.urllib.parse import urlparse
 from twisted.internet import defer
+from twisted.trial import unittest
 
-from scrapy.pipelines.files import FilesPipeline, FSFilesStore, S3FilesStore
-from scrapy.item import Item, Field
 from scrapy.http import Request, Response
+from scrapy.item import Field, Item
+from scrapy.pipelines.files import FilesPipeline, FSFilesStore, S3FilesStore
 from scrapy.settings import Settings
+from scrapy.utils.boto import is_botocore
 from scrapy.utils.python import to_bytes
 from scrapy.utils.test import assert_aws_environ, get_s3_content_and_delete
-from scrapy.utils.boto import is_botocore
-
 from tests import mock
 
 

--- a/tests/test_pipeline_images.py
+++ b/tests/test_pipeline_images.py
@@ -1,16 +1,16 @@
-import os
 import hashlib
+import os
 import random
 import warnings
-from tempfile import mkdtemp, TemporaryFile
 from shutil import rmtree
+from tempfile import TemporaryFile, mkdtemp
 
 from twisted.trial import unittest
 
-from scrapy.item import Item, Field
 from scrapy.http import Request, Response
-from scrapy.settings import Settings
+from scrapy.item import Field, Item
 from scrapy.pipelines.images import ImagesPipeline
+from scrapy.settings import Settings
 from scrapy.utils.python import to_bytes
 
 skip = False

--- a/tests/test_pipeline_media.py
+++ b/tests/test_pipeline_media.py
@@ -1,17 +1,18 @@
 from __future__ import print_function
+
 from testfixtures import LogCapture
-from twisted.trial import unittest
-from twisted.python.failure import Failure
 from twisted.internet import reactor
 from twisted.internet.defer import Deferred, inlineCallbacks
+from twisted.python.failure import Failure
+from twisted.trial import unittest
 
-from scrapy.http import Request, Response
-from scrapy.spiders import Spider
-from scrapy.utils.request import request_fingerprint
-from scrapy.pipelines.media import MediaPipeline
-from scrapy.utils.log import failure_to_exc_info
-from scrapy.utils.signal import disconnect_all
 from scrapy import signals
+from scrapy.http import Request, Response
+from scrapy.pipelines.media import MediaPipeline
+from scrapy.spiders import Spider
+from scrapy.utils.log import failure_to_exc_info
+from scrapy.utils.request import request_fingerprint
+from scrapy.utils.signal import disconnect_all
 
 
 def _mocked_download_func(request, info):

--- a/tests/test_proxy_connect.py
+++ b/tests/test_proxy_connect.py
@@ -1,18 +1,18 @@
 import json
 import os
 import time
-
 from threading import Thread
+
 from libmproxy import controller, proxy
 from netlib import http_auth
 from testfixtures import LogCapture
-
 from twisted.internet import defer
 from twisted.trial.unittest import TestCase
-from scrapy.utils.test import get_crawler
+
 from scrapy.http import Request
-from tests.spiders import SimpleSpider, SingleRequestSpider
+from scrapy.utils.test import get_crawler
 from tests.mockserver import MockServer
+from tests.spiders import SimpleSpider, SingleRequestSpider
 
 
 class HTTPSProxy(controller.Master, Thread):

--- a/tests/test_pydispatch_deprecated.py
+++ b/tests/test_pydispatch_deprecated.py
@@ -1,5 +1,6 @@
 import unittest
 import warnings
+
 from six.moves import reload_module
 
 

--- a/tests/test_responsetypes.py
+++ b/tests/test_responsetypes.py
@@ -1,8 +1,9 @@
 # -*- coding: utf-8 -*-
 import unittest
+
+from scrapy.http import Headers, HtmlResponse, Response, TextResponse, XmlResponse
 from scrapy.responsetypes import responsetypes
 
-from scrapy.http import Response, TextResponse, XmlResponse, HtmlResponse, Headers
 
 class ResponseTypesTest(unittest.TestCase):
 

--- a/tests/test_selector.py
+++ b/tests/test_selector.py
@@ -1,10 +1,12 @@
 import warnings
 import weakref
-from twisted.trial import unittest
-from scrapy.http import TextResponse, HtmlResponse, XmlResponse
-from scrapy.selector import Selector
-from scrapy.selector.lxmlsel import XmlXPathSelector, HtmlXPathSelector, XPathSelector
+
 from lxml import etree
+from twisted.trial import unittest
+
+from scrapy.http import HtmlResponse, TextResponse, XmlResponse
+from scrapy.selector import Selector
+from scrapy.selector.lxmlsel import HtmlXPathSelector, XmlXPathSelector, XPathSelector
 
 
 class SelectorTestCase(unittest.TestCase):

--- a/tests/test_selector_csstranslator.py
+++ b/tests/test_selector_csstranslator.py
@@ -2,12 +2,10 @@
 Selector tests for cssselect backend
 """
 import warnings
+
 from twisted.trial import unittest
-from scrapy.selector.csstranslator import (
-    ScrapyHTMLTranslator,
-    ScrapyGenericTranslator,
-    ScrapyXPathExpr
-)
+
+from scrapy.selector.csstranslator import ScrapyGenericTranslator, ScrapyHTMLTranslator, ScrapyXPathExpr
 
 
 class DeprecatedClassesTest(unittest.TestCase):
@@ -18,5 +16,3 @@ class DeprecatedClassesTest(unittest.TestCase):
                 obj = cls()
                 self.assertIn('%s is deprecated' % cls.__name__, str(w[-1].message),
                               'Missing deprecate warning for %s' % cls.__name__)
-
-

--- a/tests/test_settings/__init__.py
+++ b/tests/test_settings/__init__.py
@@ -1,11 +1,13 @@
-import six
 import unittest
 import warnings
 
-from scrapy.settings import (BaseSettings, Settings, SettingsAttribute,
-                             CrawlerSettings, SETTINGS_PRIORITIES,
-                             get_settings_priority)
+import six
+
+from scrapy.settings import (
+    SETTINGS_PRIORITIES, BaseSettings, CrawlerSettings, Settings, SettingsAttribute, get_settings_priority,
+)
 from tests import mock
+
 from . import default_settings
 
 

--- a/tests/test_settings/default_settings.py
+++ b/tests/test_settings/default_settings.py
@@ -2,4 +2,3 @@
 TEST_DEFAULT = 'defvalue'
 
 TEST_DICT = {'key': 'val'}
-

--- a/tests/test_spider.py
+++ b/tests/test_spider.py
@@ -7,16 +7,14 @@ from testfixtures import LogCapture
 from twisted.trial import unittest
 
 from scrapy import signals
-from scrapy.settings import Settings
-from scrapy.http import Request, Response, TextResponse, XmlResponse, HtmlResponse
-from scrapy.spiders.init import InitSpider
-from scrapy.spiders import Spider, BaseSpider, CrawlSpider, Rule, XMLFeedSpider, \
-    CSVFeedSpider, SitemapSpider
-from scrapy.linkextractors import LinkExtractor
 from scrapy.exceptions import ScrapyDeprecationWarning
-from scrapy.utils.trackref import object_ref
+from scrapy.http import HtmlResponse, Request, Response, TextResponse, XmlResponse
+from scrapy.linkextractors import LinkExtractor
+from scrapy.settings import Settings
+from scrapy.spiders import BaseSpider, CrawlSpider, CSVFeedSpider, Rule, SitemapSpider, Spider, XMLFeedSpider
+from scrapy.spiders.init import InitSpider
 from scrapy.utils.test import get_crawler
-
+from scrapy.utils.trackref import object_ref
 from tests import mock
 
 

--- a/tests/test_spiderloader/__init__.py
+++ b/tests/test_spiderloader/__init__.py
@@ -1,19 +1,18 @@
-import sys
 import os
 import shutil
+import sys
 
-from zope.interface.verify import verifyObject
 from twisted.trial import unittest
-
+from zope.interface.verify import verifyObject
 
 # ugly hack to avoid cyclic imports of scrapy.spiders when running this test
 # alone
 import scrapy
-from scrapy.interfaces import ISpiderLoader
-from scrapy.spiderloader import SpiderLoader
-from scrapy.settings import Settings
-from scrapy.http import Request
 from scrapy.crawler import CrawlerRunner
+from scrapy.http import Request
+from scrapy.interfaces import ISpiderLoader
+from scrapy.settings import Settings
+from scrapy.spiderloader import SpiderLoader
 
 module_dir = os.path.dirname(os.path.abspath(__file__))
 

--- a/tests/test_spiderloader/test_spiders/spider0.py
+++ b/tests/test_spiderloader/test_spiders/spider0.py
@@ -1,4 +1,5 @@
 from scrapy.spiders import Spider
 
+
 class Spider0(Spider):
     allowed_domains = ["scrapy1.org", "scrapy3.org"]

--- a/tests/test_spiderloader/test_spiders/spider1.py
+++ b/tests/test_spiderloader/test_spiders/spider1.py
@@ -1,5 +1,6 @@
 from scrapy.spiders import Spider
 
+
 class Spider1(Spider):
     name = "spider1"
     allowed_domains = ["scrapy1.org", "scrapy3.org"]

--- a/tests/test_spiderloader/test_spiders/spider2.py
+++ b/tests/test_spiderloader/test_spiders/spider2.py
@@ -1,5 +1,6 @@
 from scrapy.spiders import Spider
 
+
 class Spider2(Spider):
     name = "spider2"
     allowed_domains = ["scrapy2.org", "scrapy3.org"]

--- a/tests/test_spiderloader/test_spiders/spider3.py
+++ b/tests/test_spiderloader/test_spiders/spider3.py
@@ -1,5 +1,6 @@
 from scrapy.spiders import Spider
 
+
 class Spider3(Spider):
     name = "spider3"
     allowed_domains = ['spider3.com']

--- a/tests/test_spidermiddleware_depth.py
+++ b/tests/test_spidermiddleware_depth.py
@@ -1,7 +1,7 @@
 from unittest import TestCase
 
+from scrapy.http import Request, Response
 from scrapy.spidermiddlewares.depth import DepthMiddleware
-from scrapy.http import Response, Request
 from scrapy.spiders import Spider
 from scrapy.statscollectors import StatsCollector
 from scrapy.utils.test import get_crawler
@@ -40,4 +40,3 @@ class TestDepthMiddleware(TestCase):
 
     def tearDown(self):
         self.stats.close_spider(self.spider, '')
-

--- a/tests/test_spidermiddleware_httperror.py
+++ b/tests/test_spidermiddleware_httperror.py
@@ -1,15 +1,15 @@
 from unittest import TestCase
 
 from testfixtures import LogCapture
-from twisted.trial.unittest import TestCase as TrialTestCase
 from twisted.internet import defer
+from twisted.trial.unittest import TestCase as TrialTestCase
 
+from scrapy.http import Request, Response
+from scrapy.settings import Settings
+from scrapy.spidermiddlewares.httperror import HttpError, HttpErrorMiddleware
+from scrapy.spiders import Spider
 from scrapy.utils.test import get_crawler
 from tests.mockserver import MockServer
-from scrapy.http import Response, Request
-from scrapy.spiders import Spider
-from scrapy.spidermiddlewares.httperror import HttpErrorMiddleware, HttpError
-from scrapy.settings import Settings
 
 
 class _HttpErrorSpider(Spider):

--- a/tests/test_spidermiddleware_offsite.py
+++ b/tests/test_spidermiddleware_offsite.py
@@ -2,10 +2,11 @@ from unittest import TestCase
 
 from six.moves.urllib.parse import urlparse
 
-from scrapy.http import Response, Request
-from scrapy.spiders import Spider
+from scrapy.http import Request, Response
 from scrapy.spidermiddlewares.offsite import OffsiteMiddleware
+from scrapy.spiders import Spider
 from scrapy.utils.test import get_crawler
+
 
 class TestOffsiteMiddleware(TestCase):
 

--- a/tests/test_spidermiddleware_referer.py
+++ b/tests/test_spidermiddleware_referer.py
@@ -1,8 +1,8 @@
 from unittest import TestCase
 
-from scrapy.http import Response, Request
-from scrapy.spiders import Spider
+from scrapy.http import Request, Response
 from scrapy.spidermiddlewares.referer import RefererMiddleware
+from scrapy.spiders import Spider
 
 
 class TestRefererMiddleware(TestCase):
@@ -18,4 +18,3 @@ class TestRefererMiddleware(TestCase):
         out = list(self.mw.process_spider_output(res, reqs, self.spider))
         self.assertEquals(out[0].headers.get('Referer'),
                           b'http://scrapytest.org')
-

--- a/tests/test_spidermiddleware_urllength.py
+++ b/tests/test_spidermiddleware_urllength.py
@@ -1,7 +1,7 @@
 from unittest import TestCase
 
+from scrapy.http import Request, Response
 from scrapy.spidermiddlewares.urllength import UrlLengthMiddleware
-from scrapy.http import Response, Request
 from scrapy.spiders import Spider
 
 
@@ -18,4 +18,3 @@ class TestUrlLengthMiddleware(TestCase):
         spider = Spider('foo')
         out = list(mw.process_spider_output(res, reqs, spider))
         self.assertEquals(out, [short_url_req])
-

--- a/tests/test_spiderstate.py
+++ b/tests/test_spiderstate.py
@@ -1,10 +1,11 @@
 import os
 from datetime import datetime
+
 from twisted.trial import unittest
 
+from scrapy.exceptions import NotConfigured
 from scrapy.extensions.spiderstate import SpiderState
 from scrapy.spiders import Spider
-from scrapy.exceptions import NotConfigured
 from scrapy.utils.test import get_crawler
 
 

--- a/tests/test_squeues.py
+++ b/tests/test_squeues.py
@@ -1,8 +1,10 @@
 from queuelib.tests import test_queue as t
-from scrapy.squeues import MarshalFifoDiskQueue, MarshalLifoDiskQueue, PickleFifoDiskQueue, PickleLifoDiskQueue
-from scrapy.item import Item, Field
+
 from scrapy.http import Request
+from scrapy.item import Field, Item
 from scrapy.loader import ItemLoader
+from scrapy.squeues import MarshalFifoDiskQueue, MarshalLifoDiskQueue, PickleFifoDiskQueue, PickleLifoDiskQueue
+
 
 class TestItem(Item):
     name = Field()

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -1,7 +1,7 @@
 import unittest
 
 from scrapy.spiders import Spider
-from scrapy.statscollectors import StatsCollector, DummyStatsCollector
+from scrapy.statscollectors import DummyStatsCollector, StatsCollector
 from scrapy.utils.test import get_crawler
 
 

--- a/tests/test_toplevel.py
+++ b/tests/test_toplevel.py
@@ -1,5 +1,7 @@
 from unittest import TestCase
+
 import six
+
 import scrapy
 
 

--- a/tests/test_urlparse_monkeypatches.py
+++ b/tests/test_urlparse_monkeypatches.py
@@ -1,5 +1,6 @@
-from six.moves.urllib.parse import urlparse
 import unittest
+
+from six.moves.urllib.parse import urlparse
 
 
 class UrlparseTestCase(unittest.TestCase):

--- a/tests/test_utils_conf.py
+++ b/tests/test_utils_conf.py
@@ -1,7 +1,7 @@
 import unittest
 
 from scrapy.settings import BaseSettings
-from scrapy.utils.conf import build_component_list, arglist_to_dict
+from scrapy.utils.conf import arglist_to_dict, build_component_list
 
 
 class BuildComponentListTest(unittest.TestCase):

--- a/tests/test_utils_console.py
+++ b/tests/test_utils_console.py
@@ -1,6 +1,7 @@
 import unittest
 
 from scrapy.utils.console import get_shell_embed_func
+
 try:
     import bpython
     bpy = True

--- a/tests/test_utils_datatypes.py
+++ b/tests/test_utils_datatypes.py
@@ -130,4 +130,3 @@ class CaselessDictTest(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
-

--- a/tests/test_utils_defer.py
+++ b/tests/test_utils_defer.py
@@ -1,11 +1,9 @@
-from twisted.trial import unittest
-from twisted.internet import reactor, defer
-from twisted.python.failure import Failure
-
-from scrapy.utils.defer import mustbe_deferred, process_chain, \
-    process_chain_both, process_parallel, iter_errback
-
 from six.moves import xrange
+from twisted.internet import defer, reactor
+from twisted.python.failure import Failure
+from twisted.trial import unittest
+
+from scrapy.utils.defer import iter_errback, mustbe_deferred, process_chain, process_chain_both, process_parallel
 
 
 class MustbeDeferredTest(unittest.TestCase):

--- a/tests/test_utils_deprecate.py
+++ b/tests/test_utils_deprecate.py
@@ -1,11 +1,12 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import
+
 import inspect
 import unittest
 import warnings
+
 from scrapy.exceptions import ScrapyDeprecationWarning
 from scrapy.utils.deprecate import create_deprecated_class, update_classpath
-
 from tests import mock
 
 

--- a/tests/test_utils_gz.py
+++ b/tests/test_utils_gz.py
@@ -3,8 +3,8 @@ from os.path import join
 
 from w3lib.encoding import html_to_unicode
 
+from scrapy.http import Headers, Response
 from scrapy.utils.gz import gunzip, is_gzipped
-from scrapy.http import Response, Headers
 from tests import tests_datadir
 
 SAMPLEDIR = join(tests_datadir, 'compressed')

--- a/tests/test_utils_http.py
+++ b/tests/test_utils_http.py
@@ -2,6 +2,7 @@ import unittest
 
 from scrapy.utils.http import decode_chunked_transfer
 
+
 class ChunkedTest(unittest.TestCase):
 
     def test_decode_chunked_transfer(self):
@@ -16,5 +17,3 @@ class ChunkedTest(unittest.TestCase):
             "This is the data in the first chunk\r\n" +
             "and this is the second one\r\n" +
             "consequence")
-
-

--- a/tests/test_utils_httpobj.py
+++ b/tests/test_utils_httpobj.py
@@ -1,8 +1,10 @@
 import unittest
+
 from six.moves.urllib.parse import urlparse
 
 from scrapy.http import Request
 from scrapy.utils.httpobj import urlparse_cached
+
 
 class HttpobjUtilsTest(unittest.TestCase):
 

--- a/tests/test_utils_iterators.py
+++ b/tests/test_utils_iterators.py
@@ -1,10 +1,11 @@
 # -*- coding: utf-8 -*-
 import os
+
 import six
 from twisted.trial import unittest
 
-from scrapy.utils.iterators import csviter, xmliter, _body_or_str, xmliter_lxml
-from scrapy.http import XmlResponse, TextResponse, Response
+from scrapy.http import Response, TextResponse, XmlResponse
+from scrapy.utils.iterators import _body_or_str, csviter, xmliter, xmliter_lxml
 from tests import get_testdata
 
 FOOBAR_NL = u"foo" + os.linesep + u"bar"

--- a/tests/test_utils_log.py
+++ b/tests/test_utils_log.py
@@ -1,14 +1,14 @@
 # -*- coding: utf-8 -*-
 from __future__ import print_function
-import sys
+
 import logging
+import sys
 import unittest
 
 from testfixtures import LogCapture
 from twisted.python.failure import Failure
 
-from scrapy.utils.log import (failure_to_exc_info, TopLevelFormatter,
-                              LogCounterHandler, StreamLogger)
+from scrapy.utils.log import LogCounterHandler, StreamLogger, TopLevelFormatter, failure_to_exc_info
 from scrapy.utils.test import get_crawler
 
 

--- a/tests/test_utils_misc/__init__.py
+++ b/tests/test_utils_misc/__init__.py
@@ -1,9 +1,9 @@
-import sys
 import os
+import sys
 import unittest
 
-from scrapy.item import Item, Field
-from scrapy.utils.misc import load_object, arg_to_iter, walk_modules
+from scrapy.item import Field, Item
+from scrapy.utils.misc import arg_to_iter, load_object, walk_modules
 
 __doctests__ = ['scrapy.utils.misc']
 

--- a/tests/test_utils_project.py
+++ b/tests/test_utils_project.py
@@ -1,8 +1,9 @@
-import unittest
-import os
-import tempfile
-import shutil
 import contextlib
+import os
+import shutil
+import tempfile
+import unittest
+
 from scrapy.utils.project import data_path
 
 

--- a/tests/test_utils_python.py
+++ b/tests/test_utils_python.py
@@ -2,12 +2,13 @@ import functools
 import operator
 import unittest
 from itertools import count
+
 import six
 
 from scrapy.utils.python import (
-    memoizemethod_noargs, binary_is_text, equal_attributes,
-    WeakKeyCache, stringify_dict, get_func_args, to_bytes, to_unicode,
-    without_none_values)
+    WeakKeyCache, binary_is_text, equal_attributes, get_func_args, memoizemethod_noargs, stringify_dict, to_bytes,
+    to_unicode, without_none_values,
+)
 
 __doctests__ = ['scrapy.utils.python']
 

--- a/tests/test_utils_reqser.py
+++ b/tests/test_utils_reqser.py
@@ -3,7 +3,7 @@ import unittest
 
 from scrapy.http import Request
 from scrapy.spiders import Spider
-from scrapy.utils.reqser import request_to_dict, request_from_dict
+from scrapy.utils.reqser import request_from_dict, request_to_dict
 
 
 class RequestSerializationTest(unittest.TestCase):

--- a/tests/test_utils_request.py
+++ b/tests/test_utils_request.py
@@ -1,8 +1,10 @@
 from __future__ import print_function
+
 import unittest
+
 from scrapy.http import Request
-from scrapy.utils.request import request_fingerprint, _fingerprint_cache, \
-    request_authenticate, request_httprepr
+from scrapy.utils.request import _fingerprint_cache, request_authenticate, request_fingerprint, request_httprepr
+
 
 class UtilsRequestTest(unittest.TestCase):
 

--- a/tests/test_utils_response.py
+++ b/tests/test_utils_response.py
@@ -1,11 +1,13 @@
 import os
 import unittest
+
 from six.moves.urllib.parse import urlparse
 
-from scrapy.http import Response, TextResponse, HtmlResponse
+from scrapy.http import HtmlResponse, Response, TextResponse
 from scrapy.utils.python import to_bytes
-from scrapy.utils.response import (response_httprepr, open_in_browser,
-                                   get_meta_refresh, get_base_url, response_status_message)
+from scrapy.utils.response import (
+    get_base_url, get_meta_refresh, open_in_browser, response_httprepr, response_status_message,
+)
 
 __doctests__ = ['scrapy.utils.response']
 

--- a/tests/test_utils_serialize.py
+++ b/tests/test_utils_serialize.py
@@ -1,12 +1,12 @@
+import datetime
 import json
 import unittest
-import datetime
 from decimal import Decimal
 
 from twisted.internet import defer
 
-from scrapy.utils.serialize import ScrapyJSONEncoder
 from scrapy.http import Request, Response
+from scrapy.utils.serialize import ScrapyJSONEncoder
 
 
 class JsonEncoderTestCase(unittest.TestCase):

--- a/tests/test_utils_signal.py
+++ b/tests/test_utils_signal.py
@@ -1,8 +1,8 @@
-from testfixtures import LogCapture
-from twisted.trial import unittest
-from twisted.python.failure import Failure
-from twisted.internet import defer, reactor
 from pydispatch import dispatcher
+from testfixtures import LogCapture
+from twisted.internet import defer, reactor
+from twisted.python.failure import Failure
+from twisted.trial import unittest
 
 from scrapy.utils.signal import send_catch_log, send_catch_log_deferred
 

--- a/tests/test_utils_sitemap.py
+++ b/tests/test_utils_sitemap.py
@@ -2,6 +2,7 @@ import unittest
 
 from scrapy.utils.sitemap import Sitemap, sitemap_urls_from_robots
 
+
 class SitemapTest(unittest.TestCase):
 
     def test_sitemap(self):

--- a/tests/test_utils_spider.py
+++ b/tests/test_utils_spider.py
@@ -1,9 +1,9 @@
 import unittest
+
 from scrapy.http import Request
 from scrapy.item import BaseItem
-from scrapy.utils.spider import iterate_spider_output, iter_spider_classes
-
 from scrapy.spiders import CrawlSpider
+from scrapy.utils.spider import iter_spider_classes, iterate_spider_output
 
 
 class MyBaseSpider(CrawlSpider):
@@ -34,4 +34,3 @@ class UtilsSpidersTestCase(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
-

--- a/tests/test_utils_template.py
+++ b/tests/test_utils_template.py
@@ -1,9 +1,9 @@
 import os
+import unittest
 from shutil import rmtree
 from tempfile import mkdtemp
-import unittest
-from scrapy.utils.template import render_templatefile
 
+from scrapy.utils.template import render_templatefile
 
 __doctests__ = ['scrapy.utils.template']
 

--- a/tests/test_utils_trackref.py
+++ b/tests/test_utils_trackref.py
@@ -1,5 +1,7 @@
-import six
 import unittest
+
+import six
+
 from scrapy.utils import trackref
 from tests import mock
 

--- a/tests/test_utils_url.py
+++ b/tests/test_utils_url.py
@@ -5,8 +5,7 @@ import six
 from six.moves.urllib.parse import urlparse
 
 from scrapy.spiders import Spider
-from scrapy.utils.url import (url_is_from_any_domain, url_is_from_spider,
-                              add_http_if_no_scheme, guess_scheme, parse_url)
+from scrapy.utils.url import add_http_if_no_scheme, guess_scheme, parse_url, url_is_from_any_domain, url_is_from_spider
 
 __doctests__ = ['scrapy.utils.url']
 

--- a/tests/test_webclient.py
+++ b/tests/test_webclient.py
@@ -3,18 +3,22 @@ from twisted.internet import defer
 Tests borrowed from the twisted.web.client tests.
 """
 import os
+
 import six
 from six.moves.urllib.parse import urlparse
-
-from twisted.trial import unittest
-from twisted.web import server, static, util, resource
-from twisted.internet import reactor, defer
-from twisted.test.proto_helpers import StringTransport
-from twisted.python.filepath import FilePath
+from twisted.internet import defer, reactor
 from twisted.protocols.policies import WrappingFactory
+from twisted.python.filepath import FilePath
+from twisted.test.proto_helpers import StringTransport
+from twisted.trial import unittest
+from twisted.web import resource, server, static, util
+from twisted.web.test.test_webclient import (
+    BrokenDownloadResource, ErrorResource, ForeverTakingResource, HostHeaderResource, NoLengthResource,
+    PayloadResource,
+)
 
 from scrapy.core.downloader import webclient as client
-from scrapy.http import Request, Headers
+from scrapy.http import Headers, Request
 from scrapy.utils.python import to_bytes, to_unicode
 
 
@@ -210,9 +214,6 @@ class ScrapyHTTPPageGetterTests(unittest.TestCase):
             Headers({'Hello': ['World'], 'Foo': ['Bar']}))
 
 
-from twisted.web.test.test_webclient import ForeverTakingResource, \
-        ErrorResource, NoLengthResource, HostHeaderResource, \
-        PayloadResource, BrokenDownloadResource
 
 
 class EncodingResource(resource.Resource):

--- a/tox.ini
+++ b/tox.ini
@@ -87,3 +87,11 @@ changedir = {[docs]changedir}
 deps = {[docs]deps}
 commands =
     sphinx-build -W -b linkcheck . {envtmpdir}/linkcheck
+
+[testenv:isort]
+basepython = python3
+usedevelop = false
+deps = isort
+changedir = {toxinidir}
+commands =
+    isort --recursive --check-only --diff scrapy tests


### PR DESCRIPTION
This PR sorts all unsorted imports using [isort](http://isort.readthedocs.io/en/latest/). I have also enabled isort check on travis. For the ease of reviewing I have split the PR into two separate commits, one for sorting all the imports and another for enabling isort check on tavis.

There are certain imports that I had to skip from sorting in order to handle import errors and deprecation warnings. Let me know if there are any other imports that have to skipped or the ones that I've skipped are unnecessary.