### PR TITLE
Add Test Reporting to Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ branches:
     - master
     - /^\d\.\d+$/
     - /^\d\.\d+\.\d+(rc\d+|\.dev\d+)?$/
+    - add-test-reporting
 matrix:
   include:
     - python: 2.7
@@ -23,6 +24,12 @@ matrix:
       env: TOXENV=py36
     - python: 3.6
       env: TOXENV=docs
+
+before_install:
+   - mkdir -p $HOME/bin
+   - curl -fsSL https://testspace-client.s3.amazonaws.com/testspace-linux.tgz | tar -zxvf- -C $HOME/bin
+   - testspace config url $TS_ORG.testspace.com
+ 
 install:
   - |
       if [ "$TOXENV" = "pypy" ]; then
@@ -41,9 +48,16 @@ install:
       fi
   - pip install -U tox twine wheel codecov
 
-script: tox
+script: tox -- --junit-xml=testresults.xml scrapy tests
+
 after_success:
   - codecov
+
+after_script:
+  - if [ "${TOXENV}" != "docs" ]; then
+      testspace [${TOXENV}/tests]testresults.xml{tests};
+    fi
+
 notifications:
   irc:
     use_notice: true


### PR DESCRIPTION
**Test Reporting for Travis using [Testspace.com](https://testspace.com)**

Hi `scrapy` team. We added test reporting to your repo. We have a blog article on [why we are staging repos](https://blog.testspace.com/testspace-and-open-source).

Note that we contacted you in the past via an email. We thought it would be easier for you (if interested) by using a Pull Request.   

Few of the benefits using Testspace:
- view all your test results from a single dashboard
- triage and manage your test failures faster
- add more metrics
- leverage built-in analytics 
- get a [test badge](https://help.testspace.com/how-to:get-badge) 
[![Space Health](https://open.testspace.com/spaces/74470/badge?token=2f48b759d52023674602ea42e90a5508cad6c953)](https://open.testspace.com/spaces/74470?utm_campaign=badge&utm_medium=referral&utm_source=test "Test Cases")

Checkout **your** test results: https://open.testspace.com/projects/TryTestspace:scrapy from our fork.

**Why** we are doing this: https://blog.testspace.com/testspace-and-open-source 

----

**Give Testspace a try?**

1. Create **Open** (free) account: https://testspace.com/pricing
2. Add a **New Project** from the list of Github repo's
3. Add a Travis **Environment Variable**: Name: `TS_ORG`  Value: `organization name` - based on subdomain selected in step 1
4. Invite others: https://help.testspace.com/how-to:invite-other-users

