### PR TITLE
Populate spider variable when using shell.inspect_response

### DIFF
--- a/scrapy/shell.py
+++ b/scrapy/shell.py
@@ -164,7 +164,7 @@ class Shell(object):
 
 def inspect_response(response, spider):
     """Open a shell to inspect the given response"""
-    Shell(spider.crawler).start(response=response)
+    Shell(spider.crawler).start(response=response, spider=spider)
 
 
 def _request_deferred(request):


### PR DESCRIPTION
Currently the `spider` variable is not populated when using `scrapy.inspect_response`. It can be accessed through `crawler.spider`, but I think this could still be useful.

Before:
```
2017-07-03 11:07:18 [scrapy.core.engine] INFO: Spider opened
2017-07-03 11:07:18 [scrapy.extensions.logstats] INFO: Crawled 0 pages (at 0 pages/min), scraped 0 items (at 0 items/min)
[s] Available Scrapy objects:
[s]   scrapy     scrapy module (contains scrapy.Request, scrapy.Selector, etc)
[s]   crawler    <scrapy.crawler.Crawler object at 0x7f5c17d50c50>
[s]   item       {}
[s]   request    <GET http://www.example.org>
[s]   response   <200 http://www.example.org>
[s]   settings   <scrapy.settings.Settings object at 0x7f5c17d508d0>
[s] Useful shortcuts:
[s]   shelp()           Shell help (print this help)
[s]   view(response)    View response in a browser
>>> type(spider)
<type 'NoneType'>
```
After:
```
2017-07-03 11:26:10 [scrapy.core.engine] INFO: Spider opened
2017-07-03 11:26:10 [scrapy.extensions.logstats] INFO: Crawled 0 pages (at 0 pages/min), scraped 0 items (at 0 items/min)
[s] Available Scrapy objects:
[s]   scrapy     scrapy module (contains scrapy.Request, scrapy.Selector, etc)
[s]   crawler    <scrapy.crawler.Crawler object at 0x7f5237c2ddd8>
[s]   item       {}
[s]   request    <GET http://www.example.org>
[s]   response   <200 http://www.example.org>
[s]   settings   <scrapy.settings.Settings object at 0x7f5237c2dda0>
[s]   spider     <TestSpider 'inspect' at 0x7f523497add8>
[s] Useful shortcuts:
[s]   shelp()           Shell help (print this help)
[s]   view(response)    View response in a browser
>>> type(spider)
<class 'inspect_spider.TestSpider'>
```