### PR TITLE
An interface to customize download scheme for other download handlers

### DIFF
--- a/scrapy/core/downloader/handlers/__init__.py
+++ b/scrapy/core/downloader/handlers/__init__.py
@@ -56,8 +56,18 @@ class DownloadHandlers(object):
             self._handlers[scheme] = dh
         return self._handlers[scheme]
 
+    def _get_handler_scheme(self, request, spider):
+        """Customize the download scheme for other downloadhandlers,
+        say, the rendering engine.
+        """
+        if 'download_scheme' in request.meta:
+            return request.meta['download_scheme']
+        if hasattr(spider, 'download_scheme'):
+            return spider.download_scheme
+        return urlparse_cached(request).scheme
+
     def download_request(self, request, spider):
-        scheme = urlparse_cached(request).scheme
+        scheme = self._get_handler_scheme(request, spider)
         handler = self._get_handler(scheme)
         if not handler:
             raise NotSupported("Unsupported URL scheme '%s': %s" %


### PR DESCRIPTION
A little modification is made on the interface to parse download scheme,  **scrapy.core.downloader.handler**,  making it more friendly to add customized download handlers.
Say, when you want to handle the http request  via a render engine, without hacking the native download middleware. 

Resolves #3354 