### PR TITLE
Log versions information at startup

### DIFF
--- a/scrapy/commands/version.py
+++ b/scrapy/commands/version.py
@@ -1,12 +1,8 @@
 from __future__ import print_function
-import sys
-import platform
-
-import twisted
-import OpenSSL
 
 import scrapy
 from scrapy.commands import ScrapyCommand
+from scrapy.utils.log import scrapy_components_versions
 
 
 class Command(ScrapyCommand):
@@ -27,38 +23,8 @@ class Command(ScrapyCommand):
 
     def run(self, args, opts):
         if opts.verbose:
-            import cssselect
-            import parsel
-            import lxml.etree
-            import w3lib
-
-            lxml_version = ".".join(map(str, lxml.etree.LXML_VERSION))
-            libxml2_version = ".".join(map(str, lxml.etree.LIBXML_VERSION))
-
-            try:
-                w3lib_version = w3lib.__version__
-            except AttributeError:
-                w3lib_version = "<1.14.3"
-
-            print("Scrapy    : %s" % scrapy.__version__)
-            print("lxml      : %s" % lxml_version)
-            print("libxml2   : %s" % libxml2_version)
-            print("cssselect : %s" % cssselect.__version__)
-            print("parsel    : %s" % parsel.__version__)
-            print("w3lib     : %s" % w3lib_version)
-            print("Twisted   : %s" % twisted.version.short())
-            print("Python    : %s" % sys.version.replace("\n", "- "))
-            print("pyOpenSSL : %s" % self._get_openssl_version())
-            print("Platform  : %s" % platform.platform())
+            for name, version in scrapy_components_versions():
+                print("%-9s : %s" % (name, version))
         else:
             print("Scrapy %s" % scrapy.__version__)
 
-    def _get_openssl_version(self):
-        try:
-            openssl = OpenSSL.SSL.SSLeay_version(OpenSSL.SSL.SSLEAY_VERSION)\
-                .decode('ascii', errors='replace')
-        # pyOpenSSL 0.12 does not expose openssl version
-        except AttributeError:
-            openssl = 'Unknown OpenSSL version'
-
-        return '{} ({})'.format(OpenSSL.version.__version__, openssl)

--- a/scrapy/commands/version.py
+++ b/scrapy/commands/version.py
@@ -2,7 +2,7 @@ from __future__ import print_function
 
 import scrapy
 from scrapy.commands import ScrapyCommand
-from scrapy.utils.log import scrapy_components_versions
+from scrapy.utils.versions import scrapy_components_versions
 
 
 class Command(ScrapyCommand):

--- a/scrapy/utils/log.py
+++ b/scrapy/utils/log.py
@@ -11,6 +11,8 @@ from twisted.python import log as twisted_log
 import scrapy
 from scrapy.settings import overridden_settings, Settings
 from scrapy.exceptions import ScrapyDeprecationWarning
+from scrapy.utils.versions import scrapy_components_versions
+
 
 logger = logging.getLogger(__name__)
 
@@ -137,49 +139,6 @@ def _get_handler(settings):
     if settings.getbool('LOG_SHORT_NAMES'):
         handler.addFilter(TopLevelFormatter(['scrapy']))
     return handler
-
-
-def scrapy_components_versions():
-    import platform
-
-    import cssselect
-    import parsel
-    import lxml.etree
-    import twisted
-    import w3lib
-
-    lxml_version = ".".join(map(str, lxml.etree.LXML_VERSION))
-    libxml2_version = ".".join(map(str, lxml.etree.LIBXML_VERSION))
-
-    try:
-        w3lib_version = w3lib.__version__
-    except AttributeError:
-        w3lib_version = "<1.14.3"
-
-    return [
-        ("Scrapy", scrapy.__version__),
-        ("lxml", lxml_version),
-        ("libxml2", libxml2_version),
-        ("cssselect", cssselect.__version__),
-        ("parsel", parsel.__version__),
-        ("w3lib", w3lib_version),
-        ("Twisted", twisted.version.short()),
-        ("Python", sys.version.replace("\n", "- ")),
-        ("pyOpenSSL", _get_openssl_version()),
-        ("Platform",  platform.platform()),
-    ]
-
-
-def _get_openssl_version():
-    try:
-        import OpenSSL
-        openssl = OpenSSL.SSL.SSLeay_version(OpenSSL.SSL.SSLEAY_VERSION)\
-            .decode('ascii', errors='replace')
-    # pyOpenSSL 0.12 does not expose openssl version
-    except AttributeError:
-        openssl = 'Unknown OpenSSL version'
-
-    return '{} ({})'.format(OpenSSL.version.__version__, openssl)
 
 
 def log_scrapy_info(settings):

--- a/scrapy/utils/versions.py
+++ b/scrapy/utils/versions.py
@@ -1,0 +1,44 @@
+import platform
+import sys
+
+import cssselect
+import lxml.etree
+import parsel
+import twisted
+import w3lib
+
+import scrapy
+
+
+def scrapy_components_versions():
+    lxml_version = ".".join(map(str, lxml.etree.LXML_VERSION))
+    libxml2_version = ".".join(map(str, lxml.etree.LIBXML_VERSION))
+    try:
+        w3lib_version = w3lib.__version__
+    except AttributeError:
+        w3lib_version = "<1.14.3"
+
+    return [
+        ("Scrapy", scrapy.__version__),
+        ("lxml", lxml_version),
+        ("libxml2", libxml2_version),
+        ("cssselect", cssselect.__version__),
+        ("parsel", parsel.__version__),
+        ("w3lib", w3lib_version),
+        ("Twisted", twisted.version.short()),
+        ("Python", sys.version.replace("\n", "- ")),
+        ("pyOpenSSL", _get_openssl_version()),
+        ("Platform",  platform.platform()),
+    ]
+
+
+def _get_openssl_version():
+    try:
+        import OpenSSL
+        openssl = OpenSSL.SSL.SSLeay_version(OpenSSL.SSL.SSLEAY_VERSION)\
+            .decode('ascii', errors='replace')
+    # pyOpenSSL 0.12 does not expose openssl version
+    except AttributeError:
+        openssl = 'Unknown OpenSSL version'
+
+    return '{} ({})'.format(OpenSSL.version.__version__, openssl)


### PR DESCRIPTION
This is an example startup log with this patch:

```
$ scrapy shell
2017-07-27 17:22:09 [scrapy.utils.log] INFO: Scrapy 1.4.0 started (bot: scrapybot)
2017-07-27 17:22:09 [scrapy.utils.log] INFO: Versions: lxml 3.7.3.0, libxml2 2.9.3, cssselect 1.0.1, parsel 1.2.0, w3lib 1.17.0, Twisted 17.1.0, Python 2.7.12+ (default, Sep 17 2016, 12:08:02) - [GCC 6.2.0 20160914], pyOpenSSL 17.0.0 (OpenSSL 1.0.2g  1 Mar 2016), Platform Linux-4.8.0-59-generic-x86_64-with-Ubuntu-16.10-yakkety}
2017-07-27 17:22:09 [scrapy.utils.log] INFO: Overridden settings: {'LOGSTATS_INTERVAL': 0, 'DUPEFILTER_CLASS': 'scrapy.dupefilters.BaseDupeFilter'}
```

@kmike , were you thinking of something like this?