### PR TITLE
response.follow

### DIFF
--- a/docs/intro/overview.rst
+++ b/docs/intro/overview.rst
@@ -40,8 +40,7 @@ http://quotes.toscrape.com, following the pagination::
 
             next_page = response.css('li.next a::attr("href")').extract_first()
             if next_page is not None:
-                next_page = response.urljoin(next_page)
-                yield scrapy.Request(next_page, callback=self.parse)
+                yield response.follow(next_page, self.parse)
 
 
 Put this in a text file, name it to something like ``quotes_spider.py``

--- a/docs/topics/request-response.rst
+++ b/docs/topics/request-response.rst
@@ -683,6 +683,10 @@ TextResponse objects
 
             response.css('p')
 
+    .. method:: TextResponse.follow(url, ...)
+
+        Return a scrapy.Request instance to follow a link ``url``.
+
     .. method:: TextResponse.body_as_unicode()
 
         The same as :attr:`text`, but available as a method. This method is

--- a/docs/topics/request-response.rst
+++ b/docs/topics/request-response.rst
@@ -597,6 +597,9 @@ Response objects
 
             urlparse.urljoin(response.url, url)
 
+    .. automethod:: Response.follow
+
+
 .. _urlparse.urljoin: https://docs.python.org/2/library/urlparse.html#urlparse.urljoin
 
 .. _topics-request-response-ref-response-subclasses:
@@ -683,9 +686,7 @@ TextResponse objects
 
             response.css('p')
 
-    .. method:: TextResponse.follow(url, ...)
-
-        Return a scrapy.Request instance to follow a link ``url``.
+    .. automethod:: TextResponse.follow
 
     .. method:: TextResponse.body_as_unicode()
 

--- a/requirements-py3.txt
+++ b/requirements-py3.txt
@@ -3,5 +3,5 @@ lxml>=3.2.4
 pyOpenSSL>=0.13.1
 cssselect>=0.9
 queuelib>=1.1.1
-w3lib>=1.14.2
+w3lib>=1.17.0
 service_identity

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ Twisted>=13.1.0
 lxml
 pyOpenSSL
 cssselect>=0.9
-w3lib>=1.15.0
+w3lib>=1.17.0
 queuelib
 six>=1.5.2
 PyDispatcher>=2.0.5

--- a/scrapy/http/response/__init__.py
+++ b/scrapy/http/response/__init__.py
@@ -6,7 +6,9 @@ See documentation in docs/topics/request-response.rst
 """
 from six.moves.urllib.parse import urljoin
 
+from scrapy.http.request import Request
 from scrapy.http.headers import Headers
+from scrapy.link import Link
 from scrapy.utils.trackref import object_ref
 from scrapy.http.common import obsolete_setter
 from scrapy.exceptions import NotSupported
@@ -101,3 +103,30 @@ class Response(object_ref):
         is text (subclasses of TextResponse).
         """
         raise NotSupported("Response content isn't text")
+
+    def follow(self, url, callback=None, method='GET', headers=None, body=None,
+               cookies=None, meta=None, encoding='utf-8', priority=0,
+               dont_filter=False, errback=None):
+        # type: (...) -> Request
+        """
+        Return a scrapy.Request instance to follow a link ``url``.
+
+        ``url`` can be:
+
+        * absolute URL;
+        * relative URL;
+        * scrapy.link.Link object.
+        """
+        if isinstance(url, Link):
+            url = url.url
+        url = self.urljoin(url)
+        return Request(url, callback,
+                       method=method,
+                       headers=headers,
+                       body=body,
+                       cookies=cookies,
+                       meta=meta,
+                       encoding=encoding,
+                       priority=priority,
+                       dont_filter=dont_filter,
+                       errback=errback)

--- a/scrapy/http/response/__init__.py
+++ b/scrapy/http/response/__init__.py
@@ -109,13 +109,14 @@ class Response(object_ref):
                dont_filter=False, errback=None):
         # type: (...) -> Request
         """
-        Return a scrapy.Request instance to follow a link ``url``.
-
-        ``url`` can be:
-
-        * absolute URL;
-        * relative URL;
-        * scrapy.link.Link object.
+        Return a :class:`~.Request` instance to follow a link ``url``.
+        It accepts the same arguments as ``Request.__init__`` method,
+        but ``url`` can be a relative URL or a ``scrapy.link.Link`` object,
+        not only an absolute URL.
+        
+        :class:`~.TextResponse` provides a :meth:`~.TextResponse.follow` 
+        method which supports selectors in addition to absolute/relative URLs
+        and Link objects.
         """
         if isinstance(url, Link):
             url = url.url

--- a/scrapy/http/response/text.py
+++ b/scrapy/http/response/text.py
@@ -11,6 +11,7 @@ from six.moves.urllib.parse import urljoin
 import parsel
 from w3lib.encoding import html_to_unicode, resolve_encoding, \
     html_body_declared_encoding, http_content_type_encoding
+from w3lib.html import strip_html5_whitespace
 
 from scrapy.link import Link
 from scrapy.http.request import Request
@@ -142,7 +143,7 @@ class TextResponse(Response):
         if isinstance(url, Link):
             url = url.url
         elif isinstance(url, parsel.Selector):
-            url = _url_from_selector(url).strip()
+            url = _url_from_selector(url)
         elif isinstance(url, parsel.SelectorList):
             raise ValueError("SelectorList is not supported")
 
@@ -164,7 +165,7 @@ def _url_from_selector(sel):
     # type: (parsel.Selector) -> str
     if isinstance(sel.root, six.string_types):
         # e.g. ::attr(href) result
-        return sel.root
+        return strip_html5_whitespace(sel.root)
     if not hasattr(sel.root, 'tag'):
         raise ValueError("Unsupported selector: %s" % sel)
     if sel.root.tag != 'a':
@@ -173,4 +174,4 @@ def _url_from_selector(sel):
     href = sel.root.get('href')
     if href is None:
         raise ValueError("<a> element has no href attribute: %s" % sel)
-    return href
+    return strip_html5_whitespace(href)

--- a/scrapy/http/response/text.py
+++ b/scrapy/http/response/text.py
@@ -142,10 +142,9 @@ class TextResponse(Response):
         if isinstance(url, Link):
             url = url.url
         elif isinstance(url, parsel.Selector):
-            url = _url_from_selector(url)
+            url = _url_from_selector(url).strip()
         elif isinstance(url, parsel.SelectorList):
-            raise ValueError("Please pass either string")
-
+            raise ValueError("SelectorList is not supported")
 
         encoding = self.encoding if encoding is None else encoding
         url = self.urljoin(url)

--- a/scrapy/http/response/text.py
+++ b/scrapy/http/response/text.py
@@ -140,25 +140,22 @@ class TextResponse(Response):
         * a Selector for ``<a>`` element, e.g.
           ``response.css('a.my_link')[0]``.
         """
-        if isinstance(url, Link):
-            url = url.url
-        elif isinstance(url, parsel.Selector):
+        if isinstance(url, parsel.Selector):
             url = _url_from_selector(url)
         elif isinstance(url, parsel.SelectorList):
             raise ValueError("SelectorList is not supported")
-
         encoding = self.encoding if encoding is None else encoding
-        url = self.urljoin(url)
-        return Request(url, callback,
-                       method=method,
-                       headers=headers,
-                       body=body,
-                       cookies=cookies,
-                       meta=meta,
-                       encoding=encoding,
-                       priority=priority,
-                       dont_filter=dont_filter,
-                       errback=errback)
+        return super(TextResponse, self).follow(url, callback,
+            method=method,
+            headers=headers,
+            body=body,
+            cookies=cookies,
+            meta=meta,
+            encoding=encoding,
+            priority=priority,
+            dont_filter=dont_filter,
+            errback=errback
+        )
 
 
 def _url_from_selector(sel):

--- a/scrapy/http/response/text.py
+++ b/scrapy/http/response/text.py
@@ -13,7 +13,6 @@ from w3lib.encoding import html_to_unicode, resolve_encoding, \
     html_body_declared_encoding, http_content_type_encoding
 from w3lib.html import strip_html5_whitespace
 
-from scrapy.link import Link
 from scrapy.http.request import Request
 from scrapy.http.response import Response
 from scrapy.utils.response import get_base_url
@@ -127,18 +126,19 @@ class TextResponse(Response):
                dont_filter=False, errback=None):
         # type: (...) -> Request
         """
-        Return a scrapy.Request instance to follow a link ``url``.
-
-        ``url`` can be:
-
-        * absolute URL;
-        * relative URL;
-        * scrapy.link.Link object (e.g. a link extractor result);
-        * attribute Selector (not SelectorList) - e.g.
+        Return a :class:`~.Request` instance to follow a link ``url``.
+        It accepts the same arguments as ``Request.__init__`` method,
+        but ``url`` can be not only an absolute URL, but also
+        
+        * a relative URL;
+        * a scrapy.link.Link object (e.g. a link extractor result);
+        * an attribute Selector (not SelectorList) - e.g.
           ``response.css('a::attr(href)')[0]`` or
           ``response.xpath('//img/@src')[0]``.
         * a Selector for ``<a>`` element, e.g.
           ``response.css('a.my_link')[0]``.
+          
+        See :ref:`response-follow-example` for usage examples.
         """
         if isinstance(url, parsel.Selector):
             url = _url_from_selector(url)

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ setup(
     ],
     install_requires=[
         'Twisted>=13.1.0',
-        'w3lib>=1.15.0',
+        'w3lib>=1.17.0',
         'queuelib',
         'lxml',
         'pyOpenSSL',

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -26,9 +26,12 @@ try:
 except ImportError:
     import mock
 
-tests_datadir = os.path.join(os.path.abspath(os.path.dirname(__file__)), 'sample_data')
+tests_datadir = os.path.join(os.path.abspath(os.path.dirname(__file__)),
+                             'sample_data')
+
 
 def get_testdata(*paths):
     """Return test data"""
     path = os.path.join(tests_datadir, *paths)
-    return open(path, 'rb').read()
+    with open(path, 'rb') as f:
+        return f.read()

--- a/tests/test_http_response.py
+++ b/tests/test_http_response.py
@@ -411,8 +411,8 @@ class TextResponseTest(BaseResponseTest):
 
     def test_follow_selector_list(self):
         resp = self._links_response()
-        self.assertRaisesRegex(ValueError, 'SelectorList',
-                               resp.follow, resp.css('a'))
+        self.assertRaisesRegexp(ValueError, 'SelectorList',
+                                resp.follow, resp.css('a'))
 
     def test_follow_selector_attribute(self):
         resp = self._links_response()
@@ -435,7 +435,7 @@ class TextResponseTest(BaseResponseTest):
         resp1 = self.response_class(
             'http://example.com',
             encoding='utf8',
-            body='<html><body><a href="foo?привет">click me</a></body></html>'.encode('utf8')
+            body=u'<html><body><a href="foo?привет">click me</a></body></html>'.encode('utf8')
         )
         req = self._assert_followed_url(
             resp1.css('a')[0],
@@ -447,7 +447,7 @@ class TextResponseTest(BaseResponseTest):
         resp2 = self.response_class(
             'http://example.com',
             encoding='cp1251',
-            body='<html><body><a href="foo?привет">click me</a></body></html>'.encode('cp1251')
+            body=u'<html><body><a href="foo?привет">click me</a></body></html>'.encode('cp1251')
         )
         req = self._assert_followed_url(
             resp2.css('a')[0],

--- a/tests/test_http_response.py
+++ b/tests/test_http_response.py
@@ -143,6 +143,38 @@ class BaseResponseTest(unittest.TestCase):
             r.css('body')
             r.xpath('//body')
 
+    def test_follow_url_absolute(self):
+        self._assert_followed_url('http://foo.example.com',
+                                  'http://foo.example.com')
+
+    def test_follow_url_relative(self):
+        self._assert_followed_url('foo',
+                                  'http://example.com/foo')
+
+    def test_follow_link(self):
+        self._assert_followed_url(Link('http://example.com/foo'),
+                                  'http://example.com/foo')
+
+    def test_follow_whitespace_url(self):
+        self._assert_followed_url('foo ',
+                                  'http://example.com/foo%20')
+
+    def test_follow_whitespace_link(self):
+        self._assert_followed_url(Link('http://example.com/foo '),
+                                  'http://example.com/foo%20')
+
+    def _assert_followed_url(self, follow_obj, target_url, response=None):
+        if response is None:
+            response = self._links_response()
+        req = response.follow(follow_obj)
+        self.assertEqual(req.url, target_url)
+        return req
+
+    def _links_response(self):
+        body = get_testdata('link_extractor', 'sgml_linkextractor.html')
+        resp = self.response_class('http://example.com/index', body=body)
+        return resp
+
 
 class TextResponseTest(BaseResponseTest):
 
@@ -354,15 +386,80 @@ class TextResponseTest(BaseResponseTest):
         absolute = 'http://www.example.com/elsewhere/test'
         self.assertEqual(joined, absolute)
 
+    def test_follow_selector(self):
+        resp = self._links_response()
+        urls = [
+            'http://example.com/sample2.html',
+            'http://example.com/sample3.html',
+            'http://example.com/sample3.html',
+            'http://www.google.com/something',
+            'http://example.com/innertag.html'
+        ]
+
+        # select <a> elements
+        for sellist in [resp.css('a'), resp.xpath('//a')]:
+            for sel, url in zip(sellist, urls):
+                self._assert_followed_url(sel, url, response=resp)
+
+        # href attributes should work
+        for sellist in [resp.css('a::attr(href)'), resp.xpath('//a/@href')]:
+            for sel, url in zip(sellist, urls):
+                self._assert_followed_url(sel, url, response=resp)
+
+        # non-a elements are not supported
+        self.assertRaises(ValueError, resp.follow, resp.css('div')[0])
+
+    def test_follow_selector_list(self):
+        resp = self._links_response()
+        self.assertRaisesRegex(ValueError, 'SelectorList',
+                               resp.follow, resp.css('a'))
+
+    def test_follow_selector_attribute(self):
+        resp = self._links_response()
+        for src in resp.css('img::attr(src)'):
+            self._assert_followed_url(src, 'http://example.com/sample2.jpg')
+
+    def test_follow_whitespace_selector(self):
+        resp = self.response_class(
+            'http://example.com',
+            body=b'''<html><body><a href=" foo\n">click me</a></body></html>'''
+        )
+        self._assert_followed_url(resp.css('a')[0],
+                                 'http://example.com/foo',
+                                  response=resp)
+        self._assert_followed_url(resp.css('a::attr(href)')[0],
+                                 'http://example.com/foo',
+                                  response=resp)
+
+    def test_follow_encoding(self):
+        resp1 = self.response_class(
+            'http://example.com',
+            encoding='utf8',
+            body='<html><body><a href="foo?привет">click me</a></body></html>'.encode('utf8')
+        )
+        req = self._assert_followed_url(
+            resp1.css('a')[0],
+            'http://example.com/foo?%D0%BF%D1%80%D0%B8%D0%B2%D0%B5%D1%82',
+            response=resp1,
+        )
+        self.assertEqual(req.encoding, 'utf8')
+
+        resp2 = self.response_class(
+            'http://example.com',
+            encoding='cp1251',
+            body='<html><body><a href="foo?привет">click me</a></body></html>'.encode('cp1251')
+        )
+        req = self._assert_followed_url(
+            resp2.css('a')[0],
+            'http://example.com/foo?%EF%F0%E8%E2%E5%F2',
+            response=resp2,
+        )
+        self.assertEqual(req.encoding, 'cp1251')
+
 
 class HtmlResponseTest(TextResponseTest):
 
     response_class = HtmlResponse
-
-    def _links_response(self):
-        body = get_testdata('link_extractor', 'sgml_linkextractor.html')
-        resp = self.response_class('http://example.com/index', body=body)
-        return resp
 
     def test_html_encoding(self):
 
@@ -395,103 +492,6 @@ class HtmlResponseTest(TextResponseTest):
         body = b"""<html><head><meta charset="gb2312" /><title>Some page</title><body>bla bla</body>"""
         r1 = self.response_class("http://www.example.com", body=body)
         self._assert_response_values(r1, 'gb2312', body)
-
-    def assert_followed_url(self, follow_obj, target_url, response=None):
-        if response is None:
-            response = self._links_response()
-        req = response.follow(follow_obj)
-        self.assertEqual(req.url, target_url)
-        return req
-
-    def test_follow_url_absolute(self):
-        self.assert_followed_url('http://foo.example.com',
-                                 'http://foo.example.com')
-
-    def test_follow_url_relative(self):
-        self.assert_followed_url('foo',
-                                 'http://example.com/foo')
-
-    def test_follow_link(self):
-        self.assert_followed_url(Link('http://example.com/foo'),
-                                 'http://example.com/foo')
-
-    def test_follow_selector(self):
-        resp = self._links_response()
-        urls = [
-            'http://example.com/sample2.html',
-            'http://example.com/sample3.html',
-            'http://example.com/sample3.html',
-            'http://www.google.com/something',
-            'http://example.com/innertag.html'
-        ]
-
-        # select <a> elements
-        for sellist in [resp.css('a'), resp.xpath('//a')]:
-            for sel, url in zip(sellist, urls):
-                self.assert_followed_url(sel, url, response=resp)
-
-        # href attributes should work
-        for sellist in [resp.css('a::attr(href)'), resp.xpath('//a/@href')]:
-            for sel, url in zip(sellist, urls):
-                self.assert_followed_url(sel, url, response=resp)
-
-        # non-a elements are not supported
-        self.assertRaises(ValueError, resp.follow, resp.css('div')[0])
-
-    def test_follow_selector_list(self):
-        resp = self._links_response()
-        self.assertRaisesRegex(ValueError, 'SelectorList',
-                               resp.follow, resp.css('a'))
-
-    def test_follow_selector_attribute(self):
-        resp = self._links_response()
-        for src in resp.css('img::attr(src)'):
-            self.assert_followed_url(src, 'http://example.com/sample2.jpg')
-
-    def test_follow_whitespace_url(self):
-        self.assert_followed_url('foo ',
-                                 'http://example.com/foo%20')
-
-    def test_follow_whitespace_link(self):
-        self.assert_followed_url(Link('http://example.com/foo '),
-                                 'http://example.com/foo%20')
-
-    def test_follow_whitespace_selector(self):
-        resp = self.response_class(
-            'http://example.com',
-            body=b'''<html><body><a href=" foo\n">click me</a></body></html>'''
-        )
-        self.assert_followed_url(resp.css('a')[0],
-                                 'http://example.com/foo',
-                                 response=resp)
-        self.assert_followed_url(resp.css('a::attr(href)')[0],
-                                 'http://example.com/foo',
-                                 response=resp)
-
-    def test_follow_encoding(self):
-        resp1 = self.response_class(
-            'http://example.com',
-            encoding='utf8',
-            body='<html><body><a href="foo?привет">click me</a></body></html>'.encode('utf8')
-        )
-        req = self.assert_followed_url(
-            resp1.css('a')[0],
-            'http://example.com/foo?%D0%BF%D1%80%D0%B8%D0%B2%D0%B5%D1%82',
-            response=resp1,
-        )
-        self.assertEqual(req.encoding, 'utf8')
-
-        resp2 = self.response_class(
-            'http://example.com',
-            encoding='cp1251',
-            body='<html><body><a href="foo?привет">click me</a></body></html>'.encode('cp1251')
-        )
-        req = self.assert_followed_url(
-            resp2.css('a')[0],
-            'http://example.com/foo?%EF%F0%E8%E2%E5%F2',
-            response=resp2,
-        )
-        self.assertEqual(req.encoding, 'cp1251')
 
 
 class XmlResponseTest(TextResponseTest):

--- a/tests/test_http_response.py
+++ b/tests/test_http_response.py
@@ -414,10 +414,23 @@ class TextResponseTest(BaseResponseTest):
         self.assertRaisesRegexp(ValueError, 'SelectorList',
                                 resp.follow, resp.css('a'))
 
+    def test_follow_selector_invalid(self):
+        resp = self._links_response()
+        self.assertRaisesRegexp(ValueError, 'Unsupported',
+                                resp.follow, resp.xpath('count(//div)')[0])
+
     def test_follow_selector_attribute(self):
         resp = self._links_response()
         for src in resp.css('img::attr(src)'):
             self._assert_followed_url(src, 'http://example.com/sample2.jpg')
+
+    def test_follow_selector_no_href(self):
+        resp = self.response_class(
+            url='http://example.com',
+            body=b'<html><body><a name=123>click me</a></body></html>',
+        )
+        self.assertRaisesRegexp(ValueError, 'no href',
+                                resp.follow, resp.css('a')[0])
 
     def test_follow_whitespace_selector(self):
         resp = self.response_class(

--- a/tests/test_http_response.py
+++ b/tests/test_http_response.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 import unittest
 
 import six
@@ -8,6 +9,8 @@ from scrapy.http import (Request, Response, TextResponse, HtmlResponse,
 from scrapy.selector import Selector
 from scrapy.utils.python import to_native_str
 from scrapy.exceptions import NotSupported
+from scrapy.link import Link
+from tests import get_testdata
 
 
 class BaseResponseTest(unittest.TestCase):
@@ -356,6 +359,11 @@ class HtmlResponseTest(TextResponseTest):
 
     response_class = HtmlResponse
 
+    def _links_response(self):
+        body = get_testdata('link_extractor', 'sgml_linkextractor.html')
+        resp = self.response_class('http://example.com/index', body=body)
+        return resp
+
     def test_html_encoding(self):
 
         body = b"""<html><head><title>Some page</title><meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
@@ -387,6 +395,103 @@ class HtmlResponseTest(TextResponseTest):
         body = b"""<html><head><meta charset="gb2312" /><title>Some page</title><body>bla bla</body>"""
         r1 = self.response_class("http://www.example.com", body=body)
         self._assert_response_values(r1, 'gb2312', body)
+
+    def assert_followed_url(self, follow_obj, target_url, response=None):
+        if response is None:
+            response = self._links_response()
+        req = response.follow(follow_obj)
+        self.assertEqual(req.url, target_url)
+        return req
+
+    def test_follow_url_absolute(self):
+        self.assert_followed_url('http://foo.example.com',
+                                 'http://foo.example.com')
+
+    def test_follow_url_relative(self):
+        self.assert_followed_url('foo',
+                                 'http://example.com/foo')
+
+    def test_follow_link(self):
+        self.assert_followed_url(Link('http://example.com/foo'),
+                                 'http://example.com/foo')
+
+    def test_follow_selector(self):
+        resp = self._links_response()
+        urls = [
+            'http://example.com/sample2.html',
+            'http://example.com/sample3.html',
+            'http://example.com/sample3.html',
+            'http://www.google.com/something',
+            'http://example.com/innertag.html'
+        ]
+
+        # select <a> elements
+        for sellist in [resp.css('a'), resp.xpath('//a')]:
+            for sel, url in zip(sellist, urls):
+                self.assert_followed_url(sel, url, response=resp)
+
+        # href attributes should work
+        for sellist in [resp.css('a::attr(href)'), resp.xpath('//a/@href')]:
+            for sel, url in zip(sellist, urls):
+                self.assert_followed_url(sel, url, response=resp)
+
+        # non-a elements are not supported
+        self.assertRaises(ValueError, resp.follow, resp.css('div')[0])
+
+    def test_follow_selector_list(self):
+        resp = self._links_response()
+        self.assertRaisesRegex(ValueError, 'SelectorList',
+                               resp.follow, resp.css('a'))
+
+    def test_follow_selector_attribute(self):
+        resp = self._links_response()
+        for src in resp.css('img::attr(src)'):
+            self.assert_followed_url(src, 'http://example.com/sample2.jpg')
+
+    def test_follow_whitespace_url(self):
+        self.assert_followed_url('foo ',
+                                 'http://example.com/foo%20')
+
+    def test_follow_whitespace_link(self):
+        self.assert_followed_url(Link('http://example.com/foo '),
+                                 'http://example.com/foo%20')
+
+    def test_follow_whitespace_selector(self):
+        resp = self.response_class(
+            'http://example.com',
+            body=b'''<html><body><a href=" foo\n">click me</a></body></html>'''
+        )
+        self.assert_followed_url(resp.css('a')[0],
+                                 'http://example.com/foo',
+                                 response=resp)
+        self.assert_followed_url(resp.css('a::attr(href)')[0],
+                                 'http://example.com/foo',
+                                 response=resp)
+
+    def test_follow_encoding(self):
+        resp1 = self.response_class(
+            'http://example.com',
+            encoding='utf8',
+            body='<html><body><a href="foo?привет">click me</a></body></html>'.encode('utf8')
+        )
+        req = self.assert_followed_url(
+            resp1.css('a')[0],
+            'http://example.com/foo?%D0%BF%D1%80%D0%B8%D0%B2%D0%B5%D1%82',
+            response=resp1,
+        )
+        self.assertEqual(req.encoding, 'utf8')
+
+        resp2 = self.response_class(
+            'http://example.com',
+            encoding='cp1251',
+            body='<html><body><a href="foo?привет">click me</a></body></html>'.encode('cp1251')
+        )
+        req = self.assert_followed_url(
+            resp2.css('a')[0],
+            'http://example.com/foo?%EF%F0%E8%E2%E5%F2',
+            response=resp2,
+        )
+        self.assertEqual(req.encoding, 'cp1251')
 
 
 class XmlResponseTest(TextResponseTest):


### PR DESCRIPTION
A proposed fix for https://github.com/scrapy/scrapy/issues/1940.

TODO:

* [x] tests
* [x] docs
* [x] Response.follow
* [x] default encoding is response encoding, not utf8 - is it OK for auto-detected encodings ~~(which is cp1252 by default for responses without headers/meta tags)~~?