### PR TITLE
[MRG+1] Scrapy Command: add --meta/-m to the "parse" command to pass additional meta data into the request

### DIFF
--- a/docs/topics/commands.rst
+++ b/docs/topics/commands.rst
@@ -430,7 +430,7 @@ Supported options:
 * ``--callback`` or ``-c``: spider method to use as callback for parsing the
   response
 
-* ``--meta`` or ``-m``: additional request meta that will be pass to the callback 
+* ``--meta`` or ``-m``: additional request meta that will be passed to the callback 
   request. This must be a valid json string. Example: --meta='{"foo" : "bar"}'
 
 * ``--pipelines``: process items through pipelines

--- a/docs/topics/commands.rst
+++ b/docs/topics/commands.rst
@@ -430,6 +430,9 @@ Supported options:
 * ``--callback`` or ``-c``: spider method to use as callback for parsing the
   response
 
+* ``--meta`` or ``-m``: additional request meta that will be pass to the callback 
+  request. This must be a valid json string. Example: --meta='{"foo" : "bar"}'
+
 * ``--pipelines``: process items through pipelines
 
 * ``--rules`` or ``-r``: use :class:`~scrapy.spiders.CrawlSpider`


### PR DESCRIPTION
This should fix [issue 2883](https://github.com/scrapy/scrapy/issues/2883) which I opened a couple of months ago. 

The gist of this commit is to allow the ability to pass extra meta data onto a request.

Example:


scrapy parse --callback=parse_category_page --meta='{"category" : "electronics", "sub-category" : "tablets"}' "https://some-ecommerce-website.com/electronics-38df9s9/tablets-3fsfs8"

```python

... some spider code

def parse_category_page(self, response):
    category = response.meta.get('category', None)
    sub_category = response.meta.get('sub-category', None)

    # Do some parsing here 
    yield {'product_name' : 'ipad' , 'category' : category, 'sub_category' : sub_category}

... more spider code

```

The idea is that as you start testing out your spider individual parsing methods, you want to inject custom values to test individual pages. 

I currently do a lot of scraping with ecommerce, food review sites, even job boards. I need to test randomly picked pages, and different categories. 

As everybody knows, hard coding values like [@Digenis](https://github.com/scrapy/scrapy/issues/1046#issuecomment-73870424) suggested is not the right way to do things. 

I also did a little bit of refactoring that might need some additional testing. @kmike do you know how I can build tests to test out the 2 new refactored methods that I created: `process_spider_arguments` and `process_request_meta` ?