### PR TITLE
python-attrs support to Scrappy Items

### DIFF
--- a/scrapy/item.py
+++ b/scrapy/item.py
@@ -70,13 +70,12 @@ class DictItem(MutableMapping, BaseItem):
 
     def __getattr__(self, name):
         if name in self.fields:
-            raise AttributeError("Use item[%r] to get field value" % name)
+            return self.__getitem__(name)
         raise AttributeError(name)
 
     def __setattr__(self, name, value):
         if not name.startswith('_'):
-            raise AttributeError("Use item[%r] = %r to set field value" %
-                (name, value))
+            self.__setitem__(name, value)
         super(DictItem, self).__setattr__(name, value)
 
     def __len__(self):

--- a/tests/test_item.py
+++ b/tests/test_item.py
@@ -153,27 +153,30 @@ class ItemTest(unittest.TestCase):
             fields = {'load': Field(default='A')}
             save = Field(default='A')
 
-        class B(A): pass
+        class B(A):
+            pass
 
         class C(Item):
             fields = {'load': Field(default='C')}
             save = Field(default='C')
 
-        class D(B, C): pass
+        class D(B, C):
+            pass
 
         item = D(save='X', load='Y')
         self.assertEqual(item['save'], 'X')
         self.assertEqual(item['load'], 'Y')
         self.assertEqual(D.fields, {'load': {'default': 'A'},
-            'save': {'default': 'A'}})
+                                    'save': {'default': 'A'}})
 
         # D class inverted
-        class E(C, B): pass
+        class E(C, B):
+            pass
 
         self.assertEqual(E(save='X')['save'], 'X')
         self.assertEqual(E(load='X')['load'], 'X')
         self.assertEqual(E.fields, {'load': {'default': 'C'},
-            'save': {'default': 'C'}})
+                                    'save': {'default': 'C'}})
 
     def test_metaclass_multiple_inheritance_diamond(self):
         class A(Item):
@@ -181,7 +184,8 @@ class ItemTest(unittest.TestCase):
             save = Field(default='A')
             load = Field(default='A')
 
-        class B(A): pass
+        class B(A):
+            pass
 
         class C(A):
             fields = {'update': Field(default='C')}
@@ -194,7 +198,8 @@ class ItemTest(unittest.TestCase):
         self.assertEqual(D(save='X')['save'], 'X')
         self.assertEqual(D(load='X')['load'], 'X')
         self.assertEqual(D.fields, {'save': {'default': 'C'},
-            'load': {'default': 'D'}, 'update': {'default': 'D'}})
+                                    'load': {'default': 'D'},
+                                    'update': {'default': 'D'}})
 
         # D class inverted
         class E(C, B):
@@ -203,34 +208,38 @@ class ItemTest(unittest.TestCase):
         self.assertEqual(E(save='X')['save'], 'X')
         self.assertEqual(E(load='X')['load'], 'X')
         self.assertEqual(E.fields, {'save': {'default': 'C'},
-            'load': {'default': 'E'}, 'update': {'default': 'C'}})
+                                    'load': {'default': 'E'},
+                                    'update': {'default': 'C'}})
 
     def test_metaclass_multiple_inheritance_without_metaclass(self):
         class A(Item):
             fields = {'load': Field(default='A')}
             save = Field(default='A')
 
-        class B(A): pass
+        class B(A):
+            pass
 
         class C(object):
             fields = {'load': Field(default='C')}
             not_allowed = Field(default='not_allowed')
             save = Field(default='C')
 
-        class D(B, C): pass
+        class D(B, C):
+            pass
 
         self.assertRaises(KeyError, D, not_allowed='value')
         self.assertEqual(D(save='X')['save'], 'X')
         self.assertEqual(D.fields, {'save': {'default': 'A'},
-            'load': {'default': 'A'}})
+                                    'load': {'default': 'A'}})
 
         # D class inverted
-        class E(C, B): pass
+        class E(C, B):
+            pass
 
         self.assertRaises(KeyError, E, not_allowed='value')
         self.assertEqual(E(save='X')['save'], 'X')
         self.assertEqual(E.fields, {'save': {'default': 'A'},
-            'load': {'default': 'A'}})
+                                    'load': {'default': 'A'}})
 
     def test_to_dict(self):
         class TestItem(Item):
@@ -243,7 +252,7 @@ class ItemTest(unittest.TestCase):
     def test_copy(self):
         class TestItem(Item):
             name = Field()
-        item = TestItem({'name':'lower'})
+        item = TestItem({'name': 'lower'})
         copied_item = item.copy()
         self.assertNotEqual(id(item), id(copied_item))
         copied_item['name'] = copied_item['name'].upper()

--- a/tests/test_item.py
+++ b/tests/test_item.py
@@ -1,6 +1,7 @@
 import sys
 import unittest
 
+import attr
 import six
 
 from scrapy.item import ABCMeta, Item, ItemMeta, Field
@@ -273,6 +274,13 @@ class ItemTest(unittest.TestCase):
             name = Field()
         i = TestItem(name='John')
         self.assertEqual(i.name, i['name'])
+
+    def test_attr_decorated_items(self):
+        @attr.s
+        class TestItem(Item):
+            name = attr.ib(default='default')
+        i = TestItem()
+        self.assertEqual(i['name'], 'default')
 
 
 class ItemMetaTest(unittest.TestCase):

--- a/tests/test_item.py
+++ b/tests/test_item.py
@@ -84,14 +84,17 @@ class ItemTest(unittest.TestCase):
             name = Field()
 
         i = TestItem()
-        self.assertRaises(AttributeError, getattr, i, 'name')
+        self.assertRaises(KeyError, getattr, i, 'name')
+        i = TestItem(name='john')
+        self.assertEqual(i.__getattr__('name'), 'john')
 
-    def test_raise_setattr(self):
+    def test_setattr(self):
         class TestItem(Item):
             name = Field()
 
         i = TestItem()
-        self.assertRaises(AttributeError, setattr, i, 'name', 'john')
+        i.__setattr__('name', 'john')
+        self.assertEqual(i['name'], 'john')
 
     def test_custom_methods(self):
         class TestItem(Item):
@@ -257,6 +260,19 @@ class ItemTest(unittest.TestCase):
         self.assertNotEqual(id(item), id(copied_item))
         copied_item['name'] = copied_item['name'].upper()
         self.assertNotEqual(item['name'], copied_item['name'])
+
+    def test_assign_field_dot_notation(self):
+        class TestItem(Item):
+            name = Field()
+        i = TestItem()
+        i.name = u'John'
+        self.assertEqual(i['name'], u'John')
+
+    def test_get_field_dot_notation(self):
+        class TestItem(Item):
+            name = Field()
+        i = TestItem(name='John')
+        self.assertEqual(i.name, i['name'])
 
 
 class ItemMetaTest(unittest.TestCase):

--- a/tests/test_item.py
+++ b/tests/test_item.py
@@ -276,11 +276,46 @@ class ItemTest(unittest.TestCase):
         self.assertEqual(i.name, i['name'])
 
     def test_attr_decorated_items(self):
+        @attr.s(hash=True, init=False, repr=False)
+        class TestItem(Item):
+            name = attr.ib(default='Default')
+            origin = attr.ib()
+        i = TestItem()
+        self.assertEqual(i['name'], 'Default')
+        self.assertEqual(i.__str__(), "{'name': 'Default'}")
+        self.assertEqual(
+            i.fields,
+            {'origin': {}, 'name': {'default': 'Default'}}
+        )
+        with self.assertRaises(KeyError):
+            my_origin = i['origin']
+        i['origin'] = 'Origin'
+        self.assertEqual(i.__str__(), "{'name': 'Default', 'origin': 'Origin'}")
+
+    def test_attr_decorated_items_str_issues(self):
+        @attr.s(hash=True, init=False)
+        class TestItem(Item):
+            name = attr.ib(default='Default')
+            origin = attr.ib()
+        i = TestItem()
+        self.assertFalse(i.__str__() == "{'name': 'Default'}")
+
+    def test_attr_decorated_items_init_errors(self):
+        @attr.s(hash=True)
+        class TestItem(Item):
+            name = attr.ib(default='Default')
+            origin = attr.ib()
+        i = TestItem()
+        exception_text = "%s. Associated with __init__ issues" % '_value'
+        self.assertRaises(AttributeError, getattr, i, exception_text)
+
+    def test_attr_decorated_items_hash_errors(self):
         @attr.s
         class TestItem(Item):
-            name = attr.ib(default='default')
-        i = TestItem()
-        self.assertEqual(i['name'], 'default')
+            name = attr.ib(default='Default')
+            origin = attr.ib()
+        with self.assertRaises(TypeError):
+            i = TestItem()
 
 
 class ItemMetaTest(unittest.TestCase):


### PR DESCRIPTION
Fixes #2749 

Providing new ways to populate Scrapy items and adding the possibility of having @attr.s decorated Scrappy items.

This PR tries to solve the suggestions presented in issue #2749 

Certain arguments need to be passed to the decorator in order to make the decorated class (a subclass of Scrapy Item) compatible with the functioning of Scrapy Items. This is covered in the form of tests in the PR.

At the moment, the passing of default values to the attributes of the class (equivalent to Fields in normal Scrapy Items) is covered, but the passing of other metadata, such as validators, has not been considered.

This PR also covers the dot notation access to the Fields in Scrapy Items. 