### PR TITLE
[MRG+1] Use single quotes uniformly

### DIFF
--- a/scrapy/templates/spiders/basic.tmpl
+++ b/scrapy/templates/spiders/basic.tmpl
@@ -3,8 +3,8 @@ import scrapy
 
 
 class $classname(scrapy.Spider):
-    name = "$name"
-    allowed_domains = ["$domain"]
+    name = '$name'
+    allowed_domains = ['$domain']
     start_urls = ['http://$domain/']
 
     def parse(self, response):


### PR DESCRIPTION
The default spider template mixes single and double quotes. This fixes that.