### PR TITLE
add BASE_DIR to settings

### DIFF
--- a/docs/topics/settings.rst
+++ b/docs/topics/settings.rst
@@ -180,6 +180,23 @@ such as the :ref:`S3 feed storage backend <topics-feed-storage-s3>`.
 
 .. setting:: BOT_NAME
 
+BASE_DIR
+--------
+
+Default: ``os.path.abspath(os.path.dirname(__file__))``
+
+The project directory is defined as the base directory for Scrapy. Use this setting
+to read data files relative to the base directory.
+
+Example::
+
+    # my_spider.py
+    filepath = os.path.join(
+        settings.BASE_DIR,
+        "spiders/data/items_to_scrape.csv")
+
+.. setting:: BASE_DIR
+
 BOT_NAME
 --------
 

--- a/scrapy/settings/default_settings.py
+++ b/scrapy/settings/default_settings.py
@@ -14,6 +14,7 @@ Scrapy developers, if you add a setting here remember to:
 """
 
 import sys
+import os
 from importlib import import_module
 from os.path import join, abspath, dirname
 
@@ -28,6 +29,9 @@ AUTOTHROTTLE_START_DELAY = 5.0
 AUTOTHROTTLE_TARGET_CONCURRENCY = 1.0
 
 BOT_NAME = 'scrapybot'
+
+# will be populated by scrapy startproject command
+BASE_DIR = None
 
 CLOSESPIDER_TIMEOUT = 0
 CLOSESPIDER_PAGECOUNT = 0
@@ -237,7 +241,7 @@ RETRY_TIMES = 2  # initial response + 2 retries = 3 requests
 RETRY_HTTP_CODES = [500, 502, 503, 504, 522, 524, 408]
 RETRY_PRIORITY_ADJUST = -1
 
-ROBOTSTXT_OBEY = False
+ROBOTSTXT_OBEY = True
 
 SCHEDULER = 'scrapy.core.scheduler.Scheduler'
 SCHEDULER_DISK_QUEUE = 'scrapy.squeues.PickleLifoDiskQueue'

--- a/scrapy/settings/default_settings.py
+++ b/scrapy/settings/default_settings.py
@@ -14,7 +14,6 @@ Scrapy developers, if you add a setting here remember to:
 """
 
 import sys
-import os
 from importlib import import_module
 from os.path import join, abspath, dirname
 
@@ -241,7 +240,7 @@ RETRY_TIMES = 2  # initial response + 2 retries = 3 requests
 RETRY_HTTP_CODES = [500, 502, 503, 504, 522, 524, 408]
 RETRY_PRIORITY_ADJUST = -1
 
-ROBOTSTXT_OBEY = True
+ROBOTSTXT_OBEY = False
 
 SCHEDULER = 'scrapy.core.scheduler.Scheduler'
 SCHEDULER_DISK_QUEUE = 'scrapy.squeues.PickleLifoDiskQueue'

--- a/scrapy/templates/project/module/settings.py.tmpl
+++ b/scrapy/templates/project/module/settings.py.tmpl
@@ -8,12 +8,14 @@
 #     http://doc.scrapy.org/en/latest/topics/settings.html
 #     http://scrapy.readthedocs.org/en/latest/topics/downloader-middleware.html
 #     http://scrapy.readthedocs.org/en/latest/topics/spider-middleware.html
+import os
 
 BOT_NAME = '$project_name'
 
 SPIDER_MODULES = ['$project_name.spiders']
 NEWSPIDER_MODULE = '$project_name.spiders'
 
+BASE_DIR = os.path.abspath(os.path.dirname(__file__))
 
 # Crawl responsibly by identifying yourself (and your website) on the user-agent
 #USER_AGENT = '$project_name (+http://www.yourdomain.com)'


### PR DESCRIPTION
add a `BASE_DIR` setting to `settings.py`. This is useful when you want to read csvs (in spiders for eg)
```python
        filepath = os.path.join(
            settings.BASE_DIR,
            '/path/to/file.csv'
        )

        with open(filepath, 'r', errors='ignore') as csvfile:
            # code
```

