### PR TITLE
Update exporters.py

### DIFF
--- a/scrapy/exporters.py
+++ b/scrapy/exporters.py
@@ -184,7 +184,7 @@ class CsvItemExporter(BaseItemExporter):
             write_through=True,
             encoding=self.encoding
         ) if six.PY3 else file
-        self.csv_writer = csv.writer(self.stream, **kwargs, lineterminator='\n')
+        self.csv_writer = csv.writer(self.stream, lineterminator='\n', **kwargs)
         self._headers_not_written = True
         self._join_multivalued = join_multivalued
 

--- a/scrapy/exporters.py
+++ b/scrapy/exporters.py
@@ -184,7 +184,7 @@ class CsvItemExporter(BaseItemExporter):
             write_through=True,
             encoding=self.encoding
         ) if six.PY3 else file
-        self.csv_writer = csv.writer(self.stream, **kwargs)
+        self.csv_writer = csv.writer(self.stream, **kwargs, lineterminator='\n')
         self._headers_not_written = True
         self._join_multivalued = join_multivalued
 


### PR DESCRIPTION
In windows, the exported csv will produce extra blank lines. Add **lineterminator = '\ n'**, to solve this problem.