### PR TITLE
Fix OffsiteMiddleware tests

### DIFF
--- a/scrapy/spidermiddlewares/offsite.py
+++ b/scrapy/spidermiddlewares/offsite.py
@@ -52,12 +52,16 @@ class OffsiteMiddleware(object):
         """Override this method to implement a different offsite policy"""
         allowed_domains = getattr(spider, 'allowed_domains', None)
         if not allowed_domains:
-            return re.compile('') # allow all by default
+            return re.compile('')  # allow all by default
+
+        # filter out empty values
+        allowed_domains = [d for d in allowed_domains if d]
+
         url_pattern = re.compile("^https?://.*$")
         for domain in allowed_domains:
             if url_pattern.match(domain):
                 warnings.warn("allowed_domains accepts only domains, not URLs. Ignoring URL entry %s in allowed_domains." % domain, URLWarning)
-                
+
         regex = r'^(.*\.)?(%s)$' % '|'.join(re.escape(d) for d in allowed_domains if d is not None)
         return re.compile(regex)
 

--- a/scrapy/spidermiddlewares/offsite.py
+++ b/scrapy/spidermiddlewares/offsite.py
@@ -60,6 +60,7 @@ class OffsiteMiddleware(object):
         url_pattern = re.compile("^https?://.*$")
         for domain in allowed_domains:
             if url_pattern.match(domain):
+                allowed_domains.remove(domain)
                 warnings.warn("allowed_domains accepts only domains, not URLs. Ignoring URL entry %s in allowed_domains." % domain, URLWarning)
 
         regex = r'^(.*\.)?(%s)$' % '|'.join(re.escape(d) for d in allowed_domains if d is not None)

--- a/tests/test_spidermiddleware_offsite.py
+++ b/tests/test_spidermiddleware_offsite.py
@@ -1,3 +1,4 @@
+import re
 from unittest import TestCase
 
 from six.moves.urllib.parse import urlparse
@@ -95,5 +96,7 @@ class TestURLWarnings(OffsiteMiddlewareTestCase, TestCase):
         self.spider.allowed_domains = ['http://scrapytest.org', 'scrapy.org', 'scrapy.test.org']
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always")
-            self.mw.get_host_regex(self.spider)
+            host_regex = self.mw.get_host_regex(self.spider)
             assert issubclass(w[-1].category, URLWarning)
+
+        self.assertNotIn(re.escape('http://scrapytest.org'), host_regex.pattern)

--- a/tests/test_spidermiddleware_offsite.py
+++ b/tests/test_spidermiddleware_offsite.py
@@ -55,13 +55,13 @@ class TestOffsiteMiddleware2(TestOffsiteMiddleware):
 
 class TestOffsiteMiddleware3(TestOffsiteMiddleware2):
 
-    def _get_spider(self):
-        return Spider('foo')
+    def _get_spiderargs(self):
+        return dict(name='foo')
 
 
 class TestOffsiteMiddleware4(TestOffsiteMiddleware3):
 
-    def _get_spider(self):
+    def _get_spiderargs(self):
       bad_hostname = urlparse('http:////scrapytest.org').hostname
       return dict(name='foo', allowed_domains=['scrapytest.org', None, bad_hostname])
 

--- a/tests/test_spidermiddleware_offsite.py
+++ b/tests/test_spidermiddleware_offsite.py
@@ -10,71 +10,86 @@ from scrapy.utils.test import get_crawler
 import warnings
 
 
-class TestOffsiteMiddleware(TestCase):
+class OffsiteMiddlewareTestCase:
+    spider_kwargs = None
+    onsite_reqs = []
+    offsite_reqs = []
 
     def setUp(self):
         crawler = get_crawler(Spider)
-        self.spider = crawler._create_spider(**self._get_spiderargs())
+        self.spider = crawler._create_spider(**self.spider_kwargs)
         self.mw = OffsiteMiddleware.from_crawler(crawler)
         self.mw.spider_opened(self.spider)
 
-    def _get_spiderargs(self):
-        return dict(name='foo', allowed_domains=['scrapytest.org', 'scrapy.org', 'scrapy.test.org'])
-
     def test_process_spider_output(self):
-        res = Response('http://scrapytest.org')
+        """
+        Test that the processed spider's output only matches the onsite_reqs.
+        """
+        resp = Response('http://scrapytest.org')
+        reqs = self.onsite_reqs + self.offsite_reqs
 
-        onsite_reqs = [Request('http://scrapytest.org/1'),
-                       Request('http://scrapy.org/1'),
-                       Request('http://sub.scrapy.org/1'),
-                       Request('http://offsite.tld/letmepass', dont_filter=True),
-                       Request('http://scrapy.test.org/')]
-        offsite_reqs = [Request('http://scrapy2.org'),
-                        Request('http://offsite.tld/'),
-                        Request('http://offsite.tld/scrapytest.org'),
-                        Request('http://offsite.tld/rogue.scrapytest.org'),
-                        Request('http://rogue.scrapytest.org.haha.com'),
-                        Request('http://roguescrapytest.org'),
-                        Request('http://test.org/'),
-                        Request('http://notscrapy.test.org/')]
-        reqs = onsite_reqs + offsite_reqs
-
-        out = list(self.mw.process_spider_output(res, reqs, self.spider))
-        self.assertEqual(out, onsite_reqs)
+        out = list(self.mw.process_spider_output(resp, reqs, self.spider))
+        self.assertEqual(out, self.onsite_reqs)
 
 
-class TestOffsiteMiddleware2(TestOffsiteMiddleware):
+class TestOffsiteMiddleware(OffsiteMiddlewareTestCase, TestCase):
+    spider_kwargs = dict(
+        name='foo',
+        allowed_domains=['scrapytest.org', 'scrapy.org', 'scrapy.test.org'],
+    )
 
-    def _get_spiderargs(self):
-        return dict(name='foo', allowed_domains=None)
-
-    def test_process_spider_output(self):
-        res = Response('http://scrapytest.org')
-        reqs = [Request('http://a.com/b.html'), Request('http://b.com/1')]
-        out = list(self.mw.process_spider_output(res, reqs, self.spider))
-        self.assertEqual(out, reqs)
-
-
-class TestOffsiteMiddleware3(TestOffsiteMiddleware2):
-
-    def _get_spiderargs(self):
-        return dict(name='foo')
-
-
-class TestOffsiteMiddleware4(TestOffsiteMiddleware3):
-
-    def _get_spiderargs(self):
-        bad_hostname = urlparse('http:////scrapytest.org').hostname
-        return dict(name='foo', allowed_domains=['scrapytest.org', None, bad_hostname])
-
-    def test_process_spider_output(self):
-        res = Response('http://scrapytest.org')
-        reqs = [Request('http://scrapytest.org/1')]
-        out = list(self.mw.process_spider_output(res, reqs, self.spider))
-        self.assertEqual(out, reqs)
+    onsite_reqs = [
+        Request('http://scrapytest.org/1'),
+        Request('http://scrapy.org/1'),
+        Request('http://sub.scrapy.org/1'),
+        Request('http://offsite.tld/letmepass', dont_filter=True),
+        Request('http://scrapy.test.org/'),
+    ]
+    offsite_reqs = [
+        Request('http://scrapy2.org'),
+        Request('http://offsite.tld/'),
+        Request('http://offsite.tld/scrapytest.org'),
+        Request('http://offsite.tld/rogue.scrapytest.org'),
+        Request('http://rogue.scrapytest.org.haha.com'),
+        Request('http://roguescrapytest.org'),
+        Request('http://test.org/'),
+        Request('http://notscrapy.test.org/'),
+    ]
 
 
-class TestOffsiteMiddleware5(TestOffsiteMiddleware4):
+class TestEmptyDomains(OffsiteMiddlewareTestCase, TestCase):
+    spider_kwargs = dict(name='foo', allowed_domains=None)
+
+    onsite_reqs = [
+        Request('http://a.com/b.html'),
+        Request('http://b.com/1'),
+    ]
+    offsite_reqs = []
+
+
+class TestNoAllowedDomainsArgument(TestEmptyDomains):
+    spider_kwargs = dict(name='foo')
+
+
+class TestBadHostnames(OffsiteMiddlewareTestCase, TestCase):
+    bad_hostname = urlparse('http:////scrapytest.org').hostname
+    spider_kwargs = dict(
+        name='foo',
+        allowed_domains=['scrapytest.org', None, bad_hostname],
+    )
+
+    onsite_reqs = [Request('http://scrapytest.org/1')]
+    offsite_reqs = []
+
+
+class TestURLWarnings(OffsiteMiddlewareTestCase, TestCase):
+    spider_kwargs = dict(
+        name='foo',
+        allowed_domains=['http://scrapytest.org', 'scrapy.org'],
+    )
+
+    onsite_reqs = [Request('http://scrapy.org/1')]
+    offsite_reqs = [Request('http://scrapytest.org/1')]
 
     def test_get_host_regex(self):
         self.spider.allowed_domains = ['http://scrapytest.org', 'scrapy.org', 'scrapy.test.org']

--- a/tests/test_spidermiddleware_offsite.py
+++ b/tests/test_spidermiddleware_offsite.py
@@ -9,6 +9,7 @@ from scrapy.spidermiddlewares.offsite import URLWarning
 from scrapy.utils.test import get_crawler
 import warnings
 
+
 class TestOffsiteMiddleware(TestCase):
 
     def setUp(self):
@@ -29,13 +30,13 @@ class TestOffsiteMiddleware(TestCase):
                        Request('http://offsite.tld/letmepass', dont_filter=True),
                        Request('http://scrapy.test.org/')]
         offsite_reqs = [Request('http://scrapy2.org'),
-                       Request('http://offsite.tld/'),
-                       Request('http://offsite.tld/scrapytest.org'),
-                       Request('http://offsite.tld/rogue.scrapytest.org'),
-                       Request('http://rogue.scrapytest.org.haha.com'),
-                       Request('http://roguescrapytest.org'),
-                       Request('http://test.org/'),
-                       Request('http://notscrapy.test.org/')]
+                        Request('http://offsite.tld/'),
+                        Request('http://offsite.tld/scrapytest.org'),
+                        Request('http://offsite.tld/rogue.scrapytest.org'),
+                        Request('http://rogue.scrapytest.org.haha.com'),
+                        Request('http://roguescrapytest.org'),
+                        Request('http://test.org/'),
+                        Request('http://notscrapy.test.org/')]
         reqs = onsite_reqs + offsite_reqs
 
         out = list(self.mw.process_spider_output(res, reqs, self.spider))
@@ -53,6 +54,7 @@ class TestOffsiteMiddleware2(TestOffsiteMiddleware):
         out = list(self.mw.process_spider_output(res, reqs, self.spider))
         self.assertEqual(out, reqs)
 
+
 class TestOffsiteMiddleware3(TestOffsiteMiddleware2):
 
     def _get_spiderargs(self):
@@ -62,18 +64,18 @@ class TestOffsiteMiddleware3(TestOffsiteMiddleware2):
 class TestOffsiteMiddleware4(TestOffsiteMiddleware3):
 
     def _get_spiderargs(self):
-      bad_hostname = urlparse('http:////scrapytest.org').hostname
-      return dict(name='foo', allowed_domains=['scrapytest.org', None, bad_hostname])
+        bad_hostname = urlparse('http:////scrapytest.org').hostname
+        return dict(name='foo', allowed_domains=['scrapytest.org', None, bad_hostname])
 
     def test_process_spider_output(self):
-      res = Response('http://scrapytest.org')
-      reqs = [Request('http://scrapytest.org/1')]
-      out = list(self.mw.process_spider_output(res, reqs, self.spider))
-      self.assertEqual(out, reqs)
+        res = Response('http://scrapytest.org')
+        reqs = [Request('http://scrapytest.org/1')]
+        out = list(self.mw.process_spider_output(res, reqs, self.spider))
+        self.assertEqual(out, reqs)
 
 
 class TestOffsiteMiddleware5(TestOffsiteMiddleware4):
-    
+
     def test_get_host_regex(self):
         self.spider.allowed_domains = ['http://scrapytest.org', 'scrapy.org', 'scrapy.test.org']
         with warnings.catch_warnings(record=True) as w:


### PR DESCRIPTION
The tests for `OffsiteMiddleware` are not actually functioning as expected. `TestOffsiteMiddleware3` and `TestOffsiteMiddleware4` do not correctly provided the spider args, so default to the spider created in `TestOffsiteMiddleware1`, effectively testing nothing.

I'm submitting the test changes first to demonstrate the failures.

I've refactored the offsite tests to help ensure these failures don't happen in the future. Instead of unintentionally succeeding, the `setUp` would fail. Additionally, factored away the testcase inheritance, which is a little confusing to follow. This can be reverted if preferred. 