### PR TITLE
provide better error message when disabling s3 exporter

### DIFF
--- a/scrapy/extensions/feedexport.py
+++ b/scrapy/extensions/feedexport.py
@@ -269,9 +269,10 @@ class FeedExporter(object):
             try:
                 self._get_storage(uri)
                 return True
-            except NotConfigured:
-                logger.error("Disabled feed storage scheme: %(scheme)s",
-                             {'scheme': scheme})
+            except NotConfigured as e:
+                logger.error("Disabled feed storage scheme: %(scheme)s. "
+                             "Reason: %(reason)s",
+                             {'scheme': scheme, 'reason': str(e)})
         else:
             logger.error("Unknown feed storage scheme: %(scheme)s",
                          {'scheme': scheme})


### PR DESCRIPTION
Fixes: #3357 

A quick test to confirm would be to run: `scrapy shell -s FEED_URI='s3://test.com'` in a shell without either *botocore* or *boto* library installed/declared.

Output:
```
2018-07-31 19:03:55 [scrapy.utils.log] INFO: Scrapy 1.5.0 started (bot: scrapybot)
2018-07-31 19:03:55 [scrapy.utils.log] INFO: Versions: lxml 4.2.3.0, libxml2 2.9.8, cssselect 1.0.3, parsel 1.5.0, w3lib 1.19.0, Twisted 18.7.0, Python 2.7.15 (default, May  1 2018, 16:44:37) - [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.39.2)], pyOpenSSL 18.0.0 (OpenSSL 1.1.0h  27 Mar 2018), cryptography 2.3, Platform Darwin-16.7.0-x86_64-i386-64bit
2018-07-31 19:03:55 [scrapy.crawler] INFO: Overridden settings: {'FEED_URI': 's3://test.com', 'LOGSTATS_INTERVAL': 0, 'EDITOR': 'vim', 'DUPEFILTER_CLASS': 'scrapy.dupefilters.BaseDupeFilter'}
2018-07-31 19:03:56 [scrapy.extensions.feedexport] ERROR: Disabled feed storage scheme: s3. Reason: missing botocore or boto library

 <more log output truncated>
 ```