### PR TITLE
Fix SIGINT handling when using inspect_response

### DIFF
--- a/scrapy/shell.py
+++ b/scrapy/shell.py
@@ -164,7 +164,11 @@ class Shell(object):
 
 def inspect_response(response, spider):
     """Open a shell to inspect the given response"""
+    # Shell.start removes the SIGINT handler, so save it and re-add it after
+    # the shell has closed
+    sigint_handler = signal.getsignal(signal.SIGINT)
     Shell(spider.crawler).start(response=response, spider=spider)
+    signal.signal(signal.SIGINT, sigint_handler)
 
 
 def _request_deferred(request):


### PR DESCRIPTION
Currently, after calling `scrapy.shell.inspect_response` and then closing the opened shell, SIGINT (Ctrl-C) no longer works to terminate the spider.  This is because `Shell.start`, called in `inspect_response`, removes the signal handler.  To fix this, save the SIGINT handler before calling `Shell.start` in `inspect_response` and add it again after the shell has closed.

It doesn't appear that there are any tests for `inspect_response`, so I haven't added any tests for this fix.