### PR TITLE
Move logging of overriden settings to Crawler init

### DIFF
--- a/scrapy/crawler.py
+++ b/scrapy/crawler.py
@@ -11,7 +11,7 @@ from scrapy.core.engine import ExecutionEngine
 from scrapy.resolver import CachingThreadedResolver
 from scrapy.interfaces import ISpiderLoader
 from scrapy.extension import ExtensionManager
-from scrapy.settings import Settings
+from scrapy.settings import overridden_settings, Settings
 from scrapy.signalmanager import SignalManager
 from scrapy.exceptions import ScrapyDeprecationWarning
 from scrapy.utils.ossignal import install_shutdown_handlers, signal_names
@@ -33,6 +33,9 @@ class Crawler(object):
         self.spidercls = spidercls
         self.settings = settings.copy()
         self.spidercls.update_settings(self.settings)
+
+        d = dict(overridden_settings(self.settings))
+        logger.info("Overridden settings: %(settings)r", {'settings': d})
 
         self.signals = SignalManager(self)
         self.stats = load_object(self.settings['STATS_CLASS'])(self)

--- a/scrapy/utils/log.py
+++ b/scrapy/utils/log.py
@@ -9,7 +9,7 @@ from twisted.python.failure import Failure
 from twisted.python import log as twisted_log
 
 import scrapy
-from scrapy.settings import overridden_settings, Settings
+from scrapy.settings import Settings
 from scrapy.exceptions import ScrapyDeprecationWarning
 from scrapy.utils.versions import scrapy_components_versions
 
@@ -148,8 +148,6 @@ def log_scrapy_info(settings):
                 {'versions': ", ".join("%s %s" % (name, version)
                     for name, version in scrapy_components_versions()
                     if name != "Scrapy")})
-    d = dict(overridden_settings(settings))
-    logger.info("Overridden settings: %(settings)r", {'settings': d})
 
 
 class StreamLogger(object):


### PR DESCRIPTION
Fixes https://github.com/scrapy/scrapy/issues/1343

Proposal for https://github.com/scrapy/scrapy/issues/1343.
The idea here is to keep `log_scrapy_info()` only with Scrapy-framework related stuff,
and move settings and custom settings logging closer to where the framework is instantiated to perform a crawl (Crawler, Engine etc)