### PR TITLE
update default RETRY_HTTP_CODES on docs

### DIFF
--- a/docs/topics/downloader-middleware.rst
+++ b/docs/topics/downloader-middleware.rst
@@ -882,7 +882,7 @@ precedence over the :setting:`RETRY_TIMES` setting.
 RETRY_HTTP_CODES
 ^^^^^^^^^^^^^^^^
 
-Default: ``[500, 502, 503, 504, 408]``
+Default: ``[500, 502, 503, 504, 522, 524, 408]``
 
 Which HTTP response codes to retry. Other errors (DNS lookup issues,
 connections lost, etc) are always retried.


### PR DESCRIPTION
The docs on `RETRY_HTTP_CODES` are outdated in regards to the list of HTTP status codes that are retried by default by the `RetryMiddleware`.

Here's the updated list: https://github.com/scrapy/scrapy/blob/master/scrapy/settings/default_settings.py#L239