### PR TITLE
[MRG+1] ESMTPSenderFactory compatibility for Python 3

### DIFF
--- a/docs/topics/email.rst
+++ b/docs/topics/email.rst
@@ -54,10 +54,10 @@ uses `Twisted non-blocking IO`_, like the rest of the framework.
     :param smtpuser: the SMTP user. If omitted, the :setting:`MAIL_USER`
       setting will be used. If not given, no SMTP authentication will be
       performed.
-    :type smtphost: str
+    :type smtphost: str or bytes
 
     :param smtppass: the SMTP pass for authentication.
-    :type smtppass: str
+    :type smtppass: str or bytes
 
     :param smtpport: the SMTP port to connect to
     :type smtpport: int

--- a/scrapy/mail.py
+++ b/scrapy/mail.py
@@ -30,14 +30,20 @@ from scrapy.utils.python import to_bytes
 logger = logging.getLogger(__name__)
 
 
+def _to_bytes_or_none(text):
+    if text is None:
+        return None
+    return to_bytes(text)
+
+
 class MailSender(object):
 
     def __init__(self, smtphost='localhost', mailfrom='scrapy@localhost',
             smtpuser=None, smtppass=None, smtpport=25, smtptls=False, smtpssl=False, debug=False):
         self.smtphost = smtphost
         self.smtpport = smtpport
-        self.smtpuser = to_bytes(smtpuser) if smtpuser is not None else None
-        self.smtppass = to_bytes(smtppass) if smtppass is not None else None
+        self.smtpuser = _to_bytes_or_none(smtpuser)
+        self.smtppass = _to_bytes_or_none(smtppass)
         self.smtptls = smtptls
         self.smtpssl = smtpssl
         self.mailfrom = mailfrom

--- a/scrapy/mail.py
+++ b/scrapy/mail.py
@@ -24,7 +24,8 @@ else:
 
 from twisted.internet import defer, reactor, ssl
 
-from .utils.misc import arg_to_iter
+from scrapy.utils.misc import arg_to_iter
+from scrapy.utils.python import to_bytes
 
 logger = logging.getLogger(__name__)
 
@@ -35,8 +36,8 @@ class MailSender(object):
             smtpuser=None, smtppass=None, smtpport=25, smtptls=False, smtpssl=False, debug=False):
         self.smtphost = smtphost
         self.smtpport = smtpport
-        self.smtpuser = smtpuser
-        self.smtppass = smtppass
+        self.smtpuser = to_bytes(smtpuser)
+        self.smtppass = to_bytes(smtppass)
         self.smtptls = smtptls
         self.smtpssl = smtpssl
         self.mailfrom = mailfrom

--- a/scrapy/mail.py
+++ b/scrapy/mail.py
@@ -36,8 +36,8 @@ class MailSender(object):
             smtpuser=None, smtppass=None, smtpport=25, smtptls=False, smtpssl=False, debug=False):
         self.smtphost = smtphost
         self.smtpport = smtpport
-        self.smtpuser = to_bytes(smtpuser)
-        self.smtppass = to_bytes(smtppass)
+        self.smtpuser = to_bytes(smtpuser) if smtpuser is not None else None
+        self.smtppass = to_bytes(smtppass) if smtppass is not None else None
         self.smtptls = smtptls
         self.smtpssl = smtpssl
         self.mailfrom = mailfrom


### PR DESCRIPTION
twisted.mail.smtp was ported to Python 3 in this patch: https://github.com/twisted/twisted/pull/509
It is not in Twisted 17.1.0, but should be in the next released version of Twisted.

Fixes: https://github.com/scrapy/scrapy/issues/2375