### PR TITLE
Update deprecated test aliases

### DIFF
--- a/tests/test_cmdline/__init__.py
+++ b/tests/test_cmdline/__init__.py
@@ -68,4 +68,4 @@ class CmdlineTest(unittest.TestCase):
             settingsstr = settingsstr.replace(char, '"')
         settingsdict = json.loads(settingsstr)
         six.assertCountEqual(self, settingsdict.keys(), EXTENSIONS.keys())
-        self.assertEquals(200, settingsdict[EXT_PATH])
+        self.assertEqual(200, settingsdict[EXT_PATH])

--- a/tests/test_downloader_handlers.py
+++ b/tests/test_downloader_handlers.py
@@ -98,9 +98,9 @@ class FileTestCase(unittest.TestCase):
 
     def test_download(self):
         def _test(response):
-            self.assertEquals(response.url, request.url)
-            self.assertEquals(response.status, 200)
-            self.assertEquals(response.body, b'0123456789')
+            self.assertEqual(response.url, request.url)
+            self.assertEqual(response.status, 200)
+            self.assertEqual(response.body, b'0123456789')
 
         request = Request(path_to_file_uri(self.tmpname + '^'))
         assert request.url.upper().endswith('%5E')
@@ -241,28 +241,28 @@ class HttpTestCase(unittest.TestCase):
         request = Request(self.getURL('file'))
         d = self.download_request(request, Spider('foo'))
         d.addCallback(lambda r: r.body)
-        d.addCallback(self.assertEquals, b"0123456789")
+        d.addCallback(self.assertEqual, b"0123456789")
         return d
 
     def test_download_head(self):
         request = Request(self.getURL('file'), method='HEAD')
         d = self.download_request(request, Spider('foo'))
         d.addCallback(lambda r: r.body)
-        d.addCallback(self.assertEquals, b'')
+        d.addCallback(self.assertEqual, b'')
         return d
 
     def test_redirect_status(self):
         request = Request(self.getURL('redirect'))
         d = self.download_request(request, Spider('foo'))
         d.addCallback(lambda r: r.status)
-        d.addCallback(self.assertEquals, 302)
+        d.addCallback(self.assertEqual, 302)
         return d
 
     def test_redirect_status_head(self):
         request = Request(self.getURL('redirect'), method='HEAD')
         d = self.download_request(request, Spider('foo'))
         d.addCallback(lambda r: r.status)
-        d.addCallback(self.assertEquals, 302)
+        d.addCallback(self.assertEqual, 302)
         return d
 
     @defer.inlineCallbacks
@@ -285,24 +285,24 @@ class HttpTestCase(unittest.TestCase):
 
     def test_host_header_not_in_request_headers(self):
         def _test(response):
-            self.assertEquals(
+            self.assertEqual(
                 response.body, to_bytes('%s:%d' % (self.host, self.portno)))
-            self.assertEquals(request.headers, {})
+            self.assertEqual(request.headers, {})
 
         request = Request(self.getURL('host'))
         return self.download_request(request, Spider('foo')).addCallback(_test)
 
     def test_host_header_seted_in_request_headers(self):
         def _test(response):
-            self.assertEquals(response.body, b'example.com')
-            self.assertEquals(request.headers.get('Host'), b'example.com')
+            self.assertEqual(response.body, b'example.com')
+            self.assertEqual(request.headers.get('Host'), b'example.com')
 
         request = Request(self.getURL('host'), headers={'Host': 'example.com'})
         return self.download_request(request, Spider('foo')).addCallback(_test)
 
         d = self.download_request(request, Spider('foo'))
         d.addCallback(lambda r: r.body)
-        d.addCallback(self.assertEquals, b'example.com')
+        d.addCallback(self.assertEqual, b'example.com')
         return d
 
     def test_content_length_zero_bodyless_post_request_headers(self):
@@ -317,7 +317,7 @@ class HttpTestCase(unittest.TestCase):
         https://bugs.python.org/issue14721
         """
         def _test(response):
-            self.assertEquals(response.body, b'0')
+            self.assertEqual(response.body, b'0')
 
         request = Request(self.getURL('contentlength'), method='POST', headers={'Host': 'example.com'})
         return self.download_request(request, Spider('foo')).addCallback(_test)
@@ -327,8 +327,8 @@ class HttpTestCase(unittest.TestCase):
             import json
             headers = Headers(json.loads(response.text)['headers'])
             contentlengths = headers.getlist('Content-Length')
-            self.assertEquals(len(contentlengths), 1)
-            self.assertEquals(contentlengths, [b"0"])
+            self.assertEqual(len(contentlengths), 1)
+            self.assertEqual(contentlengths, [b"0"])
 
         request = Request(self.getURL('echo'), method='POST')
         return self.download_request(request, Spider('foo')).addCallback(_test)
@@ -338,7 +338,7 @@ class HttpTestCase(unittest.TestCase):
         request = Request(self.getURL('payload'), method='POST', body=body)
         d = self.download_request(request, Spider('foo'))
         d.addCallback(lambda r: r.body)
-        d.addCallback(self.assertEquals, body)
+        d.addCallback(self.assertEqual, body)
         return d
 
 
@@ -364,7 +364,7 @@ class Http11TestCase(HttpTestCase):
         request = Request(self.getURL('file'))
         d = self.download_request(request, Spider('foo'))
         d.addCallback(lambda r: r.body)
-        d.addCallback(self.assertEquals, b"0123456789")
+        d.addCallback(self.assertEqual, b"0123456789")
         return d
 
     def test_response_class_choosing_request(self):
@@ -374,7 +374,7 @@ class Http11TestCase(HttpTestCase):
         body = b'Some plain text\ndata with tabs\t and null bytes\0'
 
         def _test_type(response):
-            self.assertEquals(type(response), TextResponse)
+            self.assertEqual(type(response), TextResponse)
 
         request = Request(self.getURL('nocontenttype'), body=body)
         d = self.download_request(request, Spider('foo'))
@@ -389,7 +389,7 @@ class Http11TestCase(HttpTestCase):
         # response body. (regardless of headers)
         d = self.download_request(request, Spider('foo', download_maxsize=10))
         d.addCallback(lambda r: r.body)
-        d.addCallback(self.assertEquals, b"0123456789")
+        d.addCallback(self.assertEqual, b"0123456789")
         yield d
 
         d = self.download_request(request, Spider('foo', download_maxsize=9))
@@ -431,14 +431,14 @@ class Http11TestCase(HttpTestCase):
         request = Request(self.getURL('file'))
         d = self.download_request(request, Spider('foo', download_maxsize=100))
         d.addCallback(lambda r: r.body)
-        d.addCallback(self.assertEquals, b"0123456789")
+        d.addCallback(self.assertEqual, b"0123456789")
         return d
 
     def test_download_chunked_content(self):
         request = Request(self.getURL('chunked'))
         d = self.download_request(request, Spider('foo'))
         d.addCallback(lambda r: r.body)
-        d.addCallback(self.assertEquals, b"chunked content\n")
+        d.addCallback(self.assertEqual, b"chunked content\n")
         return d
 
     def test_download_broken_content_cause_data_loss(self, url='broken'):
@@ -597,9 +597,9 @@ class HttpProxyTestCase(unittest.TestCase):
 
     def test_download_with_proxy(self):
         def _test(response):
-            self.assertEquals(response.status, 200)
-            self.assertEquals(response.url, request.url)
-            self.assertEquals(response.body, b'http://example.com')
+            self.assertEqual(response.status, 200)
+            self.assertEqual(response.url, request.url)
+            self.assertEqual(response.body, b'http://example.com')
 
         http_proxy = self.getURL('')
         request = Request('http://example.com', meta={'proxy': http_proxy})
@@ -607,9 +607,9 @@ class HttpProxyTestCase(unittest.TestCase):
 
     def test_download_with_proxy_https_noconnect(self):
         def _test(response):
-            self.assertEquals(response.status, 200)
-            self.assertEquals(response.url, request.url)
-            self.assertEquals(response.body, b'https://example.com')
+            self.assertEqual(response.status, 200)
+            self.assertEqual(response.url, request.url)
+            self.assertEqual(response.body, b'https://example.com')
 
         http_proxy = '%s?noconnect' % self.getURL('')
         request = Request('https://example.com', meta={'proxy': http_proxy})
@@ -617,9 +617,9 @@ class HttpProxyTestCase(unittest.TestCase):
 
     def test_download_without_proxy(self):
         def _test(response):
-            self.assertEquals(response.status, 200)
-            self.assertEquals(response.url, request.url)
-            self.assertEquals(response.body, b'/path/to/resource')
+            self.assertEqual(response.status, 200)
+            self.assertEqual(response.url, request.url)
+            self.assertEqual(response.body, b'/path/to/resource')
 
         request = Request(self.getURL('path/to/resource'))
         return self.download_request(request, Spider('foo')).addCallback(_test)
@@ -978,7 +978,7 @@ class DataURITestCase(unittest.TestCase):
         uri = "data:,A%20brief%20note"
 
         def _test(response):
-            self.assertEquals(response.url, uri)
+            self.assertEqual(response.url, uri)
             self.assertFalse(response.headers)
 
         request = Request(uri)
@@ -986,39 +986,39 @@ class DataURITestCase(unittest.TestCase):
 
     def test_default_mediatype_encoding(self):
         def _test(response):
-            self.assertEquals(response.text, 'A brief note')
-            self.assertEquals(type(response),
+            self.assertEqual(response.text, 'A brief note')
+            self.assertEqual(type(response),
                               responsetypes.from_mimetype("text/plain"))
-            self.assertEquals(response.encoding, "US-ASCII")
+            self.assertEqual(response.encoding, "US-ASCII")
 
         request = Request("data:,A%20brief%20note")
         return self.download_request(request, self.spider).addCallback(_test)
 
     def test_default_mediatype(self):
         def _test(response):
-            self.assertEquals(response.text, u'\u038e\u03a3\u038e')
-            self.assertEquals(type(response),
+            self.assertEqual(response.text, u'\u038e\u03a3\u038e')
+            self.assertEqual(type(response),
                               responsetypes.from_mimetype("text/plain"))
-            self.assertEquals(response.encoding, "iso-8859-7")
+            self.assertEqual(response.encoding, "iso-8859-7")
 
         request = Request("data:;charset=iso-8859-7,%be%d3%be")
         return self.download_request(request, self.spider).addCallback(_test)
 
     def test_text_charset(self):
         def _test(response):
-            self.assertEquals(response.text, u'\u038e\u03a3\u038e')
-            self.assertEquals(response.body, b'\xbe\xd3\xbe')
-            self.assertEquals(response.encoding, "iso-8859-7")
+            self.assertEqual(response.text, u'\u038e\u03a3\u038e')
+            self.assertEqual(response.body, b'\xbe\xd3\xbe')
+            self.assertEqual(response.encoding, "iso-8859-7")
 
         request = Request("data:text/plain;charset=iso-8859-7,%be%d3%be")
         return self.download_request(request, self.spider).addCallback(_test)
 
     def test_mediatype_parameters(self):
         def _test(response):
-            self.assertEquals(response.text, u'\u038e\u03a3\u038e')
-            self.assertEquals(type(response),
+            self.assertEqual(response.text, u'\u038e\u03a3\u038e')
+            self.assertEqual(type(response),
                               responsetypes.from_mimetype("text/plain"))
-            self.assertEquals(response.encoding, "utf-8")
+            self.assertEqual(response.encoding, "utf-8")
 
         request = Request('data:text/plain;foo=%22foo;bar%5C%22%22;'
                           'charset=utf-8;bar=%22foo;%5C%22 foo ;/,%22'
@@ -1027,7 +1027,7 @@ class DataURITestCase(unittest.TestCase):
 
     def test_base64(self):
         def _test(response):
-            self.assertEquals(response.text, 'Hello, world.')
+            self.assertEqual(response.text, 'Hello, world.')
 
         request = Request('data:text/plain;base64,SGVsbG8sIHdvcmxkLg%3D%3D')
         return self.download_request(request, self.spider).addCallback(_test)

--- a/tests/test_downloadermiddleware_cookies.py
+++ b/tests/test_downloadermiddleware_cookies.py
@@ -36,7 +36,7 @@ class CookiesMiddlewareTest(TestCase):
 
         req2 = Request('http://scrapytest.org/sub1/')
         assert self.mw.process_request(req2, self.spider) is None
-        self.assertEquals(req2.headers.get('Cookie'), b"C1=value1")
+        self.assertEqual(req2.headers.get('Cookie'), b"C1=value1")
 
     def test_setting_false_cookies_enabled(self):
         self.assertRaises(
@@ -131,12 +131,12 @@ class CookiesMiddlewareTest(TestCase):
         # check that cookies are merged back
         req = Request('http://scrapytest.org/mergeme')
         assert self.mw.process_request(req, self.spider) is None
-        self.assertEquals(req.headers.get('Cookie'), b'C1=value1')
+        self.assertEqual(req.headers.get('Cookie'), b'C1=value1')
 
         # check that cookies are merged when dont_merge_cookies is passed as 0
         req = Request('http://scrapytest.org/mergeme', meta={'dont_merge_cookies': 0})
         assert self.mw.process_request(req, self.spider) is None
-        self.assertEquals(req.headers.get('Cookie'), b'C1=value1')
+        self.assertEqual(req.headers.get('Cookie'), b'C1=value1')
 
     def test_complex_cookies(self):
         # merge some cookies into jar
@@ -157,7 +157,7 @@ class CookiesMiddlewareTest(TestCase):
         # embed C2 for scrapytest.org/bar
         req = Request('http://scrapytest.org/bar')
         self.mw.process_request(req, self.spider)
-        self.assertEquals(req.headers.get('Cookie'), b'C2=value2')
+        self.assertEqual(req.headers.get('Cookie'), b'C2=value2')
 
         # embed nothing for scrapytest.org/baz
         req = Request('http://scrapytest.org/baz')
@@ -167,7 +167,7 @@ class CookiesMiddlewareTest(TestCase):
     def test_merge_request_cookies(self):
         req = Request('http://scrapytest.org/', cookies={'galleta': 'salada'})
         assert self.mw.process_request(req, self.spider) is None
-        self.assertEquals(req.headers.get('Cookie'), b'galleta=salada')
+        self.assertEqual(req.headers.get('Cookie'), b'galleta=salada')
 
         headers = {'Set-Cookie': 'C1=value1; path=/'}
         res = Response('http://scrapytest.org/', headers=headers)
@@ -181,7 +181,7 @@ class CookiesMiddlewareTest(TestCase):
     def test_cookiejar_key(self):
         req = Request('http://scrapytest.org/', cookies={'galleta': 'salada'}, meta={'cookiejar': "store1"})
         assert self.mw.process_request(req, self.spider) is None
-        self.assertEquals(req.headers.get('Cookie'), b'galleta=salada')
+        self.assertEqual(req.headers.get('Cookie'), b'galleta=salada')
 
         headers = {'Set-Cookie': 'C1=value1; path=/'}
         res = Response('http://scrapytest.org/', headers=headers, request=req)
@@ -193,7 +193,7 @@ class CookiesMiddlewareTest(TestCase):
 
         req3 = Request('http://scrapytest.org/', cookies={'galleta': 'dulce'}, meta={'cookiejar': "store2"})
         assert self.mw.process_request(req3, self.spider) is None
-        self.assertEquals(req3.headers.get('Cookie'), b'galleta=dulce')
+        self.assertEqual(req3.headers.get('Cookie'), b'galleta=dulce')
 
         headers = {'Set-Cookie': 'C2=value2; path=/'}
         res2 = Response('http://scrapytest.org/', headers=headers, request=req3)
@@ -213,16 +213,16 @@ class CookiesMiddlewareTest(TestCase):
 
         req5_2 = Request('http://scrapytest.org:1104/some-redirected-path')
         assert self.mw.process_request(req5_2, self.spider) is None
-        self.assertEquals(req5_2.headers.get('Cookie'), b'C1=value1')
+        self.assertEqual(req5_2.headers.get('Cookie'), b'C1=value1')
 
         req5_3 = Request('http://scrapytest.org/some-redirected-path')
         assert self.mw.process_request(req5_3, self.spider) is None
-        self.assertEquals(req5_3.headers.get('Cookie'), b'C1=value1')
+        self.assertEqual(req5_3.headers.get('Cookie'), b'C1=value1')
 
         #skip cookie retrieval for not http request
         req6 = Request('file:///scrapy/sometempfile')
         assert self.mw.process_request(req6, self.spider) is None
-        self.assertEquals(req6.headers.get('Cookie'), None)
+        self.assertEqual(req6.headers.get('Cookie'), None)
 
     def test_local_domain(self):
         request = Request("http://example-host/", cookies={'currencyCookie': 'USD'})

--- a/tests/test_downloadermiddleware_defaultheaders.py
+++ b/tests/test_downloadermiddleware_defaultheaders.py
@@ -22,15 +22,15 @@ class TestDefaultHeadersMiddleware(TestCase):
         defaults, spider, mw = self.get_defaults_spider_mw()
         req = Request('http://www.scrapytest.org')
         mw.process_request(req, spider)
-        self.assertEquals(req.headers, defaults)
+        self.assertEqual(req.headers, defaults)
 
     def test_update_headers(self):
         defaults, spider, mw = self.get_defaults_spider_mw()
         headers = {'Accept-Language': ['es'], 'Test-Header': ['test']}
         bytes_headers = {b'Accept-Language': [b'es'], b'Test-Header': [b'test']}
         req = Request('http://www.scrapytest.org', headers=headers)
-        self.assertEquals(req.headers, bytes_headers)
+        self.assertEqual(req.headers, bytes_headers)
 
         mw.process_request(req, spider)
         defaults.update(bytes_headers)
-        self.assertEquals(req.headers, defaults)
+        self.assertEqual(req.headers, defaults)

--- a/tests/test_downloadermiddleware_downloadtimeout.py
+++ b/tests/test_downloadermiddleware_downloadtimeout.py
@@ -18,20 +18,20 @@ class DownloadTimeoutMiddlewareTest(unittest.TestCase):
         req, spider, mw = self.get_request_spider_mw()
         mw.spider_opened(spider)
         assert mw.process_request(req, spider) is None
-        self.assertEquals(req.meta.get('download_timeout'), 180)
+        self.assertEqual(req.meta.get('download_timeout'), 180)
 
     def test_string_download_timeout(self):
         req, spider, mw = self.get_request_spider_mw({'DOWNLOAD_TIMEOUT': '20.1'})
         mw.spider_opened(spider)
         assert mw.process_request(req, spider) is None
-        self.assertEquals(req.meta.get('download_timeout'), 20.1)
+        self.assertEqual(req.meta.get('download_timeout'), 20.1)
 
     def test_spider_has_download_timeout(self):
         req, spider, mw = self.get_request_spider_mw()
         spider.download_timeout = 2
         mw.spider_opened(spider)
         assert mw.process_request(req, spider) is None
-        self.assertEquals(req.meta.get('download_timeout'), 2)
+        self.assertEqual(req.meta.get('download_timeout'), 2)
 
     def test_request_has_download_timeout(self):
         req, spider, mw = self.get_request_spider_mw()
@@ -39,4 +39,4 @@ class DownloadTimeoutMiddlewareTest(unittest.TestCase):
         mw.spider_opened(spider)
         req.meta['download_timeout'] = 1
         assert mw.process_request(req, spider) is None
-        self.assertEquals(req.meta.get('download_timeout'), 1)
+        self.assertEqual(req.meta.get('download_timeout'), 1)

--- a/tests/test_downloadermiddleware_httpauth.py
+++ b/tests/test_downloadermiddleware_httpauth.py
@@ -23,10 +23,10 @@ class HttpAuthMiddlewareTest(unittest.TestCase):
     def test_auth(self):
         req = Request('http://scrapytest.org/')
         assert self.mw.process_request(req, self.spider) is None
-        self.assertEquals(req.headers['Authorization'], b'Basic Zm9vOmJhcg==')
+        self.assertEqual(req.headers['Authorization'], b'Basic Zm9vOmJhcg==')
 
     def test_auth_already_set(self):
         req = Request('http://scrapytest.org/',
                       headers=dict(Authorization='Digest 123'))
         assert self.mw.process_request(req, self.spider) is None
-        self.assertEquals(req.headers['Authorization'], b'Digest 123')
+        self.assertEqual(req.headers['Authorization'], b'Digest 123')

--- a/tests/test_downloadermiddleware_httpcompression.py
+++ b/tests/test_downloadermiddleware_httpcompression.py
@@ -248,4 +248,4 @@ class HttpCompressionTest(TestCase):
         response = response.replace(body = None)
         newresponse = self.mw.process_response(request, response, self.spider)
         self.assertIs(newresponse, response)
-        self.assertEquals(response.body, b'')
+        self.assertEqual(response.body, b'')

--- a/tests/test_downloadermiddleware_httpproxy.py
+++ b/tests/test_downloadermiddleware_httpproxy.py
@@ -35,8 +35,8 @@ class TestDefaultHeadersMiddleware(TestCase):
         for url in ('http://e.com', 'https://e.com', 'file:///tmp/a'):
             req = Request(url)
             assert mw.process_request(req, spider) is None
-            self.assertEquals(req.url, url)
-            self.assertEquals(req.meta, {})
+            self.assertEqual(req.url, url)
+            self.assertEqual(req.meta, {})
 
     def test_enviroment_proxies(self):
         os.environ['http_proxy'] = http_proxy = 'https://proxy.for.http:3128'
@@ -48,41 +48,41 @@ class TestDefaultHeadersMiddleware(TestCase):
                 ('https://e.com', https_proxy), ('file://tmp/a', None)]:
             req = Request(url)
             assert mw.process_request(req, spider) is None
-            self.assertEquals(req.url, url)
-            self.assertEquals(req.meta.get('proxy'), proxy)
+            self.assertEqual(req.url, url)
+            self.assertEqual(req.meta.get('proxy'), proxy)
 
     def test_proxy_precedence_meta(self):
         os.environ['http_proxy'] = 'https://proxy.com'
         mw = HttpProxyMiddleware()
         req = Request('http://scrapytest.org', meta={'proxy': 'https://new.proxy:3128'})
         assert mw.process_request(req, spider) is None
-        self.assertEquals(req.meta, {'proxy': 'https://new.proxy:3128'})
+        self.assertEqual(req.meta, {'proxy': 'https://new.proxy:3128'})
 
     def test_proxy_auth(self):
         os.environ['http_proxy'] = 'https://user:pass@proxy:3128'
         mw = HttpProxyMiddleware()
         req = Request('http://scrapytest.org')
         assert mw.process_request(req, spider) is None
-        self.assertEquals(req.meta, {'proxy': 'https://proxy:3128'})
-        self.assertEquals(req.headers.get('Proxy-Authorization'), b'Basic dXNlcjpwYXNz')
+        self.assertEqual(req.meta, {'proxy': 'https://proxy:3128'})
+        self.assertEqual(req.headers.get('Proxy-Authorization'), b'Basic dXNlcjpwYXNz')
         # proxy from request.meta
         req = Request('http://scrapytest.org', meta={'proxy': 'https://username:password@proxy:3128'})
         assert mw.process_request(req, spider) is None
-        self.assertEquals(req.meta, {'proxy': 'https://proxy:3128'})
-        self.assertEquals(req.headers.get('Proxy-Authorization'), b'Basic dXNlcm5hbWU6cGFzc3dvcmQ=')
+        self.assertEqual(req.meta, {'proxy': 'https://proxy:3128'})
+        self.assertEqual(req.headers.get('Proxy-Authorization'), b'Basic dXNlcm5hbWU6cGFzc3dvcmQ=')
 
     def test_proxy_auth_empty_passwd(self):
         os.environ['http_proxy'] = 'https://user:@proxy:3128'
         mw = HttpProxyMiddleware()
         req = Request('http://scrapytest.org')
         assert mw.process_request(req, spider) is None
-        self.assertEquals(req.meta, {'proxy': 'https://proxy:3128'})
-        self.assertEquals(req.headers.get('Proxy-Authorization'), b'Basic dXNlcjo=')
+        self.assertEqual(req.meta, {'proxy': 'https://proxy:3128'})
+        self.assertEqual(req.headers.get('Proxy-Authorization'), b'Basic dXNlcjo=')
         # proxy from request.meta
         req = Request('http://scrapytest.org', meta={'proxy': 'https://username:@proxy:3128'})
         assert mw.process_request(req, spider) is None
-        self.assertEquals(req.meta, {'proxy': 'https://proxy:3128'})
-        self.assertEquals(req.headers.get('Proxy-Authorization'), b'Basic dXNlcm5hbWU6')
+        self.assertEqual(req.meta, {'proxy': 'https://proxy:3128'})
+        self.assertEqual(req.headers.get('Proxy-Authorization'), b'Basic dXNlcm5hbWU6')
 
     def test_proxy_auth_encoding(self):
         # utf-8 encoding
@@ -90,27 +90,27 @@ class TestDefaultHeadersMiddleware(TestCase):
         mw = HttpProxyMiddleware(auth_encoding='utf-8')
         req = Request('http://scrapytest.org')
         assert mw.process_request(req, spider) is None
-        self.assertEquals(req.meta, {'proxy': 'https://proxy:3128'})
-        self.assertEquals(req.headers.get('Proxy-Authorization'), b'Basic bcOhbjpwYXNz')
+        self.assertEqual(req.meta, {'proxy': 'https://proxy:3128'})
+        self.assertEqual(req.headers.get('Proxy-Authorization'), b'Basic bcOhbjpwYXNz')
 
         # proxy from request.meta
         req = Request('http://scrapytest.org', meta={'proxy': u'https://\u00FCser:pass@proxy:3128'})
         assert mw.process_request(req, spider) is None
-        self.assertEquals(req.meta, {'proxy': 'https://proxy:3128'})
-        self.assertEquals(req.headers.get('Proxy-Authorization'), b'Basic w7xzZXI6cGFzcw==')
+        self.assertEqual(req.meta, {'proxy': 'https://proxy:3128'})
+        self.assertEqual(req.headers.get('Proxy-Authorization'), b'Basic w7xzZXI6cGFzcw==')
 
         # default latin-1 encoding
         mw = HttpProxyMiddleware(auth_encoding='latin-1')
         req = Request('http://scrapytest.org')
         assert mw.process_request(req, spider) is None
-        self.assertEquals(req.meta, {'proxy': 'https://proxy:3128'})
-        self.assertEquals(req.headers.get('Proxy-Authorization'), b'Basic beFuOnBhc3M=')
+        self.assertEqual(req.meta, {'proxy': 'https://proxy:3128'})
+        self.assertEqual(req.headers.get('Proxy-Authorization'), b'Basic beFuOnBhc3M=')
 
         # proxy from request.meta, latin-1 encoding
         req = Request('http://scrapytest.org', meta={'proxy': u'https://\u00FCser:pass@proxy:3128'})
         assert mw.process_request(req, spider) is None
-        self.assertEquals(req.meta, {'proxy': 'https://proxy:3128'})
-        self.assertEquals(req.headers.get('Proxy-Authorization'), b'Basic /HNlcjpwYXNz')
+        self.assertEqual(req.meta, {'proxy': 'https://proxy:3128'})
+        self.assertEqual(req.headers.get('Proxy-Authorization'), b'Basic /HNlcjpwYXNz')
 
     def test_proxy_already_seted(self):
         os.environ['http_proxy'] = 'https://proxy.for.http:3128'
@@ -142,4 +142,4 @@ class TestDefaultHeadersMiddleware(TestCase):
         os.environ['no_proxy'] = '*'
         req = Request('http://noproxy.com', meta={'proxy': 'http://proxy.com'})
         assert mw.process_request(req, spider) is None
-        self.assertEquals(req.meta, {'proxy': 'http://proxy.com'})
+        self.assertEqual(req.meta, {'proxy': 'http://proxy.com'})

--- a/tests/test_downloadermiddleware_redirect.py
+++ b/tests/test_downloadermiddleware_redirect.py
@@ -166,7 +166,7 @@ class RedirectMiddlewareTest(unittest.TestCase):
         resp = Response('http://scrapytest.org/first', headers={'Location': latin1_location}, status=302)
         req_result = self.mw.process_response(req, resp, self.spider)
         perc_encoded_utf8_url = 'http://scrapytest.org/a%E7%E3o'
-        self.assertEquals(perc_encoded_utf8_url, req_result.url)
+        self.assertEqual(perc_encoded_utf8_url, req_result.url)
 
     def test_utf8_location(self):
         req = Request('http://scrapytest.org/first')
@@ -174,7 +174,7 @@ class RedirectMiddlewareTest(unittest.TestCase):
         resp = Response('http://scrapytest.org/first', headers={'Location': utf8_location}, status=302)
         req_result = self.mw.process_response(req, resp, self.spider)
         perc_encoded_utf8_url = 'http://scrapytest.org/a%C3%A7%C3%A3o'
-        self.assertEquals(perc_encoded_utf8_url, req_result.url)
+        self.assertEqual(perc_encoded_utf8_url, req_result.url)
 
 
 class MetaRefreshMiddlewareTest(unittest.TestCase):

--- a/tests/test_downloadermiddleware_useragent.py
+++ b/tests/test_downloadermiddleware_useragent.py
@@ -17,7 +17,7 @@ class UserAgentMiddlewareTest(TestCase):
         spider, mw = self.get_spider_and_mw('default_useragent')
         req = Request('http://scrapytest.org/')
         assert mw.process_request(req, spider) is None
-        self.assertEquals(req.headers['User-Agent'], b'default_useragent')
+        self.assertEqual(req.headers['User-Agent'], b'default_useragent')
 
     def test_remove_agent(self):
         # settings UESR_AGENT to None should remove the user agent
@@ -34,7 +34,7 @@ class UserAgentMiddlewareTest(TestCase):
         mw.spider_opened(spider)
         req = Request('http://scrapytest.org/')
         assert mw.process_request(req, spider) is None
-        self.assertEquals(req.headers['User-Agent'], b'spider_useragent')
+        self.assertEqual(req.headers['User-Agent'], b'spider_useragent')
 
     def test_header_agent(self):
         spider, mw = self.get_spider_and_mw('default_useragent')
@@ -43,7 +43,7 @@ class UserAgentMiddlewareTest(TestCase):
         req = Request('http://scrapytest.org/',
                       headers={'User-Agent': 'header_useragent'})
         assert mw.process_request(req, spider) is None
-        self.assertEquals(req.headers['User-Agent'], b'header_useragent')
+        self.assertEqual(req.headers['User-Agent'], b'header_useragent')
 
     def test_no_agent(self):
         spider, mw = self.get_spider_and_mw(None)

--- a/tests/test_http_cookies.py
+++ b/tests/test_http_cookies.py
@@ -62,7 +62,7 @@ class WrappedResponseTest(TestCase):
         self.wrapped = WrappedResponse(self.response)
 
     def test_info(self):
-        self.assert_(self.wrapped.info() is self.wrapped)
+        self.assertTrue(self.wrapped.info() is self.wrapped)
 
     def test_getheaders(self):
         self.assertEqual(self.wrapped.getheaders('content-type'), ['text/html'])

--- a/tests/test_http_cookies.py
+++ b/tests/test_http_cookies.py
@@ -62,7 +62,7 @@ class WrappedResponseTest(TestCase):
         self.wrapped = WrappedResponse(self.response)
 
     def test_info(self):
-        self.assertTrue(self.wrapped.info() is self.wrapped)
+        self.assertIs(self.wrapped.info(), self.wrapped)
 
     def test_getheaders(self):
         self.assertEqual(self.wrapped.getheaders('content-type'), ['text/html'])

--- a/tests/test_http_request.py
+++ b/tests/test_http_request.py
@@ -64,9 +64,9 @@ class RequestTest(unittest.TestCase):
         h = Headers({'key1': u'val1', u'key2': 'val2'})
         h[u'newkey'] = u'newval'
         for k, v in h.iteritems():
-            self.assertTrue(isinstance(k, bytes))
+            self.assertIsInstance(k, bytes)
             for s in v:
-                self.assertTrue(isinstance(s, bytes))
+                self.assertIsInstance(s, bytes)
 
     def test_eq(self):
         url = 'http://www.scrapy.org'

--- a/tests/test_http_request.py
+++ b/tests/test_http_request.py
@@ -64,9 +64,9 @@ class RequestTest(unittest.TestCase):
         h = Headers({'key1': u'val1', u'key2': 'val2'})
         h[u'newkey'] = u'newval'
         for k, v in h.iteritems():
-            self.assert_(isinstance(k, bytes))
+            self.assertTrue(isinstance(k, bytes))
             for s in v:
-                self.assert_(isinstance(s, bytes))
+                self.assertTrue(isinstance(s, bytes))
 
     def test_eq(self):
         url = 'http://www.scrapy.org'

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -437,7 +437,7 @@ class ProcessorsTest(unittest.TestCase):
         self.assertRaises(TypeError, proc, [None, '', 'hello', 'world'])
         self.assertEqual(proc(['', 'hello', 'world']), u' hello world')
         self.assertEqual(proc(['hello', 'world']), u'hello world')
-        self.assert_(isinstance(proc(['hello', 'world']), six.text_type))
+        self.assertTrue(isinstance(proc(['hello', 'world']), six.text_type))
 
     def test_compose(self):
         proc = Compose(lambda v: v[0], str.upper)
@@ -482,7 +482,7 @@ class SelectortemLoaderTest(unittest.TestCase):
     def test_constructor_with_selector(self):
         sel = Selector(text=u"<html><body><div>marta</div></body></html>")
         l = TestItemLoader(selector=sel)
-        self.assert_(l.selector is sel)
+        self.assertTrue(l.selector is sel)
 
         l.add_xpath('name', '//div/text()')
         self.assertEqual(l.get_output_value('name'), [u'Marta'])
@@ -490,21 +490,21 @@ class SelectortemLoaderTest(unittest.TestCase):
     def test_constructor_with_selector_css(self):
         sel = Selector(text=u"<html><body><div>marta</div></body></html>")
         l = TestItemLoader(selector=sel)
-        self.assert_(l.selector is sel)
+        self.assertTrue(l.selector is sel)
 
         l.add_css('name', 'div::text')
         self.assertEqual(l.get_output_value('name'), [u'Marta'])
 
     def test_constructor_with_response(self):
         l = TestItemLoader(response=self.response)
-        self.assert_(l.selector)
+        self.assertTrue(l.selector)
 
         l.add_xpath('name', '//div/text()')
         self.assertEqual(l.get_output_value('name'), [u'Marta'])
 
     def test_constructor_with_response_css(self):
         l = TestItemLoader(response=self.response)
-        self.assert_(l.selector)
+        self.assertTrue(l.selector)
 
         l.add_css('name', 'div::text')
         self.assertEqual(l.get_output_value('name'), [u'Marta'])
@@ -526,7 +526,7 @@ class SelectortemLoaderTest(unittest.TestCase):
 
     def test_replace_xpath(self):
         l = TestItemLoader(response=self.response)
-        self.assert_(l.selector)
+        self.assertTrue(l.selector)
         l.add_xpath('name', '//div/text()')
         self.assertEqual(l.get_output_value('name'), [u'Marta'])
         l.replace_xpath('name', '//p/text()')
@@ -552,7 +552,7 @@ class SelectortemLoaderTest(unittest.TestCase):
 
     def test_replace_xpath_re(self):
         l = TestItemLoader(response=self.response)
-        self.assert_(l.selector)
+        self.assertTrue(l.selector)
         l.add_xpath('name', '//div/text()')
         self.assertEqual(l.get_output_value('name'), [u'Marta'])
         l.replace_xpath('name', '//div/text()', re='ma')
@@ -568,7 +568,7 @@ class SelectortemLoaderTest(unittest.TestCase):
 
     def test_replace_css(self):
         l = TestItemLoader(response=self.response)
-        self.assert_(l.selector)
+        self.assertTrue(l.selector)
         l.add_css('name', 'div::text')
         self.assertEqual(l.get_output_value('name'), [u'Marta'])
         l.replace_css('name', 'p::text')
@@ -606,7 +606,7 @@ class SelectortemLoaderTest(unittest.TestCase):
 
     def test_replace_css_re(self):
         l = TestItemLoader(response=self.response)
-        self.assert_(l.selector)
+        self.assertTrue(l.selector)
         l.add_css('url', 'a::attr(href)')
         self.assertEqual(l.get_output_value('url'), [u'http://www.scrapy.org'])
         l.replace_css('url', 'a::attr(href)', re='http://www\.(.+)')

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -437,7 +437,7 @@ class ProcessorsTest(unittest.TestCase):
         self.assertRaises(TypeError, proc, [None, '', 'hello', 'world'])
         self.assertEqual(proc(['', 'hello', 'world']), u' hello world')
         self.assertEqual(proc(['hello', 'world']), u'hello world')
-        self.assertTrue(isinstance(proc(['hello', 'world']), six.text_type))
+        self.assertIsInstance(proc(['hello', 'world']), six.text_type)
 
     def test_compose(self):
         proc = Compose(lambda v: v[0], str.upper)
@@ -482,7 +482,7 @@ class SelectortemLoaderTest(unittest.TestCase):
     def test_constructor_with_selector(self):
         sel = Selector(text=u"<html><body><div>marta</div></body></html>")
         l = TestItemLoader(selector=sel)
-        self.assertTrue(l.selector is sel)
+        self.assertIs(l.selector, sel)
 
         l.add_xpath('name', '//div/text()')
         self.assertEqual(l.get_output_value('name'), [u'Marta'])
@@ -490,7 +490,7 @@ class SelectortemLoaderTest(unittest.TestCase):
     def test_constructor_with_selector_css(self):
         sel = Selector(text=u"<html><body><div>marta</div></body></html>")
         l = TestItemLoader(selector=sel)
-        self.assertTrue(l.selector is sel)
+        self.assertIs(l.selector, sel)
 
         l.add_css('name', 'div::text')
         self.assertEqual(l.get_output_value('name'), [u'Marta'])

--- a/tests/test_pipeline_images.py
+++ b/tests/test_pipeline_images.py
@@ -81,28 +81,28 @@ class ImagesPipelineTestCase(unittest.TestCase):
         COLOUR = (0, 127, 255)
         im = _create_image('JPEG', 'RGB', SIZE, COLOUR)
         converted, _ = self.pipeline.convert_image(im)
-        self.assertEquals(converted.mode, 'RGB')
-        self.assertEquals(converted.getcolors(), [(10000, COLOUR)])
+        self.assertEqual(converted.mode, 'RGB')
+        self.assertEqual(converted.getcolors(), [(10000, COLOUR)])
 
         # check that thumbnail keep image ratio
         thumbnail, _ = self.pipeline.convert_image(converted, size=(10, 25))
-        self.assertEquals(thumbnail.mode, 'RGB')
-        self.assertEquals(thumbnail.size, (10, 10))
+        self.assertEqual(thumbnail.mode, 'RGB')
+        self.assertEqual(thumbnail.size, (10, 10))
 
         # transparency case: RGBA and PNG
         COLOUR = (0, 127, 255, 50)
         im = _create_image('PNG', 'RGBA', SIZE, COLOUR)
         converted, _ = self.pipeline.convert_image(im)
-        self.assertEquals(converted.mode, 'RGB')
-        self.assertEquals(converted.getcolors(), [(10000, (205, 230, 255))])
+        self.assertEqual(converted.mode, 'RGB')
+        self.assertEqual(converted.getcolors(), [(10000, (205, 230, 255))])
 
         # transparency case with palette: P and PNG
         COLOUR = (0, 127, 255, 50)
         im = _create_image('PNG', 'RGBA', SIZE, COLOUR)
         im = im.convert('P')
         converted, _ = self.pipeline.convert_image(im)
-        self.assertEquals(converted.mode, 'RGB')
-        self.assertEquals(converted.getcolors(), [(10000, (205, 230, 255))])
+        self.assertEqual(converted.mode, 'RGB')
+        self.assertEqual(converted.getcolors(), [(10000, (205, 230, 255))])
 
 
 class DeprecatedImagesPipeline(ImagesPipeline):

--- a/tests/test_selector.py
+++ b/tests/test_selector.py
@@ -84,7 +84,7 @@ class SelectorTestCase(unittest.TestCase):
         headers = {'Content-Type': ['text/html; charset=utf-8']}
         response = HtmlResponse(url="http://example.com", headers=headers, body=html_utf8)
         x = Selector(response)
-        self.assertEquals(x.xpath("//span[@id='blank']/text()").extract(),
+        self.assertEqual(x.xpath("//span[@id='blank']/text()").extract(),
                           [u'\xa3'])
 
     def test_badly_encoded_body(self):

--- a/tests/test_spider.py
+++ b/tests/test_spider.py
@@ -207,7 +207,7 @@ class CrawlSpiderTest(SpiderTest):
         output = list(spider._requests_to_follow(response))
         self.assertEqual(len(output), 3)
         self.assertTrue(all(map(lambda r: isinstance(r, Request), output)))
-        self.assertEquals([r.url for r in output],
+        self.assertEqual([r.url for r in output],
                           ['http://example.org/somepage/item/12.html',
                            'http://example.org/about.html',
                            'http://example.org/nofollow.html'])
@@ -234,7 +234,7 @@ class CrawlSpiderTest(SpiderTest):
         output = list(spider._requests_to_follow(response))
         self.assertEqual(len(output), 2)
         self.assertTrue(all(map(lambda r: isinstance(r, Request), output)))
-        self.assertEquals([r.url for r in output],
+        self.assertEqual([r.url for r in output],
                           ['http://example.org/somepage/item/12.html',
                            'http://example.org/about.html'])
 
@@ -258,7 +258,7 @@ class CrawlSpiderTest(SpiderTest):
         output = list(spider._requests_to_follow(response))
         self.assertEqual(len(output), 3)
         self.assertTrue(all(map(lambda r: isinstance(r, Request), output)))
-        self.assertEquals([r.url for r in output],
+        self.assertEqual([r.url for r in output],
                           ['http://example.org/somepage/item/12.html',
                            'http://example.org/about.html',
                            'http://example.org/nofollow.html'])

--- a/tests/test_spidermiddleware_depth.py
+++ b/tests/test_spidermiddleware_depth.py
@@ -25,18 +25,18 @@ class TestDepthMiddleware(TestCase):
         result = [Request('http://scrapytest.org')]
 
         out = list(self.mw.process_spider_output(resp, result, self.spider))
-        self.assertEquals(out, result)
+        self.assertEqual(out, result)
 
         rdc = self.stats.get_value('request_depth_count/1', spider=self.spider)
-        self.assertEquals(rdc, 1)
+        self.assertEqual(rdc, 1)
 
         req.meta['depth'] = 1
 
         out2 = list(self.mw.process_spider_output(resp, result, self.spider))
-        self.assertEquals(out2, [])
+        self.assertEqual(out2, [])
 
         rdm = self.stats.get_value('request_depth_max', spider=self.spider)
-        self.assertEquals(rdm, 1)
+        self.assertEqual(rdm, 1)
 
     def tearDown(self):
         self.stats.close_spider(self.spider, '')

--- a/tests/test_spidermiddleware_httperror.py
+++ b/tests/test_spidermiddleware_httperror.py
@@ -67,16 +67,16 @@ class TestHttpErrorMiddleware(TestCase):
         self.res200, self.res404 = _responses(self.req, [200, 404])
 
     def test_process_spider_input(self):
-        self.assertEquals(None,
+        self.assertEqual(None,
                 self.mw.process_spider_input(self.res200, self.spider))
         self.assertRaises(HttpError,
                 self.mw.process_spider_input, self.res404, self.spider)
 
     def test_process_spider_exception(self):
-        self.assertEquals([],
+        self.assertEqual([],
                 self.mw.process_spider_exception(self.res404,
                         HttpError(self.res404), self.spider))
-        self.assertEquals(None,
+        self.assertEqual(None,
                 self.mw.process_spider_exception(self.res404,
                         Exception(), self.spider))
 
@@ -84,11 +84,11 @@ class TestHttpErrorMiddleware(TestCase):
         res = self.res404.copy()
         res.request = Request('http://scrapytest.org',
                               meta={'handle_httpstatus_list': [404]})
-        self.assertEquals(None,
+        self.assertEqual(None,
             self.mw.process_spider_input(res, self.spider))
 
         self.spider.handle_httpstatus_list = [404]
-        self.assertEquals(None,
+        self.assertEqual(None,
             self.mw.process_spider_input(self.res404, self.spider))
 
 
@@ -102,11 +102,11 @@ class TestHttpErrorMiddlewareSettings(TestCase):
         self.res200, self.res404, self.res402 = _responses(self.req, [200, 404, 402])
 
     def test_process_spider_input(self):
-        self.assertEquals(None,
+        self.assertEqual(None,
                 self.mw.process_spider_input(self.res200, self.spider))
         self.assertRaises(HttpError,
                 self.mw.process_spider_input, self.res404, self.spider)
-        self.assertEquals(None,
+        self.assertEqual(None,
                 self.mw.process_spider_input(self.res402, self.spider))
 
     def test_meta_overrides_settings(self):
@@ -117,14 +117,14 @@ class TestHttpErrorMiddlewareSettings(TestCase):
         res402 = self.res402.copy()
         res402.request = request
 
-        self.assertEquals(None,
+        self.assertEqual(None,
             self.mw.process_spider_input(res404, self.spider))
         self.assertRaises(HttpError,
                 self.mw.process_spider_input, res402, self.spider)
 
     def test_spider_override_settings(self):
         self.spider.handle_httpstatus_list = [404]
-        self.assertEquals(None,
+        self.assertEqual(None,
             self.mw.process_spider_input(self.res404, self.spider))
         self.assertRaises(HttpError,
                 self.mw.process_spider_input, self.res402, self.spider)
@@ -139,9 +139,9 @@ class TestHttpErrorMiddlewareHandleAll(TestCase):
         self.res200, self.res404, self.res402 = _responses(self.req, [200, 404, 402])
 
     def test_process_spider_input(self):
-        self.assertEquals(None,
+        self.assertEqual(None,
                 self.mw.process_spider_input(self.res200, self.spider))
-        self.assertEquals(None,
+        self.assertEqual(None,
                 self.mw.process_spider_input(self.res404, self.spider))
 
     def test_meta_overrides_settings(self):
@@ -152,7 +152,7 @@ class TestHttpErrorMiddlewareHandleAll(TestCase):
         res402 = self.res402.copy()
         res402.request = request
 
-        self.assertEquals(None,
+        self.assertEqual(None,
             self.mw.process_spider_input(res404, self.spider))
         self.assertRaises(HttpError,
                 self.mw.process_spider_input, res402, self.spider)

--- a/tests/test_spidermiddleware_offsite.py
+++ b/tests/test_spidermiddleware_offsite.py
@@ -37,7 +37,7 @@ class TestOffsiteMiddleware(TestCase):
         reqs = onsite_reqs + offsite_reqs
 
         out = list(self.mw.process_spider_output(res, reqs, self.spider))
-        self.assertEquals(out, onsite_reqs)
+        self.assertEqual(out, onsite_reqs)
 
 
 class TestOffsiteMiddleware2(TestOffsiteMiddleware):
@@ -49,7 +49,7 @@ class TestOffsiteMiddleware2(TestOffsiteMiddleware):
         res = Response('http://scrapytest.org')
         reqs = [Request('http://a.com/b.html'), Request('http://b.com/1')]
         out = list(self.mw.process_spider_output(res, reqs, self.spider))
-        self.assertEquals(out, reqs)
+        self.assertEqual(out, reqs)
 
 class TestOffsiteMiddleware3(TestOffsiteMiddleware2):
 
@@ -67,4 +67,4 @@ class TestOffsiteMiddleware4(TestOffsiteMiddleware3):
       res = Response('http://scrapytest.org')
       reqs = [Request('http://scrapytest.org/1')]
       out = list(self.mw.process_spider_output(res, reqs, self.spider))
-      self.assertEquals(out, reqs)
+      self.assertEqual(out, reqs)

--- a/tests/test_spidermiddleware_referer.py
+++ b/tests/test_spidermiddleware_referer.py
@@ -45,7 +45,7 @@ class TestRefererMiddleware(TestCase):
             response = self.get_response(origin)
             request = self.get_request(target)
             out = list(self.mw.process_spider_output(response, [request], self.spider))
-            self.assertEquals(out[0].headers.get('Referer'), referrer)
+            self.assertEqual(out[0].headers.get('Referer'), referrer)
 
 
 class MixinDefault(object):
@@ -490,7 +490,7 @@ class TestSettingsPolicyByName(TestCase):
             ]:
             settings = Settings({'REFERRER_POLICY': s})
             mw = RefererMiddleware(settings)
-            self.assertEquals(mw.default_policy, p)
+            self.assertEqual(mw.default_policy, p)
 
     def test_valid_name_casevariants(self):
         for s, p in [
@@ -506,7 +506,7 @@ class TestSettingsPolicyByName(TestCase):
             ]:
             settings = Settings({'REFERRER_POLICY': s.upper()})
             mw = RefererMiddleware(settings)
-            self.assertEquals(mw.default_policy, p)
+            self.assertEqual(mw.default_policy, p)
 
     def test_invalid_name(self):
         settings = Settings({'REFERRER_POLICY': 'some-custom-unknown-policy'})
@@ -581,7 +581,7 @@ class TestReferrerOnRedirect(TestRefererMiddleware):
             request = self.get_request(target)
 
             out = list(self.referrermw.process_spider_output(response, [request], self.spider))
-            self.assertEquals(out[0].headers.get('Referer'), init_referrer)
+            self.assertEqual(out[0].headers.get('Referer'), init_referrer)
 
             for status, url in redirections:
                 response = Response(request.url, headers={'Location': url}, status=status)
@@ -589,7 +589,7 @@ class TestReferrerOnRedirect(TestRefererMiddleware):
                 self.referrermw.request_scheduled(request, self.spider)
 
             assert isinstance(request, Request)
-            self.assertEquals(request.headers.get('Referer'), final_referrer)
+            self.assertEqual(request.headers.get('Referer'), final_referrer)
 
 
 class TestReferrerOnRedirectNoReferrer(TestReferrerOnRedirect):

--- a/tests/test_spidermiddleware_urllength.py
+++ b/tests/test_spidermiddleware_urllength.py
@@ -17,5 +17,5 @@ class TestUrlLengthMiddleware(TestCase):
         mw = UrlLengthMiddleware(maxlength=25)
         spider = Spider('foo')
         out = list(mw.process_spider_output(res, reqs, spider))
-        self.assertEquals(out, [short_url_req])
+        self.assertEqual(out, [short_url_req])
 

--- a/tests/test_urlparse_monkeypatches.py
+++ b/tests/test_urlparse_monkeypatches.py
@@ -6,7 +6,7 @@ class UrlparseTestCase(unittest.TestCase):
 
     def test_s3_url(self):
         p = urlparse('s3://bucket/key/name?param=value')
-        self.assertEquals(p.scheme, 's3')
-        self.assertEquals(p.hostname, 'bucket')
-        self.assertEquals(p.path, '/key/name')
-        self.assertEquals(p.query, 'param=value')
+        self.assertEqual(p.scheme, 's3')
+        self.assertEqual(p.hostname, 'bucket')
+        self.assertEqual(p.path, '/key/name')
+        self.assertEqual(p.query, 'param=value')

--- a/tests/test_utils_datatypes.py
+++ b/tests/test_utils_datatypes.py
@@ -202,22 +202,22 @@ class SequenceExcludeTest(unittest.TestCase):
         seq = range(10, 20, 3)
         d = SequenceExclude(seq)
         are_not_in = [v for v in range(10, 20, 3) if v in d]
-        self.assertEquals([], are_not_in)
+        self.assertEqual([], are_not_in)
 
         are_not_in = [v for v in range(10, 20) if v in d]
-        self.assertEquals([11, 12, 14, 15, 17, 18], are_not_in)
+        self.assertEqual([11, 12, 14, 15, 17, 18], are_not_in)
 
     def test_string_seq(self):
         seq = "cde"
         d = SequenceExclude(seq)
         chars = "".join(v for v in "abcdefg" if v in d)
-        self.assertEquals("abfg", chars)
+        self.assertEqual("abfg", chars)
 
     def test_stringset_seq(self):
         seq = set("cde")
         d = SequenceExclude(seq)
         chars = "".join(v for v in "abcdefg" if v in d)
-        self.assertEquals("abfg", chars)
+        self.assertEqual("abfg", chars)
 
     def test_set(self):
         """Anything that is not in the supplied sequence will evaluate as 'in' the container."""

--- a/tests/test_utils_defer.py
+++ b/tests/test_utils_defer.py
@@ -89,7 +89,7 @@ class IterErrbackTest(unittest.TestCase):
         errors = []
         out = list(iter_errback(itergood(), errors.append))
         self.assertEqual(out, list(range(10)))
-        self.failIf(errors)
+        self.assertFalse(errors)
 
     def test_iter_errback_bad(self):
         def iterbad():

--- a/tests/test_utils_iterators.py
+++ b/tests/test_utils_iterators.py
@@ -252,8 +252,8 @@ class UtilsCsvTestCase(unittest.TestCase):
 
         # explicit type check cuz' we no like stinkin' autocasting! yarrr
         for result_row in result:
-            self.assert_(all((isinstance(k, six.text_type) for k in result_row.keys())))
-            self.assert_(all((isinstance(v, six.text_type) for v in result_row.values())))
+            self.assertTrue(all((isinstance(k, six.text_type) for k in result_row.keys())))
+            self.assertTrue(all((isinstance(v, six.text_type) for v in result_row.values())))
 
     def test_csviter_delimiter(self):
         body = get_testdata('feeds', 'feed-sample3.csv').replace(b',', b'\t')

--- a/tests/test_utils_misc/__init__.py
+++ b/tests/test_utils_misc/__init__.py
@@ -23,20 +23,20 @@ class UtilsMiscTestCase(unittest.TestCase):
             'tests.test_utils_misc.test_walk_modules.mod.mod0',
             'tests.test_utils_misc.test_walk_modules.mod1',
         ]
-        self.assertEquals(set([m.__name__ for m in mods]), set(expected))
+        self.assertEqual(set([m.__name__ for m in mods]), set(expected))
 
         mods = walk_modules('tests.test_utils_misc.test_walk_modules.mod')
         expected = [
             'tests.test_utils_misc.test_walk_modules.mod',
             'tests.test_utils_misc.test_walk_modules.mod.mod0',
         ]
-        self.assertEquals(set([m.__name__ for m in mods]), set(expected))
+        self.assertEqual(set([m.__name__ for m in mods]), set(expected))
 
         mods = walk_modules('tests.test_utils_misc.test_walk_modules.mod1')
         expected = [
             'tests.test_utils_misc.test_walk_modules.mod1',
         ]
-        self.assertEquals(set([m.__name__ for m in mods]), set(expected))
+        self.assertEqual(set([m.__name__ for m in mods]), set(expected))
 
         self.assertRaises(ImportError, walk_modules, 'nomodule999')
 
@@ -51,7 +51,7 @@ class UtilsMiscTestCase(unittest.TestCase):
                 'testegg.spiders.b',
                 'testegg'
             ]
-            self.assertEquals(set([m.__name__ for m in mods]), set(expected))
+            self.assertEqual(set([m.__name__ for m in mods]), set(expected))
         finally:
             sys.path.remove(egg)
 

--- a/tests/test_utils_project.py
+++ b/tests/test_utils_project.py
@@ -25,14 +25,14 @@ def inside_a_project():
 
 class ProjectUtilsTest(unittest.TestCase):
     def test_data_path_outside_project(self):
-        self.assertEquals('.scrapy/somepath', data_path('somepath'))
-        self.assertEquals('/absolute/path', data_path('/absolute/path'))
+        self.assertEqual('.scrapy/somepath', data_path('somepath'))
+        self.assertEqual('/absolute/path', data_path('/absolute/path'))
 
     def test_data_path_inside_project(self):
         with inside_a_project() as proj_path:
             expected = os.path.join(proj_path, '.scrapy', 'somepath')
-            self.assertEquals(
+            self.assertEqual(
                 os.path.realpath(expected),
                 os.path.realpath(data_path('somepath'))
             )
-            self.assertEquals('/absolute/path', data_path('/absolute/path'))
+            self.assertEqual('/absolute/path', data_path('/absolute/path'))

--- a/tests/test_utils_python.py
+++ b/tests/test_utils_python.py
@@ -97,9 +97,9 @@ class UtilsPythonTestCase(unittest.TestCase):
         a = Obj()
         b = Obj()
         # no attributes given return False
-        self.failIf(equal_attributes(a, b, []))
+        self.assertFalse(equal_attributes(a, b, []))
         # not existent attributes
-        self.failIf(equal_attributes(a, b, ['x', 'y']))
+        self.assertFalse(equal_attributes(a, b, ['x', 'y']))
 
         a.x = 1
         b.x = 1
@@ -108,7 +108,7 @@ class UtilsPythonTestCase(unittest.TestCase):
 
         b.y = 2
         # obj1 has no attribute y
-        self.failIf(equal_attributes(a, b, ['x', 'y']))
+        self.assertFalse(equal_attributes(a, b, ['x', 'y']))
 
         a.y = 2
         # equal attributes
@@ -116,7 +116,7 @@ class UtilsPythonTestCase(unittest.TestCase):
 
         a.y = 1
         # differente attributes
-        self.failIf(equal_attributes(a, b, ['x', 'y']))
+        self.assertFalse(equal_attributes(a, b, ['x', 'y']))
 
         # test callable
         a.meta = {}
@@ -134,7 +134,7 @@ class UtilsPythonTestCase(unittest.TestCase):
         self.assertTrue(equal_attributes(a, b, [compare_z, 'x']))
         # fail z equality
         a.meta['z'] = 2
-        self.failIf(equal_attributes(a, b, [compare_z, 'x']))
+        self.assertFalse(equal_attributes(a, b, [compare_z, 'x']))
 
     def test_weakkeycache(self):
         class _Weakme(object): pass
@@ -156,9 +156,9 @@ class UtilsPythonTestCase(unittest.TestCase):
         d = {'a': 123, u'b': b'c', u'd': u'e', object(): u'e'}
         d2 = stringify_dict(d, keys_only=False)
         self.assertEqual(d, d2)
-        self.failIf(d is d2)  # shouldn't modify in place
-        self.failIf(any(isinstance(x, six.text_type) for x in d2.keys()))
-        self.failIf(any(isinstance(x, six.text_type) for x in d2.values()))
+        self.assertFalse(d is d2)  # shouldn't modify in place
+        self.assertFalse(any(isinstance(x, six.text_type) for x in d2.keys()))
+        self.assertFalse(any(isinstance(x, six.text_type) for x in d2.values()))
 
     @unittest.skipUnless(six.PY2, "deprecated function")
     def test_stringify_dict_tuples(self):
@@ -166,17 +166,17 @@ class UtilsPythonTestCase(unittest.TestCase):
         d = dict(tuples)
         d2 = stringify_dict(tuples, keys_only=False)
         self.assertEqual(d, d2)
-        self.failIf(d is d2)  # shouldn't modify in place
-        self.failIf(any(isinstance(x, six.text_type) for x in d2.keys()), d2.keys())
-        self.failIf(any(isinstance(x, six.text_type) for x in d2.values()))
+        self.assertFalse(d is d2)  # shouldn't modify in place
+        self.assertFalse(any(isinstance(x, six.text_type) for x in d2.keys()), d2.keys())
+        self.assertFalse(any(isinstance(x, six.text_type) for x in d2.values()))
 
     @unittest.skipUnless(six.PY2, "deprecated function")
     def test_stringify_dict_keys_only(self):
         d = {'a': 123, u'b': 'c', u'd': u'e', object(): u'e'}
         d2 = stringify_dict(d)
         self.assertEqual(d, d2)
-        self.failIf(d is d2)  # shouldn't modify in place
-        self.failIf(any(isinstance(x, six.text_type) for x in d2.keys()))
+        self.assertFalse(d is d2)  # shouldn't modify in place
+        self.assertFalse(any(isinstance(x, six.text_type) for x in d2.keys()))
 
     def test_get_func_args(self):
         def f1(a, b, c):

--- a/tests/test_utils_python.py
+++ b/tests/test_utils_python.py
@@ -156,7 +156,7 @@ class UtilsPythonTestCase(unittest.TestCase):
         d = {'a': 123, u'b': b'c', u'd': u'e', object(): u'e'}
         d2 = stringify_dict(d, keys_only=False)
         self.assertEqual(d, d2)
-        self.assertFalse(d is d2)  # shouldn't modify in place
+        self.assertIsNot(d, d2)  # shouldn't modify in place
         self.assertFalse(any(isinstance(x, six.text_type) for x in d2.keys()))
         self.assertFalse(any(isinstance(x, six.text_type) for x in d2.values()))
 
@@ -166,7 +166,7 @@ class UtilsPythonTestCase(unittest.TestCase):
         d = dict(tuples)
         d2 = stringify_dict(tuples, keys_only=False)
         self.assertEqual(d, d2)
-        self.assertFalse(d is d2)  # shouldn't modify in place
+        self.assertIsNot(d, d2)  # shouldn't modify in place
         self.assertFalse(any(isinstance(x, six.text_type) for x in d2.keys()), d2.keys())
         self.assertFalse(any(isinstance(x, six.text_type) for x in d2.values()))
 
@@ -175,7 +175,7 @@ class UtilsPythonTestCase(unittest.TestCase):
         d = {'a': 123, u'b': 'c', u'd': u'e', object(): u'e'}
         d2 = stringify_dict(d)
         self.assertEqual(d, d2)
-        self.assertFalse(d is d2)  # shouldn't modify in place
+        self.assertIsNot(d, d2)  # shouldn't modify in place
         self.assertFalse(any(isinstance(x, six.text_type) for x in d2.keys()))
 
     def test_get_func_args(self):

--- a/tests/test_utils_signal.py
+++ b/tests/test_utils_signal.py
@@ -29,7 +29,7 @@ class SendCatchLogTest(unittest.TestCase):
         self.assertIn('error_handler', record.getMessage())
         self.assertEqual(record.levelname, 'ERROR')
         self.assertEqual(result[0][0], self.error_handler)
-        self.assert_(isinstance(result[0][1], Failure))
+        self.assertTrue(isinstance(result[0][1], Failure))
         self.assertEqual(result[1], (self.ok_handler, "OK"))
 
         dispatcher.disconnect(self.error_handler, signal=test_signal)

--- a/tests/test_utils_signal.py
+++ b/tests/test_utils_signal.py
@@ -29,7 +29,7 @@ class SendCatchLogTest(unittest.TestCase):
         self.assertIn('error_handler', record.getMessage())
         self.assertEqual(record.levelname, 'ERROR')
         self.assertEqual(result[0][0], self.error_handler)
-        self.assertTrue(isinstance(result[0][1], Failure))
+        self.assertIsInstance(result[0][1], Failure)
         self.assertEqual(result[1], (self.ok_handler, "OK"))
 
         dispatcher.disconnect(self.error_handler, signal=test_signal)

--- a/tests/test_webclient.py
+++ b/tests/test_webclient.py
@@ -71,7 +71,7 @@ class ParseUrlTestCase(unittest.TestCase):
         for url, test in tests:
             test = tuple(
                 to_bytes(x) if not isinstance(x, int) else x for x in test)
-            self.assertEquals(client._parse(url), test, url)
+            self.assertEqual(client._parse(url), test, url)
 
     def test_externalUnicodeInterference(self):
         """
@@ -258,16 +258,16 @@ class WebClientTestCase(unittest.TestCase):
     def testPayload(self):
         s = "0123456789" * 10
         return getPage(self.getURL("payload"), body=s).addCallback(
-            self.assertEquals, to_bytes(s))
+            self.assertEqual, to_bytes(s))
 
     def testHostHeader(self):
         # if we pass Host header explicitly, it should be used, otherwise
         # it should extract from url
         return defer.gatherResults([
             getPage(self.getURL("host")).addCallback(
-                self.assertEquals, to_bytes("127.0.0.1:%d" % self.portno)),
+                self.assertEqual, to_bytes("127.0.0.1:%d" % self.portno)),
             getPage(self.getURL("host"), headers={"Host": "www.example.com"}).addCallback(
-                self.assertEquals, to_bytes("www.example.com"))])
+                self.assertEqual, to_bytes("www.example.com"))])
 
     def test_getPage(self):
         """
@@ -275,7 +275,7 @@ class WebClientTestCase(unittest.TestCase):
         the body of the response if the default method B{GET} is used.
         """
         d = getPage(self.getURL("file"))
-        d.addCallback(self.assertEquals, b"0123456789")
+        d.addCallback(self.assertEqual, b"0123456789")
         return d
 
     def test_getPageHead(self):
@@ -298,7 +298,7 @@ class WebClientTestCase(unittest.TestCase):
         """
         d = getPage(self.getURL("host"), timeout=100)
         d.addCallback(
-            self.assertEquals, to_bytes("127.0.0.1:%d" % self.portno))
+            self.assertEqual, to_bytes("127.0.0.1:%d" % self.portno))
         return d
 
     def test_timeoutTriggering(self):
@@ -326,7 +326,7 @@ class WebClientTestCase(unittest.TestCase):
         return getPage(self.getURL('notsuchfile')).addCallback(self._cbNoSuchFile)
 
     def _cbNoSuchFile(self, pageData):
-        self.assert_(b'404 - No Such Resource' in pageData)
+        self.assertTrue(b'404 - No Such Resource' in pageData)
 
     def testFactoryInfo(self):
         url = self.getURL('file')
@@ -336,16 +336,16 @@ class WebClientTestCase(unittest.TestCase):
         return factory.deferred.addCallback(self._cbFactoryInfo, factory)
 
     def _cbFactoryInfo(self, ignoredResult, factory):
-        self.assertEquals(factory.status, b'200')
-        self.assert_(factory.version.startswith(b'HTTP/'))
-        self.assertEquals(factory.message, b'OK')
-        self.assertEquals(factory.response_headers[b'content-length'], b'10')
+        self.assertEqual(factory.status, b'200')
+        self.assertTrue(factory.version.startswith(b'HTTP/'))
+        self.assertEqual(factory.message, b'OK')
+        self.assertEqual(factory.response_headers[b'content-length'], b'10')
 
     def testRedirect(self):
         return getPage(self.getURL("redirect")).addCallback(self._cbRedirect)
 
     def _cbRedirect(self, pageData):
-        self.assertEquals(pageData,
+        self.assertEqual(pageData,
                 b'\n<html>\n    <head>\n        <meta http-equiv="refresh" content="0;URL=/file">\n'
                 b'    </head>\n    <body bgcolor="#FFFFFF" text="#000000">\n    '
                 b'<a href="/file">click here</a>\n    </body>\n</html>\n')
@@ -360,6 +360,6 @@ class WebClientTestCase(unittest.TestCase):
 
     def _check_Encoding(self, response, original_body):
         content_encoding = to_unicode(response.headers[b'Content-Encoding'])
-        self.assertEquals(content_encoding, EncodingResource.out_encoding)
-        self.assertEquals(
+        self.assertEqual(content_encoding, EncodingResource.out_encoding)
+        self.assertEqual(
             response.body.decode(content_encoding), to_unicode(original_body))

--- a/tests/test_webclient.py
+++ b/tests/test_webclient.py
@@ -326,7 +326,7 @@ class WebClientTestCase(unittest.TestCase):
         return getPage(self.getURL('notsuchfile')).addCallback(self._cbNoSuchFile)
 
     def _cbNoSuchFile(self, pageData):
-        self.assertTrue(b'404 - No Such Resource' in pageData)
+        self.assertIn(b'404 - No Such Resource', pageData)
 
     def testFactoryInfo(self):
         url = self.getURL('file')


### PR DESCRIPTION
- change ``failIf`` to ``assertFalse``
- change ``asertEquals`` to ``assertEqual``
- change ``assert_`` to ``assertTrue``

https://docs.python.org/2/library/unittest.html#deprecated-aliases