### PR TITLE
Add PyPy3 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,8 @@ matrix:
       env: TOXENV=jessie
     - python: 2.7
       env: TOXENV=pypy
+    - python: 2.7
+      env: TOXENV=pypy3
     - python: 3.4
       env: TOXENV=py34
     - python: 3.5
@@ -28,6 +30,13 @@ install:
         wget "https://bitbucket.org/squeaky/portable-pypy/downloads/${PYPY_VERSION}.tar.bz2"
         tar -jxf ${PYPY_VERSION}.tar.bz2
         virtualenv --python="$PYPY_VERSION/bin/pypy" "$HOME/virtualenvs/$PYPY_VERSION"
+        source "$HOME/virtualenvs/$PYPY_VERSION/bin/activate"
+      fi
+      if [ "$TOXENV" = "pypy3" ]; then
+        export PYPY_VERSION="pypy3.5-5.9-beta-linux_x86_64-portable"
+        wget "https://bitbucket.org/squeaky/portable-pypy/downloads/${PYPY_VERSION}.tar.bz2"
+        tar -jxf ${PYPY_VERSION}.tar.bz2
+        virtualenv --python="$PYPY_VERSION/bin/pypy3" "$HOME/virtualenvs/$PYPY_VERSION"
         source "$HOME/virtualenvs/$PYPY_VERSION/bin/activate"
       fi
   - pip install -U tox twine wheel codecov

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -70,10 +70,10 @@ What Python versions does Scrapy support?
 -----------------------------------------
 
 Scrapy is supported under Python 2.7 and Python 3.4+
-under CPython (default Python implementation) and PyPy (only for Python 2.7).
+under CPython (default Python implementation) and PyPy (starting with PyPy 5.9).
 Python 2.6 support was dropped starting at Scrapy 0.20.
 Python 3 support was added in Scrapy 1.1.
-PyPy support was added in Scrapy 1.4, PyPy version tested is PyPy2-v5.9.0.
+PyPy support was added in Scrapy 1.4, PyPy3 support was added in Scrapy 1.5.
 
 .. note::
     For Python 3 support on Windows, it is recommended to use

--- a/docs/intro/install.rst
+++ b/docs/intro/install.rst
@@ -8,7 +8,7 @@ Installing Scrapy
 =================
 
 Scrapy runs on Python 2.7 and Python 3.4 or above
-under CPython (default Python implementation) and PyPy (only for Python 2.7).
+under CPython (default Python implementation) and PyPy (starting with PyPy 5.9).
 
 If you're using `Anaconda`_ or `Miniconda`_, you can install the package from
 the `conda-forge`_ channel, which has up-to-date packages for Linux, Windows
@@ -227,7 +227,8 @@ After any of these workarounds you should be able to install Scrapy::
 PyPy
 ----
 
-We recommend using the latest PyPy version. The version tested is PyPy2-v5.9.0.
+We recommend using the latest PyPy version. The version tested is 5.9.0.
+For PyPy3, only Linux installation was tested.
 
 Most scrapy dependencides now have binary wheels for CPython, but not for PyPy.
 This means that these dependecies will be built during installation.

--- a/tests/test_utils_python.py
+++ b/tests/test_utils_python.py
@@ -219,9 +219,12 @@ class UtilsPythonTestCase(unittest.TestCase):
             self.assertEqual(get_func_args(" ".join), [])
             self.assertEqual(get_func_args(operator.itemgetter(2)), [])
         else:
-            self.assertEqual(get_func_args(six.text_type.split), ['sep', 'maxsplit'])
-            self.assertEqual(get_func_args(" ".join), ['list'])
-            self.assertEqual(get_func_args(operator.itemgetter(2)), ['obj'])
+            stripself = not six.PY2  # PyPy3 exposes them as methods
+            self.assertEqual(
+                get_func_args(six.text_type.split, stripself), ['sep', 'maxsplit'])
+            self.assertEqual(get_func_args(" ".join, stripself), ['list'])
+            self.assertEqual(
+                get_func_args(operator.itemgetter(2), stripself), ['obj'])
 
 
     def test_without_none_values(self):

--- a/tox.ini
+++ b/tox.ini
@@ -79,6 +79,12 @@ deps = {[testenv:py34]deps}
 basepython = python3.6
 deps = {[testenv:py34]deps}
 
+[testenv:pypy3]
+basepython = pypy3
+deps = {[testenv:py34]deps}
+commands =
+    py.test {posargs:scrapy tests}
+
 [docs]
 changedir = docs
 deps =


### PR DESCRIPTION
Just checking how they run on Travis. Turns out that lxml on PyPy3 is no longer a problem (``PyPy 5.9.0``, ``Cython==0.27.3`` and ``lxml==4.1.1``).

Related to #2213