### PR TITLE
Add __setitem__, __getitem__ and __iter__ to class StatsCollector

### DIFF
--- a/docs/topics/stats.rst
+++ b/docs/topics/stats.rst
@@ -45,6 +45,10 @@ Set stat value::
 
     stats.set_value('hostname', socket.gethostname())
 
+or::
+
+   stats['hostname'] = socket.gethostname()
+
 Increment stat value::
 
     stats.inc_value('custom_count')
@@ -62,11 +66,24 @@ Get stat value::
     >>> stats.get_value('custom_count')
     1
 
+or::
+
+   >>> stats['custom_count']
+   1
+
 Get all stats::
 
     >>> stats.get_stats()
     {'custom_count': 1, 'start_time': datetime.datetime(2009, 7, 14, 21, 47, 28, 977139)}
 
+
+Get stat key::
+
+   >>> for key in stats:
+   ...     print(key)
+   ...
+   custom_count
+   start_time
 Available Stats Collectors
 ==========================
 

--- a/docs/topics/stats.rst
+++ b/docs/topics/stats.rst
@@ -84,6 +84,7 @@ Get stat key::
    ...
    custom_count
    start_time
+
 Available Stats Collectors
 ==========================
 

--- a/scrapy/statscollectors.py
+++ b/scrapy/statscollectors.py
@@ -1,8 +1,8 @@
 """
 Scrapy extension for collecting scraping stats
 """
-import pprint
 import logging
+import pprint
 
 logger = logging.getLogger(__name__)
 
@@ -50,6 +50,15 @@ class StatsCollector(object):
     def _persist_stats(self, stats, spider):
         pass
 
+    def __getitem__(self, key):
+        return self._stats.get(key)
+
+    def __setitem__(self, key, value):
+        self._stats[key] = value
+
+    def __iter__(self):
+        return iter(self._stats)
+
 
 class MemoryStatsCollector(StatsCollector):
 
@@ -80,5 +89,3 @@ class DummyStatsCollector(StatsCollector):
 
     def min_value(self, key, value, spider=None):
         pass
-
-

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -17,7 +17,14 @@ class StatsCollectorTest(unittest.TestCase):
         self.assertEqual(stats.get_value('anything'), None)
         self.assertEqual(stats.get_value('anything', 'default'), 'default')
         stats.set_value('test', 'value')
+        self.assertEqual(stats['test'], 'value')
         self.assertEqual(stats.get_stats(), {'test': 'value'})
+        stats['test'] = 'value2'
+        self.assertIn('test', stats)
+        self.assertEqual(stats['test'], 'value2')
+        self.assertEqual(next(iter(stats)), 'test')
+        self.assertEqual(stats.get_stats(), {'test': 'value2'})
+        stats['test'] = 'value'
         stats.set_value('test2', 23)
         self.assertEqual(stats.get_stats(), {'test': 'value', 'test2': 23})
         self.assertEqual(stats.get_value('test2'), 23)


### PR DESCRIPTION
In the issue #2746 , new methods are required to add to class `StatsCollector`. And this requirement is also supported by @kmike and @redapple .

As answering the call from them, now I have written the methods of `__setitem__`, `__getitem` and `__iter__` with a fully unittest, and also the related narrative in the document Stats Collection.

With these new methods, class `StatsCollector` now can be used more easily to set, get values, and also iterate.