### PR TITLE
Fix issue where redirects with cleanly closed connections would not be followed

### DIFF
--- a/scrapy/downloadermiddlewares/redirect.py
+++ b/scrapy/downloadermiddlewares/redirect.py
@@ -63,7 +63,7 @@ class RedirectMiddleware(BaseRedirectMiddleware):
             return response
 
         allowed_status = (301, 302, 303, 307)
-        if 'Location' not in response.headers or response.status not in allowed_status:
+        if 'location' not in response.headers or response.status not in allowed_status:
             return response
 
         location = safe_url_string(response.headers['location'])


### PR DESCRIPTION
Some servers, like `m.huffpost.com` send a 30X redirect response but close the connection after they've assumed you've read the headers. This causes scrapy to raise a Twisted `ResponseFailed` exception. We catch these exceptions in the `RedirectMiddleware`, take the headers out of the response (since that much is there), create a new scrapy `Response` object out of it, and return that for processing as usual.

At Parse.ly we routinely crawl about 100 pages per second 24 hours per day, and we found that we were hitting this issue literally thousands of times per day.

Also, I think it should be added to the documentation for the `RedirectMiddleware` that you have to set `HTTPERROR_ALLOWED_CODES = [301, 302, 303, 307]` in your settings to allow it to work. Otherwise you just raise `HttpError` exceptions and no redirects occur.