### PR TITLE
utils.curl: add parse_curl_cmd func

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -3,4 +3,5 @@ usefixtures = chdir
 python_files=test_*.py __init__.py
 python_classes=
 addopts = --doctest-modules --assert=plain
+testpaths = scrapy tests
 twisted = 1

--- a/scrapy/utils/curl.py
+++ b/scrapy/utils/curl.py
@@ -1,0 +1,51 @@
+import argparse
+from shlex import split
+from six.moves.http_cookies import SimpleCookie
+from six import string_types
+
+
+class CurlParser(argparse.ArgumentParser):
+    def error(self, message):
+        raise ValueError(message)
+
+
+curl_parser = CurlParser()
+curl_parser.add_argument('url')
+curl_parser.add_argument('-H', '--header', dest='headers', action='append')
+curl_parser.add_argument('-X', '--request', dest='method', default='get')
+curl_parser.add_argument('-d', '--data', dest='data')
+curl_parser.add_argument('--compressed', action='store_true')
+# curl_parser.parse_args(split(curl_str)[1:])
+
+
+def parse_curl_cmd(curl_args):
+    if isinstance(curl_args, string_types):
+        curl_args = split(curl_args)
+    parsed_args, argv = curl_parser.parse_known_args(curl_args[1:])
+    if argv:
+        msg = 'Unrecognized arguments: %s'
+        raise ValueError(msg % (argv,))
+
+    result = {
+        'method': parsed_args.method.upper(),
+        'url': parsed_args.url,
+    }
+
+    headers = []
+    cookies = []
+    for h in parsed_args.headers or ():
+        name, val = h.split(':', 1)
+        name = name.strip().title()
+        val = val.strip()
+        if name == 'Cookie':
+            for name, morsel in SimpleCookie(val).iteritems():
+                cookies.append((name, morsel.value))
+        else:
+            headers.append((name, val))
+    if headers:
+        result['headers'] = headers
+    if cookies:
+        result['cookies'] = dict(cookies)
+    if parsed_args.data:
+        result['body'] = parsed_args.data
+    return result

--- a/scrapy/utils/curl.py
+++ b/scrapy/utils/curl.py
@@ -1,7 +1,7 @@
 import argparse
 from shlex import split
 from six.moves.http_cookies import SimpleCookie
-from six import string_types
+from six import string_types, iteritems
 
 
 class CurlParser(argparse.ArgumentParser):
@@ -38,7 +38,7 @@ def parse_curl_cmd(curl_args):
         name = name.strip().title()
         val = val.strip()
         if name == 'Cookie':
-            for name, morsel in SimpleCookie(val).iteritems():
+            for name, morsel in iteritems(SimpleCookie(val)):
                 cookies.append((name, morsel.value))
         else:
             headers.append((name, val))

--- a/tests/test_utils_curl.py
+++ b/tests/test_utils_curl.py
@@ -80,7 +80,8 @@ class ParseCurlCmdTest(unittest.TestCase):
 
     def test_too_few_arguments_error(self):
         self.assertRaisesRegexp(
-            ValueError, 'too few arguments',
+            ValueError,
+            'too few arguments|the following arguments are required:\s*url',
             lambda: parse_curl_cmd('foobarbaz'))
 
     def test_unknown_arg_error(self):

--- a/tests/test_utils_curl.py
+++ b/tests/test_utils_curl.py
@@ -1,0 +1,98 @@
+import unittest
+
+from scrapy.utils.curl import parse_curl_cmd
+from scrapy import Request
+
+
+class ParseCurlCmdTest(unittest.TestCase):
+    maxDiff = 5000
+
+    def test_basic(self):
+        curl_cmd = (
+            "curl 'http://httpbin.org/get'"
+            " -H 'Accept-Encoding: gzip, deflate'"
+            " -H 'Accept-Language: en-US,en;q=0.9,ru;q=0.8,es;q=0.7'"
+            " -H 'Upgrade-Insecure-Requests: 1'"
+            " -H 'User-Agent: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Ubuntu Chromium/62.0.3202.75 Chrome/62.0.3202.75 Safari/537.36' -H 'Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8'"
+            " -H 'Referer: http://httpbin.org/'"
+            " -H 'Cookie: _gauges_unique_year=1; _gauges_unique=1; _gauges_unique_month=1; _gauges_unique_hour=1; _gauges_unique_day=1'"
+            " -H 'Connection: keep-alive'"
+            " --compressed"
+        ).strip()
+
+        result = parse_curl_cmd(curl_cmd)
+        self.assertEqual(result, {
+            'method': 'GET',
+            'url': 'http://httpbin.org/get',
+            'headers': [
+                ('Accept-Encoding', 'gzip, deflate'),
+                ('Accept-Language', 'en-US,en;q=0.9,ru;q=0.8,es;q=0.7'),
+                ('Upgrade-Insecure-Requests', '1'),
+                ('User-Agent',
+                 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Ubuntu Chromium/62.0.3202.75 Chrome/62.0.3202.75 Safari/537.36'),
+                ('Accept',
+                 'text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8'),
+                ('Referer', 'http://httpbin.org/'),
+                ('Connection', 'keep-alive')
+            ],
+            'cookies': dict([
+                ('_gauges_unique_year', '1'),
+                ('_gauges_unique_hour', '1'),
+                ('_gauges_unique_day', '1'),
+                ('_gauges_unique', '1'),
+                ('_gauges_unique_month', '1')
+            ]),
+        })
+        Request(**result)
+
+    def test_post_data(self):
+        curl_cmd = """
+        curl 'http://httpbin.org/post' -H 'Cookie: _gauges_unique_year=1; _gauges_unique=1; _gauges_unique_month=1; _gauges_unique_hour=1; _gauges_unique_day=1' -H 'Origin: http://httpbin.org' -H 'Accept-Encoding: gzip, deflate' -H 'Accept-Language: en-US,en;q=0.9,ru;q=0.8,es;q=0.7' -H 'Upgrade-Insecure-Requests: 1' -H 'User-Agent: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Ubuntu Chromium/62.0.3202.75 Chrome/62.0.3202.75 Safari/537.36' -H 'Content-Type: application/x-www-form-urlencoded' -H 'Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8' -H 'Cache-Control: max-age=0' -H 'Referer: http://httpbin.org/forms/post' -H 'Connection: keep-alive' --data 'custname=John+Smith&custtel=500&custemail=jsmith%40example.org&size=small&topping=cheese&topping=onion&delivery=12%3A15&comments=' --compressed
+        """.strip()
+        result = parse_curl_cmd(curl_cmd)
+        self.assertEqual(result, {
+            'method': 'GET',
+            'url': 'http://httpbin.org/post',
+            'body': 'custname=John+Smith&custtel=500&custemail=jsmith%40example.org&size=small&topping=cheese&topping=onion&delivery=12%3A15&comments=',
+            'cookies': dict([
+                ('_gauges_unique_year', '1'),
+                ('_gauges_unique_hour', '1'),
+                ('_gauges_unique_day', '1'),
+                ('_gauges_unique', '1'),
+                ('_gauges_unique_month', '1')
+            ]),
+            'headers': [
+                ('Origin', 'http://httpbin.org'),
+                ('Accept-Encoding', 'gzip, deflate'),
+                ('Accept-Language', 'en-US,en;q=0.9,ru;q=0.8,es;q=0.7'),
+                ('Upgrade-Insecure-Requests', '1'),
+                ('User-Agent',
+                 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Ubuntu Chromium/62.0.3202.75 Chrome/62.0.3202.75 Safari/537.36'),
+                ('Content-Type', 'application/x-www-form-urlencoded'),
+                ('Accept',
+                 'text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8'),
+                ('Cache-Control', 'max-age=0'),
+                ('Referer', 'http://httpbin.org/forms/post'),
+                ('Connection', 'keep-alive')
+            ],
+        })
+        Request(**result)
+
+    def test_too_few_arguments_error(self):
+        self.assertRaisesRegexp(
+            ValueError, 'too few arguments',
+            lambda: parse_curl_cmd('foobarbaz'))
+
+    def test_unknown_arg_error(self):
+        self.assertRaisesRegexp(
+            ValueError, 'Unrecognized arguments:.*--bar.*--baz',
+            lambda: parse_curl_cmd('foo --bar --baz url'))
+
+    def test_list_args(self):
+        result = parse_curl_cmd(['curl', 'http://example.org'])
+        self.assertEqual(
+            result, {
+                'method': 'GET',
+                'url': 'http://example.org',
+            }
+        )


### PR DESCRIPTION
Given that the major browsers are able to export the requests in cURL format, it's logical that we have a utility in scrapy to make it a request.

This PR works towards adding a function that creates kwargs that could be passed to a `Request` constructor.