### PR TITLE
[MRG+1] Fixes conversion of transparent PNG with palette images to jpg #2452

### DIFF
--- a/scrapy/pipelines/images.py
+++ b/scrapy/pipelines/images.py
@@ -132,6 +132,11 @@ class ImagesPipeline(FilesPipeline):
             background = Image.new('RGBA', image.size, (255, 255, 255))
             background.paste(image, image)
             image = background.convert('RGB')
+        elif image.mode == 'P':
+            image = image.convert("RGBA")
+            background = Image.new('RGBA', image.size, (255, 255, 255))
+            background.paste(image, image)
+            image = background.convert('RGB')
         elif image.mode != 'RGB':
             image = image.convert('RGB')
 

--- a/tests/test_pipeline_images.py
+++ b/tests/test_pipeline_images.py
@@ -96,6 +96,14 @@ class ImagesPipelineTestCase(unittest.TestCase):
         self.assertEquals(converted.mode, 'RGB')
         self.assertEquals(converted.getcolors(), [(10000, (205, 230, 255))])
 
+        # transparency case with palette: P and PNG
+        COLOUR = (0, 127, 255, 50)
+        im = _create_image('PNG', 'RGBA', SIZE, COLOUR)
+        im = im.convert('P')
+        converted, _ = self.pipeline.convert_image(im)
+        self.assertEquals(converted.mode, 'RGB')
+        self.assertEquals(converted.getcolors(), [(10000, (205, 230, 255))])
+
 
 class DeprecatedImagesPipeline(ImagesPipeline):
     def file_key(self, url):


### PR DESCRIPTION
Images with transparency using palette mode (pillow mode = "P") fails when converting to jpg. The resulting image will have a green background instead of white as expected.
By converting mode P images to RGBA before pasting into the white background and then converting the resulting image to RGB will fix the problem.
See #2452