### PR TITLE
Automatic port selection for servicies in unit tests

### DIFF
--- a/tests/mockserver.py
+++ b/tests/mockserver.py
@@ -211,11 +211,20 @@ def ssl_context_factory(keyfile='keys/localhost.key', certfile='keys/localhost.c
 
 
 if __name__ == "__main__":
+    http_port = 8998
+    https_port = 8999
+
+    if len(sys.argv) > 1:
+        http_port = int(sys.argv[1])
+
+    if len(sys.argv) > 2:
+        https_port = int(sys.argv[2])
+
     root = Root()
     factory = Site(root)
-    httpPort = reactor.listenTCP(8998, factory)
+    httpPort = reactor.listenTCP(http_port, factory)
     contextFactory = ssl_context_factory()
-    httpsPort = reactor.listenSSL(8999, factory, contextFactory)
+    httpsPort = reactor.listenSSL(https_port, factory, contextFactory)
 
     def print_listening():
         httpHost = httpPort.getHost()

--- a/tests/mockserver.py
+++ b/tests/mockserver.py
@@ -201,7 +201,7 @@ class MockServer():
     HTTPS = 'mock_https'
 
     @classmethod
-    def from_mock(cls, path, is_secure=False):
+    def url(cls, path, is_secure=False):
         key = cls.HTTP
         if is_secure:
             key = cls.HTTPS

--- a/tests/mockserver.py
+++ b/tests/mockserver.py
@@ -194,8 +194,11 @@ class MockServer():
     HTTPS = 'mock_https'
 
     @classmethod
-    def from_mock(cls, path):
-        return os.environ[cls.HTTP] + path
+    def from_mock(cls, path, is_secure=False):
+        key = cls.HTTP
+        if is_secure:
+            key = cls.HTTPS
+        return os.environ[key] + path
 
     def __enter__(self):
         from scrapy.utils.test import get_testenv
@@ -214,7 +217,7 @@ class MockServer():
 
             self._oldenv = os.environ.copy()
             os.environ[self.HTTP] = 'http://localhost:%s' % (http_port, )
-            os.environ[self.HTTPS] = 'http://localhost:%s' % (https_port, )
+            os.environ[self.HTTPS] = 'https://localhost:%s' % (https_port, )
 
             return self
 

--- a/tests/mockserver.py
+++ b/tests/mockserver.py
@@ -190,6 +190,9 @@ class Root(Resource):
 
 class MockServer():
 
+    HTTP = 'mock_http'
+    HTTPS = 'mock_https'
+
     def __enter__(self):
         from scrapy.utils.test import get_testenv
 
@@ -203,14 +206,19 @@ class MockServer():
 
             if self.proc.poll() is not None:
                 http_port = https_port
+                continue
 
             self._oldenv = os.environ.copy()
+            os.environ[self.HTTP] = 'http://localhost:%s' % (http_port, )
+            os.environ[self.HTTPS] = 'http://localhost:%s' % (https_port, )
+
             return self
 
     def __exit__(self, exc_type, exc_value, traceback):
         self.proc.kill()
         self.proc.wait()
         time.sleep(0.2)
+        os.environ = self._oldenv
 
 
 def ssl_context_factory(keyfile='keys/localhost.key', certfile='keys/localhost.crt'):

--- a/tests/mockserver.py
+++ b/tests/mockserver.py
@@ -198,7 +198,6 @@ class MockServer():
         http_address = self.proc.stdout.readline().strip().decode('ascii')
         https_address = self.proc.stdout.readline().strip().decode('ascii')
 
-        self._oldenv = os.environ.copy()
         self.http_address = http_address
         self.https_address = https_address
 
@@ -208,7 +207,6 @@ class MockServer():
         self.proc.kill()
         self.proc.wait()
         time.sleep(0.2)
-        os.environ = self._oldenv
 
     def address(self):
         return MockServerAddress(self.http_address, self.https_address)

--- a/tests/mockserver.py
+++ b/tests/mockserver.py
@@ -190,16 +190,6 @@ class Root(Resource):
 
 class MockServer():
 
-    HTTP = 'mock_http'
-    HTTPS = 'mock_https'
-
-    @classmethod
-    def url(cls, path, is_secure=False):
-        key = cls.HTTP
-        if is_secure:
-            key = cls.HTTPS
-        return os.environ[key] + path
-
     def __enter__(self):
         from scrapy.utils.test import get_testenv
 
@@ -209,8 +199,8 @@ class MockServer():
         https_address = self.proc.stdout.readline().strip().decode('ascii')
 
         self._oldenv = os.environ.copy()
-        os.environ[self.HTTP] = http_address
-        os.environ[self.HTTPS] = https_address
+        self.http_address = http_address
+        self.https_address = https_address
 
         return self
 
@@ -219,6 +209,22 @@ class MockServer():
         self.proc.wait()
         time.sleep(0.2)
         os.environ = self._oldenv
+
+    def address(self):
+        return MockServerAddress(self.http_address, self.https_address)
+
+
+class MockServerAddress():
+
+    def __init__(self, http_address, https_address):
+        self.http_address = http_address
+        self.https_address = https_address
+
+    def url(self, path, is_secure=False):
+        host = self.http_address
+        if is_secure:
+            host = self.https_address
+        return host + path
 
 
 def ssl_context_factory(keyfile='keys/localhost.key', certfile='keys/localhost.crt'):

--- a/tests/mockserver.py
+++ b/tests/mockserver.py
@@ -192,10 +192,20 @@ class MockServer():
 
     def __enter__(self):
         from scrapy.utils.test import get_testenv
-        self.proc = Popen([sys.executable, '-u', '-m', 'tests.mockserver'],
-                          stdout=PIPE, env=get_testenv())
-        self.proc.stdout.readline()
-        return self
+
+        http_port = str(8998)
+        for https_port in range(8999, 10000):
+            https_port = str(https_port)
+
+            self.proc = Popen([sys.executable, '-u', '-m', 'tests.mockserver', http_port, https_port],
+                              stdout=PIPE, env=get_testenv())
+            self.proc.stdout.readline()
+
+            if self.proc.poll() is not None:
+                http_port = https_port
+
+            self._oldenv = os.environ.copy()
+            return self
 
     def __exit__(self, exc_type, exc_value, traceback):
         self.proc.kill()

--- a/tests/mockserver.py
+++ b/tests/mockserver.py
@@ -212,8 +212,8 @@ class MockServer():
 
         self.proc = Popen([sys.executable, '-u', '-m', 'tests.mockserver'],
                           stdout=PIPE, env=get_testenv())
-        http_address = self.proc.stdout.readline()
-        https_address = self.proc.stdout.readline()
+        http_address = self.proc.stdout.readline().strip()
+        https_address = self.proc.stdout.readline().strip()
 
         self._oldenv = os.environ.copy()
         os.environ[self.HTTP] = http_address

--- a/tests/mockserver.py
+++ b/tests/mockserver.py
@@ -205,8 +205,8 @@ class MockServer():
 
         self.proc = Popen([sys.executable, '-u', '-m', 'tests.mockserver'],
                           stdout=PIPE, env=get_testenv())
-        http_address = self.proc.stdout.readline().strip()
-        https_address = self.proc.stdout.readline().strip()
+        http_address = self.proc.stdout.readline().strip().decode('ascii')
+        https_address = self.proc.stdout.readline().strip().decode('ascii')
 
         self._oldenv = os.environ.copy()
         os.environ[self.HTTP] = http_address

--- a/tests/mockserver.py
+++ b/tests/mockserver.py
@@ -193,6 +193,10 @@ class MockServer():
     HTTP = 'mock_http'
     HTTPS = 'mock_https'
 
+    @classmethod
+    def from_mock(cls, path):
+        return os.environ[cls.HTTP] + path
+
     def __enter__(self):
         from scrapy.utils.test import get_testenv
 

--- a/tests/mockserver.py
+++ b/tests/mockserver.py
@@ -3,7 +3,6 @@ import sys, time, random, os, json
 from six.moves.urllib.parse import urlencode
 from subprocess import Popen, PIPE
 
-import socket
 from twisted.web.server import Site, NOT_DONE_YET
 from twisted.web.resource import Resource
 from twisted.web.static import File
@@ -16,12 +15,6 @@ from twisted.internet.task import deferLater
 
 
 from scrapy.utils.python import to_bytes, to_unicode
-
-
-def get_ephemeral_port():
-    s = socket.socket()
-    s.bind(("", 0))
-    return s.getsockname()[1]
 
 
 def getarg(request, name, default=None, type=None):

--- a/tests/spiders.py
+++ b/tests/spiders.py
@@ -9,6 +9,7 @@ from scrapy.spiders import Spider
 from scrapy.http import Request
 from scrapy.item import Item
 from scrapy.linkextractors import LinkExtractor
+from tests.mockserver import MockServer
 
 
 class MetaSpider(Spider):
@@ -33,7 +34,7 @@ class FollowAllSpider(MetaSpider):
         self.urls_visited = []
         self.times = []
         qargs = {'total': total, 'show': show, 'order': order, 'maxlatency': maxlatency}
-        url = "http://localhost:8998/follow?%s" % urlencode(qargs, doseq=1)
+        url = MockServer.from_mock("/follow?%s" % urlencode(qargs, doseq=1))
         self.start_urls = [url]
 
     def parse(self, response):

--- a/tests/spiders.py
+++ b/tests/spiders.py
@@ -12,7 +12,12 @@ from scrapy.linkextractors import LinkExtractor
 from tests.mockserver import MockServer
 
 
-class MetaSpider(Spider):
+class AddressableSpider(Spider):
+    def __init__(self, address=None, *args, **kwargs):
+        super(Spider, self).__init__(*args, **kwargs)
+        self.address = address
+
+class MetaSpider(AddressableSpider):
 
     name = 'meta'
 
@@ -161,7 +166,7 @@ class SingleRequestSpider(MetaSpider):
             return self.errback_func(failure)
 
 
-class DuplicateStartRequestsSpider(Spider):
+class DuplicateStartRequestsSpider(AddressableSpider):
     dont_filter = True
     name = 'duplicatestartrequests'
     distinct_urls = 2

--- a/tests/spiders.py
+++ b/tests/spiders.py
@@ -9,12 +9,11 @@ from scrapy.spiders import Spider
 from scrapy.http import Request
 from scrapy.item import Item
 from scrapy.linkextractors import LinkExtractor
-from tests.mockserver import MockServer
 
 
 class AddressableSpider(Spider):
     def __init__(self, address=None, *args, **kwargs):
-        super(Spider, self).__init__(*args, **kwargs)
+        super(AddressableSpider, self).__init__(*args, **kwargs)
         self.address = address
 
 class MetaSpider(AddressableSpider):
@@ -39,7 +38,7 @@ class FollowAllSpider(MetaSpider):
         self.urls_visited = []
         self.times = []
         qargs = {'total': total, 'show': show, 'order': order, 'maxlatency': maxlatency}
-        url = MockServer.url("/follow?%s" % urlencode(qargs, doseq=1))
+        url = self.address.url("/follow?%s" % urlencode(qargs, doseq=1))
         self.start_urls = [url]
 
     def parse(self, response):
@@ -61,7 +60,7 @@ class DelaySpider(MetaSpider):
 
     def start_requests(self):
         self.t1 = time.time()
-        url = MockServer.url("/delay?n=%s&b=%s" % (self.n, self.b))
+        url = self.address.url("/delay?n=%s&b=%s" % (self.n, self.b))
         yield Request(url, callback=self.parse, errback=self.errback)
 
     def parse(self, response):
@@ -127,7 +126,7 @@ class BrokenStartRequestsSpider(FollowAllSpider):
 
         for s in range(100):
             qargs = {'total': 10, 'seed': s}
-            url = MockServer.url("/follow?%s") % urlencode(qargs, doseq=1)
+            url = self.address.url("/follow?%s") % urlencode(qargs, doseq=1)
             yield Request(url, meta={'seed': s})
             if self.fail_yielding:
                 2 / 0
@@ -175,7 +174,7 @@ class DuplicateStartRequestsSpider(AddressableSpider):
     def start_requests(self):
         for i in range(0, self.distinct_urls):
             for j in range(0, self.dupe_factor):
-                url = MockServer.url("/echo?headers=1&body=test%d" % i)
+                url = self.address.url("/echo?headers=1&body=test%d" % i)
                 yield Request(url, dont_filter=self.dont_filter)
 
     def __init__(self, url="http://localhost:8998", *args, **kwargs):

--- a/tests/spiders.py
+++ b/tests/spiders.py
@@ -56,7 +56,7 @@ class DelaySpider(MetaSpider):
 
     def start_requests(self):
         self.t1 = time.time()
-        url = "http://localhost:8998/delay?n=%s&b=%s" % (self.n, self.b)
+        url = MockServer.from_mock("/delay?n=%s&b=%s" % (self.n, self.b))
         yield Request(url, callback=self.parse, errback=self.errback)
 
     def parse(self, response):
@@ -122,7 +122,7 @@ class BrokenStartRequestsSpider(FollowAllSpider):
 
         for s in range(100):
             qargs = {'total': 10, 'seed': s}
-            url = "http://localhost:8998/follow?%s" % urlencode(qargs, doseq=1)
+            url = MockServer.from_mock("/follow?%s") % urlencode(qargs, doseq=1)
             yield Request(url, meta={'seed': s})
             if self.fail_yielding:
                 2 / 0
@@ -170,7 +170,7 @@ class DuplicateStartRequestsSpider(Spider):
     def start_requests(self):
         for i in range(0, self.distinct_urls):
             for j in range(0, self.dupe_factor):
-                url = "http://localhost:8998/echo?headers=1&body=test%d" % i
+                url = MockServer.from_mock("/echo?headers=1&body=test%d" % i)
                 yield Request(url, dont_filter=self.dont_filter)
 
     def __init__(self, url="http://localhost:8998", *args, **kwargs):

--- a/tests/spiders.py
+++ b/tests/spiders.py
@@ -34,7 +34,7 @@ class FollowAllSpider(MetaSpider):
         self.urls_visited = []
         self.times = []
         qargs = {'total': total, 'show': show, 'order': order, 'maxlatency': maxlatency}
-        url = MockServer.from_mock("/follow?%s" % urlencode(qargs, doseq=1))
+        url = MockServer.url("/follow?%s" % urlencode(qargs, doseq=1))
         self.start_urls = [url]
 
     def parse(self, response):
@@ -56,7 +56,7 @@ class DelaySpider(MetaSpider):
 
     def start_requests(self):
         self.t1 = time.time()
-        url = MockServer.from_mock("/delay?n=%s&b=%s" % (self.n, self.b))
+        url = MockServer.url("/delay?n=%s&b=%s" % (self.n, self.b))
         yield Request(url, callback=self.parse, errback=self.errback)
 
     def parse(self, response):
@@ -122,7 +122,7 @@ class BrokenStartRequestsSpider(FollowAllSpider):
 
         for s in range(100):
             qargs = {'total': 10, 'seed': s}
-            url = MockServer.from_mock("/follow?%s") % urlencode(qargs, doseq=1)
+            url = MockServer.url("/follow?%s") % urlencode(qargs, doseq=1)
             yield Request(url, meta={'seed': s})
             if self.fail_yielding:
                 2 / 0
@@ -170,7 +170,7 @@ class DuplicateStartRequestsSpider(Spider):
     def start_requests(self):
         for i in range(0, self.distinct_urls):
             for j in range(0, self.dupe_factor):
-                url = MockServer.from_mock("/echo?headers=1&body=test%d" % i)
+                url = MockServer.url("/echo?headers=1&body=test%d" % i)
                 yield Request(url, dont_filter=self.dont_filter)
 
     def __init__(self, url="http://localhost:8998", *args, **kwargs):

--- a/tests/spiders.py
+++ b/tests/spiders.py
@@ -11,12 +11,12 @@ from scrapy.item import Item
 from scrapy.linkextractors import LinkExtractor
 
 
-class AddressableSpider(Spider):
+class MockServerSpider(Spider):
     def __init__(self, address=None, *args, **kwargs):
-        super(AddressableSpider, self).__init__(*args, **kwargs)
+        super(MockServerSpider, self).__init__(*args, **kwargs)
         self.address = address
 
-class MetaSpider(AddressableSpider):
+class MetaSpider(MockServerSpider):
 
     name = 'meta'
 
@@ -165,7 +165,7 @@ class SingleRequestSpider(MetaSpider):
             return self.errback_func(failure)
 
 
-class DuplicateStartRequestsSpider(AddressableSpider):
+class DuplicateStartRequestsSpider(MockServerSpider):
     dont_filter = True
     name = 'duplicatestartrequests'
     distinct_urls = 2

--- a/tests/test_closespider.py
+++ b/tests/test_closespider.py
@@ -18,7 +18,7 @@ class TestCloseSpider(TestCase):
     def test_closespider_itemcount(self):
         close_on = 5
         crawler = get_crawler(ItemSpider, {'CLOSESPIDER_ITEMCOUNT': close_on})
-        yield crawler.crawl()
+        yield crawler.crawl(address=self.mockserver.address())
         reason = crawler.spider.meta['close_reason']
         self.assertEqual(reason, 'closespider_itemcount')
         itemcount = crawler.stats.get_value('item_scraped_count')
@@ -28,7 +28,7 @@ class TestCloseSpider(TestCase):
     def test_closespider_pagecount(self):
         close_on = 5
         crawler = get_crawler(FollowAllSpider, {'CLOSESPIDER_PAGECOUNT': close_on})
-        yield crawler.crawl()
+        yield crawler.crawl(address=self.mockserver.address())
         reason = crawler.spider.meta['close_reason']
         self.assertEqual(reason, 'closespider_pagecount')
         pagecount = crawler.stats.get_value('response_received_count')
@@ -38,7 +38,7 @@ class TestCloseSpider(TestCase):
     def test_closespider_errorcount(self):
         close_on = 5
         crawler = get_crawler(ErrorSpider, {'CLOSESPIDER_ERRORCOUNT': close_on})
-        yield crawler.crawl(total=1000000)
+        yield crawler.crawl(total=1000000, address=self.mockserver.address())
         reason = crawler.spider.meta['close_reason']
         self.assertEqual(reason, 'closespider_errorcount')
         key = 'spider_exceptions/{name}'\
@@ -50,7 +50,7 @@ class TestCloseSpider(TestCase):
     def test_closespider_timeout(self):
         close_on = 0.1
         crawler = get_crawler(FollowAllSpider, {'CLOSESPIDER_TIMEOUT': close_on})
-        yield crawler.crawl(total=1000000)
+        yield crawler.crawl(total=1000000, address=self.mockserver.address())
         reason = crawler.spider.meta['close_reason']
         self.assertEqual(reason, 'closespider_timeout')
         stats = crawler.stats

--- a/tests/test_crawl.py
+++ b/tests/test_crawl.py
@@ -77,7 +77,7 @@ class CrawlTestCase(TestCase):
     def test_retry_503(self):
         crawler = self.runner.create_crawler(SimpleSpider)
         with LogCapture() as l:
-            yield crawler.crawl(MockServer.from_mock("/status?n=503"))
+            yield crawler.crawl(MockServer.url("/status?n=503"))
         self._assert_retried(l)
 
     @defer.inlineCallbacks
@@ -160,7 +160,7 @@ with multiples lines
 '''})
         crawler = self.runner.create_crawler(SimpleSpider)
         with LogCapture() as l:
-            yield crawler.crawl(MockServer.from_mock("/raw?{0}".format(query)))
+            yield crawler.crawl(MockServer.url("/raw?{0}".format(query)))
         self.assertEqual(str(l).count("Got response 200"), 1)
 
     @defer.inlineCallbacks
@@ -168,7 +168,7 @@ with multiples lines
         # connection lost after receiving data
         crawler = self.runner.create_crawler(SimpleSpider)
         with LogCapture() as l:
-            yield crawler.crawl(MockServer.from_mock("/drop?abort=0"))
+            yield crawler.crawl(MockServer.url("/drop?abort=0"))
         self._assert_retried(l)
 
     @defer.inlineCallbacks
@@ -176,7 +176,7 @@ with multiples lines
         # connection lost before receiving data
         crawler = self.runner.create_crawler(SimpleSpider)
         with LogCapture() as l:
-            yield crawler.crawl(MockServer.from_mock("/drop?abort=1"))
+            yield crawler.crawl(MockServer.url("/drop?abort=1"))
         self._assert_retried(l)
 
     def _assert_retried(self, log):
@@ -186,7 +186,7 @@ with multiples lines
     @defer.inlineCallbacks
     def test_referer_header(self):
         """Referer header is set by RefererMiddleware unless it is already set"""
-        req0 = Request(MockServer.from_mock('/echo?headers=1&body=0'), dont_filter=1)
+        req0 = Request(MockServer.url('/echo?headers=1&body=0'), dont_filter=1)
         req1 = req0.replace()
         req2 = req0.replace(headers={'Referer': None})
         req3 = req0.replace(headers={'Referer': 'http://example.com'})
@@ -220,7 +220,7 @@ with multiples lines
             est.append(get_engine_status(crawler.engine))
 
         crawler = self.runner.create_crawler(SingleRequestSpider)
-        yield crawler.crawl(seed=MockServer.from_mock('/'), callback_func=cb)
+        yield crawler.crawl(seed=MockServer.url('/'), callback_func=cb)
         self.assertEqual(len(est), 1, est)
         s = dict(est[0])
         self.assertEqual(s['engine.spider.name'], crawler.spider.name)
@@ -256,7 +256,7 @@ with multiples lines
         }
         crawler = CrawlerRunner(settings).create_crawler(SimpleSpider)
         yield self.assertFailure(
-            self.runner.crawl(crawler, MockServer.from_mock("/status?n=200")),
+            self.runner.crawl(crawler, MockServer.url("/status?n=200")),
             ZeroDivisionError)
         self.assertFalse(crawler.crawling)
 
@@ -264,13 +264,13 @@ with multiples lines
     def test_crawlerrunner_accepts_crawler(self):
         crawler = self.runner.create_crawler(SimpleSpider)
         with LogCapture() as log:
-            yield self.runner.crawl(crawler, MockServer.from_mock("/status?n=200"))
+            yield self.runner.crawl(crawler, MockServer.url("/status?n=200"))
         self.assertIn("Got response 200", str(log))
 
     @defer.inlineCallbacks
     def test_crawl_multiple(self):
-        self.runner.crawl(SimpleSpider, MockServer.from_mock("/status?n=200"))
-        self.runner.crawl(SimpleSpider, MockServer.from_mock("/status?n=503"))
+        self.runner.crawl(SimpleSpider, MockServer.url("/status?n=200"))
+        self.runner.crawl(SimpleSpider, MockServer.url("/status?n=503"))
 
         with LogCapture() as log:
             yield self.runner.join()

--- a/tests/test_crawl.py
+++ b/tests/test_crawl.py
@@ -26,7 +26,7 @@ class CrawlTestCase(TestCase):
     @defer.inlineCallbacks
     def test_follow_all(self):
         crawler = self.runner.create_crawler(FollowAllSpider)
-        yield crawler.crawl()
+        yield crawler.crawl(address=self.mockserver.address())
         self.assertEqual(len(crawler.spider.urls_visited), 11)  # 10 + start_url
 
     @defer.inlineCallbacks
@@ -42,7 +42,7 @@ class CrawlTestCase(TestCase):
     def _test_delay(self, delay, randomize):
         settings = {"DOWNLOAD_DELAY": delay, 'RANDOMIZE_DOWNLOAD_DELAY': randomize}
         crawler = CrawlerRunner(settings).create_crawler(FollowAllSpider)
-        yield crawler.crawl(maxlatency=delay * 2)
+        yield crawler.crawl(maxlatency=delay * 2, address=self.mockserver.address())
         t = crawler.spider.times
         totaltime = t[-1] - t[0]
         avgd = totaltime / (len(t) - 1)
@@ -53,7 +53,7 @@ class CrawlTestCase(TestCase):
     @defer.inlineCallbacks
     def test_timeout_success(self):
         crawler = self.runner.create_crawler(DelaySpider)
-        yield crawler.crawl(n=0.5)
+        yield crawler.crawl(n=0.5, address=self.mockserver.address())
         self.assertTrue(crawler.spider.t1 > 0)
         self.assertTrue(crawler.spider.t2 > 0)
         self.assertTrue(crawler.spider.t2 > crawler.spider.t1)
@@ -61,13 +61,13 @@ class CrawlTestCase(TestCase):
     @defer.inlineCallbacks
     def test_timeout_failure(self):
         crawler = CrawlerRunner({"DOWNLOAD_TIMEOUT": 0.35}).create_crawler(DelaySpider)
-        yield crawler.crawl(n=0.5)
+        yield crawler.crawl(n=0.5, address=self.mockserver.address())
         self.assertTrue(crawler.spider.t1 > 0)
         self.assertTrue(crawler.spider.t2 == 0)
         self.assertTrue(crawler.spider.t2_err > 0)
         self.assertTrue(crawler.spider.t2_err > crawler.spider.t1)
         # server hangs after receiving response headers
-        yield crawler.crawl(n=0.5, b=1)
+        yield crawler.crawl(n=0.5, b=1, address=self.mockserver.address())
         self.assertTrue(crawler.spider.t1 > 0)
         self.assertTrue(crawler.spider.t2 == 0)
         self.assertTrue(crawler.spider.t2_err > 0)
@@ -77,14 +77,14 @@ class CrawlTestCase(TestCase):
     def test_retry_503(self):
         crawler = self.runner.create_crawler(SimpleSpider)
         with LogCapture() as l:
-            yield crawler.crawl(MockServer.url("/status?n=503"))
+            yield crawler.crawl(self.mockserver.address().url("/status?n=503"), address=self.mockserver.address())
         self._assert_retried(l)
 
     @defer.inlineCallbacks
     def test_retry_conn_failed(self):
         crawler = self.runner.create_crawler(SimpleSpider)
         with LogCapture() as l:
-            yield crawler.crawl("http://localhost:65432/status?n=503")
+            yield crawler.crawl("http://localhost:65432/status?n=503", address=self.mockserver.address())
         self._assert_retried(l)
 
     @defer.inlineCallbacks
@@ -92,14 +92,14 @@ class CrawlTestCase(TestCase):
         crawler = self.runner.create_crawler(SimpleSpider)
         with LogCapture() as l:
             # try to fetch the homepage of a non-existent domain
-            yield crawler.crawl("http://dns.resolution.invalid./")
+            yield crawler.crawl("http://dns.resolution.invalid./", address=self.mockserver.address())
         self._assert_retried(l)
 
     @defer.inlineCallbacks
     def test_start_requests_bug_before_yield(self):
         with LogCapture('scrapy', level=logging.ERROR) as l:
             crawler = self.runner.create_crawler(BrokenStartRequestsSpider)
-            yield crawler.crawl(fail_before_yield=1)
+            yield crawler.crawl(fail_before_yield=1, address=self.mockserver.address())
 
         self.assertEqual(len(l.records), 1)
         record = l.records[0]
@@ -110,7 +110,7 @@ class CrawlTestCase(TestCase):
     def test_start_requests_bug_yielding(self):
         with LogCapture('scrapy', level=logging.ERROR) as l:
             crawler = self.runner.create_crawler(BrokenStartRequestsSpider)
-            yield crawler.crawl(fail_yielding=1)
+            yield crawler.crawl(fail_yielding=1, address=self.mockserver.address())
 
         self.assertEqual(len(l.records), 1)
         record = l.records[0]
@@ -121,7 +121,7 @@ class CrawlTestCase(TestCase):
     def test_start_requests_lazyness(self):
         settings = {"CONCURRENT_REQUESTS": 1}
         crawler = CrawlerRunner(settings).create_crawler(BrokenStartRequestsSpider)
-        yield crawler.crawl()
+        yield crawler.crawl(address=self.mockserver.address())
         #self.assertTrue(False, crawler.spider.seedsseen)
         #self.assertTrue(crawler.spider.seedsseen.index(None) < crawler.spider.seedsseen.index(99),
         #                crawler.spider.seedsseen)
@@ -130,10 +130,10 @@ class CrawlTestCase(TestCase):
     def test_start_requests_dupes(self):
         settings = {"CONCURRENT_REQUESTS": 1}
         crawler = CrawlerRunner(settings).create_crawler(DuplicateStartRequestsSpider)
-        yield crawler.crawl(dont_filter=True, distinct_urls=2, dupe_factor=3)
+        yield crawler.crawl(dont_filter=True, distinct_urls=2, dupe_factor=3, address=self.mockserver.address())
         self.assertEqual(crawler.spider.visited, 6)
 
-        yield crawler.crawl(dont_filter=False, distinct_urls=3, dupe_factor=4)
+        yield crawler.crawl(dont_filter=False, distinct_urls=3, dupe_factor=4, address=self.mockserver.address())
         self.assertEqual(crawler.spider.visited, 3)
 
     @defer.inlineCallbacks
@@ -160,7 +160,7 @@ with multiples lines
 '''})
         crawler = self.runner.create_crawler(SimpleSpider)
         with LogCapture() as l:
-            yield crawler.crawl(MockServer.url("/raw?{0}".format(query)))
+            yield crawler.crawl(self.mockserver.address().url("/raw?{0}".format(query)), address=self.mockserver.address())
         self.assertEqual(str(l).count("Got response 200"), 1)
 
     @defer.inlineCallbacks
@@ -168,7 +168,7 @@ with multiples lines
         # connection lost after receiving data
         crawler = self.runner.create_crawler(SimpleSpider)
         with LogCapture() as l:
-            yield crawler.crawl(MockServer.url("/drop?abort=0"))
+            yield crawler.crawl(self.mockserver.address().url("/drop?abort=0"), address=self.mockserver.address())
         self._assert_retried(l)
 
     @defer.inlineCallbacks
@@ -176,7 +176,7 @@ with multiples lines
         # connection lost before receiving data
         crawler = self.runner.create_crawler(SimpleSpider)
         with LogCapture() as l:
-            yield crawler.crawl(MockServer.url("/drop?abort=1"))
+            yield crawler.crawl(self.mockserver.address().url("/drop?abort=1"), address=self.mockserver.address())
         self._assert_retried(l)
 
     def _assert_retried(self, log):
@@ -186,7 +186,7 @@ with multiples lines
     @defer.inlineCallbacks
     def test_referer_header(self):
         """Referer header is set by RefererMiddleware unless it is already set"""
-        req0 = Request(MockServer.url('/echo?headers=1&body=0'), dont_filter=1)
+        req0 = Request(self.mockserver.address().url('/echo?headers=1&body=0'), dont_filter=1)
         req1 = req0.replace()
         req2 = req0.replace(headers={'Referer': None})
         req3 = req0.replace(headers={'Referer': 'http://example.com'})
@@ -194,7 +194,7 @@ with multiples lines
         req1.meta['next'] = req2
         req2.meta['next'] = req3
         crawler = self.runner.create_crawler(SingleRequestSpider)
-        yield crawler.crawl(seed=req0)
+        yield crawler.crawl(seed=req0, address=self.mockserver.address())
         # basic asserts in case of weird communication errors
         self.assertIn('responses', crawler.spider.meta)
         self.assertNotIn('failures', crawler.spider.meta)
@@ -220,7 +220,7 @@ with multiples lines
             est.append(get_engine_status(crawler.engine))
 
         crawler = self.runner.create_crawler(SingleRequestSpider)
-        yield crawler.crawl(seed=MockServer.url('/'), callback_func=cb)
+        yield crawler.crawl(seed=self.mockserver.address().url('/'), callback_func=cb, address=self.mockserver.address())
         self.assertEqual(len(est), 1, est)
         s = dict(est[0])
         self.assertEqual(s['engine.spider.name'], crawler.spider.name)
@@ -244,7 +244,7 @@ with multiples lines
                 raise TestError
 
         crawler = self.runner.create_crawler(FaultySpider)
-        yield self.assertFailure(crawler.crawl(), TestError)
+        yield self.assertFailure(crawler.crawl(address=self.mockserver.address()), TestError)
         self.assertFalse(crawler.crawling)
 
     @defer.inlineCallbacks
@@ -256,7 +256,7 @@ with multiples lines
         }
         crawler = CrawlerRunner(settings).create_crawler(SimpleSpider)
         yield self.assertFailure(
-            self.runner.crawl(crawler, MockServer.url("/status?n=200")),
+            self.runner.crawl(crawler, self.mockserver.address().url("/status?n=200"), address=self.mockserver.address()),
             ZeroDivisionError)
         self.assertFalse(crawler.crawling)
 
@@ -264,13 +264,13 @@ with multiples lines
     def test_crawlerrunner_accepts_crawler(self):
         crawler = self.runner.create_crawler(SimpleSpider)
         with LogCapture() as log:
-            yield self.runner.crawl(crawler, MockServer.url("/status?n=200"))
+            yield self.runner.crawl(crawler, self.mockserver.address().url("/status?n=200"), address=self.mockserver.address())
         self.assertIn("Got response 200", str(log))
 
     @defer.inlineCallbacks
     def test_crawl_multiple(self):
-        self.runner.crawl(SimpleSpider, MockServer.url("/status?n=200"))
-        self.runner.crawl(SimpleSpider, MockServer.url("/status?n=503"))
+        self.runner.crawl(SimpleSpider, self.mockserver.address().url("/status?n=200"), address=self.mockserver.address())
+        self.runner.crawl(SimpleSpider, self.mockserver.address().url("/status?n=503"), address=self.mockserver.address())
 
         with LogCapture() as log:
             yield self.runner.join()

--- a/tests/test_crawl.py
+++ b/tests/test_crawl.py
@@ -77,7 +77,7 @@ class CrawlTestCase(TestCase):
     def test_retry_503(self):
         crawler = self.runner.create_crawler(SimpleSpider)
         with LogCapture() as l:
-            yield crawler.crawl("http://localhost:8998/status?n=503")
+            yield crawler.crawl(MockServer.from_mock("/status?n=503"))
         self._assert_retried(l)
 
     @defer.inlineCallbacks
@@ -160,7 +160,7 @@ with multiples lines
 '''})
         crawler = self.runner.create_crawler(SimpleSpider)
         with LogCapture() as l:
-            yield crawler.crawl("http://localhost:8998/raw?{0}".format(query))
+            yield crawler.crawl(MockServer.from_mock("/raw?{0}".format(query)))
         self.assertEqual(str(l).count("Got response 200"), 1)
 
     @defer.inlineCallbacks
@@ -168,7 +168,7 @@ with multiples lines
         # connection lost after receiving data
         crawler = self.runner.create_crawler(SimpleSpider)
         with LogCapture() as l:
-            yield crawler.crawl("http://localhost:8998/drop?abort=0")
+            yield crawler.crawl(MockServer.from_mock("/drop?abort=0"))
         self._assert_retried(l)
 
     @defer.inlineCallbacks
@@ -176,7 +176,7 @@ with multiples lines
         # connection lost before receiving data
         crawler = self.runner.create_crawler(SimpleSpider)
         with LogCapture() as l:
-            yield crawler.crawl("http://localhost:8998/drop?abort=1")
+            yield crawler.crawl(MockServer.from_mock("/drop?abort=1"))
         self._assert_retried(l)
 
     def _assert_retried(self, log):
@@ -186,7 +186,7 @@ with multiples lines
     @defer.inlineCallbacks
     def test_referer_header(self):
         """Referer header is set by RefererMiddleware unless it is already set"""
-        req0 = Request('http://localhost:8998/echo?headers=1&body=0', dont_filter=1)
+        req0 = Request(MockServer.from_mock('/echo?headers=1&body=0'), dont_filter=1)
         req1 = req0.replace()
         req2 = req0.replace(headers={'Referer': None})
         req3 = req0.replace(headers={'Referer': 'http://example.com'})
@@ -220,7 +220,7 @@ with multiples lines
             est.append(get_engine_status(crawler.engine))
 
         crawler = self.runner.create_crawler(SingleRequestSpider)
-        yield crawler.crawl(seed='http://localhost:8998/', callback_func=cb)
+        yield crawler.crawl(seed=MockServer.from_mock('/'), callback_func=cb)
         self.assertEqual(len(est), 1, est)
         s = dict(est[0])
         self.assertEqual(s['engine.spider.name'], crawler.spider.name)
@@ -256,7 +256,7 @@ with multiples lines
         }
         crawler = CrawlerRunner(settings).create_crawler(SimpleSpider)
         yield self.assertFailure(
-            self.runner.crawl(crawler, "http://localhost:8998/status?n=200"),
+            self.runner.crawl(crawler, MockServer.from_mock("/status?n=200")),
             ZeroDivisionError)
         self.assertFalse(crawler.crawling)
 
@@ -264,13 +264,13 @@ with multiples lines
     def test_crawlerrunner_accepts_crawler(self):
         crawler = self.runner.create_crawler(SimpleSpider)
         with LogCapture() as log:
-            yield self.runner.crawl(crawler, "http://localhost:8998/status?n=200")
+            yield self.runner.crawl(crawler, MockServer.from_mock("/status?n=200"))
         self.assertIn("Got response 200", str(log))
 
     @defer.inlineCallbacks
     def test_crawl_multiple(self):
-        self.runner.crawl(SimpleSpider, "http://localhost:8998/status?n=200")
-        self.runner.crawl(SimpleSpider, "http://localhost:8998/status?n=503")
+        self.runner.crawl(SimpleSpider, MockServer.from_mock("/status?n=200"))
+        self.runner.crawl(SimpleSpider, MockServer.from_mock("/status?n=503"))
 
         with LogCapture() as log:
             yield self.runner.join()

--- a/tests/test_downloader_handlers.py
+++ b/tests/test_downloader_handlers.py
@@ -534,14 +534,14 @@ class Http11MockServerTestCase(unittest.TestCase):
         crawler = get_crawler(SingleRequestSpider)
         # http://localhost:8998/partial set Content-Length to 1024, use download_maxsize= 1000 to avoid
         # download it
-        yield crawler.crawl(seed=Request(url=MockServer.url('/partial'), meta={'download_maxsize': 1000}))
+        yield crawler.crawl(seed=Request(url=self.mockserver.address().url('/partial'), meta={'download_maxsize': 1000}))
         failure = crawler.spider.meta['failure']
         self.assertIsInstance(failure.value, defer.CancelledError)
 
     @defer.inlineCallbacks
     def test_download(self):
         crawler = get_crawler(SingleRequestSpider)
-        yield crawler.crawl(seed=Request(url=MockServer.url('')))
+        yield crawler.crawl(seed=Request(url=self.mockserver.address().url('')))
         failure = crawler.spider.meta.get('failure')
         self.assertTrue(failure == None)
         reason = crawler.spider.meta['close_reason']
@@ -551,7 +551,7 @@ class Http11MockServerTestCase(unittest.TestCase):
     def test_download_gzip_response(self):
         crawler = get_crawler(SingleRequestSpider)
         body = b'1' * 100  # PayloadResource requires body length to be 100
-        request = Request(MockServer.url('/payload'), method='POST',
+        request = Request(self.mockserver.address().url('/payload'), method='POST',
                           body=body, meta={'download_maxsize': 50})
         yield crawler.crawl(seed=request)
         failure = crawler.spider.meta['failure']
@@ -560,7 +560,7 @@ class Http11MockServerTestCase(unittest.TestCase):
 
         if six.PY2:
             request.headers.setdefault(b'Accept-Encoding', b'gzip,deflate')
-            request = request.replace(url=MockServer.url('/xpayload'))
+            request = request.replace(url=self.mockserver.address().url('/xpayload'))
             yield crawler.crawl(seed=request)
             # download_maxsize = 50 is enough for the gzipped response
             failure = crawler.spider.meta.get('failure')

--- a/tests/test_downloader_handlers.py
+++ b/tests/test_downloader_handlers.py
@@ -534,14 +534,14 @@ class Http11MockServerTestCase(unittest.TestCase):
         crawler = get_crawler(SingleRequestSpider)
         # http://localhost:8998/partial set Content-Length to 1024, use download_maxsize= 1000 to avoid
         # download it
-        yield crawler.crawl(seed=Request(url=MockServer.from_mock('/partial'), meta={'download_maxsize': 1000}))
+        yield crawler.crawl(seed=Request(url=MockServer.url('/partial'), meta={'download_maxsize': 1000}))
         failure = crawler.spider.meta['failure']
         self.assertIsInstance(failure.value, defer.CancelledError)
 
     @defer.inlineCallbacks
     def test_download(self):
         crawler = get_crawler(SingleRequestSpider)
-        yield crawler.crawl(seed=Request(url=MockServer.from_mock('')))
+        yield crawler.crawl(seed=Request(url=MockServer.url('')))
         failure = crawler.spider.meta.get('failure')
         self.assertTrue(failure == None)
         reason = crawler.spider.meta['close_reason']
@@ -551,7 +551,7 @@ class Http11MockServerTestCase(unittest.TestCase):
     def test_download_gzip_response(self):
         crawler = get_crawler(SingleRequestSpider)
         body = b'1' * 100  # PayloadResource requires body length to be 100
-        request = Request(MockServer.from_mock('/payload'), method='POST',
+        request = Request(MockServer.url('/payload'), method='POST',
                           body=body, meta={'download_maxsize': 50})
         yield crawler.crawl(seed=request)
         failure = crawler.spider.meta['failure']
@@ -560,7 +560,7 @@ class Http11MockServerTestCase(unittest.TestCase):
 
         if six.PY2:
             request.headers.setdefault(b'Accept-Encoding', b'gzip,deflate')
-            request = request.replace(url=MockServer.from_mock('/xpayload'))
+            request = request.replace(url=MockServer.url('/xpayload'))
             yield crawler.crawl(seed=request)
             # download_maxsize = 50 is enough for the gzipped response
             failure = crawler.spider.meta.get('failure')

--- a/tests/test_downloader_handlers.py
+++ b/tests/test_downloader_handlers.py
@@ -534,14 +534,14 @@ class Http11MockServerTestCase(unittest.TestCase):
         crawler = get_crawler(SingleRequestSpider)
         # http://localhost:8998/partial set Content-Length to 1024, use download_maxsize= 1000 to avoid
         # download it
-        yield crawler.crawl(seed=Request(url='http://localhost:8998/partial', meta={'download_maxsize': 1000}))
+        yield crawler.crawl(seed=Request(url=MockServer.from_mock('/partial'), meta={'download_maxsize': 1000}))
         failure = crawler.spider.meta['failure']
         self.assertIsInstance(failure.value, defer.CancelledError)
 
     @defer.inlineCallbacks
     def test_download(self):
         crawler = get_crawler(SingleRequestSpider)
-        yield crawler.crawl(seed=Request(url='http://localhost:8998'))
+        yield crawler.crawl(seed=Request(url=MockServer.from_mock('')))
         failure = crawler.spider.meta.get('failure')
         self.assertTrue(failure == None)
         reason = crawler.spider.meta['close_reason']
@@ -551,7 +551,7 @@ class Http11MockServerTestCase(unittest.TestCase):
     def test_download_gzip_response(self):
         crawler = get_crawler(SingleRequestSpider)
         body = b'1' * 100  # PayloadResource requires body length to be 100
-        request = Request('http://localhost:8998/payload', method='POST',
+        request = Request(MockServer.from_mock('/payload'), method='POST',
                           body=body, meta={'download_maxsize': 50})
         yield crawler.crawl(seed=request)
         failure = crawler.spider.meta['failure']
@@ -560,7 +560,7 @@ class Http11MockServerTestCase(unittest.TestCase):
 
         if six.PY2:
             request.headers.setdefault(b'Accept-Encoding', b'gzip,deflate')
-            request = request.replace(url='http://localhost:8998/xpayload')
+            request = request.replace(url=MockServer.from_mock('/xpayload'))
             yield crawler.crawl(seed=request)
             # download_maxsize = 50 is enough for the gzipped response
             failure = crawler.spider.meta.get('failure')

--- a/tests/test_feedexport.py
+++ b/tests/test_feedexport.py
@@ -179,7 +179,7 @@ class FeedExportTest(unittest.TestCase):
         try:
             with MockServer() as s:
                 runner = CrawlerRunner(Settings(defaults))
-                spider_cls.start_urls = [MockServer.from_mock('/')]
+                spider_cls.start_urls = [MockServer.url('/')]
                 yield runner.crawl(spider_cls)
 
             with open(res_name, 'rb') as f:

--- a/tests/test_feedexport.py
+++ b/tests/test_feedexport.py
@@ -179,6 +179,7 @@ class FeedExportTest(unittest.TestCase):
         try:
             with MockServer() as s:
                 runner = CrawlerRunner(Settings(defaults))
+                spider_cls.start_urls = [MockServer.from_mock('/')]
                 yield runner.crawl(spider_cls)
 
             with open(res_name, 'rb') as f:
@@ -194,7 +195,6 @@ class FeedExportTest(unittest.TestCase):
         """
         class TestSpider(scrapy.Spider):
             name = 'testspider'
-            start_urls = ['http://localhost:8998/']
 
             def parse(self, response):
                 for item in items:
@@ -210,7 +210,6 @@ class FeedExportTest(unittest.TestCase):
         """
         class TestSpider(scrapy.Spider):
             name = 'testspider'
-            start_urls = ['http://localhost:8998/']
 
             def parse(self, response):
                 pass

--- a/tests/test_feedexport.py
+++ b/tests/test_feedexport.py
@@ -179,7 +179,7 @@ class FeedExportTest(unittest.TestCase):
         try:
             with MockServer() as s:
                 runner = CrawlerRunner(Settings(defaults))
-                spider_cls.start_urls = [MockServer.url('/')]
+                spider_cls.start_urls = [s.address().url('/')]
                 yield runner.crawl(spider_cls)
 
             with open(res_name, 'rb') as f:

--- a/tests/test_pipeline_crawl.py
+++ b/tests/test_pipeline_crawl.py
@@ -46,7 +46,7 @@ class RedirectedMediaDownloadSpider(MediaDownloadSpider):
 
     def _process_url(self, url):
         return add_or_replace_parameter(
-                    os.environ[MockServer.HTTP] + '/redirect-to',
+                    MockServer.from_mock('/redirect-to'),
                     'goto', url)
 
 
@@ -134,7 +134,7 @@ class FileDownloadCrawlTestCase(TestCase):
     def test_download_media(self):
         crawler = self._create_crawler(MediaDownloadSpider)
         with LogCapture() as log:
-            yield crawler.crawl(os.environ[MockServer.HTTP] + "/files/images/",
+            yield crawler.crawl(MockServer.from_mock("/files/images/"),
                 media_key=self.media_key,
                 media_urls_key=self.media_urls_key)
         self._assert_files_downloaded(self.items, str(log))
@@ -143,7 +143,7 @@ class FileDownloadCrawlTestCase(TestCase):
     def test_download_media_wrong_urls(self):
         crawler = self._create_crawler(BrokenLinksMediaDownloadSpider)
         with LogCapture() as log:
-            yield crawler.crawl(os.environ[MockServer.HTTP] + "/files/images/",
+            yield crawler.crawl(MockServer.from_mock("/files/images/"),
                 media_key=self.media_key,
                 media_urls_key=self.media_urls_key)
         self._assert_files_download_failure(crawler, self.items, 404, str(log))
@@ -152,7 +152,7 @@ class FileDownloadCrawlTestCase(TestCase):
     def test_download_media_redirected_default_failure(self):
         crawler = self._create_crawler(RedirectedMediaDownloadSpider)
         with LogCapture() as log:
-            yield crawler.crawl(os.environ[MockServer.HTTP] + "/files/images/",
+            yield crawler.crawl(MockServer.from_mock("/files/images/"),
                 media_key=self.media_key,
                 media_urls_key=self.media_urls_key)
         self._assert_files_download_failure(crawler, self.items, 302, str(log))
@@ -165,7 +165,7 @@ class FileDownloadCrawlTestCase(TestCase):
 
         crawler = self._create_crawler(RedirectedMediaDownloadSpider)
         with LogCapture() as log:
-            yield crawler.crawl(os.environ[MockServer.HTTP] + "/files/images/",
+            yield crawler.crawl(MockServer.from_mock("/files/images/"),
                 media_key=self.media_key,
                 media_urls_key=self.media_urls_key)
         self._assert_files_downloaded(self.items, str(log))

--- a/tests/test_pipeline_crawl.py
+++ b/tests/test_pipeline_crawl.py
@@ -46,7 +46,7 @@ class RedirectedMediaDownloadSpider(MediaDownloadSpider):
 
     def _process_url(self, url):
         return add_or_replace_parameter(
-                    MockServer.from_mock('/redirect-to'),
+                    MockServer.url('/redirect-to'),
                     'goto', url)
 
 
@@ -134,7 +134,7 @@ class FileDownloadCrawlTestCase(TestCase):
     def test_download_media(self):
         crawler = self._create_crawler(MediaDownloadSpider)
         with LogCapture() as log:
-            yield crawler.crawl(MockServer.from_mock("/files/images/"),
+            yield crawler.crawl(MockServer.url("/files/images/"),
                 media_key=self.media_key,
                 media_urls_key=self.media_urls_key)
         self._assert_files_downloaded(self.items, str(log))
@@ -143,7 +143,7 @@ class FileDownloadCrawlTestCase(TestCase):
     def test_download_media_wrong_urls(self):
         crawler = self._create_crawler(BrokenLinksMediaDownloadSpider)
         with LogCapture() as log:
-            yield crawler.crawl(MockServer.from_mock("/files/images/"),
+            yield crawler.crawl(MockServer.url("/files/images/"),
                 media_key=self.media_key,
                 media_urls_key=self.media_urls_key)
         self._assert_files_download_failure(crawler, self.items, 404, str(log))
@@ -152,7 +152,7 @@ class FileDownloadCrawlTestCase(TestCase):
     def test_download_media_redirected_default_failure(self):
         crawler = self._create_crawler(RedirectedMediaDownloadSpider)
         with LogCapture() as log:
-            yield crawler.crawl(MockServer.from_mock("/files/images/"),
+            yield crawler.crawl(MockServer.url("/files/images/"),
                 media_key=self.media_key,
                 media_urls_key=self.media_urls_key)
         self._assert_files_download_failure(crawler, self.items, 302, str(log))
@@ -165,7 +165,7 @@ class FileDownloadCrawlTestCase(TestCase):
 
         crawler = self._create_crawler(RedirectedMediaDownloadSpider)
         with LogCapture() as log:
-            yield crawler.crawl(MockServer.from_mock("/files/images/"),
+            yield crawler.crawl(MockServer.url("/files/images/"),
                 media_key=self.media_key,
                 media_urls_key=self.media_urls_key)
         self._assert_files_downloaded(self.items, str(log))

--- a/tests/test_pipeline_crawl.py
+++ b/tests/test_pipeline_crawl.py
@@ -46,7 +46,7 @@ class RedirectedMediaDownloadSpider(MediaDownloadSpider):
 
     def _process_url(self, url):
         return add_or_replace_parameter(
-                    MockServer.url('/redirect-to'),
+                    self.address.url('/redirect-to'),
                     'goto', url)
 
 
@@ -134,7 +134,7 @@ class FileDownloadCrawlTestCase(TestCase):
     def test_download_media(self):
         crawler = self._create_crawler(MediaDownloadSpider)
         with LogCapture() as log:
-            yield crawler.crawl(MockServer.url("/files/images/"),
+            yield crawler.crawl(self.mockserver.address().url("/files/images/"),
                 media_key=self.media_key,
                 media_urls_key=self.media_urls_key)
         self._assert_files_downloaded(self.items, str(log))
@@ -143,7 +143,7 @@ class FileDownloadCrawlTestCase(TestCase):
     def test_download_media_wrong_urls(self):
         crawler = self._create_crawler(BrokenLinksMediaDownloadSpider)
         with LogCapture() as log:
-            yield crawler.crawl(MockServer.url("/files/images/"),
+            yield crawler.crawl(self.mockserver.address().url("/files/images/"),
                 media_key=self.media_key,
                 media_urls_key=self.media_urls_key)
         self._assert_files_download_failure(crawler, self.items, 404, str(log))
@@ -152,9 +152,10 @@ class FileDownloadCrawlTestCase(TestCase):
     def test_download_media_redirected_default_failure(self):
         crawler = self._create_crawler(RedirectedMediaDownloadSpider)
         with LogCapture() as log:
-            yield crawler.crawl(MockServer.url("/files/images/"),
+            yield crawler.crawl(self.mockserver.address().url("/files/images/"),
                 media_key=self.media_key,
-                media_urls_key=self.media_urls_key)
+                media_urls_key=self.media_urls_key,
+                address=self.mockserver.address())
         self._assert_files_download_failure(crawler, self.items, 302, str(log))
 
     @defer.inlineCallbacks
@@ -165,9 +166,10 @@ class FileDownloadCrawlTestCase(TestCase):
 
         crawler = self._create_crawler(RedirectedMediaDownloadSpider)
         with LogCapture() as log:
-            yield crawler.crawl(MockServer.url("/files/images/"),
+            yield crawler.crawl(self.mockserver.address().url("/files/images/"),
                 media_key=self.media_key,
-                media_urls_key=self.media_urls_key)
+                media_urls_key=self.media_urls_key,
+                address=self.mockserver.address())
         self._assert_files_downloaded(self.items, str(log))
         self.assertEqual(crawler.stats.get_value('downloader/response_status_count/302'), 3)
 

--- a/tests/test_pipeline_crawl.py
+++ b/tests/test_pipeline_crawl.py
@@ -46,7 +46,7 @@ class RedirectedMediaDownloadSpider(MediaDownloadSpider):
 
     def _process_url(self, url):
         return add_or_replace_parameter(
-                    'http://localhost:8998/redirect-to',
+                    os.environ[MockServer.HTTP] + '/redirect-to',
                     'goto', url)
 
 
@@ -134,7 +134,7 @@ class FileDownloadCrawlTestCase(TestCase):
     def test_download_media(self):
         crawler = self._create_crawler(MediaDownloadSpider)
         with LogCapture() as log:
-            yield crawler.crawl("http://localhost:8998/files/images/",
+            yield crawler.crawl(os.environ[MockServer.HTTP] + "/files/images/",
                 media_key=self.media_key,
                 media_urls_key=self.media_urls_key)
         self._assert_files_downloaded(self.items, str(log))
@@ -143,7 +143,7 @@ class FileDownloadCrawlTestCase(TestCase):
     def test_download_media_wrong_urls(self):
         crawler = self._create_crawler(BrokenLinksMediaDownloadSpider)
         with LogCapture() as log:
-            yield crawler.crawl("http://localhost:8998/files/images/",
+            yield crawler.crawl(os.environ[MockServer.HTTP] + "/files/images/",
                 media_key=self.media_key,
                 media_urls_key=self.media_urls_key)
         self._assert_files_download_failure(crawler, self.items, 404, str(log))
@@ -152,7 +152,7 @@ class FileDownloadCrawlTestCase(TestCase):
     def test_download_media_redirected_default_failure(self):
         crawler = self._create_crawler(RedirectedMediaDownloadSpider)
         with LogCapture() as log:
-            yield crawler.crawl("http://localhost:8998/files/images/",
+            yield crawler.crawl(os.environ[MockServer.HTTP] + "/files/images/",
                 media_key=self.media_key,
                 media_urls_key=self.media_urls_key)
         self._assert_files_download_failure(crawler, self.items, 302, str(log))
@@ -165,7 +165,7 @@ class FileDownloadCrawlTestCase(TestCase):
 
         crawler = self._create_crawler(RedirectedMediaDownloadSpider)
         with LogCapture() as log:
-            yield crawler.crawl("http://localhost:8998/files/images/",
+            yield crawler.crawl(os.environ[MockServer.HTTP] + "/files/images/",
                 media_key=self.media_key,
                 media_urls_key=self.media_urls_key)
         self._assert_files_downloaded(self.items, str(log))

--- a/tests/test_proxy_connect.py
+++ b/tests/test_proxy_connect.py
@@ -61,7 +61,7 @@ class ProxyConnectTestCase(TestCase):
     def test_https_connect_tunnel(self):
         crawler = get_crawler(SimpleSpider)
         with LogCapture() as l:
-            yield crawler.crawl("https://localhost:8999/status?n=200")
+            yield crawler.crawl(MockServer.from_mock("/status?n=200"))
         self._assert_got_response_code(200, l)
 
     @defer.inlineCallbacks
@@ -70,7 +70,7 @@ class ProxyConnectTestCase(TestCase):
         os.environ['https_proxy'] = proxy + '?noconnect'
         crawler = get_crawler(SimpleSpider)
         with LogCapture() as l:
-            yield crawler.crawl("https://localhost:8999/status?n=200")
+            yield crawler.crawl(MockServer.from_mock("/status?n=200"))
         self._assert_got_response_code(200, l)
         os.environ['https_proxy'] = proxy
 
@@ -90,7 +90,7 @@ class ProxyConnectTestCase(TestCase):
         os.environ['https_proxy'] = urlunsplit(bad_auth_proxy)
         crawler = get_crawler(SimpleSpider)
         with LogCapture() as l:
-            yield crawler.crawl("https://localhost:8999/status?n=200")
+            yield crawler.crawl(MockServer.from_mock("/status?n=200", is_secure=True))
         # The proxy returns a 407 error code but it does not reach the client;
         # he just sees a TunnelError.
         self._assert_got_tunnel_error(l)
@@ -98,7 +98,7 @@ class ProxyConnectTestCase(TestCase):
 
     @defer.inlineCallbacks
     def test_https_tunnel_without_leak_proxy_authorization_header(self):
-        request = Request("https://localhost:8999/echo")
+        request = Request(MockServer.from_mock("/echo"))
         crawler = get_crawler(SingleRequestSpider)
         with LogCapture() as l:
             yield crawler.crawl(seed=request)
@@ -115,7 +115,7 @@ class ProxyConnectTestCase(TestCase):
         os.environ['https_proxy'] = urlunsplit(bad_auth_proxy) + '?noconnect'
         crawler = get_crawler(SimpleSpider)
         with LogCapture() as l:
-            yield crawler.crawl("https://localhost:8999/status?n=200")
+            yield crawler.crawl(MockServer.from_mock("/status?n=200", is_secure=True))
         self._assert_got_response_code(407, l)
 
     def _assert_got_response_code(self, code, log):

--- a/tests/test_proxy_connect.py
+++ b/tests/test_proxy_connect.py
@@ -111,6 +111,7 @@ class ProxyConnectTestCase(TestCase):
         with LogCapture() as l:
             yield crawler.crawl(MockServer.from_mock("/status?n=200", is_secure=True))
         self._assert_got_response_code(407, l)
+        os.environ['https_proxy'] = proxy
 
     def _assert_got_response_code(self, code, log):
         print(log)

--- a/tests/test_proxy_connect.py
+++ b/tests/test_proxy_connect.py
@@ -58,7 +58,7 @@ class ProxyConnectTestCase(TestCase):
     def test_https_connect_tunnel(self):
         crawler = get_crawler(SimpleSpider)
         with LogCapture() as l:
-            yield crawler.crawl(MockServer.url("/status?n=200"))
+            yield crawler.crawl(self.mockserver.address().url("/status?n=200"))
         self._assert_got_response_code(200, l)
 
     @defer.inlineCallbacks
@@ -67,7 +67,7 @@ class ProxyConnectTestCase(TestCase):
         os.environ['https_proxy'] = proxy + '?noconnect'
         crawler = get_crawler(SimpleSpider)
         with LogCapture() as l:
-            yield crawler.crawl(MockServer.url("/status?n=200"))
+            yield crawler.crawl(self.mockserver.address().url("/status?n=200"))
         self._assert_got_response_code(200, l)
 
     @defer.inlineCallbacks
@@ -86,14 +86,14 @@ class ProxyConnectTestCase(TestCase):
         os.environ['https_proxy'] = urlunsplit(bad_auth_proxy)
         crawler = get_crawler(SimpleSpider)
         with LogCapture() as l:
-            yield crawler.crawl(MockServer.url("/status?n=200", is_secure=True))
+            yield crawler.crawl(self.mockserver.address().url("/status?n=200", is_secure=True))
         # The proxy returns a 407 error code but it does not reach the client;
         # he just sees a TunnelError.
         self._assert_got_tunnel_error(l)
 
     @defer.inlineCallbacks
     def test_https_tunnel_without_leak_proxy_authorization_header(self):
-        request = Request(MockServer.url("/echo"))
+        request = Request(self.mockserver.address().url("/echo"))
         crawler = get_crawler(SingleRequestSpider)
         with LogCapture() as l:
             yield crawler.crawl(seed=request)
@@ -110,7 +110,7 @@ class ProxyConnectTestCase(TestCase):
         os.environ['https_proxy'] = urlunsplit(bad_auth_proxy) + '?noconnect'
         crawler = get_crawler(SimpleSpider)
         with LogCapture() as l:
-            yield crawler.crawl(MockServer.url("/status?n=200", is_secure=True))
+            yield crawler.crawl(self.mockserver.address().url("/status?n=200", is_secure=True))
         self._assert_got_response_code(407, l)
 
     def _assert_got_response_code(self, code, log):

--- a/tests/test_proxy_connect.py
+++ b/tests/test_proxy_connect.py
@@ -55,7 +55,7 @@ class ProxyConnectTestCase(TestCase):
     def test_https_connect_tunnel(self):
         crawler = get_crawler(SimpleSpider)
         with LogCapture() as l:
-            yield crawler.crawl(MockServer.from_mock("/status?n=200"))
+            yield crawler.crawl(MockServer.url("/status?n=200"))
         self._assert_got_response_code(200, l)
 
     @defer.inlineCallbacks
@@ -64,7 +64,7 @@ class ProxyConnectTestCase(TestCase):
         os.environ['https_proxy'] = proxy + '?noconnect'
         crawler = get_crawler(SimpleSpider)
         with LogCapture() as l:
-            yield crawler.crawl(MockServer.from_mock("/status?n=200"))
+            yield crawler.crawl(MockServer.url("/status?n=200"))
         self._assert_got_response_code(200, l)
         os.environ['https_proxy'] = proxy
 
@@ -84,7 +84,7 @@ class ProxyConnectTestCase(TestCase):
         os.environ['https_proxy'] = urlunsplit(bad_auth_proxy)
         crawler = get_crawler(SimpleSpider)
         with LogCapture() as l:
-            yield crawler.crawl(MockServer.from_mock("/status?n=200", is_secure=True))
+            yield crawler.crawl(MockServer.url("/status?n=200", is_secure=True))
         # The proxy returns a 407 error code but it does not reach the client;
         # he just sees a TunnelError.
         self._assert_got_tunnel_error(l)
@@ -92,7 +92,7 @@ class ProxyConnectTestCase(TestCase):
 
     @defer.inlineCallbacks
     def test_https_tunnel_without_leak_proxy_authorization_header(self):
-        request = Request(MockServer.from_mock("/echo"))
+        request = Request(MockServer.url("/echo"))
         crawler = get_crawler(SingleRequestSpider)
         with LogCapture() as l:
             yield crawler.crawl(seed=request)
@@ -109,7 +109,7 @@ class ProxyConnectTestCase(TestCase):
         os.environ['https_proxy'] = urlunsplit(bad_auth_proxy) + '?noconnect'
         crawler = get_crawler(SimpleSpider)
         with LogCapture() as l:
-            yield crawler.crawl(MockServer.from_mock("/status?n=200", is_secure=True))
+            yield crawler.crawl(MockServer.url("/status?n=200", is_secure=True))
         self._assert_got_response_code(407, l)
         os.environ['https_proxy'] = proxy
 

--- a/tests/test_proxy_connect.py
+++ b/tests/test_proxy_connect.py
@@ -69,7 +69,6 @@ class ProxyConnectTestCase(TestCase):
         with LogCapture() as l:
             yield crawler.crawl(MockServer.url("/status?n=200"))
         self._assert_got_response_code(200, l)
-        os.environ['https_proxy'] = proxy
 
     @defer.inlineCallbacks
     def test_https_connect_tunnel_error(self):
@@ -91,7 +90,6 @@ class ProxyConnectTestCase(TestCase):
         # The proxy returns a 407 error code but it does not reach the client;
         # he just sees a TunnelError.
         self._assert_got_tunnel_error(l)
-        os.environ['https_proxy'] = proxy
 
     @defer.inlineCallbacks
     def test_https_tunnel_without_leak_proxy_authorization_header(self):
@@ -114,7 +112,6 @@ class ProxyConnectTestCase(TestCase):
         with LogCapture() as l:
             yield crawler.crawl(MockServer.url("/status?n=200", is_secure=True))
         self._assert_got_response_code(407, l)
-        os.environ['https_proxy'] = proxy
 
     def _assert_got_response_code(self, code, log):
         print(log)

--- a/tests/test_proxy_connect.py
+++ b/tests/test_proxy_connect.py
@@ -44,7 +44,6 @@ class ProxyConnectTestCase(TestCase):
 
         # Wait for the proxy to start.
         time.sleep(1.0)
-        os.environ['http_proxy'] = 'http://scrapy:scrapy@localhost:%d' % (http_port, )
         os.environ['https_proxy'] = 'http://scrapy:scrapy@localhost:%d' % (http_port, )
 
     def tearDown(self):

--- a/tests/test_proxy_connect.py
+++ b/tests/test_proxy_connect.py
@@ -13,7 +13,7 @@ from twisted.trial.unittest import TestCase
 from scrapy.utils.test import get_crawler
 from scrapy.http import Request
 from tests.spiders import SimpleSpider, SingleRequestSpider
-from tests.mockserver import MockServer
+from tests.mockserver import MockServer, get_ephemeral_port
 
 
 class HTTPSProxy(controller.Master, Thread):
@@ -38,14 +38,9 @@ class ProxyConnectTestCase(TestCase):
         self.mockserver.__enter__()
         self._oldenv = os.environ.copy()
 
-        for http_port in range(8000, 10000):
-
-            try:
-                self._proxy = HTTPSProxy(http_port)
-                self._proxy.start()
-                break
-            except Exception:
-                pass
+        http_port = get_ephemeral_port()
+        self._proxy = HTTPSProxy(http_port)
+        self._proxy.start()
 
         # Wait for the proxy to start.
         time.sleep(1.0)

--- a/tests/test_spidermiddleware_httperror.py
+++ b/tests/test_spidermiddleware_httperror.py
@@ -11,9 +11,10 @@ from scrapy.http import Response, Request
 from scrapy.spiders import Spider
 from scrapy.spidermiddlewares.httperror import HttpErrorMiddleware, HttpError
 from scrapy.settings import Settings
+from tests.spiders import AddressableSpider
 
 
-class _HttpErrorSpider(Spider):
+class _HttpErrorSpider(AddressableSpider):
     name = 'httperror'
     bypass_status_codes = set()
 

--- a/tests/test_spidermiddleware_httperror.py
+++ b/tests/test_spidermiddleware_httperror.py
@@ -11,10 +11,10 @@ from scrapy.http import Response, Request
 from scrapy.spiders import Spider
 from scrapy.spidermiddlewares.httperror import HttpErrorMiddleware, HttpError
 from scrapy.settings import Settings
-from tests.spiders import AddressableSpider
+from tests.spiders import MockServerSpider
 
 
-class _HttpErrorSpider(AddressableSpider):
+class _HttpErrorSpider(MockServerSpider):
     name = 'httperror'
     bypass_status_codes = set()
 

--- a/tests/test_spidermiddleware_httperror.py
+++ b/tests/test_spidermiddleware_httperror.py
@@ -20,10 +20,10 @@ class _HttpErrorSpider(Spider):
     def __init__(self, *args, **kwargs):
         super(_HttpErrorSpider, self).__init__(*args, **kwargs)
         self.start_urls = [
-            MockServer.url("/status?n=200"),
-            MockServer.url("/status?n=404"),
-            MockServer.url("/status?n=402"),
-            MockServer.url("/status?n=500"),
+           self.address.url("/status?n=200"),
+           self.address.url("/status?n=404"),
+           self.address.url("/status?n=402"),
+           self.address.url("/status?n=500"),
         ]
         self.failed = set()
         self.skipped = set()
@@ -169,7 +169,7 @@ class TestHttpErrorMiddlewareIntegrational(TrialTestCase):
     @defer.inlineCallbacks
     def test_middleware_works(self):
         crawler = get_crawler(_HttpErrorSpider)
-        yield crawler.crawl()
+        yield crawler.crawl(address=self.mockserver.address())
         assert not crawler.spider.skipped, crawler.spider.skipped
         self.assertEqual(crawler.spider.parsed, {'200'})
         self.assertEqual(crawler.spider.failed, {'404', '402', '500'})
@@ -184,7 +184,7 @@ class TestHttpErrorMiddlewareIntegrational(TrialTestCase):
     def test_logging(self):
         crawler = get_crawler(_HttpErrorSpider)
         with LogCapture() as log:
-            yield crawler.crawl(bypass_status_codes={402})
+            yield crawler.crawl(address=self.mockserver.address(), bypass_status_codes={402})
         self.assertEqual(crawler.spider.parsed, {'200', '402'})
         self.assertEqual(crawler.spider.skipped, {'402'})
         self.assertEqual(crawler.spider.failed, {'404', '500'})
@@ -199,7 +199,7 @@ class TestHttpErrorMiddlewareIntegrational(TrialTestCase):
         # HttpError logs ignored responses with level INFO
         crawler = get_crawler(_HttpErrorSpider)
         with LogCapture(level=logging.INFO) as log:
-            yield crawler.crawl()
+            yield crawler.crawl(address=self.mockserver.address())
         self.assertEqual(crawler.spider.parsed, {'200'})
         self.assertEqual(crawler.spider.failed, {'404', '402', '500'})
 
@@ -211,7 +211,7 @@ class TestHttpErrorMiddlewareIntegrational(TrialTestCase):
         # with level WARNING, we shouldn't capture anything from HttpError
         crawler = get_crawler(_HttpErrorSpider)
         with LogCapture(level=logging.WARNING) as log:
-            yield crawler.crawl()
+            yield crawler.crawl(address=self.mockserver.address())
         self.assertEqual(crawler.spider.parsed, {'200'})
         self.assertEqual(crawler.spider.failed, {'404', '402', '500'})
 

--- a/tests/test_spidermiddleware_httperror.py
+++ b/tests/test_spidermiddleware_httperror.py
@@ -20,10 +20,10 @@ class _HttpErrorSpider(Spider):
     def __init__(self, *args, **kwargs):
         super(_HttpErrorSpider, self).__init__(*args, **kwargs)
         self.start_urls = [
-            MockServer.from_mock("/status?n=200"),
-            MockServer.from_mock("/status?n=404"),
-            MockServer.from_mock("/status?n=402"),
-            MockServer.from_mock("/status?n=500"),
+            MockServer.url("/status?n=200"),
+            MockServer.url("/status?n=404"),
+            MockServer.url("/status?n=402"),
+            MockServer.url("/status?n=500"),
         ]
         self.failed = set()
         self.skipped = set()

--- a/tests/test_spidermiddleware_httperror.py
+++ b/tests/test_spidermiddleware_httperror.py
@@ -15,16 +15,16 @@ from scrapy.settings import Settings
 
 class _HttpErrorSpider(Spider):
     name = 'httperror'
-    start_urls = [
-        "http://localhost:8998/status?n=200",
-        "http://localhost:8998/status?n=404",
-        "http://localhost:8998/status?n=402",
-        "http://localhost:8998/status?n=500",
-    ]
     bypass_status_codes = set()
 
     def __init__(self, *args, **kwargs):
         super(_HttpErrorSpider, self).__init__(*args, **kwargs)
+        self.start_urls = [
+            MockServer.from_mock("/status?n=200"),
+            MockServer.from_mock("/status?n=404"),
+            MockServer.from_mock("/status?n=402"),
+            MockServer.from_mock("/status?n=500"),
+        ]
         self.failed = set()
         self.skipped = set()
         self.parsed = set()


### PR DESCRIPTION
On a busy host usual ports are already occupied by different services. Tests just fails if some base server can not listen on port.
This pull-request add ability searching of free port for `mockserver` and `proxyserver`