### PR TITLE
Add JsonStatsCollector class to log scraping run stats as json

### DIFF
--- a/docs/topics/stats.rst
+++ b/docs/topics/stats.rst
@@ -95,6 +95,16 @@ MemoryStatsCollector
        A dict of dicts (keyed by spider name) containing the stats of the last
        scraping run for each spider.
 
+JsonStatsCollector
+--------------------
+
+.. class:: JsonStatsCollector
+
+   Iherits MemoryStatsCollector, the only difference being that this
+   statcollector class logs the run statistics in json for ease of further log
+   parsing.
+
+
 DummyStatsCollector
 -------------------
 

--- a/scrapy/statscollectors.py
+++ b/scrapy/statscollectors.py
@@ -1,8 +1,11 @@
 """
 Scrapy extension for collecting scraping stats
 """
+import json
 import pprint
 import logging
+
+from scrapy.utils.serialize import ScrapyJSONEncoder
 
 logger = logging.getLogger(__name__)
 
@@ -61,6 +64,25 @@ class MemoryStatsCollector(StatsCollector):
         self.spider_stats[spider.name] = stats
 
 
+class JsonStatsCollector(MemoryStatsCollector):
+    """Extends the MemoryStatsCollector to log the spider's stats as json"""
+
+    def close_spider(self, spider, reason):
+        if self._dump:
+            json_encoded_stats = json.dumps(
+                self._stats,
+                cls=ScrapyJSONEncoder,
+                ensure_ascii=False,
+                sort_keys=True,
+                indent=4,
+            )
+            logger.info(
+                "Dumping Scrapy stats:\n" +
+                json_encoded_stats
+            )
+        self._persist_stats(self._stats, spider)
+
+
 class DummyStatsCollector(StatsCollector):
 
     def get_value(self, key, default=None, spider=None):
@@ -80,5 +102,3 @@ class DummyStatsCollector(StatsCollector):
 
     def min_value(self, key, value, spider=None):
         pass
-
-

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -1,7 +1,12 @@
 import unittest
 
 from scrapy.spiders import Spider
-from scrapy.statscollectors import StatsCollector, DummyStatsCollector
+from scrapy.statscollectors import (
+    StatsCollector,
+    DummyStatsCollector,
+    MemoryStatsCollector,
+    JsonStatsCollector
+)
 from scrapy.utils.test import get_crawler
 
 
@@ -11,8 +16,8 @@ class StatsCollectorTest(unittest.TestCase):
         self.crawler = get_crawler(Spider)
         self.spider = self.crawler._create_spider('foo')
 
-    def test_collector(self):
-        stats = StatsCollector(self.crawler)
+    def collector_test_from_cls(self, cls):
+        stats = cls(self.crawler)
         self.assertEqual(stats.get_stats(), {})
         self.assertEqual(stats.get_value('anything'), None)
         self.assertEqual(stats.get_value('anything', 'default'), 'default')
@@ -37,6 +42,15 @@ class StatsCollectorTest(unittest.TestCase):
         self.assertEqual(stats.get_value('test2'), 35)
         stats.min_value('test4', 7)
         self.assertEqual(stats.get_value('test4'), 7)
+
+    def test_collector(self):
+        self.collector_test_from_cls(StatsCollector)
+
+    def test_memory_collector(self):
+        self.collector_test_from_cls(MemoryStatsCollector)
+
+    def test_json_collector(self):
+        self.collector_test_from_cls(JsonStatsCollector)
 
     def test_dummy_collector(self):
         stats = DummyStatsCollector(self.crawler)


### PR DESCRIPTION
I have added a JsonStatsCollector class which inherits MemoryStatsCollector and overrides the close_spider method to log stats as json.
This would make further parsing of the logs easier, i.e. when using the ELK stack and Filebeat.