### PR TITLE
use os.stat in FilesystemCacheStorage

### DIFF
--- a/scrapy/extensions/httpcache.py
+++ b/scrapy/extensions/httpcache.py
@@ -326,9 +326,12 @@ class FilesystemCacheStorage(object):
     def _read_meta(self, spider, request):
         rpath = self._get_request_path(spider, request)
         metapath = os.path.join(rpath, 'pickled_meta')
-        if not os.path.exists(metapath):
-            return  # not found
-        mtime = os.stat(metapath).st_mtime
+        try:
+            mtime = os.stat(metapath).st_mtime
+        except OSError as exc:
+            if exc.errno == os.errno.ENOENT:
+                return  # not found
+            raise
         if 0 < self.expiration_secs < time() - mtime:
             return  # expired
         with self._open(metapath, 'rb') as f:


### PR DESCRIPTION
From the python doc: https://docs.python.org/3/library/os.path.html#os.path.exists
> Return True if path refers to an existing path or an open file descriptor. Returns False for broken symbolic links. On some platforms, this function may return False if permission is not granted to execute os.stat() on the requested file, even if the path physically exists.

I recently restored a backup of my cache, while omitting to preserve ownership.
When I tried to crawl using `HTTPCACHE_IGNORE_MISSING`
all the requests seemed to be missing from the cache.
The FilesystemCacheStorage uses os.path.exists,
which internally calls os.stat,
which, as the doc says, may return False when lacking permissions.

From my python:
```python
def exists(path):
    """Test whether a path exists.  Returns False for broken symbolic links"""
    try:
        os.stat(path)
    except os.error:
        return False
    return True
```

I suggest we replace os.path.exists with os.stat
while catching only ENOENT.
This way, such mistakes will not pass silently
when using `HTTPCACHE_IGNORE_MISSING`.
When not using this setting, `store_response()` already fails the same way.