### PR TITLE
[MRG+1] Fixed the FIXME in FSFilesStore

### DIFF
--- a/scrapy/pipelines/files.py
+++ b/scrapy/pipelines/files.py
@@ -58,7 +58,7 @@ class FSFilesStore(object):
         absolute_path = self._get_filesystem_path(path)
         try:
             last_modified = os.path.getmtime(absolute_path)
-        except:  # FIXME: catching everything!
+        except os.error:
             return {}
 
         with open(absolute_path, 'rb') as f:


### PR DESCRIPTION
More specific exception catching: [os.path.getmtime](https://docs.python.org/2/library/os.path.html#os.path.getmtime) can only raise [os.error](https://docs.python.org/2/library/os.html#os.error).