### PR TITLE
Use getfullargspec under the scenes for py3 to stop DeprecationWarning

### DIFF
--- a/scrapy/utils/python.py
+++ b/scrapy/utils/python.py
@@ -197,8 +197,8 @@ def binary_is_text(data):
     return all(c not in _BINARYCHARS for c in data)
 
 
-def getargspec_py23(func):
-    """getargspec_py23(function) -> named tuple ArgSpec(args, varargs, keywords,
+def _getargspec_py23(func):
+    """_getargspec_py23(function) -> named tuple ArgSpec(args, varargs, keywords,
                                                         defaults)
 
     Identical to inspect.getargspec() in python2, but uses
@@ -208,19 +208,19 @@ def getargspec_py23(func):
     >>> def f(a, b=2, *ar, **kw):
     ...     pass
 
-    >>> getargspec_py23(f)
+    >>> _getargspec_py23(f)
     ArgSpec(args=['a', 'b'], varargs='ar', keywords='kw', defaults=(2,))
     """
-    if six.PY3:
-        full_argspec = list(inspect.getfullargspec(func))
-        return inspect.ArgSpec(*full_argspec[:4])
-    return inspect.getargspec(func)
+    if six.PY2:
+        return inspect.getargspec(func)
+
+    return inspect.ArgSpec(*inspect.getfullargspec(func)[:4])
 
 
 def get_func_args(func, stripself=False):
     """Return the argument name list of a callable"""
     if inspect.isfunction(func):
-        func_args, _, _, _ = getargspec_py23(func)
+        func_args, _, _, _ = _getargspec_py23(func)
     elif inspect.isclass(func):
         return get_func_args(func.__init__, True)
     elif inspect.ismethod(func):
@@ -267,9 +267,9 @@ def get_spec(func):
     """
 
     if inspect.isfunction(func) or inspect.ismethod(func):
-        spec = getargspec_py23(func)
+        spec = _getargspec_py23(func)
     elif hasattr(func, '__call__'):
-        spec = getargspec_py23(func.__call__)
+        spec = _getargspec_py23(func.__call__)
     else:
         raise TypeError('%s is not callable' % type(func))
 

--- a/scrapy/utils/python.py
+++ b/scrapy/utils/python.py
@@ -10,9 +10,17 @@ import errno
 import six
 from functools import partial, wraps
 import sys
-import time
 
 from scrapy.utils.decorators import deprecated
+
+
+# In py3, getargspec is deprecated, so use getfullargspec with same
+# behavior to silence the warning.
+if six.PY3:
+    def getargspec(func):
+        full_argspec = list(inspect.getfullargspec(func))
+        return inspect.ArgSpec(*full_argspec[:4])
+    inspect.getargspec = getargspec
 
 
 def flatten(x):


### PR DESCRIPTION
fixes #2862

I also ran `tox` for the tests, but there are slight differences for the packages used inside the library, so in `tests/requirements.txt`:
- `netlib` can be easily updated to `0.17` to support both py2 and py3
- `mitmproxy` on the other hand can't w/o some modifications; its version `0.18+` that supports both py3 and py2 doesn't contain `libmproxy` that's used in `tests/test_proxy_connect.py`. So yea, related to https://github.com/scrapy/scrapy/issues/2545 actually, so nevermind.

Other than that issue, everything worked fine, no errors for py2 nor py3.

Also I tested the branch in our project and the `DeprecationWarning` has disappeared now :).