### PR TITLE
Remove redundant slot.add_request() call in ExecutionEngine

### DIFF
--- a/scrapy/core/engine.py
+++ b/scrapy/core/engine.py
@@ -218,10 +218,8 @@ class ExecutionEngine(object):
                                         request=request, spider=spider)
 
     def download(self, request, spider):
-        slot = self.slot
-        slot.add_request(request)
         d = self._download(request, spider)
-        d.addBoth(self._downloaded, slot, request, spider)
+        d.addBoth(self._downloaded, self.slot, request, spider)
         return d
 
     def _downloaded(self, response, slot, request, spider):


### PR DESCRIPTION
The `slot.add_request(request)` in `download()` is also done in `_download()` which is called right after.