### PR TITLE
Make the version of ipython less than 6.0 in python 2.7

### DIFF
--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -10,4 +10,4 @@ brotlipy
 testfixtures
 # optional for shell wrapper tests
 bpython
-ipython
+ipython<6.0


### PR DESCRIPTION
Make the version of ipython less than 6.0 in python 2.7, since ipython stop supporting python 2.7 in >= v6.0