### PR TITLE
Fix tests to account for changes in w3lib 1.19

### DIFF
--- a/tests/test_http_response.py
+++ b/tests/test_http_response.py
@@ -272,7 +272,10 @@ class TextResponseTest(BaseResponseTest):
                                  headers={"Content-type": ["text/html; charset=utf-8"]},
                                  body=b"\xef\xbb\xbfWORD\xe3\xab")
         self.assertEqual(r6.encoding, 'utf-8')
-        self.assertEqual(r6.text, u'WORD\ufffd\ufffd')
+        self.assertIn(r6.text, {
+            u'WORD\ufffd\ufffd',  # w3lib < 1.19.0
+            u'WORD\ufffd',        # w3lib >= 1.19.0
+        })
 
     def test_bom_is_removed_from_body(self):
         # Inferring encoding from body also cache decoded body as sideeffect,


### PR DESCRIPTION
Currently tests are failing because of behavior change introduced in https://github.com/scrapy/w3lib/pull/101.