### PR TITLE
[MRG+1] .devN release suffix must be preceded with a dot

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ branches:
   only:
     - master
     - /^\d\.\d+$/
-    - /^\d\.\d+\.\d+(rc\d+|dev\d+)?$/
+    - /^\d\.\d+\.\d+(rc\d+|\.dev\d+)?$/
 env:
  - TOXENV=py27
  - TOXENV=jessie
@@ -35,4 +35,4 @@ deploy:
   on:
     tags: true
     repo: scrapy/scrapy
-    condition: "$TOXENV == py27 && $TRAVIS_TAG =~ ^[0-9]+[.][0-9]+[.][0-9]+(rc[0-9]+|dev[0-9]+)?$"
+    condition: "$TOXENV == py27 && $TRAVIS_TAG =~ ^[0-9]+[.][0-9]+[.][0-9]+(rc[0-9]+|[.]dev[0-9]+)?$"


### PR DESCRIPTION
https://packaging.python.org/distributing/#standards-compliance-for-interoperability