### PR TITLE
Add handling of errors in contract methods

### DIFF
--- a/scrapy/contracts/__init__.py
+++ b/scrapy/contracts/__init__.py
@@ -41,7 +41,11 @@ class ContractsManager(object):
         requests = []
         for method in self.tested_methods_from_spidercls(type(spider)):
             bound_method = spider.__getattribute__(method)
-            requests.append(self.from_method(bound_method, results))
+            try:
+                requests.append(self.from_method(bound_method, results))
+            except:
+                case = _create_testcase(bound_method, 'contract')
+                results.addError(case, sys.exc_info())
 
         return requests
 


### PR DESCRIPTION
This change adds the following benefits in case an exception inside contract (e.g. in `adjust_request_args`):

- exit code of `scrapy check` will be non-zero;
- exception will not be silenced and thus no need to add `--loglevel=CRITICAL` to see traceback;
- other methods will be tested as the exception is caught now.

Closes #3364.