### PR TITLE
allow specifying max_active_size for scraper.slot in settings

### DIFF
--- a/scrapy/core/scraper.py
+++ b/scrapy/core/scraper.py
@@ -26,7 +26,7 @@ class Slot(object):
 
     MIN_RESPONSE_SIZE = 1024
 
-    def __init__(self, max_active_size=5000000):
+    def __init__(self, max_active_size):
         self.max_active_size = max_active_size
         self.queue = deque()
         self.active = set()
@@ -77,7 +77,7 @@ class Scraper(object):
     @defer.inlineCallbacks
     def open_spider(self, spider):
         """Open the given spider for scraping and allocate resources for it"""
-        self.slot = Slot()
+        self.slot = Slot(self.crawler.getint('SCRAPER_SLOT_MAX_ACTIVE_SIZE'))
         yield self.itemproc.open_spider(spider)
 
     def close_spider(self, spider):

--- a/scrapy/core/scraper.py
+++ b/scrapy/core/scraper.py
@@ -77,7 +77,7 @@ class Scraper(object):
     @defer.inlineCallbacks
     def open_spider(self, spider):
         """Open the given spider for scraping and allocate resources for it"""
-        self.slot = Slot(self.crawler.getint('SCRAPER_SLOT_MAX_ACTIVE_SIZE'))
+        self.slot = Slot(self.crawler.settings.getint('SCRAPER_SLOT_MAX_ACTIVE_SIZE'))
         yield self.itemproc.open_spider(spider)
 
     def close_spider(self, spider):

--- a/scrapy/settings/default_settings.py
+++ b/scrapy/settings/default_settings.py
@@ -249,6 +249,8 @@ SCHEDULER_DISK_QUEUE = 'scrapy.squeues.PickleLifoDiskQueue'
 SCHEDULER_MEMORY_QUEUE = 'scrapy.squeues.LifoMemoryQueue'
 SCHEDULER_PRIORITY_QUEUE = 'queuelib.PriorityQueue'
 
+SCRAPER_SLOT_MAX_ACTIVE_SIZE = 5000000
+
 SPIDER_LOADER_CLASS = 'scrapy.spiderloader.SpiderLoader'
 SPIDER_LOADER_WARN_ONLY = False
 


### PR DESCRIPTION
fixes #1410

For some cases when I have many big (~20-30mb)  files to scrape, the spider just waits until everything of one file is scraped and enqueued and then takes on the new file, which makes my scraping almost synchronous. If I increase the `max_active_size` to a big value (x100) since we have machines with large ram, it works fine. 

This parameter needs to be configurable for the project/spider.