### PR TITLE
[MRG+1] Removed contrib section in contribution documentation

### DIFF
--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -124,15 +124,6 @@ Scrapy:
 * Don't put your name in the code you contribute. Our policy is to keep
   the contributor's name in the `AUTHORS`_ file distributed with Scrapy.
 
-Scrapy Contrib
-==============
-
-Scrapy contrib shares a similar rationale as Django contrib, which is explained
-in `this post <https://jacobian.org/writing/what-is-django-contrib/>`_. If you
-are working on a new functionality, please follow that rationale to decide
-whether it should be a Scrapy contrib. If unsure, you can ask in
-`scrapy-users`_.
-
 Documentation policies
 ======================
 


### PR DESCRIPTION
`contrib` is deprecated
#2634 