### PR TITLE
[MRG+2] Fixes #685 FilesPipeline support for Google Cloud Storage.

### DIFF
--- a/docs/topics/media-pipeline.rst
+++ b/docs/topics/media-pipeline.rst
@@ -15,7 +15,8 @@ typically you'll either use the Files Pipeline or the Images Pipeline.
 Both pipelines implement these features:
 
 * Avoid re-downloading media that was downloaded recently
-* Specifying where to store the media (filesystem directory, Amazon S3 bucket)
+* Specifying where to store the media (filesystem directory, Amazon S3 bucket,
+  Google Cloud Storage bucket)
 
 The Images Pipeline has a few extra functions for processing images:
 
@@ -116,10 +117,11 @@ For the Images Pipeline, set the :setting:`IMAGES_STORE` setting::
 Supported Storage
 =================
 
-File system is currently the only officially supported storage, but there is
-also support for storing files in `Amazon S3`_.
+File system is currently the only officially supported storage, but there are
+also support for storing files in `Amazon S3`_ and `Google Cloud Storage`_.
 
 .. _Amazon S3: https://aws.amazon.com/s3/
+.. _Google Cloud Storage: https://cloud.google.com/storage/
 
 File system storage
 -------------------
@@ -170,6 +172,25 @@ policy::
 For more information, see `canned ACLs`_ in the Amazon S3 Developer Guide.
 
 .. _canned ACLs: http://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#canned-acl
+
+Google Cloud Storage
+---------------------
+
+.. setting:: GCS_PROJECT_ID
+
+:setting:`FILES_STORE` and :setting:`IMAGES_STORE` can represent a Google Cloud Storage
+bucket. Scrapy will automatically upload the files to the bucket. (requires `google-cloud-storage`_ )
+
+.. _google-cloud-storage: https://cloud.google.com/storage/docs/reference/libraries#client-libraries-install-python
+
+For example, these are valid :setting:`IMAGES_STORE` and :setting:`GCS_PROJECT_ID` settings::
+
+    IMAGES_STORE = 'gs://bucket/images/'
+    GCS_PROJECT_ID = 'project_id'
+
+For information about authentication, see this `documentation`_.
+
+.. _documentation: https://cloud.google.com/docs/authentication/production
 
 Usage example
 =============

--- a/scrapy/pipelines/files.py
+++ b/scrapy/pipelines/files.py
@@ -218,6 +218,12 @@ class GCSFilesStore(object):
 
         return threads.deferToThread(self.bucket.get_blob, path).addCallback(_onsuccess)
 
+    def _get_content_type(self, headers):
+        if headers and 'Content-Type' in headers:
+            return headers['Content-Type']
+        else:
+            return 'application/octet-stream'
+
     def persist_file(self, path, buf, info, meta=None, headers=None):
         blob = self.bucket.blob(self.prefix + path)
         blob.cache_control = self.CACHE_CONTROL
@@ -225,7 +231,7 @@ class GCSFilesStore(object):
         return threads.deferToThread(
             blob.upload_from_string,
             data=buf.getvalue(),
-            content_type='application/octet-stream'
+            content_type=self._get_content_type(headers)
         )
 
 

--- a/scrapy/pipelines/images.py
+++ b/scrapy/pipelines/images.py
@@ -91,6 +91,9 @@ class ImagesPipeline(FilesPipeline):
         s3store.AWS_SECRET_ACCESS_KEY = settings['AWS_SECRET_ACCESS_KEY']
         s3store.POLICY = settings['IMAGES_STORE_S3_ACL']
 
+        gcs_store = cls.STORE_SCHEMES['gs']
+        gcs_store.GCS_PROJECT_ID = settings['GCS_PROJECT_ID']
+
         store_uri = settings['IMAGES_STORE']
         return cls(store_uri, settings=settings)
 

--- a/scrapy/utils/test.py
+++ b/scrapy/utils/test.py
@@ -20,6 +20,12 @@ def assert_aws_environ():
     if 'AWS_ACCESS_KEY_ID' not in os.environ:
         raise SkipTest("AWS keys not found")
 
+
+def assert_gcs_environ():
+    if 'GCS_PROJECT_ID' not in os.environ:
+        raise SkipTest("GCS_PROJECT_ID not found")
+
+
 def skip_if_no_boto():
     try:
         is_botocore()
@@ -44,6 +50,15 @@ def get_s3_content_and_delete(bucket, path, with_key=False):
         content = key.get_contents_as_string()
         bucket.delete_key(path)
     return (content, key) if with_key else content
+
+def get_gcs_content_and_delete(bucket, path):
+    from google.cloud import storage
+    client = storage.Client(project=os.environ.get('GCS_PROJECT_ID'))
+    bucket = client.get_bucket(bucket)
+    blob = bucket.get_blob(path)
+    content = blob.download_as_string()
+    bucket.delete_blob(path)
+    return content, blob
 
 def get_crawler(spidercls=None, settings_dict=None):
     """Return an unconfigured Crawler object. If settings_dict is given, it

--- a/tox.ini
+++ b/tox.ini
@@ -11,6 +11,7 @@ deps =
     -rrequirements.txt
     # Extras
     botocore
+    google-cloud-storage
     Pillow != 3.0.0
     leveldb
     -rtests/requirements.txt
@@ -18,6 +19,8 @@ passenv =
     S3_TEST_FILE_URI
     AWS_ACCESS_KEY_ID
     AWS_SECRET_ACCESS_KEY
+    GCS_TEST_FILE_URI
+    GCS_PROJECT_ID
 commands =
     py.test --cov=scrapy --cov-report= {posargs:scrapy tests}
 


### PR DESCRIPTION
* Fixes #685
* [FilesPipeline](https://scrapy.readthedocs.io/en/stable/topics/media-pipeline.html#using-the-files-pipeline) support for Google Cloud Storage.
* This feature use two setting values.
  * FILES_STORE = 'gs://your_bucket/'
  * GCS_PROJECT_ID = 'your_project_id'
* Using [google-cloud-storage](https://cloud.google.com/storage/docs/reference/libraries) as optional dependency. For information about authenticating, see [this page](https://cloud.google.com/docs/authentication/production).
* Added some tests and passed. (the last line)

```bash
(venv) ~/github/scrapy/scrapy % GCS_PROJECT_ID="myproject" GCS_TEST_FILE_URI="gs://my-bucket/" tox -- tests/test_pipeline_files.py -v

...

tests/test_pipeline_files.py::FilesPipelineTestCase::test_file_expired <- .tox/py27/lib/python2.7/site-packages/twisted/internet/defer.py PASSED
tests/test_pipeline_files.py::FilesPipelineTestCase::test_file_not_expired <- .tox/py27/lib/python2.7/site-packages/twisted/internet/defer.py PASSED
tests/test_pipeline_files.py::FilesPipelineTestCase::test_file_path PASSED
tests/test_pipeline_files.py::FilesPipelineTestCase::test_fs_store PASSED
tests/test_pipeline_files.py::DeprecatedFilesPipelineTestCase::test_default_file_key_method PASSED
tests/test_pipeline_files.py::DeprecatedFilesPipelineTestCase::test_overridden_file_key_method PASSED
tests/test_pipeline_files.py::FilesPipelineTestCaseFields::test_item_fields_default PASSED
tests/test_pipeline_files.py::FilesPipelineTestCaseFields::test_item_fields_override_settings PASSED
tests/test_pipeline_files.py::FilesPipelineTestCaseCustomSettings::test_cls_attrs_with_DEFAULT_prefix PASSED
tests/test_pipeline_files.py::FilesPipelineTestCaseCustomSettings::test_custom_settings_and_class_attrs_for_subclasses PASSED
tests/test_pipeline_files.py::FilesPipelineTestCaseCustomSettings::test_custom_settings_for_subclasses PASSED
tests/test_pipeline_files.py::FilesPipelineTestCaseCustomSettings::test_different_settings_for_different_instances PASSED
tests/test_pipeline_files.py::FilesPipelineTestCaseCustomSettings::test_no_custom_settings_for_subclasses PASSED
tests/test_pipeline_files.py::FilesPipelineTestCaseCustomSettings::test_subclass_attributes_preserved_if_no_settings PASSED
tests/test_pipeline_files.py::FilesPipelineTestCaseCustomSettings::test_subclass_attrs_preserved_custom_settings PASSED
tests/test_pipeline_files.py::FilesPipelineTestCaseCustomSettings::test_user_defined_subclass_default_key_names PASSED
tests/test_pipeline_files.py::TestS3FilesStore::test_persist <- .tox/py27/lib/python2.7/site-packages/twisted/internet/defer.py SKIPPED
tests/test_pipeline_files.py::TestGCSFilesStore::test_persist <- .tox/py27/lib/python2.7/site-packages/twisted/internet/defer.py PASSED

========================================================================================== 17 passed, 1 skipped in 11.54 seconds ===========================================================================================
_________________________________________________________________________________________________________ summary __________________________________________________________________________________________________________
  py27: commands succeeded
  congratulations :)
```