### PR TITLE
[MRG+1] Doc: binary mode is required for exporters

### DIFF
--- a/docs/topics/exporters.rst
+++ b/docs/topics/exporters.rst
@@ -225,7 +225,8 @@ XmlItemExporter
 
    Exports Items in XML format to the specified file object.
 
-   :param file: the file-like object to use for exporting the data.
+   :param file: the file-like object to use for exporting the data. Its ``write`` method should
+                accept ``bytes`` (a disk file opened in binary mode, a ``io.BytesIO`` object, etc)
 
    :param root_element: The name of root element in the exported XML.
    :type root_element: str
@@ -281,7 +282,8 @@ CsvItemExporter
    CSV columns and their order. The :attr:`export_empty_fields` attribute has
    no effect on this exporter.
 
-   :param file: the file-like object to use for exporting the data.
+   :param file: the file-like object to use for exporting the data. Its ``write`` method should
+                accept ``bytes`` (a disk file opened in binary mode, a ``io.BytesIO`` object, etc)
 
    :param include_headers_line: If enabled, makes the exporter output a header
       line with the field names taken from
@@ -312,7 +314,8 @@ PickleItemExporter
 
    Exports Items in pickle format to the given file-like object.
 
-   :param file: the file-like object to use for exporting the data.
+   :param file: the file-like object to use for exporting the data. Its ``write`` method should
+                accept ``bytes`` (a disk file opened in binary mode, a ``io.BytesIO`` object, etc)
 
    :param protocol: The pickle protocol to use.
    :type protocol: int
@@ -333,7 +336,8 @@ PprintItemExporter
 
    Exports Items in pretty print format to the specified file object.
 
-   :param file: the file-like object to use for exporting the data.
+   :param file: the file-like object to use for exporting the data. Its ``write`` method should
+                accept ``bytes`` (a disk file opened in binary mode, a ``io.BytesIO`` object, etc)
 
    The additional keyword arguments of this constructor are passed to the
    :class:`BaseItemExporter` constructor.
@@ -356,7 +360,8 @@ JsonItemExporter
    arguments to the `JSONEncoder`_ constructor, so you can use any
    `JSONEncoder`_ constructor argument to customize this exporter.
 
-   :param file: the file-like object to use for exporting the data.
+   :param file: the file-like object to use for exporting the data. Its ``write`` method should
+                accept ``bytes`` (a disk file opened in binary mode, a ``io.BytesIO`` object, etc)
 
    A typical output of this exporter would be::
 
@@ -386,7 +391,8 @@ JsonLinesItemExporter
    the `JSONEncoder`_ constructor, so you can use any `JSONEncoder`_
    constructor argument to customize this exporter.
 
-   :param file: the file-like object to use for exporting the data.
+   :param file: the file-like object to use for exporting the data. Its ``write`` method should
+                accept ``bytes`` (a disk file opened in binary mode, a ``io.BytesIO`` object, etc)
 
    A typical output of this exporter would be::
 


### PR DESCRIPTION
Closes #2553

~I left `XmlItemExporter` out of the modifications, it's the only class which does not seem to have problems writing to either `bytes` or `str` streams (`io.BytesIO` or `io.StringIO`, for instance).~

```
from io import BytesIO, StringIO

with BytesIO(b'') as f:
    exporter = XmlItemExporter(f)
    exporter.start_exporting()
    exporter.export_item({'some': 'value'})
    exporter.finish_exporting()
    print(f.getvalue())

with StringIO(u'') as f:
    exporter = XmlItemExporter(f)
    exporter.start_exporting()
    exporter.export_item({'some': 'value'})
    exporter.finish_exporting()
    print(f.getvalue())
```
outputs:
```
b'<?xml version="1.0" encoding="utf-8"?>\n<items><item><some>value</some></item></items>'
<?xml version="1.0" encoding="utf-8"?>
<items><item><some>value</some></item></items>
```
/cc @kmike 