### PR TITLE
tweak coverage reports

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,6 @@
+comment:
+  layout: "header, diff, tree"
+
+coverage:
+  status:
+    project: false


### PR DESCRIPTION
Codecov moved from settings defined in UI to settings defined in codecov.yml file.

In this file I'm disabling project coverage check, because it is fine for project coverage % to decrease - it may happen if you e.g. remove unneeded code. Patch coverage is what is important.