### PR TITLE
TST fixed ProjectUtilsTest on OS X

### DIFF
--- a/tests/test_utils_project.py
+++ b/tests/test_utils_project.py
@@ -31,5 +31,8 @@ class ProjectUtilsTest(unittest.TestCase):
     def test_data_path_inside_project(self):
         with inside_a_project() as proj_path:
             expected = os.path.join(proj_path, '.scrapy', 'somepath')
-            self.assertEquals(expected, data_path('somepath'))
+            self.assertEquals(
+                os.path.realpath(expected),
+                os.path.realpath(data_path('somepath'))
+            )
             self.assertEquals('/absolute/path', data_path('/absolute/path'))


### PR DESCRIPTION
Temp folder can be a symlink on OS X; tests failed for me with this exception:

```
tests/test_utils_project.py F.

================================================================== FAILURES ===================================================================
_______________________________________________ ProjectUtilsTest.test_data_path_inside_project ________________________________________________

self = <tests.test_utils_project.ProjectUtilsTest testMethod=test_data_path_inside_project>

    def test_data_path_inside_project(self):
        with inside_a_project() as proj_path:
            expected = os.path.join(proj_path, '.scrapy', 'somepath')
>           self.assertEquals(expected, data_path('somepath'))
E           AssertionError: '/var/folders/_5/cbsg50991szfp1r9nwxpx85800[31 chars]path' != '/private/var/folders/_5/cbsg50991szfp1r9nw[39 chars]path'
E           - /var/folders/_5/cbsg50991szfp1r9nwxpx8580000gn/T/tmp_v300tga/.scrapy/somepath
E           + /private/var/folders/_5/cbsg50991szfp1r9nwxpx8580000gn/T/tmp_v300tga/.scrapy/somepath
E           ? ++++++++
```

This PR fixed that.