### PR TITLE
[MRG+1] Add feature to set RETRY_TIMES per request (#2642)

### DIFF
--- a/docs/topics/downloader-middleware.rst
+++ b/docs/topics/downloader-middleware.rst
@@ -852,6 +852,11 @@ Default: ``2``
 
 Maximum number of times to retry, in addition to the first download.
 
+.. reqmeta:: max_retry_times
+
+If :attr:`Request.meta <scrapy.http.Request.meta>` has ``max_retry_times`` key
+set to some value, this setting will be ignored by this middleware for the corresponding request.
+
 .. setting:: RETRY_HTTP_CODES
 
 RETRY_HTTP_CODES

--- a/docs/topics/downloader-middleware.rst
+++ b/docs/topics/downloader-middleware.rst
@@ -852,10 +852,10 @@ Default: ``2``
 
 Maximum number of times to retry, in addition to the first download.
 
-.. reqmeta:: max_retry_times
-
-If :attr:`Request.meta <scrapy.http.Request.meta>` has ``max_retry_times`` key
-set to some value, this setting will be ignored by this middleware for the corresponding request.
+Maximum number of retries can also be specified per-request using
+:reqmeta:`max_retry_times` attribute of :attr:`Request.meta <scrapy.http.Request.meta>`.
+When initialized, the :reqmeta:`max_retry_times` meta key takes higher
+precedence over the :setting:`RETRY_TIMES` setting.
 
 .. setting:: RETRY_HTTP_CODES
 

--- a/docs/topics/request-response.rst
+++ b/docs/topics/request-response.rst
@@ -308,6 +308,7 @@ Those are:
 * ``ftp_user`` (See :setting:`FTP_USER` for more info)
 * ``ftp_password`` (See :setting:`FTP_PASSWORD` for more info)
 * :reqmeta:`referrer_policy`
+* :reqmeta:`max_retry_times`
 
 .. reqmeta:: bindaddress
 
@@ -341,6 +342,13 @@ download_fail_on_dataloss
 
 Whether or not to fail on broken responses. See:
 :setting:`DOWNLOAD_FAIL_ON_DATALOSS`.
+
+.. reqmeta:: max_retry_times
+
+max_retry_times
+---------------
+
+The meta key is used set retry times per request. When initialized, the :setting:`RETRY_TIMES` setting will be ignored by the downloader middleware.
 
 .. _topics-request-response-ref-request-subclasses:
 

--- a/docs/topics/request-response.rst
+++ b/docs/topics/request-response.rst
@@ -348,7 +348,9 @@ Whether or not to fail on broken responses. See:
 max_retry_times
 ---------------
 
-The meta key is used set retry times per request. When initialized, the :setting:`RETRY_TIMES` setting will be ignored by the downloader middleware.
+The meta key is used set retry times per request. When initialized, the
+:reqmeta:`max_retry_times` meta key takes higher precedence over the
+:setting:`RETRY_TIMES` setting.
 
 .. _topics-request-response-ref-request-subclasses:
 

--- a/scrapy/downloadermiddlewares/retry.py
+++ b/scrapy/downloadermiddlewares/retry.py
@@ -63,6 +63,9 @@ class RetryMiddleware(object):
     def _retry(self, request, reason, spider):
         retries = request.meta.get('retry_times', 0) + 1
 
+        if 'max_retry_times' in request.meta:
+            self.max_retry_times = request.meta['max_retry_times']
+
         stats = spider.crawler.stats
         if retries <= self.max_retry_times:
             logger.debug("Retrying %(request)s (failed %(retries)d times): %(reason)s",

--- a/scrapy/downloadermiddlewares/retry.py
+++ b/scrapy/downloadermiddlewares/retry.py
@@ -63,7 +63,10 @@ class RetryMiddleware(object):
     def _retry(self, request, reason, spider):
         retries = request.meta.get('retry_times', 0) + 1
 
-        retry_times = request.meta.get('max_retry_times') or self.max_retry_times
+        retry_times = self.max_retry_times
+
+        if 'max_retry_times' in request.meta:
+            retry_times = request.meta['max_retry_times']
 
         stats = spider.crawler.stats
         if retries <= retry_times:

--- a/scrapy/downloadermiddlewares/retry.py
+++ b/scrapy/downloadermiddlewares/retry.py
@@ -63,10 +63,7 @@ class RetryMiddleware(object):
     def _retry(self, request, reason, spider):
         retries = request.meta.get('retry_times', 0) + 1
 
-        retry_times = self.max_retry_times
-
-        if 'max_retry_times' in request.meta:
-            retry_times = request.meta['max_retry_times']
+        retry_times = request.meta.get('max_retry_times') or self.max_retry_times
 
         stats = spider.crawler.stats
         if retries <= retry_times:

--- a/scrapy/downloadermiddlewares/retry.py
+++ b/scrapy/downloadermiddlewares/retry.py
@@ -63,11 +63,13 @@ class RetryMiddleware(object):
     def _retry(self, request, reason, spider):
         retries = request.meta.get('retry_times', 0) + 1
 
+        retry_times = self.max_retry_times
+
         if 'max_retry_times' in request.meta:
-            self.max_retry_times = request.meta['max_retry_times']
+            retry_times = request.meta['max_retry_times']
 
         stats = spider.crawler.stats
-        if retries <= self.max_retry_times:
+        if retries <= retry_times:
             logger.debug("Retrying %(request)s (failed %(retries)d times): %(reason)s",
                          {'request': request, 'retries': retries, 'reason': reason},
                          extra={'spider': spider})


### PR DESCRIPTION
Allows the user to set `RETRY_TIMES` per request using `request.meta` key `max_retry_times`.
Recommended in #2642 