### PR TITLE
[MRG+1] Add ``errors`` argument to Headers.to_unicode_dict().

### DIFF
--- a/scrapy/http/headers.py
+++ b/scrapy/http/headers.py
@@ -79,13 +79,13 @@ class Headers(CaselessDict):
     def to_string(self):
         return headers_dict_to_raw(self)
 
-    def to_unicode_dict(self):
+    def to_unicode_dict(self, errors='strict'):
         """ Return headers as a CaselessDict with unicode keys
         and unicode values. Multiple values are joined with ','.
         """
         return CaselessDict(
-            (to_unicode(key, encoding=self.encoding),
-             to_unicode(b','.join(value), encoding=self.encoding))
+            (to_unicode(key, encoding=self.encoding, errors=errors),
+             to_unicode(b','.join(value), encoding=self.encoding, errors=errors))
             for key, value in self.items())
 
     def __copy__(self):

--- a/scrapy/http/headers.py
+++ b/scrapy/http/headers.py
@@ -79,13 +79,15 @@ class Headers(CaselessDict):
     def to_string(self):
         return headers_dict_to_raw(self)
 
-    def to_unicode_dict(self, errors='strict'):
+    def to_unicode_dict(self, encoding=None, errors='strict'):
         """ Return headers as a CaselessDict with unicode keys
         and unicode values. Multiple values are joined with ','.
         """
+        if encoding is None:
+            encoding = self.encoding
         return CaselessDict(
-            (to_unicode(key, encoding=self.encoding, errors=errors),
-             to_unicode(b','.join(value), encoding=self.encoding, errors=errors))
+            (to_unicode(key, encoding=encoding, errors=errors),
+             to_unicode(b','.join(value), encoding=encoding, errors=errors))
             for key, value in self.items())
 
     def __copy__(self):

--- a/tests/test_http_headers.py
+++ b/tests/test_http_headers.py
@@ -160,6 +160,8 @@ class HeadersTest(unittest.TestCase):
         h = Headers({b'header': b'value'})
         self.assertEqual(h.to_unicode_dict(), {u'header': u'value'})
 
-    def test_to_unicode_dict_with_errors(self):
+    def test_to_unicode_dict_with_params(self):
         h = Headers({b'l\xc3\xa1\x99': b'\xc3\xb1e\x99'})
         self.assertEqual(h.to_unicode_dict(errors='ignore'), {u'l\xe1': u'\xf1e'})
+        h = Headers({b'l\xf1\x99': b'\xb1e\x99'})
+        self.assertEqual(h.to_unicode_dict(encoding='latin1'), {u'l\xf1\x99': u'\xb1e\x99'})

--- a/tests/test_http_headers.py
+++ b/tests/test_http_headers.py
@@ -155,3 +155,11 @@ class HeadersTest(unittest.TestCase):
                                 Headers().setdefault, 'foo', object())
         self.assertRaisesRegexp(TypeError, 'Unsupported value type',
                                 Headers().setlist, 'foo', [object()])
+
+    def test_to_unicode_dict(self):
+        h = Headers({b'header': b'value'})
+        self.assertEqual(h.to_unicode_dict(), {u'header': u'value'})
+
+    def test_to_unicode_dict_with_errors(self):
+        h = Headers({b'l\xc3\xa1\x99': b'\xc3\xb1e\x99'})
+        self.assertEqual(h.to_unicode_dict(errors='ignore'), {u'l\xe1': u'\xf1e'})


### PR DESCRIPTION
Fixes #2589