### PR TITLE
Allow passing Failure object to middlewares

### DIFF
--- a/docs/topics/downloader-middleware.rst
+++ b/docs/topics/downloader-middleware.rst
@@ -148,6 +148,11 @@ more of the following methods:
       :meth:`process_exception` methods of the middleware the same as returning a
       response would.
 
+      If the function is decorated by :func:`scrapy.middleware.use_failure`_
+      the `exception` parameter will be a Twisted `Failure`_ object instead of
+      an `Exception`_. This allow to retrieve the saved traceback of the
+      error.
+
       :param request: the request that generated the exception
       :type request: is a :class:`~scrapy.http.Request` object
 
@@ -982,3 +987,4 @@ The default encoding for proxy authentication on :class:`HttpProxyMiddleware`.
 
 .. _DBM: https://en.wikipedia.org/wiki/Dbm
 .. _anydbm: https://docs.python.org/2/library/anydbm.html
+.. _Failure: https://twistedmatrix.com/documents/current/api/twisted.python.failure.Failure.html

--- a/docs/topics/spider-middleware.rst
+++ b/docs/topics/spider-middleware.rst
@@ -127,6 +127,11 @@ following methods:
         If it returns an iterable the :meth:`process_spider_output` pipeline
         kicks in, and no other :meth:`process_spider_exception` will be called.
 
+        If the function is decorated by :func:`scrapy.middleware.use_failure`_
+        the `exception` parameter will be a Twisted `Failure`_ object instead of
+        an `Exception`_. This allow to retrieve the saved traceback of the
+        error.
+
         :param response: the response being processed when the exception was
           raised
         :type response: :class:`~scrapy.http.Response` object
@@ -431,3 +436,4 @@ UrlLengthMiddleware
 
       * :setting:`URLLENGTH_LIMIT` - The maximum URL length to allow for crawled URLs.
 
+.. _Failure: https://twistedmatrix.com/documents/current/api/twisted.python.failure.Failure.html

--- a/scrapy/core/downloader/middleware.py
+++ b/scrapy/core/downloader/middleware.py
@@ -60,8 +60,10 @@ class DownloaderMiddlewareManager(MiddlewareManager):
 
         @defer.inlineCallbacks
         def process_exception(_failure):
-            exception = _failure.value
             for method in self.methods['process_exception']:
+                exception = _failure
+                if not getattr(method, 'use_failure', False):
+                    exception = _failure.value
                 response = yield method(request=request, exception=exception,
                                         spider=spider)
                 assert response is None or isinstance(response, (Response, Request)), \

--- a/scrapy/core/spidermw.py
+++ b/scrapy/core/spidermw.py
@@ -49,8 +49,10 @@ class SpiderMiddlewareManager(MiddlewareManager):
             return scrape_func(response, request, spider)
 
         def process_spider_exception(_failure):
-            exception = _failure.value
             for method in self.methods['process_spider_exception']:
+                exception = _failure
+                if not getattr(method, 'use_failure', False):
+                    exception = _failure.value
                 result = method(response=response, exception=exception, spider=spider)
                 assert result is None or _isiterable(result), \
                     'Middleware %s must returns None, or an iterable object, got %s ' % \

--- a/scrapy/middleware.py
+++ b/scrapy/middleware.py
@@ -9,6 +9,13 @@ from scrapy.utils.defer import process_parallel, process_chain, process_chain_bo
 logger = logging.getLogger(__name__)
 
 
+def use_failure(func):
+    """Decorator settings the targetted function to receive an Twisted failure
+    object instead of an Exception."""
+    func.use_failure = True
+    return func
+
+
 class MiddlewareManager(object):
     """Base class for implementing middleware managers"""
 


### PR DESCRIPTION
Trying to handle errors coming from middleware, it happens that Twisted strip traceback from an exception returned from a completed deferred (Needed to avoid GC issues). This mean that trying to use `exception.__traceback__` always yield `None`.

This PR adds a decorator that can be used on middleware `process_exception` or `process_spider_exception` to get a Failure object instead of an Exception. The Failure object provides a `getTracebackObject` to get a `Traceback`-like object which come really handy when trying to pinpoint an issue.