### PR TITLE
[MRG+2] Added: Allowing optional arguments for `scrapy.http.cookies.CookieJar.clear`

### DIFF
--- a/scrapy/http/cookies.py
+++ b/scrapy/http/cookies.py
@@ -58,8 +58,8 @@ class CookieJar(object):
     def clear_session_cookies(self, *args, **kwargs):
         return self.jar.clear_session_cookies(*args, **kwargs)
 
-    def clear(self):
-        return self.jar.clear()
+    def clear(self, domain=None, path=None, name=None):
+        return self.jar.clear(domain, path, name)
 
     def __iter__(self):
         return iter(self.jar)


### PR DESCRIPTION
So it matches the signature of the underlying [`http.cookiejar.CookieJar.clear`](https://docs.python.org/3/library/http.cookiejar.html#http.cookiejar.CookieJar.clear) object.