### PR TITLE
remove “Python 3 progress” badge

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -13,10 +13,6 @@ Scrapy
 .. image:: https://img.shields.io/badge/wheel-yes-brightgreen.svg
    :target: https://pypi.python.org/pypi/Scrapy
    :alt: Wheel Status
-   
-.. image:: http://static.scrapy.org/py3progress/badge.svg
-   :target: https://github.com/scrapy/scrapy/wiki/Python-3-Porting
-   :alt: Python 3 Porting Status
 
 .. image:: https://img.shields.io/codecov/c/github/scrapy/scrapy/master.svg
    :target: http://codecov.io/github/scrapy/scrapy?branch=master


### PR DESCRIPTION
Badge doesn’t work, and Scrapy already works fine in Python 3
for practical purposes.