### PR TITLE
[MRG+1] Explicit message for scrapy parse callback

### DIFF
--- a/scrapy/spiders/__init__.py
+++ b/scrapy/spiders/__init__.py
@@ -87,7 +87,7 @@ class Spider(object_ref):
         return Request(url, dont_filter=True)
 
     def parse(self, response):
-        raise NotImplementedError('Spider.parse callback is not defined')
+        raise NotImplementedError('{}.parse callback is not defined'.format(self.__class__.__name__))
 
     @classmethod
     def update_settings(cls, settings):

--- a/scrapy/spiders/__init__.py
+++ b/scrapy/spiders/__init__.py
@@ -87,7 +87,7 @@ class Spider(object_ref):
         return Request(url, dont_filter=True)
 
     def parse(self, response):
-        raise NotImplementedError
+        raise NotImplementedError('Spider.parse callback is not defined')
 
     @classmethod
     def update_settings(cls, settings):

--- a/tests/test_spider.py
+++ b/tests/test_spider.py
@@ -429,3 +429,17 @@ class DeprecationTest(unittest.TestCase):
             self.assertEqual(len(requests), 1)
             self.assertEqual(requests[0].url, 'http://example.com/foo')
             self.assertEqual(len(w), 1)
+
+
+class NoParseMethodSpiderTest(unittest.TestCase):
+
+    spider_class = Spider
+
+    def test_undefined_parse_method(self):
+        spider = self.spider_class('example.com')
+        text = 'Random text response'
+        resp = TextResponse(url="http://www.example.com/random_url", body=text)
+
+        exc_msg = 'Spider.parse callback is not defined'
+        with self.assertRaisesRegexp(NotImplementedError, exc_msg):
+            spider.parse(resp)

--- a/tests/test_spider.py
+++ b/tests/test_spider.py
@@ -437,7 +437,7 @@ class NoParseMethodSpiderTest(unittest.TestCase):
 
     def test_undefined_parse_method(self):
         spider = self.spider_class('example.com')
-        text = 'Random text response'
+        text = b'Random text'
         resp = TextResponse(url="http://www.example.com/random_url", body=text)
 
         exc_msg = 'Spider.parse callback is not defined'


### PR DESCRIPTION
The scrapy parse method raises a NotImplementedError when not defined,
but for new comers it can be hard to debug what might be going wrong.

Adding an explicit message for NotImplementedError will help new users.

Refer #2831