### PR TITLE
[MRG+1] Fix OS signal names

### DIFF
--- a/scrapy/utils/ossignal.py
+++ b/scrapy/utils/ossignal.py
@@ -1,16 +1,17 @@
 
 from __future__ import absolute_import
+import signal
 
 from twisted.internet import reactor
 
-import signal
 
 signal_names = {}
 for signame in dir(signal):
-    if signame.startswith("SIG"):
+    if signame.startswith('SIG') and not signame.startswith('SIG_'):
         signum = getattr(signal, signame)
         if isinstance(signum, int):
             signal_names[signum] = signame
+
 
 def install_shutdown_handlers(function, override_sigint=True):
     """Install the given function as a signal handler for all common shutdown
@@ -24,5 +25,5 @@ def install_shutdown_handlers(function, override_sigint=True):
             override_sigint:
         signal.signal(signal.SIGINT, function)
     # Catch Ctrl-Break in windows
-    if hasattr(signal, "SIGBREAK"):
+    if hasattr(signal, 'SIGBREAK'):
         signal.signal(signal.SIGBREAK, function)


### PR DESCRIPTION
Using Ctrl-C to stop Scrapy when running it on Python 2 leads to this message:
`Received SIGINT, shutting down gracefully. Send again to force`

However, on some Python 3 versions (at least Python 3.5 and 3.6) Scrapy does not correctly detect the SIGINT signal:
`Received SIG_SETMASK, shutting down gracefully. Send again to force` 

Some constants defined in the signal module need to be skipped in order to filter only the signals.
For reference:
https://github.com/python/cpython/blob/master/Lib/signal.py