### PR TITLE
[MRG+1] TST remove temp files and folders

### DIFF
--- a/tests/test_feedexport.py
+++ b/tests/test_feedexport.py
@@ -57,8 +57,11 @@ class FileFeedStorageTest(unittest.TestCase):
         file.write(b"content")
         yield storage.store(file)
         self.assertTrue(os.path.exists(path))
-        with open(path, 'rb') as fp:
-            self.assertEqual(fp.read(), b"content")
+        try:
+            with open(path, 'rb') as fp:
+                self.assertEqual(fp.read(), b"content")
+        finally:
+            os.unlink(path)
 
 
 class FTPFeedStorageTest(unittest.TestCase):
@@ -79,12 +82,15 @@ class FTPFeedStorageTest(unittest.TestCase):
         file.write(b"content")
         yield storage.store(file)
         self.assertTrue(os.path.exists(path))
-        with open(path, 'rb') as fp:
-            self.assertEqual(fp.read(), b"content")
-        # again, to check s3 objects are overwritten
-        yield storage.store(BytesIO(b"new content"))
-        with open(path, 'rb') as fp:
-            self.assertEqual(fp.read(), b"new content")
+        try:
+            with open(path, 'rb') as fp:
+                self.assertEqual(fp.read(), b"content")
+            # again, to check s3 objects are overwritten
+            yield storage.store(BytesIO(b"new content"))
+            with open(path, 'rb') as fp:
+                self.assertEqual(fp.read(), b"new content")
+        finally:
+            os.unlink(path)
 
 
 class BlockingFeedStorageTest(unittest.TestCase):

--- a/tests/test_spiderstate.py
+++ b/tests/test_spiderstate.py
@@ -1,5 +1,6 @@
 import os
 from datetime import datetime
+import shutil
 from twisted.trial import unittest
 
 from scrapy.extensions.spiderstate import SpiderState
@@ -13,20 +14,23 @@ class SpiderStateTest(unittest.TestCase):
     def test_store_load(self):
         jobdir = self.mktemp()
         os.mkdir(jobdir)
-        spider = Spider(name='default')
-        dt = datetime.now()
+        try:
+            spider = Spider(name='default')
+            dt = datetime.now()
 
-        ss = SpiderState(jobdir)
-        ss.spider_opened(spider)
-        spider.state['one'] = 1
-        spider.state['dt'] = dt
-        ss.spider_closed(spider)
+            ss = SpiderState(jobdir)
+            ss.spider_opened(spider)
+            spider.state['one'] = 1
+            spider.state['dt'] = dt
+            ss.spider_closed(spider)
 
-        spider2 = Spider(name='default')
-        ss2 = SpiderState(jobdir)
-        ss2.spider_opened(spider2)
-        self.assertEqual(spider.state, {'one': 1, 'dt': dt})
-        ss2.spider_closed(spider2)
+            spider2 = Spider(name='default')
+            ss2 = SpiderState(jobdir)
+            ss2.spider_opened(spider2)
+            self.assertEqual(spider.state, {'one': 1, 'dt': dt})
+            ss2.spider_closed(spider2)
+        finally:
+            shutil.rmtree(jobdir)
 
     def test_state_attribute(self):
         # state attribute must be present if jobdir is not set, to provide a

--- a/tests/test_webclient.py
+++ b/tests/test_webclient.py
@@ -350,7 +350,7 @@ class WebClientTestCase(unittest.TestCase):
                 b'    </head>\n    <body bgcolor="#FFFFFF" text="#000000">\n    '
                 b'<a href="/file">click here</a>\n    </body>\n</html>\n')
 
-    def test_Encoding(self):
+    def test_encoding(self):
         """ Test that non-standart body encoding matches
         Content-Encoding header """
         body = b'\xd0\x81\xd1\x8e\xd0\xaf'


### PR DESCRIPTION
This PR makes sure temp files are deleted in tests. It also fixes a **weird** pytest+OS X issue. Previously tests failed for me with exception like this:

```
______________________________________________ ERROR at setup of WebClientTestCase.test_Encoding ______________________________________________

cls = <class 'py._path.local.LocalPath'>, prefix = 'test_Encoding'
rootdir = local('/private/var/folders/_5/cbsg50991szfp1r9nwxpx8580000gn/T/pytest-of-kmike/pytest-0'), keep = 0, lock_timeout = None

    def make_numbered_dir(cls, prefix='session-', rootdir=None, keep=3,
                          lock_timeout = 172800):   # two days
        """ return unique directory with a number greater than the current
                maximum one.  The number is assumed to start directly after prefix.
                if keep is true directories with a number less than (maxnum-keep)
                will be removed.
            """
        if rootdir is None:
            rootdir = cls.get_temproot()

        def parse_num(path):
            """ parse the number out of a path (if it matches the prefix) """
            bn = path.basename
            if bn.startswith(prefix):
                try:
                    return int(bn[len(prefix):])
                except ValueError:
                    pass

        # compute the maximum number currently in use with the
        # prefix
        lastmax = None
        while True:
            maxnum = -1
            for path in rootdir.listdir():
                num = parse_num(path)
                if num is not None:
                    maxnum = max(maxnum, num)

            # make the new directory
            try:
>               udir = rootdir.mkdir(prefix + str(maxnum+1))

/Users/kmike/svn/scrapy/.tox/py36/lib/python3.6/site-packages/py/_path/local.py:825:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
/Users/kmike/svn/scrapy/.tox/py36/lib/python3.6/site-packages/py/_path/local.py:459: in mkdir
    py.error.checked_call(os.mkdir, fspath(p))
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <py._error.ErrorMaker object at 0x110844518>, func = <built-in function mkdir>
args = ('/private/var/folders/_5/cbsg50991szfp1r9nwxpx8580000gn/T/pytest-of-kmike/pytest-0/test_Encoding0',), kwargs = {}
__tracebackhide__ = False, cls = <class 'py.error.EEXIST'>, value = FileExistsError(17, 'File exists'), tb = <traceback object at 0x117b3f248>
errno = 17

    def checked_call(self, func, *args, **kwargs):
        """ call a function and raise an errno-exception if applicable. """
        __tracebackhide__ = True
        try:
            return func(*args, **kwargs)
        except self.Error:
            raise
        except (OSError, EnvironmentError):
            cls, value, tb = sys.exc_info()
            if not hasattr(value, 'errno'):
                raise
            __tracebackhide__ = False
            errno = value.errno
            try:
                if not isinstance(value, WindowsError):
                    raise NameError
            except NameError:
                # we are not on Windows, or we got a proper OSError
                cls = self._geterrnoclass(errno)
            else:
                try:
                    cls = self._geterrnoclass(_winerrnomap[errno])
                except KeyError:
                    raise value
>           raise cls("%s%r" % (func.__name__, args))
E           py.error.EEXIST: [File exists]: mkdir('/private/var/folders/_5/cbsg50991szfp1r9nwxpx8580000gn/T/pytest-of-kmike/pytest-0/test_Encoding0',)
```