### PR TITLE
[MRG+1] Fix/low parsel version number

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ setup(
         'pyOpenSSL',
         'cssselect>=0.9',
         'six>=1.5.2',
-        'parsel>=0.9.3',
+        'parsel>=0.9.5',
         'PyDispatcher>=2.0.5',
         'service_identity',
     ],


### PR DESCRIPTION
if the `parsel` version == 0.9.3 which is the lowest version scrapy needed in `setup.py`, there will be attribute error.
tested in ubuntu 16.04 python 2.7.12 and 2.7.6 with scrapy==1.1.0 and 1.2.2

upgrade to `parsel==0.9.5` as `requirements.txt` will fix this attribute error

```
Python 2.7.12 (default, Nov 19 2016, 06:48:10)
[GCC 5.4.0 20160609] on linux2
Type "help", "copyright", "credits" or "license" for more information.
>>> from scrapy.selector import Selector
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "scrapy/__init__.py", line 34, in <module>
    from scrapy.spiders import Spider
  File "scrapy/spiders/__init__.py", line 116, in <module>
    from scrapy.spiders.feed import XMLFeedSpider, CSVFeedSpider
  File "scrapy/spiders/feed.py", line 8, in <module>
    from scrapy.utils.iterators import xmliter, csviter
  File "scrapy/utils/iterators.py", line 12, in <module>
    from scrapy.selector import Selector
  File "scrapy/selector/__init__.py", line 4, in <module>
    from scrapy.selector.unified import *
  File "scrapy/selector/unified.py", line 29, in <module>
    class SelectorList(_ParselSelector.selectorlist_cls, object_ref):
AttributeError: type object 'Selector' has no attribute 'selectorlist_cls'
```