### PR TITLE
[MRG+1] TST test agains latest pypy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ install:
         source "$HOME/virtualenvs/$PYPY_VERSION/bin/activate"
       fi
       if [ "$TOXENV" = "pypy3" ]; then
-        export PYPY_VERSION="pypy3.5-6.0.0-linux_x86_64-portable"
+        export PYPY_VERSION="pypy3.5-5.9-beta-linux_x86_64-portable"
         wget "https://bitbucket.org/squeaky/portable-pypy/downloads/${PYPY_VERSION}.tar.bz2"
         tar -jxf ${PYPY_VERSION}.tar.bz2
         virtualenv --python="$PYPY_VERSION/bin/pypy3" "$HOME/virtualenvs/$PYPY_VERSION"

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,14 +26,14 @@ matrix:
 install:
   - |
       if [ "$TOXENV" = "pypy" ]; then
-        export PYPY_VERSION="pypy-5.9-linux_x86_64-portable"
+        export PYPY_VERSION="pypy-6.0.0-linux_x86_64-portable"
         wget "https://bitbucket.org/squeaky/portable-pypy/downloads/${PYPY_VERSION}.tar.bz2"
         tar -jxf ${PYPY_VERSION}.tar.bz2
         virtualenv --python="$PYPY_VERSION/bin/pypy" "$HOME/virtualenvs/$PYPY_VERSION"
         source "$HOME/virtualenvs/$PYPY_VERSION/bin/activate"
       fi
       if [ "$TOXENV" = "pypy3" ]; then
-        export PYPY_VERSION="pypy3.5-5.9-beta-linux_x86_64-portable"
+        export PYPY_VERSION="pypy3.5-6.0.0-linux_x86_64-portable"
         wget "https://bitbucket.org/squeaky/portable-pypy/downloads/${PYPY_VERSION}.tar.bz2"
         tar -jxf ${PYPY_VERSION}.tar.bz2
         virtualenv --python="$PYPY_VERSION/bin/pypy3" "$HOME/virtualenvs/$PYPY_VERSION"


### PR DESCRIPTION
I think it is better to test against latest pypy, as it is still a moving target, and we don't absolutely need to support older pypy versions.