### PR TITLE
[MRG+2] [logformatter] 'flags' format spec backward compatibility

### DIFF
--- a/scrapy/logformatter.py
+++ b/scrapy/logformatter.py
@@ -43,6 +43,7 @@ class LogFormatter(object):
                 'request_flags' : request_flags,
                 'referer': referer_str(request),
                 'response_flags': response_flags,
+                'flags': response_flags
             }
         }
 

--- a/scrapy/logformatter.py
+++ b/scrapy/logformatter.py
@@ -43,6 +43,7 @@ class LogFormatter(object):
                 'request_flags' : request_flags,
                 'referer': referer_str(request),
                 'response_flags': response_flags,
+                # backward compatibility with Scrapy logformatter below 1.4 version
                 'flags': response_flags
             }
         }

--- a/tests/test_logformatter.py
+++ b/tests/test_logformatter.py
@@ -66,7 +66,6 @@ class LoggingContribTest(unittest.TestCase):
 
 
 class LogFormatterSubclass(LogFormatter):
-    # Formatter with format spec that is same as in Scrapy before 1.3 version.
     def crawled(self, request, response, spider):
         kwargs = super(LogFormatterSubclass, self).crawled(
         request, response, spider)
@@ -82,7 +81,6 @@ class LogFormatterSubclass(LogFormatter):
 
 
 class LogformatterSubclassTest(LoggingContribTest):
-    # Test if old crawledmsg format string still works fine
     def setUp(self):
         self.formatter = LogFormatterSubclass()
         self.spider = Spider('default')

--- a/tests/test_logformatter.py
+++ b/tests/test_logformatter.py
@@ -64,5 +64,32 @@ class LoggingContribTest(unittest.TestCase):
         assert all(isinstance(x, six.text_type) for x in lines)
         self.assertEqual(lines, [u"Scraped from <200 http://www.example.com>", u'name: \xa3'])
 
+
+class LogFormatterSubclass(LogFormatter):
+    # Formatter with format spec that is same as in Scrapy before 1.3 version.
+    def crawled(self, request, response, spider):
+        kwargs = super(LogFormatterSubclass, self).crawled(
+        request, response, spider)
+        CRAWLEDMSG = (
+            u"Crawled (%(status)s) %(request)s (referer: "
+            u"%(referer)s)%(flags)s"
+        )
+        return {
+            'level': kwargs['level'],
+            'msg': CRAWLEDMSG,
+            'args': kwargs['args']
+        }
+
+
+class LogformatterSubclassTest(LoggingContribTest):
+    # Test if old crawledmsg format string still works fine
+    def setUp(self):
+        self.formatter = LogFormatterSubclass()
+        self.spider = Spider('default')
+
+    def test_flags_in_request(self):
+        pass
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
pass 'flags' kwarg to logger so that it is compatible with old format of CRAWLEDMSG. fixes #2647