### PR TITLE
Fix large compressed responses causes scrapy to hang (#2658)

### DIFF
--- a/scrapy/downloadermiddlewares/httpcompression.py
+++ b/scrapy/downloadermiddlewares/httpcompression.py
@@ -1,3 +1,4 @@
+import logging
 import zlib
 
 from scrapy.utils.gz import gunzip

--- a/scrapy/utils/gz.py
+++ b/scrapy/utils/gz.py
@@ -30,25 +30,25 @@ def gunzip(data):
     This is resilient to CRC checksum errors.
     """
     f = GzipFile(fileobj=BytesIO(data))
-    output = b''
+    output_list = []
     chunk = b'.'
     while chunk:
         try:
             chunk = read1(f, 8196)
-            output += chunk
+            output_list.append(chunk)
         except (IOError, EOFError, struct.error):
             # complete only if there is some data, otherwise re-raise
             # see issue 87 about catching struct.error
-            # some pages are quite small so output is '' and f.extrabuf
+            # some pages are quite small so output_list is empty and f.extrabuf
             # contains the whole page content
-            if output or getattr(f, 'extrabuf', None):
+            if output_list or getattr(f, 'extrabuf', None):
                 try:
-                    output += f.extrabuf[-f.extrasize:]
+                    output_list.append(f.extrabuf[-f.extrasize:])
                 finally:
                     break
             else:
                 raise
-    return output
+    return b''.join(output_list)
 
 _is_gzipped = re.compile(br'^application/(x-)?gzip\b', re.I).search
 _is_octetstream = re.compile(br'^(application|binary)/octet-stream\b', re.I).search

--- a/tests/test_downloadermiddleware_httpcompression.py
+++ b/tests/test_downloadermiddleware_httpcompression.py
@@ -5,6 +5,7 @@ from gzip import GzipFile
 
 from scrapy.spiders import Spider
 from scrapy.http import Response, Request, HtmlResponse
+from scrapy.settings import Settings
 from scrapy.downloadermiddlewares.httpcompression import HttpCompressionMiddleware, \
     ACCEPTED_ENCODINGS
 from scrapy.responsetypes import responsetypes
@@ -28,7 +29,8 @@ class HttpCompressionTest(TestCase):
 
     def setUp(self):
         self.spider = Spider('foo')
-        self.mw = HttpCompressionMiddleware()
+        # TODO: Test settings properly before merging.
+        self.mw = HttpCompressionMiddleware(Settings())
 
     def _getresponse(self, coding):
         if coding not in FORMAT:


### PR DESCRIPTION
This is a fix for issue #2658 

**Problem**
some websites, e.g. http://www.safetradeintl.com sends a small gzipped file with >99% compression ratio, this causes 
1) The gunzip method in scrapy to hang, the way gunzip is uncompressing files is very slow for large files
2) Virtually unbounded sized responses, making the scraping less robust (note that download_maxsize setting doesn't work here)

An example site below:
$ wget -v http://www.safetradeintl.com
[...]
HTTP request sent, awaiting response... 200 OK
Length: 10420385 (9.9M) [text/html]
Saving to: 'index.html'
[...]

$ gunzip -l index.html.gz 
  compressed uncompressed  ratio uncompressed_name
    10420385   2147483648  99.5% index.html

**Solution**
1) Improve the gunzipping to not copy the entire output string in each iteration, effectively causing an O(n^2) performance
2) introduce a limit for uncompressed body size in httpcompression middleware

The PR in the current form is intended as a Draft and comments are welcomed!
Thanks!