### PR TITLE
[MRG+1] Fix part of issue #3128 - None should not be a valid type for 'url' in Response.follow

### DIFF
--- a/scrapy/http/response/__init__.py
+++ b/scrapy/http/response/__init__.py
@@ -120,6 +120,8 @@ class Response(object_ref):
         """
         if isinstance(url, Link):
             url = url.url
+        elif url is None:
+            raise ValueError("url can't be None")
         url = self.urljoin(url)
         return Request(url, callback,
                        method=method,

--- a/tests/test_http_response.py
+++ b/tests/test_http_response.py
@@ -155,6 +155,10 @@ class BaseResponseTest(unittest.TestCase):
         self._assert_followed_url(Link('http://example.com/foo'),
                                   'http://example.com/foo')
 
+    def test_follow_None_url(self):
+        r = self.response_class("http://example.com")
+        self.assertRaises(ValueError, r.follow, None)
+
     def test_follow_whitespace_url(self):
         self._assert_followed_url('foo ',
                                   'http://example.com/foo%20')


### PR DESCRIPTION
the issue reason should be: 'urljoin from urllib return baseurl if targeturl is None'

the empty url issue haven't been touched because @kmike says: 'this is an intended behavior.'