### PR TITLE
[MRG+1] Changed unhelpful log message from core.downloader.handlers.http11

### DIFF
--- a/scrapy/core/downloader/handlers/http11.py
+++ b/scrapy/core/downloader/handlers/http11.py
@@ -412,9 +412,10 @@ class _ResponseReader(protocol.Protocol):
 
         if self._maxsize and self._bytes_received > self._maxsize:
             logger.error("Received (%(bytes)s) bytes larger than download "
-                         "max size (%(maxsize)s).",
+                         "max size (%(maxsize)s) in request %(request)s.",
                          {'bytes': self._bytes_received,
-                          'maxsize': self._maxsize})
+                          'maxsize': self._maxsize,
+                          'request': self._request})
             # Clear buffer earlier to avoid keeping data in memory for a long
             # time.
             self._bodybuf.truncate(0)

--- a/scrapy/core/downloader/handlers/http11.py
+++ b/scrapy/core/downloader/handlers/http11.py
@@ -344,8 +344,8 @@ class ScrapyAgent(object):
 
         if warnsize and expected_size > warnsize:
             logger.warning("Expected response size (%(size)s) larger than "
-                           "download warn size (%(warnsize)s).",
-                           {'size': expected_size, 'warnsize': warnsize})
+                           "download warn size (%(warnsize)s) in request (%(request)s).",
+                           {'size': expected_size, 'warnsize': warnsize, 'request': request})
 
         def _cancel(_):
             # Abort connection inmediately.
@@ -412,10 +412,9 @@ class _ResponseReader(protocol.Protocol):
 
         if self._maxsize and self._bytes_received > self._maxsize:
             logger.error("Received (%(bytes)s) bytes larger than download "
-                         "max size (%(maxsize)s) in request %(request)s.",
+                         "max size (%(maxsize)s).",
                          {'bytes': self._bytes_received,
-                          'maxsize': self._maxsize,
-                          'request': self._request})
+                          'maxsize': self._maxsize})
             # Clear buffer earlier to avoid keeping data in memory for a long
             # time.
             self._bodybuf.truncate(0)

--- a/scrapy/core/downloader/handlers/http11.py
+++ b/scrapy/core/downloader/handlers/http11.py
@@ -344,7 +344,7 @@ class ScrapyAgent(object):
 
         if warnsize and expected_size > warnsize:
             logger.warning("Expected response size (%(size)s) larger than "
-                           "download warn size (%(warnsize)s) in request (%(request)s).",
+                           "download warn size (%(warnsize)s) in request %(request)s.",
                            {'size': expected_size, 'warnsize': warnsize, 'request': request})
 
         def _cancel(_):


### PR DESCRIPTION
Changed the warning message to give information about the request generating it
as requested in: [#2927](https://github.com/scrapy/scrapy/issues/2927)

Tested with spider:
```
import scrapy


class QuotesSpider(scrapy.Spider):
    name = "test_spider"

    custom_settings = {
    	'DOWNLOAD_WARNSIZE': '123',
    }

    def start_requests(self):
        urls = [
            'http://example.com',
        ]
        for url in urls:
            yield scrapy.Request(url=url, callback=self.parse)

    def parse(self, response):
        page = response.url.split("/")[-2]
        filename = 'test_spider-%s.html' % page
        with open(filename, 'wb') as f:
            f.write(response.body)
        self.log('Saved file %s' % filename)
```

Which gives the requested warning message:
```
2017-10-05 15:41:01 [scrapy.core.downloader.handlers.http11] WARNING: Expected response size (606) larger than download warn size (123) in request <GET http://example.com>.
```
