### PR TITLE
Fix spelling error in scrapy.1 manpage.

### DIFF
--- a/extras/scrapy.1
+++ b/extras/scrapy.1
@@ -28,16 +28,16 @@ Query Scrapy settings
 Print raw setting value
 .TP
 .I --getbool=SETTING
-Print setting value, intepreted as a boolean
+Print setting value, interpreted as a boolean
 .TP
 .I --getint=SETTING
-Print setting value, intepreted as an integer
+Print setting value, interpreted as an integer
 .TP
 .I --getfloat=SETTING
-Print setting value, intepreted as an float
+Print setting value, interpreted as an float
 .TP
 .I --getlist=SETTING
-Print setting value, intepreted as an float
+Print setting value, interpreted as an float
 .TP
 .I --init
 Print initial setting value (before loading extensions and spiders)

--- a/extras/scrapy.1
+++ b/extras/scrapy.1
@@ -34,10 +34,10 @@ Print setting value, interpreted as a boolean
 Print setting value, interpreted as an integer
 .TP
 .I --getfloat=SETTING
-Print setting value, interpreted as an float
+Print setting value, interpreted as a float
 .TP
 .I --getlist=SETTING
-Print setting value, interpreted as an float
+Print setting value, interpreted as a float
 .TP
 .I --init
 Print initial setting value (before loading extensions and spiders)


### PR DESCRIPTION
The word "intepreted" should be "interpreted".