### PR TITLE
[MRG+1] Added possibility to fine-tune logging in CrawlerProcess

### DIFF
--- a/scrapy/crawler.py
+++ b/scrapy/crawler.py
@@ -239,10 +239,10 @@ class CrawlerProcess(CrawlerRunner):
     process. See :ref:`run-from-script` for an example.
     """
 
-    def __init__(self, settings=None):
+    def __init__(self, settings=None, install_root_logging_handler=True):
         super(CrawlerProcess, self).__init__(settings)
         install_shutdown_handlers(self._signal_shutdown)
-        configure_logging(self.settings)
+        configure_logging(self.settings, install_root_logging_handler)
         log_scrapy_info(self.settings)
 
     def _signal_shutdown(self, signum, _):


### PR DESCRIPTION
Hello!
This little PR adds possibility to overwrite `install_root_handler` setting for `scrapy.utils.log.configure_logging` in `CrawlerProcess`, to remedy a situations like [this](https://github.com/celery/celery/issues/2876).