### PR TITLE
[MRG+1] Remove code required to support ancient twisted versions.

### DIFF
--- a/scrapy/core/downloader/handlers/http.py
+++ b/scrapy/core/downloader/handlers/http.py
@@ -1,10 +1,6 @@
-from scrapy import twisted_version
+from __future__ import absolute_import
 from .http10 import HTTP10DownloadHandler
-
-if twisted_version >= (11, 1, 0):
-    from .http11 import HTTP11DownloadHandler as HTTPDownloadHandler
-else:
-    HTTPDownloadHandler = HTTP10DownloadHandler
+from .http11 import HTTP11DownloadHandler as HTTPDownloadHandler
 
 
 # backwards compatibility

--- a/tests/test_downloadermiddleware_retry.py
+++ b/tests/test_downloadermiddleware_retry.py
@@ -5,7 +5,6 @@ from twisted.internet.error import TimeoutError, DNSLookupError, \
         ConnectionLost, TCPTimedOutError
 from twisted.web.client import ResponseFailed
 
-from scrapy import twisted_version
 from scrapy.downloadermiddlewares.retry import RetryMiddleware
 from scrapy.spiders import Spider
 from scrapy.http import Request, Response
@@ -74,9 +73,7 @@ class RetryTest(unittest.TestCase):
     def test_twistederrors(self):
         exceptions = [defer.TimeoutError, TCPTimedOutError, TimeoutError,
                 DNSLookupError, ConnectionRefusedError, ConnectionDone,
-                ConnectError, ConnectionLost]
-        if twisted_version >= (11, 1, 0): # http11 available
-            exceptions.append(ResponseFailed)
+                ConnectError, ConnectionLost, ResponseFailed]
 
         for exc in exceptions:
             req = Request('http://www.scrapytest.org/%s' % exc.__name__)


### PR DESCRIPTION
A follow-up to #1887.