### PR TITLE
[MRG+1] settings: fixing name of the pipeline template

### DIFF
--- a/scrapy/templates/project/module/settings.py.tmpl
+++ b/scrapy/templates/project/module/settings.py.tmpl
@@ -65,7 +65,7 @@ ROBOTSTXT_OBEY = True
 # Configure item pipelines
 # See http://scrapy.readthedocs.org/en/latest/topics/item-pipeline.html
 #ITEM_PIPELINES = {
-#    '$project_name.pipelines.SomePipeline': 300,
+#    '$project_name.pipelines.${ProjectName}Pipeline': 300,
 #}
 
 # Enable and configure the AutoThrottle extension (disabled by default)


### PR DESCRIPTION
`scrapy startproject myproject` creates a `pipelines.py` with an example Pipeline with already the name of the project, it only feels natural that this should also be the name on `settings.py` pipelines section.