### PR TITLE
Partial fix for #3090 - only addresses JSON feeds.

### DIFF
--- a/scrapy/exporters.py
+++ b/scrapy/exporters.py
@@ -129,9 +129,9 @@ class JsonItemExporter(BaseItemExporter):
 
     def export_item(self, item):
         itemdict = dict(self._get_serialized_fields(item))
-        data = self.encoder.encode(itemdict)
+        data = to_bytes(self.encoder.encode(itemdict), self.encoding)
         self._add_comma_after_first()
-        self.file.write(to_bytes(data, self.encoding))
+        self.file.write(data)
 
 
 class XmlItemExporter(BaseItemExporter):

--- a/scrapy/exporters.py
+++ b/scrapy/exporters.py
@@ -112,6 +112,13 @@ class JsonItemExporter(BaseItemExporter):
         if self.indent is not None:
             self.file.write(b'\n')
 
+    def _add_comma_after_first(self):
+        if self.first_item:
+            self.first_item = False
+        else:
+            self.file.write(b',')
+            self._beautify_newline()
+
     def start_exporting(self):
         self.file.write(b"[")
         self._beautify_newline()
@@ -121,13 +128,9 @@ class JsonItemExporter(BaseItemExporter):
         self.file.write(b"]")
 
     def export_item(self, item):
-        if self.first_item:
-            self.first_item = False
-        else:
-            self.file.write(b',')
-            self._beautify_newline()
         itemdict = dict(self._get_serialized_fields(item))
         data = self.encoder.encode(itemdict)
+        self._add_comma_after_first()
         self.file.write(to_bytes(data, self.encoding))
 
 

--- a/tests/test_exporters.py
+++ b/tests/test_exporters.py
@@ -455,11 +455,11 @@ class JsonItemExporterTest(JsonLinesItemExporterTest):
 
     def test_two_items_with_failure_between(self):
         i1 = TestItem(name=u'Joseph\xa3', age='22')
-        i2 = TestItem(name=u'Maria', age=date(1234, 1, 1))  # should fail, per https://github.com/scrapy/scrapy/issues/3090
+        i2 = TestItem(name=u'Maria', age=1j)  # Invalid datetimes didn't consistently fail between Python versions
         i3 = TestItem(name=u'Jesus', age='44')
         self.ie.start_exporting()
         self.ie.export_item(i1)
-        self.assertRaises(ValueError, self.ie.export_item, i2)
+        self.assertRaises(TypeError, self.ie.export_item, i2)
         self.ie.export_item(i3)
         self.ie.finish_exporting()
         exported = json.loads(to_unicode(self.output.getvalue()))

--- a/tests/test_exporters.py
+++ b/tests/test_exporters.py
@@ -497,6 +497,25 @@ class JsonItemExporterTest(JsonLinesItemExporterTest):
         self.assertEqual(exported, [item])
 
 
+class JsonItemExporterToBytesTest(BaseItemExporterTest):
+
+    def _get_exporter(self, **kwargs):
+        kwargs['encoding'] = 'latin'
+        return JsonItemExporter(self.output, **kwargs)
+
+    def test_two_items_with_failure_between(self):
+        i1 = TestItem(name=u'Joseph', age='22')
+        i2 = TestItem(name=u'\u263a', age=u'11')
+        i3 = TestItem(name=u'Jesus', age='44')
+        self.ie.start_exporting()
+        self.ie.export_item(i1)
+        self.assertRaises(UnicodeEncodeError, self.ie.export_item, i2)
+        self.ie.export_item(i3)
+        self.ie.finish_exporting()
+        exported = json.loads(to_unicode(self.output.getvalue(), encoding='latin'))
+        self.assertEqual(exported, [dict(i1), dict(i3)])
+
+
 class CustomItemExporterTest(unittest.TestCase):
 
     def test_exporter_custom_serializer(self):


### PR DESCRIPTION
Quick fix for #3090, but the general problem of failure-during-multistep-serialisation also probably affects our XML exporter. A more broad fix would be to buffer changes and then "commit" them once everything has succeeded, but that's a bigger change than I felt comfortable writing without some discussion. :)