### PR TITLE
support giantfiles download ,fix CVE-2017-14158

### DIFF
--- a/scrapy/cmdline.py
+++ b/scrapy/cmdline.py
@@ -11,7 +11,6 @@ from scrapy.commands import ScrapyCommand
 from scrapy.exceptions import UsageError
 from scrapy.utils.misc import walk_modules
 from scrapy.utils.project import inside_project, get_project_settings
-from scrapy.utils.python import garbage_collect
 from scrapy.settings.deprecated import check_deprecated_settings
 
 def _iter_command_classes(module_name):
@@ -166,9 +165,4 @@ def _run_command_profiled(cmd, args, opts):
         p.dump_stats(opts.profile)
 
 if __name__ == '__main__':
-    try:
-        execute()
-    finally:
-        # Twisted prints errors in DebugInfo.__del__, but PyPy does not run gc.collect()
-        # on exit: http://doc.pypy.org/en/latest/cpython_differences.html?highlight=gc.collect#differences-related-to-garbage-collection-strategies
-        garbage_collect()
+    execute()

--- a/scrapy/contrib/pipeline/giantfiles.py
+++ b/scrapy/contrib/pipeline/giantfiles.py
@@ -1,0 +1,2 @@
+
+from scrapy.pipelines.giantfiles import *

--- a/scrapy/extensions/httpcache.py
+++ b/scrapy/extensions/httpcache.py
@@ -13,7 +13,7 @@ from scrapy.responsetypes import responsetypes
 from scrapy.utils.request import request_fingerprint
 from scrapy.utils.project import data_path
 from scrapy.utils.httpobj import urlparse_cached
-from scrapy.utils.python import to_bytes, to_unicode, garbage_collect
+from scrapy.utils.python import to_bytes, to_unicode
 
 
 logger = logging.getLogger(__name__)
@@ -362,7 +362,6 @@ class LeveldbCacheStorage(object):
         # avoid them being removed in storages with timestamp-based autoremoval.
         self.db.CompactRange()
         del self.db
-        garbage_collect()
 
     def retrieve_response(self, spider, request):
         data = self._read_data(spider, request)

--- a/scrapy/http/__init__.py
+++ b/scrapy/http/__init__.py
@@ -7,6 +7,7 @@ Request and Response outside this module.
 
 from scrapy.http.headers import Headers
 
+from scrapy.http.request.giantfiles import GiantFilesRequest
 from scrapy.http.request import Request
 from scrapy.http.request.form import FormRequest
 from scrapy.http.request.rpc import XmlRpcRequest

--- a/scrapy/http/request/giantfiles.py
+++ b/scrapy/http/request/giantfiles.py
@@ -1,0 +1,37 @@
+from scrapy.http.request import Request
+from scrapy.http.headers import Headers
+class GiantFilesRequest(Request):
+    '''
+    most of the codes are the same as Request, but now I have changed several parts to fit the GiantFilesPipeline
+    '''
+    def __init__(self, url,store_path,callback=None, method='GET', headers=None, body=None,
+                 cookies=None, meta=None, encoding='utf-8', priority=0,
+                 dont_filter=False, errback=None,flags=None):
+
+        self._encoding = encoding  # this one has to be set first
+        self.method = str(method).upper()
+        self._set_url(url)
+        self._set_body(body)
+        assert isinstance(priority, int), "Request priority not an integer: %r" % priority
+        self.priority = priority
+        self.store_path = store_path  #the FILES_STORE attribute in the SETTINSG
+        assert callback or not errback, "Cannot use errback without a callback"
+        self.callback = callback
+        self.errback = errback
+
+        self.cookies = cookies or {}
+        self.headers = Headers(headers or {}, encoding=encoding)
+        self.dont_filter = dont_filter
+
+        self._meta = dict(meta) if meta else None
+        self.flags = [] if flags is None else list(flags)
+    def replace(self, *args, **kwargs):
+        """Create a new GiantFileRequest with the same attributes except for those
+        given new values.
+        """
+        for x in ['url','store_path', 'method', 'headers', 'body', 'cookies', 'meta',
+                  'encoding', 'priority', 'dont_filter', 'callback', 'errback']:#added the store_path attribute here
+            kwargs.setdefault(x, getattr(self, x))
+        cls = kwargs.pop('cls', self.__class__)
+        return cls(*args, **kwargs)
+

--- a/scrapy/pipelines/giantfiles.py
+++ b/scrapy/pipelines/giantfiles.py
@@ -1,0 +1,29 @@
+from scrapy.http.request.giantfiles import GiantFilesRequest
+from scrapy.pipelines.files import FilesPipeline
+
+from scrapy.utils.misc import md5sum
+
+class GiantFilesPipeline(FilesPipeline):
+    """Abstract pipeline that implement the giant file downloading
+    """
+    def gen_giant_file_request(self,url): 
+   
+        return GiantFilesRequest(url,self.store.basedir)
+    
+        #GiantFilesPipeline._get_store(
+    def get_media_requests(self, item, info):
+        #print self.store.basedir
+        return [GiantFilesRequest(x,self.store.basedir) for x in item.get(self.files_urls_field, [])]
+    def file_downloaded(self, response, request, info):
+        if isinstance(request,GiantFilesRequest):
+            #response.body here is the stream of the giant file in fact 
+            checksum=""
+            try:
+                f = open(response.body,'r')
+                checksum = md5sum(f)
+            finally:
+                f.close()
+            
+            return checksum
+        else:
+            raise Exception("Type error: not  a request of a giantfile")

--- a/scrapy/resolver.py
+++ b/scrapy/resolver.py
@@ -22,8 +22,7 @@ class CachingThreadedResolver(ThreadedResolver):
         # to enforce Scrapy's DNS_TIMEOUT setting's value
         timeout = (self.timeout,)
         d = super(CachingThreadedResolver, self).getHostByName(name, timeout)
-        if dnscache.limit:
-            d.addCallback(self._cache_result, name)
+        d.addCallback(self._cache_result, name)
         return d
 
     def _cache_result(self, result, name):

--- a/scrapy/utils/python.py
+++ b/scrapy/utils/python.py
@@ -1,7 +1,6 @@
 """
 This module contains essential stuff that should've come with Python itself ;)
 """
-import gc
 import os
 import re
 import inspect
@@ -9,8 +8,6 @@ import weakref
 import errno
 import six
 from functools import partial, wraps
-import sys
-import time
 
 from scrapy.utils.decorators import deprecated
 
@@ -358,13 +355,3 @@ def global_object_name(obj):
     'scrapy.http.request.Request'
     """
     return "%s.%s" % (obj.__module__, obj.__name__)
-
-
-if hasattr(sys, "pypy_version_info"):
-    def garbage_collect():
-        # Collecting weakreferences can take two collections on PyPy.
-        gc.collect()
-        gc.collect()
-else:
-    def garbage_collect():
-        gc.collect()


### PR DESCRIPTION
from the issue https://github.com/scrapy/scrapy/issues/482.
We can see if we download a file with filespipeline, the whole file is stored into the memory.
If the file is a giant file or an extremely giant file,(over 1G or more), the crawling thread will be crashed.
We can use this POC to prove it.
[POC.zip](https://github.com/scrapy/scrapy/files/1289514/POC.zip)

This has been asigned CVE-2017-14158.
but in this new testcase using GiantFilesPipeline in the commit,we can download it correctly.

[testdownload.zip](https://github.com/scrapy/scrapy/files/1289512/testdownload.zip)

