### PR TITLE
Python 3.7 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,8 @@ matrix:
       env: TOXENV=py36
     - python: 3.7
       env: TOXENV=py37
+      dist: xenial
+      sudo: true
     - python: 3.6
       env: TOXENV=docs
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,8 @@ matrix:
       env: TOXENV=py36
     - python: 3.6
       env: TOXENV=docs
+    - python: 3.7-dev
+      env: TOXENV=py37
 install:
   - |
       if [ "$TOXENV" = "pypy" ]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,10 +21,10 @@ matrix:
       env: TOXENV=py35
     - python: 3.6
       env: TOXENV=py36
-    - python: 3.6
-      env: TOXENV=docs
     - python: 3.7
       env: TOXENV=py37
+    - python: 3.6
+      env: TOXENV=docs
 install:
   - |
       if [ "$TOXENV" = "pypy" ]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ matrix:
       env: TOXENV=py36
     - python: 3.6
       env: TOXENV=docs
-    - python: 3.7-dev
+    - python: 3.7
       env: TOXENV=py37
 install:
   - |

--- a/requirements-py3.txt
+++ b/requirements-py3.txt
@@ -1,4 +1,4 @@
-Twisted >= 17.9.0
+git+https://github.com/lopuhin/twisted.git@9384-remove-async-param
 lxml>=3.2.4
 pyOpenSSL>=0.13.1
 cssselect>=0.9

--- a/requirements-py3.txt
+++ b/requirements-py3.txt
@@ -1,4 +1,4 @@
-git+https://github.com/lopuhin/twisted.git@9384-remove-async-param
+Twisted>=17.9.0
 lxml>=3.2.4
 pyOpenSSL>=0.13.1
 cssselect>=0.9

--- a/scrapy/extensions/telnet.py
+++ b/scrapy/extensions/telnet.py
@@ -6,6 +6,7 @@ See documentation in docs/topics/telnetconsole.rst
 
 import pprint
 import logging
+import traceback
 
 from twisted.internet import protocol
 try:
@@ -13,6 +14,7 @@ try:
     from twisted.conch.insults import insults
     TWISTED_CONCH_AVAILABLE = True
 except (ImportError, SyntaxError):
+    _TWISTED_CONCH_TRACEBACK = traceback.format_exc()
     TWISTED_CONCH_AVAILABLE = False
 
 from scrapy.exceptions import NotConfigured
@@ -40,8 +42,9 @@ class TelnetConsole(protocol.ServerFactory):
         if not crawler.settings.getbool('TELNETCONSOLE_ENABLED'):
             raise NotConfigured
         if not TWISTED_CONCH_AVAILABLE:
-            raise NotConfigured('TelnetConsole not enabled: failed to import '
-                                'required twisted modules.')
+            raise NotConfigured(
+                'TELNETCONSOLE_ENABLED setting is True but required twisted '
+                'modules failed to import:\n' + _TWISTED_CONCH_TRACEBACK)
         self.crawler = crawler
         self.noisy = False
         self.portrange = [int(x) for x in crawler.settings.getlist('TELNETCONSOLE_PORT')]

--- a/scrapy/extensions/telnet.py
+++ b/scrapy/extensions/telnet.py
@@ -12,7 +12,7 @@ try:
     from twisted.conch import manhole, telnet
     from twisted.conch.insults import insults
     TWISTED_CONCH_AVAILABLE = True
-except ImportError:
+except (ImportError, SyntaxError):
     TWISTED_CONCH_AVAILABLE = False
 
 from scrapy.exceptions import NotConfigured
@@ -40,7 +40,8 @@ class TelnetConsole(protocol.ServerFactory):
         if not crawler.settings.getbool('TELNETCONSOLE_ENABLED'):
             raise NotConfigured
         if not TWISTED_CONCH_AVAILABLE:
-            raise NotConfigured
+            raise NotConfigured('TelnetConsole not enabled: failed to import '
+                                'required twisted modules.')
         self.crawler = crawler
         self.noisy = False
         self.portrange = [int(x) for x in crawler.settings.getlist('TELNETCONSOLE_PORT')]

--- a/scrapy/utils/iterators.py
+++ b/scrapy/utils/iterators.py
@@ -98,8 +98,9 @@ def csviter(obj, delimiter=None, headers=None, encoding=None, quotechar=None):
     """
 
     encoding = obj.encoding if isinstance(obj, TextResponse) else encoding or 'utf-8'
-    def _getrow(csv_r):
-        return [to_unicode(field, encoding) for field in next(csv_r)]
+
+    def row_to_unicode(row_):
+        return [to_unicode(field, encoding) for field in row_]
 
     # Python 3 csv reader input object needs to return strings
     if six.PY3:
@@ -113,10 +114,14 @@ def csviter(obj, delimiter=None, headers=None, encoding=None, quotechar=None):
     csv_r = csv.reader(lines, **kwargs)
 
     if not headers:
-        headers = _getrow(csv_r)
+        try:
+            row = next(csv_r)
+        except StopIteration:
+            return
+        headers = row_to_unicode(row)
 
-    while True:
-        row = _getrow(csv_r)
+    for row in csv_r:
+        row = row_to_unicode(row)
         if len(row) != len(headers):
             logger.warning("ignoring row %(csvlnum)d (length: %(csvrow)d, "
                            "should be: %(csvheader)d)",

--- a/tests/requirements-py3.txt
+++ b/tests/requirements-py3.txt
@@ -1,6 +1,6 @@
-pytest==2.9.2
+pytest==3.6.3
 pytest-twisted
-pytest-cov==2.2.1
+pytest-cov==2.5.1
 testfixtures
 jmespath
 leveldb

--- a/tests/test_crawler.py
+++ b/tests/test_crawler.py
@@ -1,5 +1,4 @@
 import logging
-import os
 import tempfile
 import warnings
 import unittest
@@ -14,8 +13,9 @@ from scrapy.spiderloader import SpiderLoader
 from scrapy.utils.log import configure_logging, get_scrapy_root_handler
 from scrapy.utils.spider import DefaultSpider
 from scrapy.utils.misc import load_object
-from scrapy.utils.test import get_crawler
 from scrapy.extensions.throttle import AutoThrottle
+from scrapy.extensions import telnet
+
 
 class BaseCrawlerTest(unittest.TestCase):
 
@@ -100,6 +100,8 @@ class CrawlerLoggingTestCase(unittest.TestCase):
                 custom_settings = {
                     'LOG_LEVEL': 'INFO',
                     'LOG_FILE': log_file.name,
+                    # disable telnet if not available to avoid an extra warning
+                    'TELNETCONSOLE_ENABLED': telnet.TWISTED_CONCH_AVAILABLE,
                 }
 
             configure_logging()

--- a/tests/test_utils_log.py
+++ b/tests/test_utils_log.py
@@ -10,6 +10,7 @@ from twisted.python.failure import Failure
 from scrapy.utils.log import (failure_to_exc_info, TopLevelFormatter,
                               LogCounterHandler, StreamLogger)
 from scrapy.utils.test import get_crawler
+from scrapy.extensions import telnet
 
 
 class FailureToExcInfoTest(unittest.TestCase):
@@ -65,10 +66,14 @@ class TopLevelFormatterTest(unittest.TestCase):
 class LogCounterHandlerTest(unittest.TestCase):
 
     def setUp(self):
+        settings = {'LOG_LEVEL': 'WARNING'}
+        if not telnet.TWISTED_CONCH_AVAILABLE:
+            # disable it to avoid the extra warning
+            settings['TELNETCONSOLE_ENABLED'] = False
         self.logger = logging.getLogger('test')
         self.logger.setLevel(logging.NOTSET)
         self.logger.propagate = False
-        self.crawler = get_crawler(settings_dict={'LOG_LEVEL': 'WARNING'})
+        self.crawler = get_crawler(settings_dict=settings)
         self.handler = LogCounterHandler(self.crawler)
         self.logger.addHandler(self.handler)
 

--- a/tox.ini
+++ b/tox.ini
@@ -81,6 +81,10 @@ deps = {[testenv:py34]deps}
 basepython = python3.6
 deps = {[testenv:py34]deps}
 
+[testenv:py37]
+basepython = python3.7
+deps = {[testenv:py34]deps}
+
 [testenv:pypy3]
 basepython = pypy3
 deps = {[testenv:py34]deps}


### PR DESCRIPTION
Continue @patiences work on python 3.7 compatibility from #3150, fixes #3143. Thanks a lot @patiences!

It's likely that we'll release scrapy 1.6 before new twisted version with https://github.com/twisted/twisted/pull/966 is released (sorry for making the PR stall), so in this PR I work around this issue, so that scrapy at least works, although without telnet console support yet.

Also pytest is updated, so that ``tox -e py37`` can collect the tests (2.9 was released more than 2 years ago).

~~WIP as I want to check how tests work on travis early (there are still a few failures due to PEP 479 left which didn't show up in #3150).~~

