### PR TITLE
Make autothrottle slow down on HTTP 429 response

### DIFF
--- a/docs/topics/autothrottle.rst
+++ b/docs/topics/autothrottle.rst
@@ -59,8 +59,10 @@ AutoThrottle algorithm adjusts download delays based on the following rules:
    and ``N`` is :setting:`AUTOTHROTTLE_TARGET_CONCURRENCY`.
 3. download delay for next requests is set to the average of previous
    download delay and the target download delay;
-4. latencies of non-200 responses are not allowed to decrease the delay;
-5. download delay can't become less than :setting:`DOWNLOAD_DELAY` or greater
+4. When the ::setting::`AUTOTHROTTLE_429_DELAY` is set and a 429 is received
+   it will increase the delay with this value
+5. latencies of non-200 responses are not allowed to decrease the delay;
+6. download delay can't become less than :setting:`DOWNLOAD_DELAY` or greater
    than :setting:`AUTOTHROTTLE_MAX_DELAY`
 
 .. note:: The AutoThrottle extension honours the standard Scrapy settings for
@@ -89,6 +91,7 @@ The settings used to control the AutoThrottle extension are:
 * :setting:`AUTOTHROTTLE_START_DELAY`
 * :setting:`AUTOTHROTTLE_MAX_DELAY`
 * :setting:`AUTOTHROTTLE_TARGET_CONCURRENCY`
+* :setting:`AUTOTHROTTLE_429_DELAY`
 * :setting:`AUTOTHROTTLE_DEBUG`
 * :setting:`CONCURRENT_REQUESTS_PER_DOMAIN`
 * :setting:`CONCURRENT_REQUESTS_PER_IP`
@@ -152,6 +155,19 @@ of concurrent requests.
 At every given time point Scrapy can be sending more or less concurrent
 requests than ``AUTOTHROTTLE_TARGET_CONCURRENCY``; it is a suggested
 value the crawler tries to approach, not a hard limit.
+
+.. setting:: AUTOTHROTTLE_429_DELAY
+
+AUTOTHROTTLE_429_DELAY
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Default: `None`
+
+Delay to add when the HTTP 429 (Too Many Requests) status is received.
+
+By default the AutoThrottle will ignore the 429 requests because the latency is low.
+Sometimes it is wanted to decrease the scraping speed when a 429 is received.
+Set this value to a value to delay the spider with this value each time a 429 is received.
 
 .. setting:: AUTOTHROTTLE_DEBUG
 

--- a/scrapy/extensions/throttle.py
+++ b/scrapy/extensions/throttle.py
@@ -83,13 +83,14 @@ class AutoThrottle(object):
         # It works better with problematic sites.
         new_delay = max(target_delay, new_delay)
 
-        # Make sure self.mindelay <= new_delay <= self.max_delay
-        new_delay = min(max(self.mindelay, new_delay), self.maxdelay)
-
         # When the status is 429 (too many request) the delay should always go up
-        # so the new_delay is set to the current delay added by a configurable value
+        # But the latency of a 429 is very small because it has no content
+        # so the new_delay is set to the current delay added by the too_many_request_delay
         if response.status == 429 and self.too_many_request_delay:
             new_delay = slot.delay + self.too_many_request_delay
+
+        # Make sure self.mindelay <= new_delay <= self.max_delay
+        new_delay = min(max(self.mindelay, new_delay), self.maxdelay)
 
         # Dont adjust delay if response status != 200 and new delay is smaller
         # than old one, as error pages (and redirections) are usually small and

--- a/scrapy/extensions/throttle.py
+++ b/scrapy/extensions/throttle.py
@@ -24,7 +24,7 @@ class AutoThrottle(object):
     def _spider_opened(self, spider):
         self.mindelay = self._min_delay(spider)
         self.maxdelay = self._max_delay(spider)
-        self.too_many_request_delay = self._too_many_requests_delay(spider)
+        self.too_many_request_delay = self._too_many_requests_delay
         spider.download_delay = self._start_delay(spider)
 
     def _min_delay(self, spider):
@@ -37,7 +37,7 @@ class AutoThrottle(object):
     def _start_delay(self, spider):
         return max(self.mindelay, self.crawler.settings.getfloat('AUTOTHROTTLE_START_DELAY'))
 
-    def _too_many_requests_delay(self, spider):
+    def _too_many_requests_delay(self):
         return self.crawler.settings.getfloat('AUTOTHROTTLE_429_DELAY')
 
     def _response_downloaded(self, response, request, spider):


### PR DESCRIPTION
When a response has status 429 (Too Many Requests) it is ignored by the AutoThrottle (because the latency is low, so otherwise the spider will speed up). I think that the wanted behaviour is that the spider will slow down when a 429 is received, but currently the spider will stay at a constant scraping speed. 

This PR adds a new setting `AUTOTHROTTLE_429_DELAY` when it is set the download delay will be increased with this value every time a 429 is received. It still respects the 'MAX_DOWNLOAD_DELAY` value.  