### PR TITLE
[MRG+1] Changing README to README.rst

### DIFF
--- a/artwork/README.rst
+++ b/artwork/README.rst
@@ -1,3 +1,5 @@
+:orphan:
+
 Scrapy artwork
 ==============
 

--- a/docs/README.rst
+++ b/docs/README.rst
@@ -1,3 +1,5 @@
+:orphan:
+
 ======================================
 Scrapy documentation quick start guide
 ======================================

--- a/sep/README.rst
+++ b/sep/README.rst
@@ -1,3 +1,5 @@
+:orphan:
+
 Scrapy Enhancement Proposals
 ============================
 


### PR DESCRIPTION
README files are not readable (well-formatted) inside github because of the missing extension, we can  also exclude them from sphinx build with `:orphan:`