### PR TITLE
Fix Deprecated SafeConfigParser -> ConfigParser

### DIFF
--- a/scrapy/utils/conf.py
+++ b/scrapy/utils/conf.py
@@ -4,7 +4,7 @@ import numbers
 from operator import itemgetter
 
 import six
-from six.moves.configparser import SafeConfigParser
+from six.moves.configparser import ConfigParser
 
 from scrapy.settings import BaseSettings
 from scrapy.utils.deprecate import update_classpath
@@ -92,9 +92,9 @@ def init_env(project='default', set_syspath=True):
 
 
 def get_config(use_closest=True):
-    """Get Scrapy config file as a SafeConfigParser"""
+    """Get Scrapy config file as a ConfigParser"""
     sources = get_sources(use_closest)
-    cfg = SafeConfigParser()
+    cfg = ConfigParser()
     cfg.read(sources)
     return cfg
 


### PR DESCRIPTION
When running with a low Log Level on python >= 3.2, you get a DeprecationWarning, saying SafeConfigParser was renamed to ConfigParser in python 3.2. Since Scrapy only supports python 2.7 and python 3.3 and above, this is a simple fix preventing an annoying warning.