### PR TITLE
Replicate stdout and stderr to logfile

### DIFF
--- a/scrapy/utils/log.py
+++ b/scrapy/utils/log.py
@@ -92,8 +92,9 @@ def configure_logging(settings=None, install_root_handler=True):
     if isinstance(settings, dict) or settings is None:
         settings = Settings(settings)
 
-    if settings.getbool('LOG_STDOUT'):
-        sys.stdout = StreamLogger(logging.getLogger('stdout'))
+    if settings.getbool('LOG_STDOUT') and settings.get('LOG_FILE'):
+        sys.stdout = twisted_log.StdioOnnaStick()
+        sys.stderr = twisted_log.StdioOnnaStick(isError=True)
 
     if install_root_handler:
         logging.root.setLevel(logging.NOTSET)

--- a/scrapy/utils/log.py
+++ b/scrapy/utils/log.py
@@ -131,26 +131,6 @@ def log_scrapy_info(settings):
     logger.info("Overridden settings: %(settings)r", {'settings': d})
 
 
-class StreamLogger(object):
-    """Fake file-like stream object that redirects writes to a logger instance
-
-    Taken from:
-        http://www.electricmonk.nl/log/2011/08/14/redirect-stdout-and-stderr-to-a-logger-in-python/
-    """
-    def __init__(self, logger, log_level=logging.INFO):
-        self.logger = logger
-        self.log_level = log_level
-        self.linebuf = ''
-
-    def write(self, buf):
-        for line in buf.rstrip().splitlines():
-            self.logger.log(self.log_level, line.rstrip())
-
-    def flush(self):
-        for h in self.logger.handlers:
-            h.flush()
-
-
 class LogCounterHandler(logging.Handler):
     """Record log levels count into a crawler stats"""
 

--- a/tests/test_utils_log.py
+++ b/tests/test_utils_log.py
@@ -8,7 +8,7 @@ from testfixtures import LogCapture
 from twisted.python.failure import Failure
 
 from scrapy.utils.log import (failure_to_exc_info, TopLevelFormatter,
-                              LogCounterHandler, StreamLogger)
+                              LogCounterHandler)
 from scrapy.utils.test import get_crawler
 
 
@@ -90,20 +90,3 @@ class LogCounterHandlerTest(unittest.TestCase):
     def test_filtered_out_level(self):
         self.logger.debug('test log msg')
         self.assertIsNone(self.crawler.stats.get_value('log_count/INFO'))
-
-
-class StreamLoggerTest(unittest.TestCase):
-
-    def setUp(self):
-        self.stdout = sys.stdout
-        logger = logging.getLogger('test')
-        logger.setLevel(logging.WARNING)
-        sys.stdout = StreamLogger(logger, logging.ERROR)
-
-    def tearDown(self):
-        sys.stdout = self.stdout
-
-    def test_redirect(self):
-        with LogCapture() as l:
-            print('test log msg')
-        l.check(('test', 'ERROR', 'test log msg'))


### PR DESCRIPTION
Context: https://github.com/scrapy/scrapy/issues/1964#issuecomment-216814406

When specifying `LOG_STDOUT = True`
the stdout shouldn't be redirected to the log
but replicated. Same for stderr.

I remember another issue
with exceptions in places such as spiders' `__init__` methods
that were missing their tracebacks in the log,
being logged only on stdout/stderr.
I recently discovered that it's a problem on twisted-15.5.0
but not 16.2.0.

The second commit can be ignored for now.
I was just testing something if the StreamLogger can be deprecated.