### PR TITLE
[MRG+1] Add m4v extension to IGNORED_EXTENSIONS in LinkExtractor.

### DIFF
--- a/scrapy/linkextractors/__init__.py
+++ b/scrapy/linkextractors/__init__.py
@@ -28,7 +28,7 @@ IGNORED_EXTENSIONS = [
 
     # video
     '3gp', 'asf', 'asx', 'avi', 'mov', 'mp4', 'mpg', 'qt', 'rm', 'swf', 'wmv',
-    'm4a',
+    'm4a', 'm4v',
 
     # office suites
     'xls', 'xlsx', 'ppt', 'pptx', 'pps', 'doc', 'docx', 'odt', 'ods', 'odg',


### PR DESCRIPTION
Add m4v extension (video) to `IGNORED_EXTENSIONS` in LinkExtractor so it can be ignored by default in the same way other video formats are already ignored.

fix #2928 