### PR TITLE
[MRG+1] Fix for #3034, CSV export unnecessary blank lines problem on Windows

### DIFF
--- a/scrapy/exporters.py
+++ b/scrapy/exporters.py
@@ -214,7 +214,8 @@ class CsvItemExporter(BaseItemExporter):
             file,
             line_buffering=False,
             write_through=True,
-            encoding=self.encoding
+            encoding=self.encoding,
+            newline='' # Windows needs this https://github.com/scrapy/scrapy/issues/3034
         ) if six.PY3 else file
         self.csv_writer = csv.writer(self.stream, **kwargs)
         self._headers_not_written = True


### PR DESCRIPTION
Fixed the issue I've mentioned there, this is the pull request to merge, (added one line), hope all is fine. 
https://github.com/scrapy/scrapy/issues/3034

Closes #3034 