### PR TITLE
When item export fails, mention the item itself in error msg

### DIFF
--- a/scrapy/exporters.py
+++ b/scrapy/exporters.py
@@ -41,6 +41,15 @@ class BaseItemExporter(object):
             raise TypeError("Unexpected options: %s" % ', '.join(options.keys()))
 
     def export_item(self, item):
+        try:
+            return self._export_item_impl(item)
+        except Exception as err:
+            exc_info = sys.exc_info()
+            new_err = ValueError("Cannot serialize item: %s: %s\nitem=%s" % (
+                type(err).__name__, err, item))
+            six.reraise(type(new_err), new_err, exc_info[2])
+
+    def _export_item_impl(self, item):
         raise NotImplementedError
 
     def serialize_field(self, field, name, value):
@@ -88,7 +97,7 @@ class JsonLinesItemExporter(BaseItemExporter):
         kwargs.setdefault('ensure_ascii', not self.encoding)
         self.encoder = ScrapyJSONEncoder(**kwargs)
 
-    def export_item(self, item):
+    def _export_item_impl(self, item):
         itemdict = dict(self._get_serialized_fields(item))
         data = self.encoder.encode(itemdict) + '\n'
         self.file.write(to_bytes(data, self.encoding))
@@ -120,7 +129,7 @@ class JsonItemExporter(BaseItemExporter):
         self._beautify_newline()
         self.file.write(b"]")
 
-    def export_item(self, item):
+    def _export_item_impl(self, item):
         if self.first_item:
             self.first_item = False
         else:
@@ -154,7 +163,7 @@ class XmlItemExporter(BaseItemExporter):
         self.xg.startElement(self.root_element, {})
         self._beautify_newline(new_item=True)
 
-    def export_item(self, item):
+    def _export_item_impl(self, item):
         self._beautify_indent(depth=1)
         self.xg.startElement(self.item_element, {})
         self._beautify_newline()
@@ -232,7 +241,7 @@ class CsvItemExporter(BaseItemExporter):
                 pass
         return value
 
-    def export_item(self, item):
+    def _export_item_impl(self, item):
         if self._headers_not_written:
             self._headers_not_written = False
             self._write_headers_and_set_fields_to_export(item)
@@ -269,7 +278,7 @@ class PickleItemExporter(BaseItemExporter):
         self.file = file
         self.protocol = protocol
 
-    def export_item(self, item):
+    def _export_item_impl(self, item):
         d = dict(self._get_serialized_fields(item))
         pickle.dump(d, self.file, self.protocol)
 
@@ -280,7 +289,7 @@ class MarshalItemExporter(BaseItemExporter):
         self._configure(kwargs)
         self.file = file
 
-    def export_item(self, item):
+    def _export_item_impl(self, item):
         marshal.dump(dict(self._get_serialized_fields(item)), self.file)
 
 
@@ -290,7 +299,7 @@ class PprintItemExporter(BaseItemExporter):
         self._configure(kwargs)
         self.file = file
 
-    def export_item(self, item):
+    def _export_item_impl(self, item):
         itemdict = dict(self._get_serialized_fields(item))
         self.file.write(to_bytes(pprint.pformat(itemdict) + '\n'))
 
@@ -332,7 +341,7 @@ class PythonItemExporter(BaseItemExporter):
             key = to_bytes(key) if self.binary else key
             yield key, self._serialize_value(val)
 
-    def export_item(self, item):
+    def _export_item_impl(self, item):
         result = dict(self._get_serialized_fields(item))
         if self.binary:
             result = dict(self._serialize_dict(result))


### PR DESCRIPTION
I have recently run into an error when an item that looked like `{"foo": {None: "bar"}}` broke the exporter. I was able to deduce that there was a `None` key in the dictionary from the error message, but I was clueless as to where and how did it happen:
```
Traceback:
  ...
  File "/usr/local/lib/python2.7/site-packages/scrapy/exporters.py", line 289, in export_item
    result = dict(self._get_serialized_fields(item))
  File "/usr/local/lib/python2.7/site-packages/scrapy/exporters.py", line 75, in _get_serialized_fields
    value = self.serialize_field(field, field_name, item[field_name])
  File "/usr/local/lib/python2.7/site-packages/scrapy/exporters.py", line 269, in serialize_field
    return serializer(value)
  File "/usr/local/lib/python2.7/site-packages/scrapy/exporters.py", line 275, in _serialize_value
    return dict(self._serialize_dict(value))
  File "/usr/local/lib/python2.7/site-packages/scrapy/exporters.py", line 285, in _serialize_dict
    key = to_bytes(key) if self.binary else key
  File "/usr/local/lib/python2.7/site-packages/scrapy/utils/python.py", line 117, in to_bytes
    'object, got %s' % type(text).__name__)
TypeError: to_bytes must receive a unicode, str or bytes object, got NoneType
```

I have tweaked the exporter classes so that the error message now includes the culprit item itself and it  looks like this:
```
In [9]: try: exporter.export_item({'foo': {None: 'bar'}})
   ...: except Exception: traceback.print_exc()
   ...: 
Traceback (most recent call last):
  File "<ipython-input-9-6392cb271d68>", line 1, in <module>
    try: exporter.export_item({'foo': {None: 'bar'}})
  File "scrapy/exporters.py", line 50, in export_item
    six.reraise(type(new_err), new_err, exc_info[2])
  File "scrapy/exporters.py", line 45, in export_item
    return self._export_item_impl(item)
  File "scrapy/exporters.py", line 345, in _export_item_impl
    result = dict(self._get_serialized_fields(item))
  File "scrapy/exporters.py", line 85, in _get_serialized_fields
    value = self.serialize_field(field, field_name, item[field_name])
  File "scrapy/exporters.py", line 325, in serialize_field
    return serializer(value)
  File "scrapy/exporters.py", line 331, in _serialize_value
    return dict(self._serialize_dict(value))
  File "scrapy/exporters.py", line 341, in _serialize_dict
    key = to_bytes(key) if self.binary else key
  File "scrapy/utils/python.py", line 117, in to_bytes
    'object, got %s' % type(text).__name__)
ValueError: Cannot serialize item: TypeError: to_bytes must receive a unicode, str or bytes object, got NoneType
item={'foo': {None: 'bar'}}
```

The PR slightly tweaks the implementation details for `ItemExporters.export_item`: 
- ideally, you'd now override `_export_item_impl` function instead of `export_item` itself, but classes inherited from the old version should work as before
- if there's code that catches exceptions from `export_item`, it might break now that it only throws `ValueError` instances
 - "Item Exporters" page in the doc should be updated, I'll do it if the PR is OK otherwise