### PR TITLE
Avoid missing base item fields in item loaders

### DIFF
--- a/scrapy/loader/__init__.py
+++ b/scrapy/loader/__init__.py
@@ -113,7 +113,7 @@ class ItemLoader(object):
         item = self.item
         for field_name in tuple(self._values):
             value = self.get_output_value(field_name)
-            if value is not None:
+            if value is not None and value != []:
                 item[field_name] = value
 
         return item

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -99,6 +99,15 @@ class BasicItemLoaderTest(unittest.TestCase):
         il.replace_value('sku', [valid_fragment], re=sku_re)
         self.assertEqual(il.load_item()['sku'], u'1234')
 
+    def test_get_output_value_before_load_item(self):
+        item = TestItem(url='http://example.com', summary='foo bar')
+        il = ItemLoader(item)
+        il.get_output_value('url')
+        self.assertEqual(il.load_item(), {
+            'url': 'http://example.com',
+            'summary': 'foo bar',
+        })
+
     def test_self_referencing_loader(self):
         class MyLoader(ItemLoader):
             url_out = TakeFirst()


### PR DESCRIPTION
This is an attempt to fix the behavior described in #3046.

Instead of just checking if the value inside the loader is not None in order to decide if a field from the initial item should be overwritten or not, `load_item()` should also make sure that the value returned by `get_output_value()` is not an empty list.

That is because `self._local_values` , which stores the new values included via `add_*` or `replace_*` methods, is a[`defaultdict(list)`](https://github.com/scrapy/scrapy/blob/master/scrapy/loader/__init__.py#L37). Then, when we call `get_output_value()` for a field only available in the initial item, an empty list will be set for that field in `self._local_values` (because of [this](https://github.com/scrapy/scrapy/blob/master/scrapy/loader/__init__.py#L125)).


This way, we make sure we don't miss fields from the initial item, in case `get_output_value()` gets called for one of the pre-populated fields before `load_item()`, as described on #3046.