### PR TITLE
Fixes #3246:OffsiteMiddleware silently filtering (invalid) URLs

### DIFF
--- a/scrapy/utils/httpobj.py
+++ b/scrapy/utils/httpobj.py
@@ -10,5 +10,7 @@ def urlparse_cached(request_or_response):
     Request or Response object
     """
     if request_or_response not in _urlparse_cache:
-        _urlparse_cache[request_or_response] = urlparse(request_or_response.url)
+        #Make sure we clean out any domains that might have \n, \t in them.
+        url = request_or_response.url.strip()
+        _urlparse_cache[request_or_response] = urlparse(url)
     return _urlparse_cache[request_or_response]

--- a/tests/test_utils_httpobj.py
+++ b/tests/test_utils_httpobj.py
@@ -21,6 +21,29 @@ class HttpobjUtilsTest(unittest.TestCase):
         assert req1a is not req2
         assert req1a is not req2
 
+    def test_urlparse_cached_strip():
+
+        #Test out that urlparse_cached strips out any \n
+        # or \t from its url
+
+        normal_url = "http://quotes.toscrape.com/
+        dirty_url = "\nhttp://quotes.toscrape.com/\n"
+
+        request1 = Request(normal_url)
+        request2 = Request(dirty_url)
+        req1a = urlparse_cached(request1)
+        req1b = urlparse_cached(request1)
+        req2 = urlparse_cached(request2)
+        urlp = urlparse(url)
+
+        assert req1a == req2
+        assert req1a == urlp
+        assert req1a is req1b
+        assert req1a is not req2
+        assert req1a is not req2
+
+
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_utils_httpobj.py
+++ b/tests/test_utils_httpobj.py
@@ -26,7 +26,7 @@ class HttpobjUtilsTest(unittest.TestCase):
         #Test out that urlparse_cached strips out any \n
         # or \t from its url
 
-        normal_url = "http://quotes.toscrape.com/
+        normal_url = "http://quotes.toscrape.com/"
         dirty_url = "\nhttp://quotes.toscrape.com/\n"
 
         request1 = Request(normal_url)

--- a/tests/test_utils_httpobj.py
+++ b/tests/test_utils_httpobj.py
@@ -21,7 +21,7 @@ class HttpobjUtilsTest(unittest.TestCase):
         assert req1a is not req2
         assert req1a is not req2
 
-    def test_urlparse_cached_strip():
+    def test_urlparse_cached_strip(self):
 
         #Test out that urlparse_cached strips out any \n
         # or \t from its url
@@ -31,16 +31,12 @@ class HttpobjUtilsTest(unittest.TestCase):
 
         request1 = Request(normal_url)
         request2 = Request(dirty_url)
-        req1a = urlparse_cached(request1)
-        req1b = urlparse_cached(request1)
+        req1 = urlparse_cached(request1)
         req2 = urlparse_cached(request2)
         urlp = urlparse(url)
 
-        assert req1a == req2
-        assert req1a == urlp
-        assert req1a is req1b
-        assert req1a is not req2
-        assert req1a is not req2
+        assert req1 == req2
+        assert req1 != urlp
 
 
 


### PR DESCRIPTION
Fixes #3246 

`urlparse_cached()` strips out any \n, \t from the domain's url before passing it to `urlparse()`. This will make sure we don't get empty hostnames  from a domain like this : `\nhttp://quotes.toscrape.com/`.