### PR TITLE
ur'string' not needed in Py 2, syntax error in Py3

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -191,7 +191,7 @@ htmlhelp_basename = 'Scrapydoc'
 # Grouping the document tree into LaTeX files. List of tuples
 # (source start file, target name, title, author, document class [howto/manual]).
 latex_documents = [
-  ('index', 'Scrapy.tex', ur'Scrapy Documentation',
+  ('index', 'Scrapy.tex', u'Scrapy Documentation',
    ur'Scrapy developers', 'manual'),
 ]
 

--- a/docs/utils/linkfix.py
+++ b/docs/utils/linkfix.py
@@ -20,7 +20,7 @@ _filename = None
 _contents = None
 
 # A regex that matches standard linkcheck output lines
-line_re = re.compile(ur'(.*)\:\d+\:\s\[(.*)\]\s(?:(.*)\sto\s(.*)|(.*))')
+line_re = re.compile(u'(.*)\:\d+\:\s\[(.*)\]\s(?:(.*)\sto\s(.*)|(.*))')
 
 # Read lines from the linkcheck output file
 try:


### PR DESCRIPTION
Fixes #2891 

* `ur'string'`is converted to `u'string'`in Python 2.
* `ur'string'`is a syntax error in Python 3.

