### PR TITLE
[MRG+1] Separate building request from _requests_to_follow in CrawlSpider

### DIFF
--- a/scrapy/spiders/crawl.py
+++ b/scrapy/spiders/crawl.py
@@ -48,6 +48,11 @@ class CrawlSpider(Spider):
     def process_results(self, response, results):
         return results
 
+    def _build_request(self, rule, link):
+        r = Request(url=link.url, callback=self._response_downloaded)
+        r.meta.update(rule=rule, link_text=link.text)
+        return r
+
     def _requests_to_follow(self, response):
         if not isinstance(response, HtmlResponse):
             return
@@ -59,8 +64,7 @@ class CrawlSpider(Spider):
                 links = rule.process_links(links)
             for link in links:
                 seen.add(link)
-                r = Request(url=link.url, callback=self._response_downloaded)
-                r.meta.update(rule=n, link_text=link.text)
+                r = self._build_request(n, link)
                 yield rule.process_request(r)
 
     def _response_downloaded(self, response):


### PR DESCRIPTION
I use scrapy-splash for javascript and sometimes want to change the request to another request  like splash one because it should be convenient using same logic for html after runing javascript.

scrapy-splash's request is following:
https://github.com/scrapy-plugins/scrapy-splash#examples

What do you think about that? Should I implement new spider?