### PR TITLE
remove unused imports from scrapy/settings/__init__.py

### DIFF
--- a/scrapy/settings/__init__.py
+++ b/scrapy/settings/__init__.py
@@ -1,12 +1,9 @@
 import six
 import json
 import copy
-import warnings
 from collections import MutableMapping
 from importlib import import_module
 from pprint import pformat
-
-from scrapy.exceptions import ScrapyDeprecationWarning
 
 from . import default_settings
 


### PR DESCRIPTION
This is a follow-up to https://github.com/scrapy/scrapy/pull/3327.