### PR TITLE
[MRG+1] Decode header values with UTF-8 and ISO-8859-1 as fallback.

### DIFF
--- a/scrapy/http/headers.py
+++ b/scrapy/http/headers.py
@@ -7,7 +7,19 @@ from scrapy.utils.python import to_unicode
 class Headers(CaselessDict):
     """Case insensitive http headers dictionary"""
 
-    def __init__(self, seq=None, encoding='utf-8'):
+    def __init__(self, seq=None, encoding=None):
+        """Initialize headers object.
+
+        Parameters
+        ----------
+        seq : items, optional
+            Headers items.
+        encoding : str, optional
+            Encoding used for encoding/decoding header values. If not given,
+            default for encoding is UTF-8 and for decoding UTF-8 with
+            ISO-8859-1 fallback.
+
+        """
         self.encoding = encoding
         super(Headers, self).__init__(seq)
 
@@ -26,13 +38,14 @@ class Headers(CaselessDict):
 
         return [self._tobytes(x) for x in value]
 
-    def _tobytes(self, x):
+    def _tobytes(self, x, default_encoding='utf-8'):
+        encoding = self.encoding or default_encoding
         if isinstance(x, bytes):
             return x
         elif isinstance(x, six.text_type):
-            return x.encode(self.encoding)
+            return x.encode(encoding)
         elif isinstance(x, int):
-            return six.text_type(x).encode(self.encoding)
+            return six.text_type(x).encode(encoding)
         else:
             raise TypeError('Unsupported value type: {}'.format(type(x)))
 
@@ -79,17 +92,41 @@ class Headers(CaselessDict):
     def to_string(self):
         return headers_dict_to_raw(self)
 
-    def to_unicode_dict(self):
+    def to_unicode_dict(self, encoding=None):
         """ Return headers as a CaselessDict with unicode keys
         and unicode values. Multiple values are joined with ','.
+
+        Parameters
+        ----------
+        encoding : str or list, optional
+            A encoding or list of encodings to use for decoding headers. If an
+            encoding was passed in the constructor, that value is used for
+            decoding bytes into unicod strings. Otherwise attempts to decode
+            the values using UTF-8 and fallbacks to ISO-8859-1.
+
         """
+        encoding = encoding or self.encoding
+        if encoding is None:
+            encoding_list = ['utf-8', 'iso-8859-1']
+        elif isinstance(encoding, (list, tuple)):
+            encoding_list = encoding
+        else:
+            encoding_list = [encoding]
+
         return CaselessDict(
-            (to_unicode(key, encoding=self.encoding),
-             to_unicode(b','.join(value), encoding=self.encoding))
-            for key, value in self.items())
+            (self._decode(key, *encoding_list),
+             self._decode(b','.join(value), *encoding_list))
+            for key, value in self.items()
+        )
+
+    def _decode(self, value, *encodings):
+        for encoding in encodings[:-1]:
+            try:
+                return to_unicode(value, encoding=encoding)
+            except UnicodeDecodeError:
+                pass
+        return to_unicode(value, encoding=encodings[-1])
 
     def __copy__(self):
         return self.__class__(self)
     copy = __copy__
-
-


### PR DESCRIPTION
In the example below, all headers except `Public-Key-Pins` are UTF-8 compatible:

```
In [3]: response.headers

{b'Accept-Ranges': b'bytes',
 b'Cache-Control': b'max-age=604800',
 b'Content-Type': b'text/html',
 b'Date': b'Thu, 23 Feb 2017 22:21:35 GMT',
 b'Etag': b'"3acb6d9a9acf1:0"',
 b'Last-Modified': b'Mon, 06 Jan 2014 06:38:03 GMT',
 b'Public-Key-Pins': b'pin-sha256=\x94SPKI_digest#1"; pin-sha256="SPKI_digest#2"; max-age=31536000',
 b'Server': b'Microsoft-IIS/7.5',
 b'Strict-Transport-Security': b'max-age=31536000; includeSubDomains',
 b'Vary': b'Accept-Encoding',
 b'X-Powered-By': b'ASP.NET',
 b'X-Powered-By-Plesk': b'PleskWin'}

In [4]: response.headers.to_unicode_dict()

{'accept-ranges': 'bytes',
 'cache-control': 'max-age=604800',
 'content-type': 'text/html',
 'date': 'Thu, 23 Feb 2017 22:21:35 GMT',
 'etag': '"3acb6d9a9acf1:0"',
 'last-modified': 'Mon, 06 Jan 2014 06:38:03 GMT',
 'public-key-pins': 'pin-sha256=\x94SPKI_digest#1"; pin-sha256="SPKI_digest#2"; max-age=31536000',
 'server': 'Microsoft-IIS/7.5',
 'strict-transport-security': 'max-age=31536000; includeSubDomains',
 'vary': 'Accept-Encoding',
 'x-powered-by': 'ASP.NET',
 'x-powered-by-plesk': 'PleskWin'}
```