### PR TITLE
[MRG+1] Add support for executing scrapy using -m option of python

### DIFF
--- a/scrapy/__main__.py
+++ b/scrapy/__main__.py
@@ -1,0 +1,4 @@
+from scrapy.cmdline import execute
+
+if __name__ == '__main__':
+    execute()


### PR DESCRIPTION
This pull-request enable execute scrapy from python module.

```
python -m scrapy
```
On windows, this probably works, too. Although I did not test because I do not have Windows

```
py -3 -m scrapy
```
