### PR TITLE
Add signals to handle error from downloader or pipeline

### DIFF
--- a/docs/topics/signals.rst
+++ b/docs/topics/signals.rst
@@ -135,6 +135,29 @@ item_dropped
         to be dropped
     :type exception: :exc:`~scrapy.exceptions.DropItem` exception
 
+item_error
+----------
+
+.. signal:: item_error
+.. function:: item_error(item, response, failure, spider)
+
+    Sent after some stage of the :ref:`topics-item-pipeline` raised an
+    exception other than the :exc:`~scrapy.exceptions.DropItem` exception.
+
+    This signal supports returning deferreds from their handlers.
+
+    :param item: the item processed by the :ref:`topics-item-pipeline`
+    :type item: dict or :class:`~scrapy.item.Item` object
+
+    :param spider: the spider which scraped the item
+    :type spider: :class:`~scrapy.spiders.Spider` object
+
+    :param response: the response from where the item was scraped
+    :type response: :class:`~scrapy.http.Response` object
+
+    :param failure: the exception raised as a Twisted `Failure`_ object
+    :type failure: `Failure`_ object
+
 spider_closed
 -------------
 
@@ -293,6 +316,28 @@ response_downloaded
     :type request: :class:`~scrapy.http.Request` object
 
     :param spider: the spider for which the response is intended
+    :type spider: :class:`~scrapy.spiders.Spider` object
+
+download_error
+--------------
+
+.. signal:: download_error
+.. function:: download_error(failure, request, spider)
+
+    Sent by the downloader when an error was raised in one of the downloader
+    middleware or the download engine. Unlike the download middleware
+    `process_exception` method, this signal also handles exception from
+    the `process_response` method.
+
+    This signal supports returning deferreds from their handlers.
+
+    :param failure: the exception raised as a Twisted `Failure`_ object
+    :type failure: `Failure`_ object
+
+    :param request: the request that generated the error
+    :type request: :class:`~scrapy.http.Request` object
+
+    :param spider: the spider that yielded the request
     :type spider: :class:`~scrapy.spiders.Spider` object
 
 .. _Failure: https://twistedmatrix.com/documents/current/api/twisted.python.failure.Failure.html

--- a/scrapy/core/scraper.py
+++ b/scrapy/core/scraper.py
@@ -212,6 +212,9 @@ class Scraper(object):
                     logger.error('Error downloading %(request)s: %(errmsg)s',
                                  {'request': request, 'errmsg': errmsg},
                                  extra={'spider': spider})
+            return self.signals.send_catch_log_deferred(
+                signal=signals.download_error, request=request,
+                spider=spider, failure=download_failure)
 
         if spider_failure is not download_failure:
             return spider_failure
@@ -232,6 +235,9 @@ class Scraper(object):
                 logger.error('Error processing %(item)s', {'item': item},
                              exc_info=failure_to_exc_info(output),
                              extra={'spider': spider})
+                return self.signals.send_catch_log_deferred(
+                    signal=signals.item_error, item=item, response=response,
+                    spider=spider, failure=output)
         else:
             logkws = self.logformatter.scraped(output, response, spider)
             logger.log(*logformatter_adapter(logkws), extra={'spider': spider})

--- a/scrapy/signals.py
+++ b/scrapy/signals.py
@@ -15,8 +15,10 @@ request_scheduled = object()
 request_dropped = object()
 response_received = object()
 response_downloaded = object()
+download_error = object()
 item_scraped = object()
 item_dropped = object()
+item_error = object()
 
 # for backwards compatibility
 stats_spider_opened = spider_opened


### PR DESCRIPTION
As of right now, there's is no simple way to handle exception coming from items pipeline or a the `process_response` of a downloader middleware.

This PR adds two signals for those use case. Note that the downloader signals also catch any exception from the downloader engine, including `process_request` and `process_exception`.