### PR TITLE
Add mention to dont_merge_cookies in CookiesMiddlewares docs (#2999)

### DIFF
--- a/docs/topics/downloader-middleware.rst
+++ b/docs/topics/downloader-middleware.rst
@@ -190,6 +190,12 @@ The following settings can be used to configure the cookie middleware:
 * :setting:`COOKIES_ENABLED`
 * :setting:`COOKIES_DEBUG`
 
+Notice that if the :class:`~scrapy.http.Request` 
+has ``meta['dont_merge_cookies']`` present then 
+despite the value of :setting:`COOKIES_ENABLED` the cookies received in the
+:class:`~scrapy.http.Response` will **not** be merged with the existing 
+cookies.
+
 .. reqmeta:: cookiejar
 
 Multiple cookie sessions per spider

--- a/docs/topics/downloader-middleware.rst
+++ b/docs/topics/downloader-middleware.rst
@@ -190,12 +190,6 @@ The following settings can be used to configure the cookie middleware:
 * :setting:`COOKIES_ENABLED`
 * :setting:`COOKIES_DEBUG`
 
-Notice that if the :class:`~scrapy.http.Request` 
-has ``meta['dont_merge_cookies']`` present then 
-despite the value of :setting:`COOKIES_ENABLED` the cookies received in the
-:class:`~scrapy.http.Response` will **not** be merged with the existing 
-cookies.
-
 .. reqmeta:: cookiejar
 
 Multiple cookie sessions per spider
@@ -231,6 +225,17 @@ Default: ``True``
 
 Whether to enable the cookies middleware. If disabled, no cookies will be sent
 to web servers.
+
+Notice that if the :class:`~scrapy.http.Request` 
+has ``meta['dont_merge_cookies']`` evaluates to ``True``. 
+despite the value of :setting:`COOKIES_ENABLED` the cookies will **not** be 
+sent to web servers and received cookies in 
+:class:`~scrapy.http.Response` will **not** be merged with the existing 
+cookies.
+
+For more detailed information see the ``cookies`` parameter in 
+:class:`~scrapy.http.Request`
+
 
 .. setting:: COOKIES_DEBUG
 

--- a/docs/topics/downloader-middleware.rst
+++ b/docs/topics/downloader-middleware.rst
@@ -227,7 +227,7 @@ Whether to enable the cookies middleware. If disabled, no cookies will be sent
 to web servers.
 
 Notice that if the :class:`~scrapy.http.Request` 
-has ``meta['dont_merge_cookies']`` evaluates to ``True``. 
+has ``meta['dont_merge_cookies']`` evaluated to ``True``. 
 despite the value of :setting:`COOKIES_ENABLED` the cookies will **not** be 
 sent to web servers and received cookies in 
 :class:`~scrapy.http.Response` will **not** be merged with the existing 


### PR DESCRIPTION
Add mention to dont_merge_cookies in the Documentation of CookiesMIddlewares issue: #2999 