### PR TITLE
[PEDANTIC] FIX trailing whitespaces in LICENSE.

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -4,10 +4,10 @@ All rights reserved.
 Redistribution and use in source and binary forms, with or without modification,
 are permitted provided that the following conditions are met:
 
-    1. Redistributions of source code must retain the above copyright notice, 
+    1. Redistributions of source code must retain the above copyright notice,
        this list of conditions and the following disclaimer.
-    
-    2. Redistributions in binary form must reproduce the above copyright 
+
+    2. Redistributions in binary form must reproduce the above copyright
        notice, this list of conditions and the following disclaimer in the
        documentation and/or other materials provided with the distribution.
 


### PR DESCRIPTION
Spotted while developping a license recognizer þ It was breaking my paragraph splitting (now fixed).