### PR TITLE
[NOT A Pull Request] Trigger slot engine unclean shutdown

### DIFF
--- a/tests/mockserver.py
+++ b/tests/mockserver.py
@@ -200,7 +200,7 @@ class MockServer():
     def __exit__(self, exc_type, exc_value, traceback):
         self.proc.kill()
         self.proc.wait()
-        time.sleep(0.2)
+        time.sleep(20)
 
 
 def ssl_context_factory(keyfile='keys/localhost.key', certfile='keys/localhost.crt'):


### PR DESCRIPTION
This is demonstration of how to reproduce bad interaction between engine and slot even in cpython

Without extended time out problem is not triggered reliable, but manifest itself from time to time
```
runinenv.sh ~/ves/scrapy tox -e=py27 -- tests/test_feedexport.py::FeedExportTest::test_export_indentation
Executing tox -e=py27 -- tests/test_feedexport.py::FeedExportTest::test_export_indentation in /home/nikita/ves/scrapy
GLOB sdist-make: /home/nikita/dev/scrapy/setup.py
py27 inst-nodeps: /home/nikita/dev/scrapy/.tox/dist/Scrapy-1.5.0.zip
py27 installed: You are using pip version 9.0.3, however version 10.0.1 is available.,You should consider upgrading via the 'pip install --upgrade pip' command.,asn1crypto==0.24.0,attrs==17.4.0,Automat==0.6.0,backports.shutil-get-terminal-size==1.0.0,blessings==1.6.1,botocore==1.10.3,bpython==0.17.1,brotlipy==0.7.0,cachetools==2.0.1,certifi==2018.1.18,cffi==1.11.5,chardet==3.0.4,click==6.7,constantly==15.1.0,coverage==4.5.1,cryptography==2.2.2,cssselect==1.0.3,curtsies==0.3.0,decorator==4.2.1,docutils==0.14,enum34==1.1.6,Flask==0.12.2,funcsigs==1.0.2,futures==3.2.0,google-api-core==1.1.0,google-auth==1.4.1,google-cloud-core==0.28.1,google-cloud-storage==1.8.0,google-resumable-media==0.3.1,googleapis-common-protos==1.5.3,greenlet==0.4.13,hyperlink==18.0.0,idna==2.6,incremental==17.5.0,ipaddress==1.0.19,ipython==5.6.0,ipython-genutils==0.2.0,itsdangerous==0.24,Jinja2==2.10,jmespath==0.9.3,leveldb==0.194,lxml==4.2.1,MarkupSafe==1.0,mitmproxy==0.10.1,mock==2.0.0,ndg-httpsclient==0.4.4,netlib==0.10.1,parsel==1.4.0,pathlib2==2.3.0,pbr==4.0.1,pexpect==4.4.0,pickleshare==0.7.4,Pillow==5.1.0,prompt-toolkit==1.0.15,protobuf==3.5.2.post1,ptyprocess==0.5.2,py==1.5.3,pyasn1==0.4.2,pyasn1-modules==0.2.1,pycparser==2.18,PyDispatcher==2.0.5,Pygments==2.2.0,pyOpenSSL==17.5.0,pytest==2.9.2,pytest-cov==2.2.1,pytest-twisted==1.7.1,python-dateutil==2.6.1,pytz==2018.4,queuelib==1.5.0,requests==2.18.4,rsa==3.4.2,scandir==1.7,Scrapy==1.5.0,service-identity==17.0.0,simplegeneric==0.8.1,six==1.11.0,testfixtures==6.0.0,traitlets==4.3.2,Twisted==17.9.0,typing==3.6.4,urllib3==1.22,urwid==2.0.1,w3lib==1.19.0,wcwidth==0.1.7,Werkzeug==0.14.1,zope.interface==4.4.3
py27 runtests: PYTHONHASHSEED='1002297310'
py27 runtests: commands[0] | py.test --cov=scrapy --cov-report= tests/test_feedexport.py::FeedExportTest::test_export_indentation
============================================================ test session starts =============================================================
platform linux2 -- Python 2.7.6, pytest-2.9.2, py-1.5.3, pluggy-0.3.1
rootdir: /home/nikita/dev/scrapy, inifile: pytest.ini
plugins: twisted-1.7.1, cov-2.2.1
collected 9 items 

tests/test_feedexport.py FE

=================================================================== ERRORS ===================================================================
________________________________________ ERROR at teardown of FeedExportTest.test_export_indentation _________________________________________
NOTE: Incompatible Exception Representation, displaying natively:

DirtyReactorAggregateError: Reactor was unclean.
DelayedCalls: (set twisted.internet.base.DelayedCall.debug = True to debug)
<DelayedCall 0x7f9dc8290878 [4.99724078178s] called=0 cancelled=0 LoopingCall<5>(CallLaterOnce.schedule, *(), **{})()>
<DelayedCall 0x7f9dc824acf8 [59.9955928326s] called=0 cancelled=0 LoopingCall<60>(Downloader._slot_gc, *(), **{})()>
<DelayedCall 0x7f9dc82918c0 [59.9972960949s] called=0 cancelled=0 LoopingCall<60.0>(MemoryUsage.update, *(), **{})()>
<DelayedCall 0x7f9dc8290bd8 [59.99695611s] called=0 cancelled=0 LoopingCall<60.0>(LogStats.log, *(<TestSpider 'testspider' at 0x7f9dc81f2590>,), **{})()>
<DelayedCall 0x7f9dc81ecab8 [179.999843121s] called=0 cancelled=0 Deferred.cancel()>

------------------------------------------------------------ Captured stdout call ------------------------------------------------------------
('json', None)
('json', -1)
('json', 0)
('json', 2)
('json', 4)
('json', 5)
------------------------------------------------------------ Captured stderr call ------------------------------------------------------------
Coverage.py warning: --include is ignored because --source is set (include-ignored)
Coverage.py warning: --include is ignored because --source is set (include-ignored)
Coverage.py warning: --include is ignored because --source is set (include-ignored)
Coverage.py warning: --include is ignored because --source is set (include-ignored)
Coverage.py warning: --include is ignored because --source is set (include-ignored)
Coverage.py warning: --include is ignored because --source is set (include-ignored)
Coverage.py warning: --include is ignored because --source is set (include-ignored)
Coverage.py warning: --include is ignored because --source is set (include-ignored)
Coverage.py warning: --include is ignored because --source is set (include-ignored)
Coverage.py warning: --include is ignored because --source is set (include-ignored)
Coverage.py warning: --include is ignored because --source is set (include-ignored)
Coverage.py warning: --include is ignored because --source is set (include-ignored)
Coverage.py warning: --include is ignored because --source is set (include-ignored)
Coverage.py warning: --include is ignored because --source is set (include-ignored)
================================================================== FAILURES ==================================================================
___________________________________________________ FeedExportTest.test_export_indentation ___________________________________________________
NOTE: Incompatible Exception Representation, displaying natively:

TimeoutError: <tests.test_feedexport.FeedExportTest testMethod=test_export_indentation> (test_export_indentation) still running at 120.0 secs

------------------------------------------------------------ Captured stdout call ------------------------------------------------------------
('json', None)
('json', -1)
('json', 0)
('json', 2)
('json', 4)
('json', 5)
------------------------------------------------------------ Captured stderr call ------------------------------------------------------------
Coverage.py warning: --include is ignored because --source is set (include-ignored)
Coverage.py warning: --include is ignored because --source is set (include-ignored)
Coverage.py warning: --include is ignored because --source is set (include-ignored)
Coverage.py warning: --include is ignored because --source is set (include-ignored)
Coverage.py warning: --include is ignored because --source is set (include-ignored)
Coverage.py warning: --include is ignored because --source is set (include-ignored)
Coverage.py warning: --include is ignored because --source is set (include-ignored)
Coverage.py warning: --include is ignored because --source is set (include-ignored)
Coverage.py warning: --include is ignored because --source is set (include-ignored)
Coverage.py warning: --include is ignored because --source is set (include-ignored)
Coverage.py warning: --include is ignored because --source is set (include-ignored)
Coverage.py warning: --include is ignored because --source is set (include-ignored)
Coverage.py warning: --include is ignored because --source is set (include-ignored)
Coverage.py warning: --include is ignored because --source is set (include-ignored)
==================================================== 1 failed, 1 error in 125.18 seconds =====================================================
ERROR: InvocationError for command '/home/nikita/dev/scrapy/.tox/py27/bin/py.test --cov=scrapy --cov-report= tests/test_feedexport.py::FeedExportTest::test_export_indentation' (exited with code 1)
__________________________________________________________________ summary ___________________________________________________________________
ERROR:   py27: commands failed
```