### PR TITLE
[WIP] An option to limit the cache size for the media pipeline

### DIFF
--- a/docs/topics/broad-crawls.rst
+++ b/docs/topics/broad-crawls.rst
@@ -163,3 +163,17 @@ It is turned OFF by default because it has some performance overhead,
 and enabling it for focused crawls doesn't make much sense.
 
 .. _ajax crawlable: https://developers.google.com/webmasters/ajax-crawling/docs/getting-started
+
+Limit media pipeline caching
+============================
+
+By default media pipeline caches meta information
+(url, path and checksum) for all downloaded files and images
+in order to avoid downloading the same file multiple times.
+This caching might consume noticeable amount of memory for large-scale crawls
+with millions of items downloaded.
+It's possible to :ref:`limit caching <topics-media-pipeline-cache>`
+to cap the memory usage::
+
+    MEDIA_CACHE_SIZE = 10000
+

--- a/docs/topics/leaks.rst
+++ b/docs/topics/leaks.rst
@@ -53,6 +53,17 @@ While not necessarily a leak, this can take a lot of memory. Enabling
 :ref:`persistent job queue <topics-jobs>` could help keeping memory usage
 in control.
 
+Media pipeline caching
+----------------------
+
+By default media pipeline caches meta information
+(url, path and checksum) for all downloaded files and images
+in order to avoid downloading the same file multiple times.
+This caching might consume noticeable amount of memory for large-scale crawls
+with millions of items downloaded.
+It's possible to :ref:`limit caching <topics-media-pipeline-cache>`
+to cap the memory usage.
+
 .. _topics-leaks-trackrefs:
 
 Debugging memory leaks with ``trackref``

--- a/docs/topics/media-pipeline.rst
+++ b/docs/topics/media-pipeline.rst
@@ -113,6 +113,18 @@ For the Images Pipeline, set the :setting:`IMAGES_STORE` setting::
 
    IMAGES_STORE = '/path/to/valid/dir'
 
+
+It is also recommended to review several options that are explained
+in more details below:
+
+- ``MEDIA_ALLOW_REDIRECTS`` to allow redirects when downloading media items:
+  by default redirects are not followed.
+  See :ref:`topics-media-pipeline-redirects`.
+- ``MEDIA_CACHE_SIZE`` to limit the cache size: by default meta information
+  (url, path and checksum) for all downloaded files and images is cached.
+  See :ref:`topics-media-pipeline-cache`.
+
+
 Supported Storage
 =================
 
@@ -320,6 +332,8 @@ all be dropped because at least one dimension is shorter than the constraint.
 
 By default, there are no size constraints, so all images are processed.
 
+.. _topics-media-pipeline-redirects:
+
 Allowing redirections
 ---------------------
 
@@ -331,6 +345,23 @@ to a media file URL request will mean the media download is considered failed.
 To handle media redirections, set this setting to ``True``::
 
     MEDIA_ALLOW_REDIRECTS = True
+
+.. _topics-media-pipeline-cache:
+
+Limiting cache size
+-------------------
+
+.. setting:: MEDIA_CACHE_SIZE
+
+By default media pipeline caches meta information
+(url, path and checksum) for all downloaded files and images.
+This might consume noticeable amount of memory for large-scale crawls
+with millions of items downloaded. Set it to the number of most recently
+used items you wish to keep::
+
+    MEDIA_CACHE_SIZE = 10000
+
+Zero is also an allowed value, this will disable the cache completely.
 
 .. _topics-media-pipeline-override:
 

--- a/docs/topics/media-pipeline.rst
+++ b/docs/topics/media-pipeline.rst
@@ -121,7 +121,8 @@ in more details below:
   by default redirects are not followed.
   See :ref:`topics-media-pipeline-redirects`.
 - ``MEDIA_CACHE_SIZE`` to limit the cache size: by default meta information
-  (url, path and checksum) for all downloaded files and images is cached.
+  (url, path and checksum) for all downloaded files and images is cached
+  in order to avoid downloading the same file multiple times.
   See :ref:`topics-media-pipeline-cache`.
 
 
@@ -354,14 +355,20 @@ Limiting cache size
 .. setting:: MEDIA_CACHE_SIZE
 
 By default media pipeline caches meta information
-(url, path and checksum) for all downloaded files and images.
-This might consume noticeable amount of memory for large-scale crawls
-with millions of items downloaded. Set it to the number of most recently
-used items you wish to keep::
+(url, path and checksum) for all downloaded files and images
+in order to avoid downloading the same file multiple times.
+This caching might consume noticeable amount of memory for large-scale crawls
+with millions of items downloaded. In order to limit the cache size
+(and memory usage), set the maximal cache size::
 
     MEDIA_CACHE_SIZE = 10000
 
-Zero is also an allowed value, this will disable the cache completely.
+Zero is also an allowed value, this will disable the cache completely::
+
+    MEDIA_CACHE_SIZE = 0
+
+Cache size is not limited by default, a ``None`` or an empty string ``''``
+value for ``MEDIA_CACHE_SIZE`` enable this behaviour.
 
 .. _topics-media-pipeline-override:
 


### PR DESCRIPTION
Fixes #939  (the memory issue with media pipeline)

Only docs so far - if this looks good, I'll proceed with implementation. An option to limit the cache size to some fixed number complicated implementation a little bit, but seems it's worth it in case the crawler is downloading all images, so the same image can be referenced from multiple pages.