### PR TITLE
[MRG+1] Fix contract errback (#3370)

### DIFF
--- a/scrapy/contracts/__init__.py
+++ b/scrapy/contracts/__init__.py
@@ -84,7 +84,7 @@ class ContractsManager(object):
 
         def eb_wrapper(failure):
             case = _create_testcase(method, 'errback')
-            exc_info = failure.value, failure.type, failure.getTracebackObject()
+            exc_info = failure.type, failure.value, failure.getTracebackObject()
             results.addError(case, exc_info)
 
         request.callback = cb_wrapper

--- a/tests/test_contracts.py
+++ b/tests/test_contracts.py
@@ -1,7 +1,9 @@
 from unittest import TextTestResult
 
+from twisted.python import failure
 from twisted.trial import unittest
 
+from scrapy.spidermiddlewares.httperror import HttpError
 from scrapy.spiders import Spider
 from scrapy.http import Request
 from scrapy.item import Item, Field
@@ -185,3 +187,18 @@ class ContractsManagerTest(unittest.TestCase):
                 self.results)
         request.callback(response)
         self.should_fail()
+
+    def test_errback(self):
+        spider = TestSpider()
+        response = ResponseMock()
+
+        try:
+            raise HttpError(response, 'Ignoring non-200 response')
+        except HttpError:
+            failure_mock = failure.Failure()
+
+        request = self.conman.from_method(spider.returns_request, self.results)
+        request.errback(failure_mock)
+
+        self.assertFalse(self.results.failures)
+        self.assertTrue(self.results.errors)


### PR DESCRIPTION
Fix an `AttributeError` which was raised in Python 3 due to incorrect order of `exc_info` components.

Fixes #3370.