### PR TITLE
Print cryptography package version

### DIFF
--- a/scrapy/commands/version.py
+++ b/scrapy/commands/version.py
@@ -23,8 +23,11 @@ class Command(ScrapyCommand):
 
     def run(self, args, opts):
         if opts.verbose:
-            for name, version in scrapy_components_versions():
-                print("%-9s : %s" % (name, version))
+            versions = scrapy_components_versions()
+            width = max(len(n) for (n, _) in versions)
+            patt = "%-{}s : %s".format(width)
+            for name, version in versions:
+                print(patt % (name, version))
         else:
             print("Scrapy %s" % scrapy.__version__)
 

--- a/scrapy/utils/versions.py
+++ b/scrapy/utils/versions.py
@@ -17,6 +17,11 @@ def scrapy_components_versions():
         w3lib_version = w3lib.__version__
     except AttributeError:
         w3lib_version = "<1.14.3"
+    try:
+        import cryptography
+        cryptography_version = cryptography.__version__
+    except ImportError:
+        cryptography_version = "unknown"
 
     return [
         ("Scrapy", scrapy.__version__),
@@ -28,6 +33,7 @@ def scrapy_components_versions():
         ("Twisted", twisted.version.short()),
         ("Python", sys.version.replace("\n", "- ")),
         ("pyOpenSSL", _get_openssl_version()),
+        ("cryptography", cryptography_version),
         ("Platform",  platform.platform()),
     ]
 

--- a/tests/test_command_version.py
+++ b/tests/test_command_version.py
@@ -28,4 +28,4 @@ class VersionTest(ProcessTest, unittest.TestCase):
         self.assertEqual(headers, ['Scrapy', 'lxml', 'libxml2',
                                    'cssselect', 'parsel', 'w3lib',
                                    'Twisted', 'Python', 'pyOpenSSL',
-                                   'Platform'])
+                                   'cryptography', 'Platform'])


### PR DESCRIPTION
`scrapy version -v` does not currently output `cryptography` version, which can be useful.

I've added a `try/except` when reading cryptography's version because I don't know when it became a dependency of `pyOpenSSL`. But it may be fine to remove it.
Scrapy's current baseline of Debian Jessie uses `pyOpenSSL==0.14` and `cryptography==0.6`