### PR TITLE
Adding support and issue template docs to .scrapy

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,9 @@
+If you are creating an issue to seek help or support with your
+_usage_ of Scrapy, however, please consider posting instead
+to a more appropriate forum: We support Reddit, IRC, and Stack
+Overflow. Check our Community portal for details:
+https://scrapy.org/community/
+
+Otherwise, feel free to delete the above and make your issue!
+If it's a bug, try to make it reproducible and minimal.
+But don't sweat it. Thanks for contributing to Scrapy! :)

--- a/.github/SUPPORT.md
+++ b/.github/SUPPORT.md
@@ -1,0 +1,15 @@
+# Getting Support as a Scrapy User
+
+This repository's "Issues" pane is not the place to request support
+or advice on using Scrapy. For that, we suggest joining the [Scrapy
+community][community] over at:
+
+* The [/r/scrapy subreddit][subreddit]
+* The [#scrapy IRC Channel][irc]
+* StackOverflow, using the ['scrapy' tag][stackoverflow]
+
+[community]: https://scrapy.org/community/
+[subreddit]: http://reddit.com/r/scrapy
+[irc]: http://webchat.freenode.net/?channels=scrapy
+[stackoverflow]: http://stackoverflow.com/questions/tagged/scrapy
+


### PR DESCRIPTION
Adding these 'magic files' will make Github show a template on new issues, encouraging them to seek support elsewhere, and a pop-up with a link to a "Support" document above the new issue box.

The idea is to gently discourage issues-as-support-requests, without discouraging bug reports, feature requests, or security issues.