### PR TITLE
[MRG+1] Allow dropping field in from_response formdata

### DIFF
--- a/docs/topics/request-response.rst
+++ b/docs/topics/request-response.rst
@@ -417,7 +417,9 @@ fields with form data from :class:`Response` objects.
 
        :param formdata: fields to override in the form data. If a field was
           already present in the response ``<form>`` element, its value is
-          overridden by the one passed in this parameter.
+          overridden by the one passed in this parameter. If a value passed in
+          this parameter is ``None``, the field will not be included in the
+          request, even if it was present in the response ``<form>`` element.
        :type formdata: dict
 
        :param clickdata: attributes to lookup the control clicked. If it's not

--- a/scrapy/http/request/form.py
+++ b/scrapy/http/request/form.py
@@ -135,7 +135,7 @@ def _get_inputs(form, formdata, dont_click, clickdata, response):
         if clickable and clickable[0] not in formdata and not clickable[0] is None:
             values.append(clickable)
 
-    values.extend(formdata.items())
+    values.extend((k, v) for k, v in formdata.items() if v is not None)
     return values
 
 

--- a/tests/test_http_request.py
+++ b/tests/test_http_request.py
@@ -425,6 +425,17 @@ class FormRequestTest(RequestTest):
         self.assertEqual(fs[b'one'], [b'1'])
         self.assertEqual(fs[b'two'], [b'2'])
 
+    def test_from_response_drop_params(self):
+        response = _buildresponse(
+            """<form action="get.php" method="POST">
+            <input type="hidden" name="one" value="1">
+            <input type="hidden" name="two" value="3">
+            </form>""")
+        req = self.request_class.from_response(response, formdata={'two': None})
+        fs = _qs(req)
+        self.assertEqual(fs[b'one'], [b'1'])
+        self.assertNotIn(b'two', fs)
+
     def test_from_response_override_method(self):
         response = _buildresponse(
                 '''<html><body>


### PR DESCRIPTION
Implements #667.  `FormRequest.from_response` is very helpful, but sometimes it includes a field that you would like to remove.  With this change, you can include a field with value `None` in `formdata` when calling `from_response`, and the field will be omitted from the body of the returned request.