### PR TITLE
[MRG+1] Add sphinx_rtd_theme to docs setup readme

### DIFF
--- a/docs/README.rst
+++ b/docs/README.rst
@@ -15,7 +15,7 @@ and all its dependencies run
 
 ::
 
-    pip install 'Sphinx >= 1.3'
+    pip install 'Sphinx >= 1.3' sphinx_rtd_theme
 
 
 Compile the documentation

--- a/docs/README.rst
+++ b/docs/README.rst
@@ -15,7 +15,7 @@ and all its dependencies run
 
 ::
 
-    pip install 'Sphinx >= 1.3' sphinx_rtd_theme
+    pip install -r requirements.txt
 
 
 Compile the documentation

--- a/docs/README.rst
+++ b/docs/README.rst
@@ -11,7 +11,7 @@ Setup the environment
 ---------------------
 
 To compile the documentation you need Sphinx Python library. To install it
-and all its dependencies run
+and all its dependencies run the following command from this dir
 
 ::
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,2 @@
+'Sphinx >= 1.3'
+sphinx_rtd_theme

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,2 +1,2 @@
-'Sphinx >= 1.3'
+Sphinx>=1.3
 sphinx_rtd_theme

--- a/tox.ini
+++ b/tox.ini
@@ -82,8 +82,7 @@ deps = {[testenv:py33]deps}
 [docs]
 changedir = docs
 deps =
-    Sphinx
-    sphinx_rtd_theme
+    -rdocs/requirements.txt
 
 [testenv:docs]
 changedir = {[docs]changedir}


### PR DESCRIPTION
Concerns Sphinx 1.4 release #1893 . `sphinx_rtd_theme` has to be installed manually.