### PR TITLE
[MRG+1] Improve docs of S3 Storage to make Python version more explicit

### DIFF
--- a/docs/topics/feed-exports.rst
+++ b/docs/topics/feed-exports.rst
@@ -177,7 +177,7 @@ The feeds are stored on `Amazon S3`_.
    * ``s3://mybucket/path/to/export.csv``
    * ``s3://aws_key:aws_secret@mybucket/path/to/export.csv``
 
- * Required external libraries: `botocore`_ or `boto`_
+ * Required external libraries: `botocore`_ (Python 2 and Python 3) or `boto`_ (Python 2 only)
 
 The AWS credentials can be passed as user/password in the URI, or they can be
 passed through the following settings:


### PR DESCRIPTION
The documentation of the S3 storage backend (https://doc.scrapy.org/en/latest/topics/feed-exports.html#s3) suggest the use of the libraries botocore (https://github.com/boto/botocore) or boto (https://github.com/boto/boto). However, boto library will work only if the user is using Python 2 (as it is correctly explained here https://doc.scrapy.org/en/latest/topics/feed-exports.html#storages).

Besides the fact of this information is there, I believe that it would be better for the user reading the documentation to have this note also inside the specific section of S3 storage backend.

When issue #1866 is resolved, this could be removed anyway.