### PR TITLE
 Fix FormRequest.formdata with GET method duplicates same key in querystring (#2919)

### DIFF
--- a/scrapy/http/request/form.py
+++ b/scrapy/http/request/form.py
@@ -33,10 +33,11 @@ class FormRequest(Request):
                 self.headers.setdefault(b'Content-Type', b'application/x-www-form-urlencoded')
                 self._set_body(querystr)
             else:
-                query = dict(parse_qsl(urlparse(self.url).query))
+                query = parse_qsl(urlparse(self.url).query)
                 if query:
-                    query.update(dict(items))
-                    querystr = _urlencode(query.items(), self.encoding)
+                    items_dict = dict(items)
+                    items += [(k, v) for k, v in query if k not in items_dict]
+                    querystr = _urlencode(items, self.encoding)
                 self._set_url(urljoin(self.url, '?' + querystr))
 
     @classmethod

--- a/scrapy/http/request/form.py
+++ b/scrapy/http/request/form.py
@@ -6,7 +6,7 @@ See documentation in docs/topics/request-response.rst
 """
 
 import six
-from six.moves.urllib.parse import urljoin, urlencode,urlunparse, parse_qsl, urlparse
+from six.moves.urllib.parse import parse_qsl, urlencode, urljoin, urlparse
 
 import lxml.html
 from parsel.selector import create_root_node
@@ -33,12 +33,11 @@ class FormRequest(Request):
                 self.headers.setdefault(b'Content-Type', b'application/x-www-form-urlencoded')
                 self._set_body(querystr)
             else:
-                url_parts = list(urlparse(self.url))
-                query = dict(parse_qsl(url_parts[4]))
-                query.update(formdata)
-                url_parts[4] = urlencode(query)
-
-                self._set_url(urlunparse(url_parts))
+                query = dict(parse_qsl(urlparse(self.url).query))
+                if query:
+                    query.update(dict(items))
+                    querystr = _urlencode(query.items(), self.encoding)
+                self._set_url(urljoin(self.url, '?' + querystr))
 
     @classmethod
     def from_response(cls, response, formname=None, formid=None, formnumber=0, formdata=None,

--- a/scrapy/http/request/form.py
+++ b/scrapy/http/request/form.py
@@ -6,7 +6,7 @@ See documentation in docs/topics/request-response.rst
 """
 
 import six
-from six.moves.urllib.parse import urljoin, urlencode
+from six.moves.urllib.parse import urljoin, urlencode,urlunparse, parse_qsl, urlparse
 
 import lxml.html
 from parsel.selector import create_root_node
@@ -33,7 +33,12 @@ class FormRequest(Request):
                 self.headers.setdefault(b'Content-Type', b'application/x-www-form-urlencoded')
                 self._set_body(querystr)
             else:
-                self._set_url(self.url + ('&' if '?' in self.url else '?') + querystr)
+                url_parts = list(urlparse(self.url))
+                query = dict(parse_qsl(url_parts[4]))
+                query.update(formdata)
+                url_parts[4] = urlencode(query)
+
+                self._set_url(urlunparse(url_parts))
 
     @classmethod
     def from_response(cls, response, formname=None, formid=None, formnumber=0, formdata=None,

--- a/tests/test_http_request.py
+++ b/tests/test_http_request.py
@@ -270,11 +270,18 @@ class FormRequestTest(RequestTest):
         self.assertEqual(r1.body, b'')
 
     def test_formdata_overrides_querystring(self):
-        data = {'one': 'one', 'two': 'two'}
-        req = self.request_class('http://www.example.com?one=1', method='GET', formdata=data)
+        data = {'one': '1', 'two': '2'}
+        req = self.request_class('http://www.example.com?one=one&one=2', method='GET', formdata=data)
         fs = _qs(req)
-        self.assertEqual(fs[b'one'], [b'one'])
-        self.assertEqual(fs[b'two'], [b'two'])
+        self.assertEqual(fs[b'one'], [b'1'])
+        self.assertEqual(fs[b'two'], [b'2'])
+
+    def test_formdata_overrides_querystring_same_key_multiple_values(self):
+        data = [('one', 'a'), ('one', 'b'), ('two', '2'), ('two', 'two')]
+        req = self.request_class('http://www.example.com?one=one&one=2', method='GET', formdata=data)
+        fs = _qs(req)
+        six.assertCountEqual(self, fs[b'one'], [b'a', b'b'])
+        six.assertCountEqual(self, fs[b'two'], [b'2', b'two'])
 
     def test_default_encoding_bytes(self):
         # using default encoding (utf-8)

--- a/tests/test_http_request.py
+++ b/tests/test_http_request.py
@@ -269,6 +269,13 @@ class FormRequestTest(RequestTest):
         r1 = self.request_class("http://www.example.com", formdata={})
         self.assertEqual(r1.body, b'')
 
+    def test_formdata_overrides_querystring(self):
+        data = {'one': 'one', 'two': 'two'}
+        req = self.request_class('http://www.example.com?one=1', method='GET', formdata=data)
+        fs = _qs(req)
+        self.assertEqual(fs[b'one'], [b'one'])
+        self.assertEqual(fs[b'two'], [b'two'])
+
     def test_default_encoding_bytes(self):
         # using default encoding (utf-8)
         data = {b'one': b'two', b'price': b'\xc2\xa3 100'}


### PR DESCRIPTION
This is the fix for issue #2919 This is my first time contributing to an open source project.  This PR is based on gekco's PR [here](https://github.com/scrapy/scrapy/pull/3151).  I followed the instruction in [Submitting Patches](https://doc.scrapy.org/en/master/contributing.html#submitting-patches) for updating an existing PR.  Hopefully I have done it correctly. 
