### PR TITLE
[MRG+1] Use yield with nested parsing of responses

### DIFF
--- a/docs/topics/request-response.rst
+++ b/docs/topics/request-response.rst
@@ -207,12 +207,12 @@ different fields from different pages::
         request = scrapy.Request("http://www.example.com/some_page.html",
                                  callback=self.parse_page2)
         request.meta['item'] = item
-        return request
+        yield request
 
     def parse_page2(self, response):
         item = response.meta['item']
         item['other_url'] = response.url
-        return item
+        yield item
 
 
 .. _topics-request-response-ref-errbacks:


### PR DESCRIPTION
In my project I found that `return` made the spider terminate early, while `yield` worked as intended. `yield` is also used throughout other examples of the `parse` function in the documentation, so even if functionality is similar, using `yield` in this example improves consistency.