### PR TITLE
Prevent installation of Twisted >= 16.7 (temporarily)

### DIFF
--- a/requirements-py3.txt
+++ b/requirements-py3.txt
@@ -1,4 +1,4 @@
-Twisted >= 15.5.0
+Twisted >= 15.5.0,<16.7
 lxml>=3.2.4
 pyOpenSSL>=0.13.1
 cssselect>=0.9

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Twisted>=13.1.0
+Twisted>=13.1.0,<16.7
 lxml
 pyOpenSSL
 cssselect>=0.9

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ setup(
         'Topic :: Software Development :: Libraries :: Python Modules',
     ],
     install_requires=[
-        'Twisted>=13.1.0',
+        'Twisted>=13.1.0,<16.7',
         'w3lib>=1.15.0',
         'queuelib',
         'lxml',


### PR DESCRIPTION
This is a (hopefully) temporary measure to prevent users installing the [upcoming Twisted 16.7 release](https://twistedmatrix.com/pipermail/twisted-python/2016-December/030984.html) which does not seem to play well (at all) with Scrapy (see https://github.com/scrapy/scrapy/issues/2461, there are other issues)

We can release a 1.3.1 with this, and also backport to 1.1 and 1.2 branches.