### PR TITLE
[MRG+1] Mention how to disable request filtering in documentation of DUPEFILTER_CLASS setting

### DIFF
--- a/docs/topics/settings.rst
+++ b/docs/topics/settings.rst
@@ -646,6 +646,13 @@ override its ``request_fingerprint`` method. This method should accept
 scrapy :class:`~scrapy.http.Request` object and return its fingerprint
 (a string).
 
+You can disable filtering of duplicate requests by setting
+:setting:`DUPEFILTER_CLASS` to ``'scrapy.dupefilters.BaseDupeFilter'``.
+Be very careful about this however, because you can get into crawling loops.
+It's usually a better idea to set the ``dont_filter`` parameter to
+``True`` on the specific :class:`~scrapy.http.Request` that should not be
+filtered.
+
 .. setting:: DUPEFILTER_DEBUG
 
 DUPEFILTER_DEBUG


### PR DESCRIPTION
I'm a novice scrappy user and I noticed the documentation does not mention how to disable duplicate request filtering in the settings.
This was useful to me recently as a command line option to a spider.
I also added a warning to consider using the dont_filter parameter of Request instead.