### PR TITLE
Allow custom files storage class

### DIFF
--- a/scrapy/pipelines/files.py
+++ b/scrapy/pipelines/files.py
@@ -217,6 +217,11 @@ class FilesPipeline(MediaPipeline):
 
     MEDIA_NAME = "file"
     EXPIRES = 90
+    STORE_SCHEMES = {
+        '': FSFilesStore,
+        'file': FSFilesStore,
+        's3': S3FilesStore,
+    }
     DEFAULT_FILES_URLS_FIELD = 'file_urls'
     DEFAULT_FILES_RESULT_FIELD = 'files'
 

--- a/scrapy/pipelines/images.py
+++ b/scrapy/pipelines/images.py
@@ -86,6 +86,7 @@ class ImagesPipeline(FilesPipeline):
 
     @classmethod
     def from_settings(cls, settings):
+        cls.STORE_SCHEMES = cls._load_components(settings, 'FILES_STORE_SCHEMES')
         s3store = cls.STORE_SCHEMES['s3']
         s3store.AWS_ACCESS_KEY_ID = settings['AWS_ACCESS_KEY_ID']
         s3store.AWS_SECRET_ACCESS_KEY = settings['AWS_SECRET_ACCESS_KEY']

--- a/scrapy/pipelines/images.py
+++ b/scrapy/pipelines/images.py
@@ -46,6 +46,7 @@ class ImagesPipeline(FilesPipeline):
     THUMBS = {}
     DEFAULT_IMAGES_URLS_FIELD = 'image_urls'
     DEFAULT_IMAGES_RESULT_FIELD = 'images'
+    S3_POLICY_KEY = 'IMAGES_STORE_S3_ACL'
 
     def __init__(self, store_uri, download_func=None, settings=None):
         super(ImagesPipeline, self).__init__(store_uri, settings=settings,
@@ -87,10 +88,6 @@ class ImagesPipeline(FilesPipeline):
     @classmethod
     def from_settings(cls, settings):
         cls.STORE_SCHEMES = cls._load_components(settings, 'FILES_STORE_SCHEMES')
-        s3store = cls.STORE_SCHEMES['s3']
-        s3store.AWS_ACCESS_KEY_ID = settings['AWS_ACCESS_KEY_ID']
-        s3store.AWS_SECRET_ACCESS_KEY = settings['AWS_SECRET_ACCESS_KEY']
-        s3store.POLICY = settings['IMAGES_STORE_S3_ACL']
 
         store_uri = settings['IMAGES_STORE']
         return cls(store_uri, settings=settings)

--- a/scrapy/settings/default_settings.py
+++ b/scrapy/settings/default_settings.py
@@ -164,6 +164,12 @@ FEED_EXPORTERS_BASE = {
 FEED_EXPORT_INDENT = 0
 
 FILES_STORE_S3_ACL = 'private'
+FILES_STORE_SCHEMES = {}
+FILES_STORE_SCHEMES_BASE = {
+    '': 'scrapy.pipelines.files.FSFilesStore',
+    'file': 'scrapy.pipelines.files.FSFilesStore',
+    's3': 'scrapy.pipelines.files.S3FilesStore',
+}
 
 FTP_USER = 'anonymous'
 FTP_PASSWORD = 'guest'

--- a/tests/test_pipeline_files.py
+++ b/tests/test_pipeline_files.py
@@ -340,6 +340,30 @@ class FilesPipelineTestCaseCustomSettings(unittest.TestCase):
                              expected_value)
 
 
+class FilesPipelineTestCaseS3Settings(unittest.TestCase):
+
+    def test_aws_settings(self):
+        """
+        The AWS settings should be set from settings.
+        """
+        pipe = FilesPipeline.from_settings(Settings({'FILES_STORE': 's3://example/files/',
+                                                     'AWS_ACCESS_KEY_ID': 'example_id',
+                                                     'AWS_SECRET_ACCESS_KEY': 'example_key'}))
+        self.assertEqual(pipe.store.AWS_ACCESS_KEY_ID, 'example_id')
+        self.assertEqual(pipe.store.AWS_SECRET_ACCESS_KEY, 'example_key')
+
+    def test_policy_settings(self):
+        """
+        If FILES_STORE_S3_ACL is set, the POLICY attribute should be overridden.
+        """
+        pipe = FilesPipeline.from_settings(Settings({'FILES_STORE': 's3://example/files/',
+                                                     'FILES_STORE_S3_ACL': 'public'}))
+        self.assertEqual(pipe.store.POLICY, 'public')
+        pipe = FilesPipeline.from_settings(Settings({'FILES_STORE': 's3://example/files/',
+                                                     'FILES_STORE_S3_ACL': 'private'}))
+        self.assertEqual(pipe.store.POLICY, 'private')
+
+
 class TestS3FilesStore(unittest.TestCase):
     @defer.inlineCallbacks
     def test_persist(self):
@@ -404,7 +428,7 @@ class FilesPipelineCustomStorageTestCase(unittest.TestCase):
 
 class DictFilesStore(object):
 
-    def __init__(self, uri):
+    def __init__(self, uri, **kwargs):
         assert uri.startswith('dict://')
         self.basedir = uri[5:]
         self.checksums = {}

--- a/tests/test_pipeline_images.py
+++ b/tests/test_pipeline_images.py
@@ -393,6 +393,33 @@ class ImagesPipelineTestCaseCustomSettings(unittest.TestCase):
             self.assertEqual(getattr(pipeline_cls, pipe_attr.lower()),
                              expected_value)
 
+
+class ImagesPipelineTestCaseS3Settings(unittest.TestCase):
+
+    def test_aws_settings(self):
+        """
+        The AWS settings should be set from settings.
+        """
+        pipe = ImagesPipeline.from_settings(Settings({'IMAGES_STORE': 's3://example/files/',
+                                                      'AWS_ACCESS_KEY_ID': 'example_id',
+                                                      'AWS_SECRET_ACCESS_KEY': 'example_key'}))
+        self.assertEqual(pipe.store.AWS_ACCESS_KEY_ID, 'example_id')
+        self.assertEqual(pipe.store.AWS_SECRET_ACCESS_KEY, 'example_key')
+
+
+    def test_policy_settings(self):
+        """
+        If IMAGES_STORE_S3_ACL is set, the POLICY attribute should be overridden.
+        """
+        pipe = ImagesPipeline.from_settings(Settings({'IMAGES_STORE': 's3://example/files/',
+                                                      'IMAGES_STORE_S3_ACL': 'public'}))
+        self.assertEqual(pipe.store.POLICY, 'public')
+
+        pipe = ImagesPipeline.from_settings(Settings({'IMAGES_STORE': 's3://example/files/',
+                                                      'IMAGES_STORE_S3_ACL': 'private'}))
+        self.assertEqual(pipe.store.POLICY, 'private')
+
+
 def _create_image(format, *a, **kw):
     buf = TemporaryFile()
     Image.new(*a, **kw).save(buf, format)


### PR DESCRIPTION
Recently I found that it is too restrictive to only have S3 storage when using scrapy on scrapinghub.
Hopefully we could use any custom storage classes.