### PR TITLE
Adding domain

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -56,3 +56,4 @@ Here is the list of the primary authors & contributors:
  * Vikas Dhiman
  * Juan Picca
  * Nicolás Ramírez
+ * Tianhui Michael Li

--- a/docs/topics/settings.rst
+++ b/docs/topics/settings.rst
@@ -1095,11 +1095,11 @@ If enabled, Scrapy will respect robots.txt policies. For more information see
 SCHEDULER
 ---------
 
-Default: ``'scrapy.core.scheduler.DefaultScheduler'``
+Default: ``'scrapy.core.scheduler.Scheduler'``
 
-The scheduler to use for crawling.  Can also be set to a domain-aware that round
-robin cycles through the domains as it outputs requests to reduce the load on
-servers and accelerate scraping: ``'scrapy.core.scheduler.DomainScheduler'``.
+The scheduler to use for crawling.  Can also be set to a domain-aware scheduler
+that round-robin cycles through the domains as it outputs requests to reduce
+the load on servers and accelerate scraping: ``'scrapy.core.scheduler.RoundRobinScheduler'``.
 
 .. setting:: SCHEDULER_DEBUG
 

--- a/docs/topics/settings.rst
+++ b/docs/topics/settings.rst
@@ -1100,6 +1100,7 @@ Default: ``'scrapy.core.scheduler.Scheduler'``
 The scheduler to use for crawling.  Can also be set to a domain-aware scheduler
 that round-robin cycles through the domains as it outputs requests to reduce
 the load on servers and accelerate scraping: ``'scrapy.core.scheduler.RoundRobinScheduler'``.
+In this latter is used, priorities are ignored (see class for more details).
 
 .. setting:: SCHEDULER_DEBUG
 

--- a/docs/topics/settings.rst
+++ b/docs/topics/settings.rst
@@ -1097,11 +1097,12 @@ SCHEDULER
 
 Default: ``'scrapy.core.scheduler.DefaultScheduler'``
 
-The scheduler to use for crawling.
+The scheduler to use for crawling.  Can also be set to a domain-aware that round
+robin cycles through the domains as it outputs requests to reduce the load on
+servers and accelerate scraping: ``'scrapy.core.scheduler.DomainScheduler'``.
 
 .. setting:: SCHEDULER_DEBUG
 
-Can also be set to a domain-aware that round robin cycles through the domains as it outputs requests to reduce the load on servers and accelerate scraping: ``'scrapy.core.scheduler.DomainScheduler'``.
 
 SCHEDULER_DEBUG
 ---------------

--- a/docs/topics/settings.rst
+++ b/docs/topics/settings.rst
@@ -1095,11 +1095,13 @@ If enabled, Scrapy will respect robots.txt policies. For more information see
 SCHEDULER
 ---------
 
-Default: ``'scrapy.core.scheduler.Scheduler'``
+Default: ``'scrapy.core.scheduler.DefaultScheduler'``
 
 The scheduler to use for crawling.
 
 .. setting:: SCHEDULER_DEBUG
+
+Can also be set to a domain-aware that round robin cycles through the domains as it outputs requests to reduce the load on servers and accelerate scraping: ``'scrapy.core.scheduler.DomainScheduler'``.
 
 SCHEDULER_DEBUG
 ---------------

--- a/requirements-py2.txt
+++ b/requirements-py2.txt
@@ -2,8 +2,8 @@ Twisted>=13.1.0
 lxml
 pyOpenSSL
 cssselect>=0.9
-queuelib
 w3lib>=1.17.0
+queuelib>=1.5.0
 six>=1.5.2
 PyDispatcher>=2.0.5
 parsel>=1.4

--- a/requirements-py3.txt
+++ b/requirements-py3.txt
@@ -1,4 +1,4 @@
-Twisted>=17.9.0
+Twisted >= 17.9.0
 lxml>=3.2.4
 pyOpenSSL>=0.13.1
 cssselect>=0.9

--- a/requirements-py3.txt
+++ b/requirements-py3.txt
@@ -2,7 +2,7 @@ Twisted >= 17.9.0
 lxml>=3.2.4
 pyOpenSSL>=0.13.1
 cssselect>=0.9
-git+git://github.com/scrapy/queuelib.git
+queuelib>=1.5.0
 w3lib>=1.17.0
 six>=1.5.2
 PyDispatcher>=2.0.5

--- a/requirements-py3.txt
+++ b/requirements-py3.txt
@@ -2,7 +2,7 @@ Twisted >= 17.9.0
 lxml>=3.2.4
 pyOpenSSL>=0.13.1
 cssselect>=0.9
-queuelib>=1.1.1
+git+git://github.com/scrapy/queuelib.git
 w3lib>=1.17.0
 six>=1.5.2
 PyDispatcher>=2.0.5

--- a/scrapy/core/scheduler.py
+++ b/scrapy/core/scheduler.py
@@ -1,4 +1,3 @@
-from abc import ABC
 import hashlib
 import json
 import logging
@@ -24,7 +23,7 @@ def _make_file_safe(string):
     return "{}-{}".format(clean_string[:40], hash_string[:10])
 
 
-class BaseScheduler(ABC):
+class BaseScheduler(object):
 
     def __init__(self, dupefilter, jobdir=None, dqclass=None, mqclass=None,
                  logunser=False, stats=None, pqclass=None):

--- a/scrapy/core/scheduler.py
+++ b/scrapy/core/scheduler.py
@@ -175,8 +175,8 @@ class RoundRobinScheduler(BaseScheduler):
     consecutive requests to a domain if multiple links were discovered and
     added consecutively.  This scheduler spreads those out that workload.
 
-    Uses `RoundRobinQueue`.  The pqclass parameter and SCHEDULER_PRIORITY_QUEUE
-    are ignored.
+    Uses `RoundRobinQueue`.  Does not take a pqclass parameter
+    `SCHEDULER_PRIORITY_QUEUE` is ignored, and does not use priorities.
     """
 
     def __init__(self, dupefilter, jobdir=None, dqclass=None, mqclass=None,

--- a/scrapy/core/scheduler.py
+++ b/scrapy/core/scheduler.py
@@ -161,10 +161,7 @@ class DomainScheduler(BaseScheduler):
                  logunser=False, stats=None, pqclass=None):
         super(DomainScheduler, self).__init__(dupefilter, jobdir=jobdir, dqclass=dqclass,
                                               mqclass=mqclass, logunser=logunser,
-                                              stats=stats, pqclass=pqclass)
-
-        self.pqclass = RoundRobinQueue
+                                              stats=stats, pqclass=RoundRobinQueue)
 
     def request_key(cls, request):
         return urlparse(request.url).netloc
-

--- a/scrapy/core/scheduler.py
+++ b/scrapy/core/scheduler.py
@@ -175,12 +175,12 @@ class RoundRobinScheduler(BaseScheduler):
     consecutive requests to a domain if multiple links were discovered and
     added consecutively.  This scheduler spreads those out that workload.
 
-    Uses `RoundRobinQueue`.  Does not take a pqclass parameter
-    `SCHEDULER_PRIORITY_QUEUE` is ignored, and does not use priorities.
+    Uses `RoundRobinQueue`.  The `pqclass` parameter and
+    `SCHEDULER_PRIORITY_QUEUE` are ignored, and does not use priorities.
     """
 
     def __init__(self, dupefilter, jobdir=None, dqclass=None, mqclass=None,
-                 logunser=False, stats=None):
+                 logunser=False, stats=None, pqclass=None):
         super(RoundRobinScheduler, self).__init__(dupefilter, jobdir=jobdir, dqclass=dqclass,
                                                   mqclass=mqclass, logunser=logunser,
                                                   stats=stats, pqclass=RoundRobinQueue)

--- a/scrapy/core/scheduler.py
+++ b/scrapy/core/scheduler.py
@@ -50,10 +50,7 @@ class BaseScheduler(object):
                    stats=crawler.stats, pqclass=pqclass, dqclass=dqclass, mqclass=mqclass)
 
     def request_key(self, request):
-        if 'scheduler_slot' in request.meta:
-            return request.meta['scheduler_slot']
-
-        return self._request_key(request)
+        return request.meta.get('scheduler_slot', self._request_key(request))
 
     @abc.abstractmethod
     def _request_key(self, request):

--- a/scrapy/core/scheduler.py
+++ b/scrapy/core/scheduler.py
@@ -157,7 +157,7 @@ class BaseScheduler(object):
             return dqdir
 
 
-class Scheduler(BaseScheduler):
+class DefaultScheduler(BaseScheduler):
     """
     Key is the priority of the request (an integer)
     """

--- a/scrapy/settings/default_settings.py
+++ b/scrapy/settings/default_settings.py
@@ -241,7 +241,7 @@ RETRY_PRIORITY_ADJUST = -1
 
 ROBOTSTXT_OBEY = False
 
-SCHEDULER = 'scrapy.core.scheduler.Scheduler'
+SCHEDULER = 'scrapy.core.scheduler.DefaultScheduler'
 SCHEDULER_DISK_QUEUE = 'scrapy.squeues.PickleLifoDiskQueue'
 SCHEDULER_MEMORY_QUEUE = 'scrapy.squeues.LifoMemoryQueue'
 SCHEDULER_PRIORITY_QUEUE = 'queuelib.PriorityQueue'

--- a/scrapy/settings/default_settings.py
+++ b/scrapy/settings/default_settings.py
@@ -241,7 +241,7 @@ RETRY_PRIORITY_ADJUST = -1
 
 ROBOTSTXT_OBEY = False
 
-SCHEDULER = 'scrapy.core.scheduler.DefaultScheduler'
+SCHEDULER = 'scrapy.core.scheduler.Scheduler'
 SCHEDULER_DISK_QUEUE = 'scrapy.squeues.PickleLifoDiskQueue'
 SCHEDULER_MEMORY_QUEUE = 'scrapy.squeues.LifoMemoryQueue'
 SCHEDULER_PRIORITY_QUEUE = 'queuelib.PriorityQueue'

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -1,0 +1,58 @@
+import unittest
+
+from scrapy.core.scheduler import Scheduler, RoundRobinScheduler
+from scrapy.spiders import Spider
+from scrapy.utils.test import get_crawler
+from scrapy.http import Request
+from scrapy.dupefilters import RFPDupeFilter
+
+
+class BaseSchedulerTestCase(unittest.TestCase):
+
+    Scheduler = None
+
+    def setUp(self):
+        self.crawler = get_crawler(Spider, None)
+        self.spider = self.crawler._create_spider('foo')
+        self.scheduler = self.Scheduler.from_crawler(self.crawler)
+        self.scheduler.open(self.spider)
+
+    def tearDown(self):
+        self.scheduler.close('finished')
+
+
+class SchedulerTestCase(BaseSchedulerTestCase):
+    Scheduler = Scheduler
+    def test_scheduler(self):
+        self.scheduler.enqueue_request(Request("http://foo.com/a"))
+        self.scheduler.enqueue_request(Request("http://foo.com/b"))
+
+        self.assertEqual(self.scheduler.next_request().url, "http://foo.com/b")
+        self.assertEqual(self.scheduler.next_request().url, "http://foo.com/a")
+
+    def test_scheduler_priorities(self):
+        self.scheduler.enqueue_request(Request("http://foo.com/a", priority=1))
+        self.scheduler.enqueue_request(Request("http://foo.com/b", priority=0))
+
+        self.assertEqual(self.scheduler.next_request().url, "http://foo.com/a")
+        self.assertEqual(self.scheduler.next_request().url, "http://foo.com/b")
+
+
+class RoundRobinSchedulerTestCase(BaseSchedulerTestCase):
+
+    Scheduler = RoundRobinScheduler
+
+    def test_scheduler(self):
+        self.scheduler.enqueue_request(Request("http://foo.com/a"))
+        self.scheduler.enqueue_request(Request("http://foo.com/b"))
+        self.scheduler.enqueue_request(Request("http://bar.com/a"))
+        self.scheduler.enqueue_request(Request("http://bar.com/b"))
+
+        self.assertEqual(self.scheduler.next_request().url, "http://foo.com/b")
+        self.assertEqual(self.scheduler.next_request().url, "http://bar.com/b")
+        self.assertEqual(self.scheduler.next_request().url, "http://foo.com/a")
+        self.assertEqual(self.scheduler.next_request().url, "http://bar.com/a")
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Merges DomainScheduler implemented in https://github.com/tianhuil/domain_scheduler into scrapy. It scrapes in a domain-smart way: by round-robin cycling through the domains. This has two benefits:

1. Spreading out load on the target servers instead of hitting the server with many requests at once
2. Reducing delays caused by server-throttling or scrapy's own `CONCURRENT_REQUESTS_PER_IP` restrictions.  Empirical testing has shown this to be quite effective.

It implements the solution proposed in https://github.com/scrapy/scrapy/issues/1802#issue-135260562 which found similar performance improvements.  **Original proposal** was first posted https://github.com/scrapy/scrapy/issues/1802 (code no longer available), https://github.com/scrapy/scrapy/issues/2474, and https://github.com/scrapy/scrapy/issues/3140.  

**Note:** It requires more than just using `SCHEDULER_PRIORITY_QUEUE` as it needs an API change to the queue (passing in a non-integer key, i.e. the domain, to a new round robin queue).

- Implements https://github.com/scrapy/scrapy/issues/3140
- Depends on merged queuelib PR https://github.com/scrapy/queuelib/pull/21

Would love to get feedback @pablohoffman, @dangra, and @kmike!