### PR TITLE
Blacklist twisted version with regression

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Twisted>=13.1.0
+Twisted>=13.1.0,!=18.4.0
 lxml
 pyOpenSSL
 cssselect>=0.9


### PR DESCRIPTION
There is a known regression in `twisted==18.4.0` https://github.com/twisted/twisted/pull/1008 . It affects file serving in python2. All unit-tests on all PRs related to file-serving are in fail state for python2 and pypy2 (e.g. https://github.com/scrapy/scrapy/pull/3260, https://github.com/scrapy/scrapy/pull/3256 etc).
There is no intention to release a version with a fix from twisted developers https://twistedmatrix.com/pipermail/twisted-python/2018-May/031917.html .
My proposal is to blacklist twisted version with regression for python2.