### PR TITLE
Link "Debugging in Python" article to its new location

### DIFF
--- a/docs/topics/extensions.rst
+++ b/docs/topics/extensions.rst
@@ -280,7 +280,7 @@ An integer which specifies a number of items. If the spider scrapes more than
 that amount and those items are passed by the item pipeline, the
 spider will be closed with the reason ``closespider_itemcount``.
 Requests which  are currently in the downloader queue (up to
-:setting:`CONCURRENT_REQUESTS` requests) are still processed. 
+:setting:`CONCURRENT_REQUESTS` requests) are still processed.
 If zero (or non set), spiders won't be closed by number of passed items.
 
 .. setting:: CLOSESPIDER_PAGECOUNT
@@ -373,4 +373,4 @@ For more info see `Debugging in Python`.
 This extension only works on POSIX-compliant platforms (ie. not Windows).
 
 .. _Python debugger: https://docs.python.org/2/library/pdb.html
-.. _Debugging in Python: http://www.ferg.org/papers/debugging_in_python.html
+.. _Debugging in Python: https://pythonconquerstheuniverse.wordpress.com/2009/09/10/debugging-in-python/


### PR DESCRIPTION
Reference: https://web.archive.org/web/20170203104051/http://www.ferg.org/papers/debugging_in_python.html