### PR TITLE
Handle Webp Image transparency

### DIFF
--- a/scrapy/pipelines/images.py
+++ b/scrapy/pipelines/images.py
@@ -131,7 +131,7 @@ class ImagesPipeline(FilesPipeline):
             yield thumb_path, thumb_image, thumb_buf
 
     def convert_image(self, image, size=None):
-        if image.format == 'PNG' and image.mode == 'RGBA':
+        if (image.format == 'PNG' or image.format == 'WEBP') and image.mode == 'RGBA':
             background = Image.new('RGBA', image.size, (255, 255, 255))
             background.paste(image, image)
             image = background.convert('RGB')


### PR DESCRIPTION
Webp transparent image have a dark background : 

reference image : https://www.lavera.de/typo3temp/fl_realurl_image/105115-4021457609482-glossylips-deliciouspeach09-1294b-43402bf213-6cf9c.png