### PR TITLE
[MRG+1] Do not serialize unpickable objects (py3)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,4 @@ queuelib
 six>=1.5.2
 PyDispatcher>=2.0.5
 service_identity
-parsel>=1.1
+parsel>=1.4

--- a/scrapy/squeues.py
+++ b/scrapy/squeues.py
@@ -25,9 +25,9 @@ def _serializable_queue(queue_class, serialize, deserialize):
 def _pickle_serialize(obj):
     try:
         return pickle.dumps(obj, protocol=2)
-    # Python<=3.4 raises pickle.PicklingError here while
-    # Python>=3.5 raises AttributeError and
-    # Python>=3.6 raises TypeError
+    # Python <= 3.4 raises pickle.PicklingError here while
+    # 3.5 <= Python < 3.6 raises AttributeError and
+    # Python >= 3.6 raises TypeError
     except (pickle.PicklingError, AttributeError, TypeError) as e:
         raise ValueError(str(e))
 

--- a/scrapy/squeues.py
+++ b/scrapy/squeues.py
@@ -25,9 +25,10 @@ def _serializable_queue(queue_class, serialize, deserialize):
 def _pickle_serialize(obj):
     try:
         return pickle.dumps(obj, protocol=2)
-    # Python>=3.5 raises AttributeError here while
-    # Python<=3.4 raises pickle.PicklingError
-    except (pickle.PicklingError, AttributeError) as e:
+    # Python<=3.4 raises pickle.PicklingError here while
+    # Python>=3.5 raises AttributeError and
+    # Python>=3.6 raises TypeError
+    except (pickle.PicklingError, AttributeError, TypeError) as e:
         raise ValueError(str(e))
 
 PickleFifoDiskQueue = _serializable_queue(queue.FifoDiskQueue, \

--- a/setup.py
+++ b/setup.py
@@ -71,7 +71,7 @@ setup(
         'pyOpenSSL',
         'cssselect>=0.9',
         'six>=1.5.2',
-        'parsel>=1.1',
+        'parsel>=1.4',
         'PyDispatcher>=2.0.5',
         'service_identity',
     ],

--- a/tests/test_squeues.py
+++ b/tests/test_squeues.py
@@ -1,4 +1,3 @@
-from sys import version_info
 import pickle
 
 from queuelib.tests import test_queue as t
@@ -32,10 +31,9 @@ def nonserializable_object_test(self):
         a = A()
         a.__reduce__ = a.__reduce_ex__ = None
         self.assertRaises(ValueError, q.push, a)
-    if version_info.major == 3 and version_info.minor >= 6:
-        # Selectors should fail (lxml.html.HtmlElement objects can't be pickled)
-        sel = Selector(text='<html><body><p>some text</p></body></html>')
-        self.assertRaises(ValueError, q.push, sel)
+    # Selectors should fail (lxml.html.HtmlElement objects can't be pickled)
+    sel = Selector(text='<html><body><p>some text</p></body></html>')
+    self.assertRaises(ValueError, q.push, sel)
 
 class MarshalFifoDiskQueueTest(t.FifoDiskQueueTest):
 

--- a/tests/test_squeues.py
+++ b/tests/test_squeues.py
@@ -1,3 +1,4 @@
+from sys import version_info
 import pickle
 
 from queuelib.tests import test_queue as t
@@ -5,6 +6,7 @@ from scrapy.squeues import MarshalFifoDiskQueue, MarshalLifoDiskQueue, PickleFif
 from scrapy.item import Item, Field
 from scrapy.http import Request
 from scrapy.loader import ItemLoader
+from scrapy.selector import Selector
 
 class TestItem(Item):
     name = Field()
@@ -17,20 +19,23 @@ class TestLoader(ItemLoader):
     name_out = staticmethod(_test_procesor)
 
 def nonserializable_object_test(self):
+    q = self.queue()
     try:
         pickle.dumps(lambda x: x)
     except Exception:
         # Trigger Twisted bug #7989
         import twisted.persisted.styles  # NOQA
-        q = self.queue()
         self.assertRaises(ValueError, q.push, lambda x: x)
     else:
         # Use a different unpickleable object
         class A(object): pass
         a = A()
         a.__reduce__ = a.__reduce_ex__ = None
-        q = self.queue()
         self.assertRaises(ValueError, q.push, a)
+    if version_info.major == 3 and version_info.minor >= 6:
+        # Selectors should fail (lxml.html.HtmlElement objects can't be pickled)
+        sel = Selector(text='<html><body><p>some text</p></body></html>')
+        self.assertRaises(ValueError, q.push, sel)
 
 class MarshalFifoDiskQueueTest(t.FifoDiskQueueTest):
 


### PR DESCRIPTION
~This addresses #3054 partially, as it catches the exception raised by `pickle`.
However, since this exception is only raised in python >= 3.6, for earlier versions it's still not able to realize it shouldn't serialize some requests.~

Fixes #3054.

~Added a monkey patch to prevent the pickling of `lxml.html.HtmlElement` objects.~

Updated: raise an exception when pickling Selector/SelectorList objects (https://github.com/scrapy/parsel/pull/108), catch it in the queue.