### PR TITLE
[MRG] Enforce DNS resolution timeout

### DIFF
--- a/scrapy/resolver.py
+++ b/scrapy/resolver.py
@@ -16,8 +16,11 @@ class CachingThreadedResolver(ThreadedResolver):
     def getHostByName(self, name, timeout=None):
         if name in dnscache:
             return defer.succeed(dnscache[name])
-        if not timeout:
-            timeout = self.timeout
+        # in Twisted<=16.6, getHostByName() is always called with
+        # a default timeout of 60s (actually passed as (1, 3, 11, 45) tuple),
+        # so the input argument above is simply overridden
+        # to enforce Scrapy's DNS_TIMEOUT setting's value
+        timeout = (self.timeout,)
         d = super(CachingThreadedResolver, self).getHostByName(name, timeout)
         d.addCallback(self._cache_result, name)
         return d


### PR DESCRIPTION
Fixes #2461 

As [@rolando noticed](https://github.com/scrapy/scrapy/issues/2461#issue-197219248), `DNS_TIMEOUT` setting was never actually used by Scrapy with 14<=Twisted<=16.6, because a `(1, 3, 11, 45)` tuple was always passed to the DNS resolver by Twisted internally:

```
Successfully installed twisted-14.0.2
$ scrapy fetch --headers https://www.example.com -s DNS_TIMEOUT=15
2017-01-13 16:06:33 [scrapy.utils.log] INFO: Scrapy 1.3.0 started (bot: scrapybot)
2017-01-13 16:06:33 [scrapy.utils.log] INFO: Overridden settings: {'DNS_TIMEOUT': '15'}
(...)
CachingThreadedResolver.getHostByName(name='www.example.com', timeout=(1, 3, 11, 45))
2017-01-13 16:06:33 [scrapy.core.engine] DEBUG: Crawled (200) <GET https://www.example.com> (referer: None)


Successfully installed twisted-15.5.0
$ scrapy fetch --headers https://www.example.com -s DNS_TIMEOUT=15
2017-01-13 16:07:05 [scrapy.utils.log] INFO: Scrapy 1.3.0 started (bot: scrapybot)
2017-01-13 16:07:05 [scrapy.utils.log] INFO: Overridden settings: {'DNS_TIMEOUT': '15'}
(...)
CachingThreadedResolver.getHostByName(name='www.example.com', timeout=(1, 3, 11, 45))
2017-01-13 16:07:06 [scrapy.core.engine] DEBUG: Crawled (200) <GET https://www.example.com> (referer: None)


Successfully installed twisted-16.6.0
$ scrapy fetch --headers https://www.example.com -s DNS_TIMEOUT=15
2017-01-13 16:07:20 [scrapy.utils.log] INFO: Scrapy 1.3.0 started (bot: scrapybot)
2017-01-13 16:07:20 [scrapy.utils.log] INFO: Overridden settings: {'DNS_TIMEOUT': '15'}
(...)
CachingThreadedResolver.getHostByName(name='www.example.com', timeout=(1, 3, 11, 45))
2017-01-13 16:07:21 [scrapy.core.engine] DEBUG: Crawled (200) <GET https://www.example.com> (referer: None)
```

And Twisted 16.7 actually stops passing this default value, but a tuple (or list) of ints is expected.