### PR TITLE
[MRG+1] fix the test case name of HttpProxyMiddleware

### DIFF
--- a/tests/test_downloadermiddleware_httpproxy.py
+++ b/tests/test_downloadermiddleware_httpproxy.py
@@ -13,7 +13,7 @@ from scrapy.settings import Settings
 spider = Spider('foo')
 
 
-class TestDefaultHeadersMiddleware(TestCase):
+class TestHttpProxyMiddleware(TestCase):
 
     failureException = AssertionError
 


### PR DESCRIPTION
As the title said, fix the test case name.