### PR TITLE
Bring back documentation for methods in CrawlSpider

### DIFF
--- a/docs/topics/spiders.rst
+++ b/docs/topics/spiders.rst
@@ -362,7 +362,13 @@ CrawlSpider
        described below. If multiple rules match the same link, the first one
        will be used, according to the order they're defined in this attribute.
 
-   This spider also exposes an overrideable method:
+   This spider also exposes a few overrideable methods:
+
+   .. method:: parse(response)
+
+      This function is called by the framework core for all the
+      start_urls. Do not override this function, override parse_start_url
+      instead.
 
    .. method:: parse_start_url(response)
 
@@ -370,6 +376,15 @@ CrawlSpider
       the initial responses and must return either an
       :class:`~scrapy.item.Item` object, a :class:`~scrapy.http.Request`
       object, or an iterable containing any of them.
+
+   .. method:: process_results(response, results)
+
+      This overridable method is called for each result (item or request)
+      returned by the spider, and it's intended to perform any last time
+      processing required before returning the results to the framework core,
+      for example setting the item GUIDs. It receives a list of results and
+      the response which originated that results. It must return a list
+      of results (Items or Requests).
 
 Crawling rules
 ~~~~~~~~~~~~~~


### PR DESCRIPTION
#2727 
This brings back the docstring comments in CrawlSpider that were removed in [e2290a5](https://github.com/scrapy/scrapy/commit/e2290a5359ee80c75d8bcf8de8b6894e61fad83a) to the [spiders.rst](https://github.com/scrapy/scrapy/blob/master/docs/topics/spiders.rst)

Compared to #2819, private methods are not included in spiders.rst. Docstrings are not included in the CrawlSpider class (in response to the duplication issue pointed out by @kmike in #2819  and  #2814 ).