### PR TITLE
Add option to expand date and time in logs as UTC

### DIFF
--- a/docs/topics/logging.rst
+++ b/docs/topics/logging.rst
@@ -149,6 +149,7 @@ These settings can be used to configure the logging:
 * :setting:`LOG_LEVEL`
 * :setting:`LOG_FORMAT`
 * :setting:`LOG_DATEFORMAT`
+* :setting:`LOG_DATETIME_UTC`
 * :setting:`LOG_STDOUT`
 * :setting:`LOG_SHORT_NAMES`
 
@@ -171,8 +172,17 @@ listed in `logging's logrecord attributes docs
 <https://docs.python.org/2/library/datetime.html#strftime-and-strptime-behavior>`_
 respectively.
 
+.. note::
+    By default, when expanding ``%(asctime)s`` from :setting:`LOG_FORMAT`,
+    **a non-timezone-aware time object is used.**
+
+    To use UTC time, you need to set ``LOG_DATETIME_UTC = True``.
+    In addition to this, you may also want to update :setting:`LOG_FORMAT`
+    to follow ISO 8601 for UTC date and time,
+    e.g. ``LOG_FORMAT = '%Y-%m-%dT%H:%M:%SZ'`` or ``LOG_FORMAT = '%Y-%m-%dT%H:%M:%S+0000'``
+
 If :setting:`LOG_SHORT_NAMES` is set, then the logs will not display the scrapy
-component that prints the log. It is unset by default, hence logs contain the 
+component that prints the log. It is unset by default, hence logs contain the
 scrapy component responsible for that log output.
 
 Command-line options

--- a/docs/topics/settings.rst
+++ b/docs/topics/settings.rst
@@ -836,6 +836,22 @@ directives.
 
 .. _Python datetime documentation: https://docs.python.org/2/library/datetime.html#strftime-and-strptime-behavior
 
+.. warning::
+    ``%z`` may not work as expected on all systems. If you need unambiguous
+    date and time in log records, one option is to set :setting:`LOG_DATETIME_UTC`
+    to ``True`` and use a UTC format such as ``'%Y-%m-%dT%H:%M:%S+0000'``
+
+.. setting:: LOG_DATETIME_UTC
+
+LOG_DATETIME_UTC
+----------------
+
+Default: ``False``
+
+If ``True``,  the ``%(asctime)s`` placeholder in :setting:`LOG_FORMAT`
+will be expanded as a UTC time object, following :setting:`LOG_DATEFORMAT`,
+instead of system local date and time.
+
 .. setting:: LOG_LEVEL
 
 LOG_LEVEL

--- a/scrapy/settings/default_settings.py
+++ b/scrapy/settings/default_settings.py
@@ -191,6 +191,7 @@ LOG_ENABLED = True
 LOG_ENCODING = 'utf-8'
 LOG_FORMATTER = 'scrapy.logformatter.LogFormatter'
 LOG_FORMAT = '%(asctime)s [%(name)s] %(levelname)s: %(message)s'
+LOG_DATETIME_UTC = False
 LOG_DATEFORMAT = '%Y-%m-%d %H:%M:%S'
 LOG_STDOUT = False
 LOG_LEVEL = 'DEBUG'

--- a/scrapy/utils/log.py
+++ b/scrapy/utils/log.py
@@ -2,6 +2,7 @@
 
 import sys
 import logging
+import time
 import warnings
 from logging.config import dictConfig
 
@@ -132,6 +133,8 @@ def _get_handler(settings):
         fmt=settings.get('LOG_FORMAT'),
         datefmt=settings.get('LOG_DATEFORMAT')
     )
+    if settings.getbool('LOG_DATETIME_UTC'):
+        formatter.converter = time.gmtime
     handler.setFormatter(formatter)
     handler.setLevel(settings.get('LOG_LEVEL'))
     if settings.getbool('LOG_SHORT_NAMES'):


### PR DESCRIPTION
Fixes #2802

This adds a `LOG_DATETIME_UTC` setting, defaulting to `False`, to expand datetimes as UTC if set to `True`.
This new setting would be most useful with `LOG_DATEFORMAT` with a `Z` or `+0000` suffix.