### PR TITLE
Refactoring to make possible to optimize item loaders' performance

### DIFF
--- a/scrapy/loader/__init__.py
+++ b/scrapy/loader/__init__.py
@@ -96,6 +96,9 @@ class ItemLoader(object):
         self._values.pop(field_name, None)
         self._add_value(field_name, value)
 
+    def _wrap_loader_context(self, proc):
+        return wrap_loader_context(proc, self.context)
+
     def get_value(self, value, *processors, **kw):
         regex = kw.get('re', None)
         if regex:
@@ -105,7 +108,7 @@ class ItemLoader(object):
         for proc in processors:
             if value is None:
                 break
-            proc = wrap_loader_context(proc, self.context)
+            proc = self._wrap_loader_context(proc)
             value = proc(value)
         return value
 
@@ -120,7 +123,7 @@ class ItemLoader(object):
 
     def get_output_value(self, field_name):
         proc = self.get_output_processor(field_name)
-        proc = wrap_loader_context(proc, self.context)
+        proc = self._wrap_loader_context(proc)
         try:
             return proc(self._values[field_name])
         except Exception as e:
@@ -146,7 +149,7 @@ class ItemLoader(object):
 
     def _process_input_value(self, field_name, value):
         proc = self.get_input_processor(field_name)
-        proc = wrap_loader_context(proc, self.context)
+        proc = self._wrap_loader_context(proc)
         return proc(value)
 
     def _get_item_field_attr(self, field_name, key, default=None):

--- a/scrapy/loader/processors.py
+++ b/scrapy/loader/processors.py
@@ -40,12 +40,15 @@ class Compose(object):
         self.stop_on_none = default_loader_context.get('stop_on_none', True)
         self.default_loader_context = default_loader_context
 
+    def _wrap_loader_context(self, func, context):
+        return wrap_loader_context(func, context)
+
     def __call__(self, value, loader_context=None):
         if loader_context:
             context = MergeDict(loader_context, self.default_loader_context)
         else:
             context = self.default_loader_context
-        wrapped_funcs = [wrap_loader_context(f, context) for f in self.functions]
+        wrapped_funcs = [self._wrap_loader_context(f, context) for f in self.functions]
         for func in wrapped_funcs:
             if value is None and self.stop_on_none:
                 break

--- a/scrapy/loader/processors.py
+++ b/scrapy/loader/processors.py
@@ -15,13 +15,16 @@ class MapCompose(object):
         self.functions = functions
         self.default_loader_context = default_loader_context
 
+    def _wrap_loader_context(self, func, context):
+        return wrap_loader_context(func, context)
+
     def __call__(self, value, loader_context=None):
         values = arg_to_iter(value)
         if loader_context:
             context = MergeDict(loader_context, self.default_loader_context)
         else:
             context = self.default_loader_context
-        wrapped_funcs = [wrap_loader_context(f, context) for f in self.functions]
+        wrapped_funcs = [self._wrap_loader_context(f, context) for f in self.functions]
         for func in wrapped_funcs:
             next_values = []
             for v in values:


### PR DESCRIPTION
Hello, the aim of these changes is to allow to optimize item loaders that don't need to use a context.
I'm working on a project that has spiders that load hundreds/thousands of items per request and they are using item loaders and I noticed that there's a big difference in performance when using plain dicts instead of item loaders for these cases.

After profiling I found that a good part of the time was spent in the  wrap_loader_context function which inspects the processors arguments to see if it accepts the loader_context param. The change I suggest to do is to move this function to a method(also this is done for the MapCompose loader) so that it's easier to subclass ItemLoader and redefine that method to just return the same function it's given when the item loader doesn't use contexts.

Here's the test I did to verify the performance improvements. In my pc the first loop runs in 46 seconds and the second one in 21 seconds.

```import scrapy
import time
from scrapy.loader import ItemLoader

class OptimizedLoader(ItemLoader):
    def _wrap_loader_context(self, proc):
        return proc

class Loader(ItemLoader):
    pass

class Product(scrapy.Item):
    item = scrapy.Field()
    
class Spider(scrapy.Spider):
    name = 'test'
    start_urls = ['http://google.com']

    def parse(self, response):
        count = 500000
        start = time.time()
        for x in range(count):
            loader = Loader(item=Product())
            loader.add_value('item', x)
            i = loader.load_item()

        end = time.time()
        self.log('non optimized {}'.format(end - start))
        self.log('average {}'.format((end - start) / count))

        start = time.time()
        for x in range(count):
            loader = OptimizedLoader(item=Product())
            loader.add_value('item', x)
            i = loader.load_item()

        end = time.time()
        self.log('optimized {}'.format(end - start))
        self.log('average {}'.format((end - start) / count))
```