### PR TITLE
fix a typo in a test class name

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ six>=1.5.2
 PyDispatcher>=2.0.5
 service_identity
 parsel>=1.4
+functools32

--- a/scrapy/downloadermiddlewares/httpproxy.py
+++ b/scrapy/downloadermiddlewares/httpproxy.py
@@ -1,14 +1,14 @@
 import base64
-from six.moves.urllib.request import getproxies, proxy_bypass
-from six.moves.urllib.parse import unquote
 try:
     from urllib2 import _parse_proxy
 except ImportError:
     from urllib.request import _parse_proxy
-from six.moves.urllib.parse import urlunparse
 
-from scrapy.utils.httpobj import urlparse_cached
+from six.moves.urllib.parse import urlunparse, unquote
+from six.moves.urllib.request import getproxies, proxy_bypass
+
 from scrapy.exceptions import NotConfigured
+from scrapy.utils.httpobj import urlparse_cached
 from scrapy.utils.python import to_bytes
 
 
@@ -17,8 +17,8 @@ class HttpProxyMiddleware(object):
     def __init__(self, auth_encoding='latin-1'):
         self.auth_encoding = auth_encoding
         self.proxies = {}
-        for type, url in getproxies().items():
-            self.proxies[type] = self._get_proxy(url, type)
+        for type_, url in getproxies().items():
+            self.proxies[type_] = self._get_proxy(url, type_)
 
     @classmethod
     def from_crawler(cls, crawler):

--- a/scrapy/downloadermiddlewares/httpproxy.py
+++ b/scrapy/downloadermiddlewares/httpproxy.py
@@ -1,5 +1,9 @@
 import base64
 try:
+    from functools import lru_cache
+except:
+    from functools32 import lru_cache
+try:
     from urllib2 import _parse_proxy
 except ImportError:
     from urllib.request import _parse_proxy
@@ -12,13 +16,34 @@ from scrapy.utils.httpobj import urlparse_cached
 from scrapy.utils.python import to_bytes
 
 
+@lru_cache
+def basic_auth_header(auth_encoding, username, password):
+    user_pass = to_bytes(
+        '%s:%s' % (unquote(username), unquote(password)),
+        encoding=auth_encoding)
+    return base64.b64encode(user_pass).strip()
+
+
+@lru_cache
+def get_proxy(auth_encoding, url, orig_type):
+    proxy_type, user, password, hostport = _parse_proxy(url)
+    proxy_url = urlunparse((proxy_type or orig_type, hostport, '', '', '', ''))
+
+    if user:
+        creds = basic_auth_header(auth_encoding, user, password)
+    else:
+        creds = None
+
+    return creds, proxy_url
+
+
 class HttpProxyMiddleware(object):
 
     def __init__(self, auth_encoding='latin-1'):
         self.auth_encoding = auth_encoding
         self.proxies = {}
         for type_, url in getproxies().items():
-            self.proxies[type_] = self._get_proxy(url, type_)
+            self.proxies[type_] = get_proxy(self.auth_encoding, url, type_)
 
     @classmethod
     def from_crawler(cls, crawler):
@@ -27,30 +52,13 @@ class HttpProxyMiddleware(object):
         auth_encoding = crawler.settings.get('HTTPPROXY_AUTH_ENCODING')
         return cls(auth_encoding)
 
-    def _basic_auth_header(self, username, password):
-        user_pass = to_bytes(
-            '%s:%s' % (unquote(username), unquote(password)),
-            encoding=self.auth_encoding)
-        return base64.b64encode(user_pass).strip()
-
-    def _get_proxy(self, url, orig_type):
-        proxy_type, user, password, hostport = _parse_proxy(url)
-        proxy_url = urlunparse((proxy_type or orig_type, hostport, '', '', '', ''))
-
-        if user:
-            creds = self._basic_auth_header(user, password)
-        else:
-            creds = None
-
-        return creds, proxy_url
-
     def process_request(self, request, spider):
         # ignore if proxy is already set
         if 'proxy' in request.meta:
             if request.meta['proxy'] is None:
                 return
             # extract credentials if present
-            creds, proxy_url = self._get_proxy(request.meta['proxy'], '')
+            creds, proxy_url = get_proxy(self.auth_encoding, request.meta['proxy'], '')
             request.meta['proxy'] = proxy_url
             if creds and not request.headers.get('Proxy-Authorization'):
                 request.headers['Proxy-Authorization'] = b'Basic ' + creds

--- a/scrapy/downloadermiddlewares/httpproxy.py
+++ b/scrapy/downloadermiddlewares/httpproxy.py
@@ -16,7 +16,7 @@ from scrapy.utils.httpobj import urlparse_cached
 from scrapy.utils.python import to_bytes
 
 
-@lru_cache
+@lru_cache(maxsize=128)
 def basic_auth_header(auth_encoding, username, password):
     user_pass = to_bytes(
         '%s:%s' % (unquote(username), unquote(password)),
@@ -24,7 +24,7 @@ def basic_auth_header(auth_encoding, username, password):
     return base64.b64encode(user_pass).strip()
 
 
-@lru_cache
+@lru_cache(maxsize=128)
 def get_proxy(auth_encoding, url, orig_type):
     proxy_type, user, password, hostport = _parse_proxy(url)
     proxy_url = urlunparse((proxy_type or orig_type, hostport, '', '', '', ''))

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -10,4 +10,4 @@ brotlipy
 testfixtures
 # optional for shell wrapper tests
 bpython
-ipython
+ipython<6

--- a/tests/test_downloadermiddleware_httpproxy.py
+++ b/tests/test_downloadermiddleware_httpproxy.py
@@ -13,7 +13,7 @@ from scrapy.settings import Settings
 spider = Spider('foo')
 
 
-class TestDefaultHeadersMiddleware(TestCase):
+class TestHttpProxyMiddleware(TestCase):
 
     failureException = AssertionError
 

--- a/tests/test_downloadermiddleware_httpproxy.py
+++ b/tests/test_downloadermiddleware_httpproxy.py
@@ -3,7 +3,7 @@ import sys
 from functools import partial
 from twisted.trial.unittest import TestCase, SkipTest
 
-from scrapy.downloadermiddlewares.httpproxy import HttpProxyMiddleware
+from scrapy.downloadermiddlewares.httpproxy import HttpProxyMiddleware, basic_auth_header, get_proxy
 from scrapy.exceptions import NotConfigured
 from scrapy.http import Response, Request
 from scrapy.spiders import Spider
@@ -30,9 +30,12 @@ class TestHttpProxyMiddleware(TestCase):
 
     def test_no_environment_proxies(self):
         os.environ = {'dummy_proxy': 'reset_env_and_do_not_raise'}
-        mw = HttpProxyMiddleware()
 
         for url in ('http://e.com', 'https://e.com', 'file:///tmp/a'):
+            mw = HttpProxyMiddleware()
+            basic_auth_header.cache_clear()
+            get_proxy.cache_clear()
+
             req = Request(url)
             assert mw.process_request(req, spider) is None
             self.assertEqual(req.url, url)
@@ -42,11 +45,15 @@ class TestHttpProxyMiddleware(TestCase):
         os.environ['http_proxy'] = http_proxy = 'https://proxy.for.http:3128'
         os.environ['https_proxy'] = https_proxy = 'http://proxy.for.https:8080'
         os.environ.pop('file_proxy', None)
-        mw = HttpProxyMiddleware()
 
         for url, proxy in [('http://e.com', http_proxy),
                 ('https://e.com', https_proxy), ('file://tmp/a', None)]:
             req = Request(url)
+
+            mw = HttpProxyMiddleware()
+            basic_auth_header.cache_clear()
+            get_proxy.cache_clear()
+
             assert mw.process_request(req, spider) is None
             self.assertEqual(req.url, url)
             self.assertEqual(req.meta.get('proxy'), proxy)
@@ -61,11 +68,16 @@ class TestHttpProxyMiddleware(TestCase):
     def test_proxy_auth(self):
         os.environ['http_proxy'] = 'https://user:pass@proxy:3128'
         mw = HttpProxyMiddleware()
+        basic_auth_header.cache_clear()
+        get_proxy.cache_clear()
         req = Request('http://scrapytest.org')
         assert mw.process_request(req, spider) is None
         self.assertEqual(req.meta, {'proxy': 'https://proxy:3128'})
         self.assertEqual(req.headers.get('Proxy-Authorization'), b'Basic dXNlcjpwYXNz')
         # proxy from request.meta
+        mw = HttpProxyMiddleware()
+        basic_auth_header.cache_clear()
+        get_proxy.cache_clear()
         req = Request('http://scrapytest.org', meta={'proxy': 'https://username:password@proxy:3128'})
         assert mw.process_request(req, spider) is None
         self.assertEqual(req.meta, {'proxy': 'https://proxy:3128'})
@@ -74,11 +86,16 @@ class TestHttpProxyMiddleware(TestCase):
     def test_proxy_auth_empty_passwd(self):
         os.environ['http_proxy'] = 'https://user:@proxy:3128'
         mw = HttpProxyMiddleware()
+        basic_auth_header.cache_clear()
+        get_proxy.cache_clear()
         req = Request('http://scrapytest.org')
         assert mw.process_request(req, spider) is None
         self.assertEqual(req.meta, {'proxy': 'https://proxy:3128'})
         self.assertEqual(req.headers.get('Proxy-Authorization'), b'Basic dXNlcjo=')
         # proxy from request.meta
+        mw = HttpProxyMiddleware()
+        basic_auth_header.cache_clear()
+        get_proxy.cache_clear()
         req = Request('http://scrapytest.org', meta={'proxy': 'https://username:@proxy:3128'})
         assert mw.process_request(req, spider) is None
         self.assertEqual(req.meta, {'proxy': 'https://proxy:3128'})
@@ -88,12 +105,17 @@ class TestHttpProxyMiddleware(TestCase):
         # utf-8 encoding
         os.environ['http_proxy'] = u'https://m\u00E1n:pass@proxy:3128'
         mw = HttpProxyMiddleware(auth_encoding='utf-8')
+        basic_auth_header.cache_clear()
+        get_proxy.cache_clear()
         req = Request('http://scrapytest.org')
         assert mw.process_request(req, spider) is None
         self.assertEqual(req.meta, {'proxy': 'https://proxy:3128'})
         self.assertEqual(req.headers.get('Proxy-Authorization'), b'Basic bcOhbjpwYXNz')
 
         # proxy from request.meta
+        mw = HttpProxyMiddleware(auth_encoding='utf-8')
+        basic_auth_header.cache_clear()
+        get_proxy.cache_clear()
         req = Request('http://scrapytest.org', meta={'proxy': u'https://\u00FCser:pass@proxy:3128'})
         assert mw.process_request(req, spider) is None
         self.assertEqual(req.meta, {'proxy': 'https://proxy:3128'})
@@ -101,12 +123,17 @@ class TestHttpProxyMiddleware(TestCase):
 
         # default latin-1 encoding
         mw = HttpProxyMiddleware(auth_encoding='latin-1')
+        basic_auth_header.cache_clear()
+        get_proxy.cache_clear()
         req = Request('http://scrapytest.org')
         assert mw.process_request(req, spider) is None
         self.assertEqual(req.meta, {'proxy': 'https://proxy:3128'})
         self.assertEqual(req.headers.get('Proxy-Authorization'), b'Basic beFuOnBhc3M=')
 
         # proxy from request.meta, latin-1 encoding
+        mw = HttpProxyMiddleware(auth_encoding='latin-1')
+        basic_auth_header.cache_clear()
+        get_proxy.cache_clear()
         req = Request('http://scrapytest.org', meta={'proxy': u'https://\u00FCser:pass@proxy:3128'})
         assert mw.process_request(req, spider) is None
         self.assertEqual(req.meta, {'proxy': 'https://proxy:3128'})
@@ -122,6 +149,8 @@ class TestHttpProxyMiddleware(TestCase):
     def test_no_proxy(self):
         os.environ['http_proxy'] = 'https://proxy.for.http:3128'
         mw = HttpProxyMiddleware()
+        basic_auth_header.cache_clear()
+        get_proxy.cache_clear()
 
         os.environ['no_proxy'] = '*'
         req = Request('http://noproxy.com')
@@ -129,17 +158,26 @@ class TestHttpProxyMiddleware(TestCase):
         assert 'proxy' not in req.meta
 
         os.environ['no_proxy'] = 'other.com'
+        mw = HttpProxyMiddleware()
+        basic_auth_header.cache_clear()
+        get_proxy.cache_clear()
         req = Request('http://noproxy.com')
         assert mw.process_request(req, spider) is None
         assert 'proxy' in req.meta
 
         os.environ['no_proxy'] = 'other.com,noproxy.com'
+        mw = HttpProxyMiddleware()
+        basic_auth_header.cache_clear()
+        get_proxy.cache_clear()
         req = Request('http://noproxy.com')
         assert mw.process_request(req, spider) is None
         assert 'proxy' not in req.meta
 
         # proxy from meta['proxy'] takes precedence
         os.environ['no_proxy'] = '*'
+        mw = HttpProxyMiddleware()
+        basic_auth_header.cache_clear()
+        get_proxy.cache_clear()
         req = Request('http://noproxy.com', meta={'proxy': 'http://proxy.com'})
         assert mw.process_request(req, spider) is None
         self.assertEqual(req.meta, {'proxy': 'http://proxy.com'})

--- a/tox.ini
+++ b/tox.ini
@@ -50,6 +50,7 @@ deps =
     Pillow==2.6.1
     cssselect==0.9.1
     zope.interface==4.1.1
+    functools
     -rtests/requirements.txt
 
 [testenv:trunk]

--- a/tox.ini
+++ b/tox.ini
@@ -50,7 +50,7 @@ deps =
     Pillow==2.6.1
     cssselect==0.9.1
     zope.interface==4.1.1
-    functools
+    functools32
     -rtests/requirements.txt
 
 [testenv:trunk]


### PR DESCRIPTION
Fix a typo in the name of the test case for the class HttpProxyMiddleware.