### PR TITLE
Bug fix -- LinkExtractor.extract_links() raises AttributeError

### DIFF
--- a/scrapy/linkextractors/lxmlhtml.py
+++ b/scrapy/linkextractors/lxmlhtml.py
@@ -53,6 +53,9 @@ class LxmlParserLinkExtractor(object):
                 yield (el, attrib, attribs[attrib])
 
     def _extract_links(self, selector, response_url, response_encoding, base_url):
+        if selector.root is None:
+            return []
+
         links = []
         # hacky way to get the underlying lxml parsed document
         for el, attr, attr_val in self._iter_links(selector.root):

--- a/tests/test_linkextractors.py
+++ b/tests/test_linkextractors.py
@@ -451,6 +451,12 @@ class Base:
                 Link(url='http://example.org/item3.html', text=u'Item 3', nofollow=False),
             ])
 
+        def test_comment_only_response(self):
+            html = b"<!-- hello world -->"
+            response = HtmlResponse("http://example.org/index.html", body=html)
+            lx = self.extractor_cls()
+            self.assertEqual(lx.extract_links(response), [])
+
 
 class LxmlLinkExtractorTestCase(Base.LinkExtractorTestCase):
     extractor_cls = LxmlLinkExtractor


### PR DESCRIPTION
If response.body contains just a comment(such as `<-- hello world -->`), `LinkExtractor.extract_links()` will raise `AttributeError`