### PR TITLE
Base url - Remove comments before asking for base urls

### DIFF
--- a/scrapy/linkextractors/lxmlhtml.py
+++ b/scrapy/linkextractors/lxmlhtml.py
@@ -78,12 +78,8 @@ class LxmlParserLinkExtractor(object):
 
     def extract_links(self, response):
         base_url = get_base_url(response)
-<<<<<<< HEAD
         return self._extract_links(response.selector, response.url,
                                    response.encoding, base_url)
-=======
-        return self._extract_links(response.selector, response.url, response.encoding, base_url)
->>>>>>> parent of 0e86a9f... Update lxmlhtml.py
 
     def _process_links(self, links):
         """ Normalize and filter extracted links

--- a/scrapy/linkextractors/lxmlhtml.py
+++ b/scrapy/linkextractors/lxmlhtml.py
@@ -12,6 +12,7 @@ from scrapy.link import Link
 from scrapy.utils.misc import arg_to_iter, rel_has_nofollow
 from scrapy.utils.python import unique as unique_list, to_native_str
 from scrapy.utils.response import get_base_url
+from scrapy.http import TextResponse
 from scrapy.linkextractors import FilteringLinkExtractor
 
 
@@ -77,9 +78,9 @@ class LxmlParserLinkExtractor(object):
 
     def extract_links(self, response):
         base_url = get_base_url(response)
-        return self._extract_links(response.selector, response.url, 
+        return self._extract_links(response.selector, response.url,
                                    response.encoding, base_url)
-        
+
     def _process_links(self, links):
         """ Normalize and filter extracted links
 
@@ -117,7 +118,7 @@ class LxmlLinkExtractor(FilteringLinkExtractor):
             canonicalize=canonicalize, deny_extensions=deny_extensions)
 
     def extract_links(self, response):
-        if not isinstance(response, scrapy.http.TextResponse):
+        if not isinstance(response, TextResponse):
             return []
         base_url = get_base_url(response)
         if self.restrict_xpaths:

--- a/scrapy/linkextractors/lxmlhtml.py
+++ b/scrapy/linkextractors/lxmlhtml.py
@@ -76,14 +76,10 @@ class LxmlParserLinkExtractor(object):
         return self._deduplicate_if_needed(links)
 
     def extract_links(self, response):
-        if type(response) == scrapy.http.TextResponse:
-            base_url = get_base_url(response)
-            return self._extract_links(response.selector, response.url, 
-                                       response.encoding, base_url)
-        else:
-            return []
+        base_url = get_base_url(response)
+        return self._extract_links(response.selector, response.url, 
+                                   response.encoding, base_url)
         
-
     def _process_links(self, links):
         """ Normalize and filter extracted links
 
@@ -121,6 +117,8 @@ class LxmlLinkExtractor(FilteringLinkExtractor):
             canonicalize=canonicalize, deny_extensions=deny_extensions)
 
     def extract_links(self, response):
+        if not isinstance(response, scrapy.http.TextResponse):
+            return []
         base_url = get_base_url(response)
         if self.restrict_xpaths:
             docs = [subdoc

--- a/scrapy/linkextractors/lxmlhtml.py
+++ b/scrapy/linkextractors/lxmlhtml.py
@@ -76,7 +76,7 @@ class LxmlParserLinkExtractor(object):
         return self._deduplicate_if_needed(links)
 
     def extract_links(self, response):
-        if hasattr(response, 'text'):
+        if type(response) == scrapy.http.TextResponse:
             base_url = get_base_url(response)
             return self._extract_links(response.selector, response.url, 
                                        response.encoding, base_url)

--- a/scrapy/linkextractors/lxmlhtml.py
+++ b/scrapy/linkextractors/lxmlhtml.py
@@ -78,8 +78,12 @@ class LxmlParserLinkExtractor(object):
 
     def extract_links(self, response):
         base_url = get_base_url(response)
+<<<<<<< HEAD
         return self._extract_links(response.selector, response.url,
                                    response.encoding, base_url)
+=======
+        return self._extract_links(response.selector, response.url, response.encoding, base_url)
+>>>>>>> parent of 0e86a9f... Update lxmlhtml.py
 
     def _process_links(self, links):
         """ Normalize and filter extracted links
@@ -118,8 +122,6 @@ class LxmlLinkExtractor(FilteringLinkExtractor):
             canonicalize=canonicalize, deny_extensions=deny_extensions)
 
     def extract_links(self, response):
-        if not isinstance(response, TextResponse):
-            return []
         base_url = get_base_url(response)
         if self.restrict_xpaths:
             docs = [subdoc

--- a/scrapy/linkextractors/lxmlhtml.py
+++ b/scrapy/linkextractors/lxmlhtml.py
@@ -76,8 +76,13 @@ class LxmlParserLinkExtractor(object):
         return self._deduplicate_if_needed(links)
 
     def extract_links(self, response):
-        base_url = get_base_url(response)
-        return self._extract_links(response.selector, response.url, response.encoding, base_url)
+        if hasattr(response, 'text'):
+            base_url = get_base_url(response)
+            return self._extract_links(response.selector, response.url, 
+                                       response.encoding, base_url)
+        else:
+            return []
+        
 
     def _process_links(self, links):
         """ Normalize and filter extracted links

--- a/scrapy/utils/response.py
+++ b/scrapy/utils/response.py
@@ -25,7 +25,7 @@ def get_base_url(response):
     """Return the base url of the given response, joined with the response url"""
     if response not in _baseurl_cache:
         text = response.text[0:4096]
-        text = html.remove_comments(text, response.encoding)
+        text = html.remove_comments(text, reponse.encoding)
         _baseurl_cache[response] = html.get_base_url(text, response.url,
             response.encoding)
     return _baseurl_cache[response]

--- a/scrapy/utils/response.py
+++ b/scrapy/utils/response.py
@@ -25,7 +25,7 @@ def get_base_url(response):
     """Return the base url of the given response, joined with the response url"""
     if response not in _baseurl_cache:
         text = response.text[0:4096]
-        text = html.remove_comments(text, reponse.encoding)
+        text = html.remove_comments(text, response.encoding)
         _baseurl_cache[response] = html.get_base_url(text, response.url,
             response.encoding)
     return _baseurl_cache[response]

--- a/scrapy/utils/response.py
+++ b/scrapy/utils/response.py
@@ -25,6 +25,7 @@ def get_base_url(response):
     """Return the base url of the given response, joined with the response url"""
     if response not in _baseurl_cache:
         text = response.text[0:4096]
+        text = html.remove_comments(text, reponse.encoding)
         _baseurl_cache[response] = html.get_base_url(text, response.url,
             response.encoding)
     return _baseurl_cache[response]


### PR DESCRIPTION
Remove commented tags from the HTML before asking for a base tag to w3lib. 
If comments are not removed, w3lib will assume `<!-- <base href="....."> -->` is a valid base tag.