### PR TITLE
[MRG+1] use INFO log level to show telnet host/port

### DIFF
--- a/scrapy/extensions/telnet.py
+++ b/scrapy/extensions/telnet.py
@@ -55,9 +55,9 @@ class TelnetConsole(protocol.ServerFactory):
     def start_listening(self):
         self.port = listen_tcp(self.portrange, self.host, self)
         h = self.port.getHost()
-        logger.debug("Telnet console listening on %(host)s:%(port)d",
-                     {'host': h.host, 'port': h.port},
-                     extra={'crawler': self.crawler})
+        logger.info("Telnet console listening on %(host)s:%(port)d",
+                    {'host': h.host, 'port': h.port},
+                    extra={'crawler': self.crawler})
 
     def stop_listening(self):
         self.port.stopListening()


### PR DESCRIPTION
Hey,

What do you think about using INFO log level for displaying telnet host/port information? 

In production log level is often changed to INFO+. At the same time, a concrete telnet port is chosen from a range of ports. It means that log may be useless when someone wants to figure out how to connect to a running production spider, and Scrapy doesn't announce this port by other means.

I can also imagine that using INFO can raise awareness of users of this feature; some may want to disable it after realizing Scrapy is starting a telnet server by default, and some may do the opposite and start using the feature.