### PR TITLE
[MRG] Support kwargs for response.xpath()

### DIFF
--- a/docs/topics/selectors.rst
+++ b/docs/topics/selectors.rst
@@ -283,6 +283,40 @@ XPath specification.
 
 .. _Location Paths: https://www.w3.org/TR/xpath#location-paths
 
+.. _topics-selectors-xpath-variables:
+
+Variables in XPath expressions
+------------------------------
+
+XPath allows you to reference variables in your XPath expressions, using
+the ``$somevariable`` syntax. This is somewhat similar to parameterized
+queries or prepared statements in the SQL world where you replace
+some arguments in your queries with placeholders like ``?``,
+which are then substituted with values passed with the query.
+
+Here's an example to match an element based on its "id" attribute value,
+without hard-coding it (that was shown previously)::
+
+    >>> # `$val` used in the expression, a `val` argument needs to be passed
+    >>> response.xpath('//div[@id=$val]/a/text()', val='images').extract_first()
+    u'Name: My image 1 '
+
+Here's another example, to find the "id" attribute of a ``<div>`` tag containing
+five ``<a>`` children (here we pass the value ``5`` as an integer)::
+
+    >>> response.xpath('//div[count(a)=$cnt]/@id', cnt=5).extract_first()
+    u'images'
+
+All variable references must have a binding value when calling ``.xpath()``
+(otherwise you'll get a ``ValueError: XPath error:`` exception).
+This is done by passing as many named arguments as necessary.
+
+`parsel`_, the library powering Scrapy selectors, has more details and examples
+on `XPath variables`_.
+
+.. _parsel: https://parsel.readthedocs.io/
+.. _XPath variables: https://parsel.readthedocs.io/en/latest/usage.html#variables-in-xpath-expressions
+
 Using EXSLT extensions
 ----------------------
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,4 @@ queuelib
 six>=1.5.2
 PyDispatcher>=2.0.5
 service_identity
-parsel>=0.9.5
+parsel>=1.1

--- a/scrapy/http/response/text.py
+++ b/scrapy/http/response/text.py
@@ -111,8 +111,8 @@ class TextResponse(Response):
             self._cached_selector = Selector(self)
         return self._cached_selector
 
-    def xpath(self, query):
-        return self.selector.xpath(query)
+    def xpath(self, query, **kwargs):
+        return self.selector.xpath(query, **kwargs)
 
     def css(self, query):
         return self.selector.css(query)

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ setup(
         'pyOpenSSL',
         'cssselect>=0.9',
         'six>=1.5.2',
-        'parsel>=0.9.5',
+        'parsel>=1.1',
         'PyDispatcher>=2.0.5',
         'service_identity',
     ],


### PR DESCRIPTION
Allow passing named variables and `namespaces` dict arguments on `.xpath()` shortcut, now that https://github.com/scrapy/parsel/pull/45 is merged