### PR TITLE
Documentation of CrawlSpider methods in Spiders.rst 

### DIFF
--- a/docs/topics/spiders.rst
+++ b/docs/topics/spiders.rst
@@ -362,7 +362,7 @@ CrawlSpider
        described below. If multiple rules match the same link, the first one
        will be used, according to the order they're defined in this attribute.
 
-   This spider also exposes an overrideable method:
+   This spider also exposes a few overrideable methods:
 
    .. method:: parse_start_url(response)
 
@@ -370,6 +370,28 @@ CrawlSpider
       the initial responses and must return either an
       :class:`~scrapy.item.Item` object, a :class:`~scrapy.http.Request`
       object, or an iterable containing any of them.
+
+   .. method:: process_results(response, results)
+
+      This overridable method is called for each result (item or request)
+      returned by the spider, and it's intended to perform any last time
+      processing required before returning the results to the framework core,
+      for example setting the item GUIDs. It receives a list of results and
+      the response which originated that results. It must return a list
+      of results (Items or Requests).
+
+   .. method:: _requests_to_follow(response)
+
+      This method iterates over each of the spider's rules, extracts the links
+      matching each case, filters them (if needed), and returns a list of unique
+      requests per response.
+
+   .. method:: _response_downloaded(response)
+
+      This is were any response arrives, and were it's decided whether
+      to extract links or not from it, and if it will be parsed or not.
+      It returns a list of requests/items.
+
 
 Crawling rules
 ~~~~~~~~~~~~~~


### PR DESCRIPTION
#2727 
Added the documentation from CrawlSpider source code to the [spiders.rst](https://github.com/scrapy/scrapy/blob/master/docs/topics/spiders.rst)