### PR TITLE
fix Spider.log to record right caller information

### DIFF
--- a/scrapy/spiders/__init__.py
+++ b/scrapy/spiders/__init__.py
@@ -44,7 +44,8 @@ class Spider(object_ref):
         can use it directly (e.g. Spider.logger.info('msg')) or use any other
         Python logger too.
         """
-        self.logger.log(level, message, **kw)
+        kw.setdefault('args', ())
+        self.logger._log(level, message, **kw)
 
     @classmethod
     def from_crawler(cls, crawler, *args, **kwargs):


### PR DESCRIPTION
Spider.log always log itself in `pathname), funcName, lineno, etc.` format. Because `currentframe = lambda: sys._getframe(3)` and `f = f.f_back` in ``logging.Logger.findCaller`.