### PR TITLE
[MRG+1] doc: fix documentation error in link-extractor.rst

### DIFF
--- a/docs/topics/link-extractors.rst
+++ b/docs/topics/link-extractors.rst
@@ -8,7 +8,7 @@ Link extractors are objects whose only purpose is to extract links from web
 pages (:class:`scrapy.http.Response` objects) which will be eventually
 followed.
 
-There is ``from scrapy.linkextractors import LinkExtractor`` available
+There is ``from scrapy.linkextractors`` available
 in Scrapy, but you can create your own custom Link Extractors to suit your
 needs by implementing a simple interface.
 

--- a/docs/topics/link-extractors.rst
+++ b/docs/topics/link-extractors.rst
@@ -8,7 +8,7 @@ Link extractors are objects whose only purpose is to extract links from web
 pages (:class:`scrapy.http.Response` objects) which will be eventually
 followed.
 
-There is ``from scrapy.linkextractors`` available
+There is ``scrapy.linkextractors.LinkExtractor`` available
 in Scrapy, but you can create your own custom Link Extractors to suit your
 needs by implementing a simple interface.
 

--- a/docs/topics/link-extractors.rst
+++ b/docs/topics/link-extractors.rst
@@ -8,7 +8,7 @@ Link extractors are objects whose only purpose is to extract links from web
 pages (:class:`scrapy.http.Response` objects) which will be eventually
 followed.
 
-There is ``scrapy.linkextractors import LinkExtractor`` available
+There is ``from scrapy.linkextractors import LinkExtractor`` available
 in Scrapy, but you can create your own custom Link Extractors to suit your
 needs by implementing a simple interface.
 


### PR DESCRIPTION
This PR adds the missing word "from" that makes up statement 
```python
from scrapy.linkextractors import LinkExtractor
``` 
in link-extractor's documentation.