### PR TITLE
Check if attribute has a value before moving forward with the link extraction

### DIFF
--- a/scrapy/linkextractors/lxmlhtml.py
+++ b/scrapy/linkextractors/lxmlhtml.py
@@ -60,6 +60,8 @@ class LxmlParserLinkExtractor(object):
             try:
                 if self.strip:
                     attr_val = strip_html5_whitespace(attr_val)
+                if not attr_val:
+                    continue
                 attr_val = urljoin(base_url, attr_val)
             except ValueError:
                 continue  # skipping bogus links


### PR DESCRIPTION
I run into this bug using a link extractor to get all the images in a web page. The link extractor was returning the base_url for some reason. Investigated, and found out that the logic is not checking if the attribute is empty before url joining it with the base url.

As attr_val was empty this line:

`attr_val = urljoin(base_url, attr_val) `

was returning just the base_url.