### PR TITLE
[MRG+1] Add ability to use FormRequest in contracts

### DIFF
--- a/docs/topics/contracts.rst
+++ b/docs/topics/contracts.rst
@@ -86,8 +86,9 @@ override three methods:
     .. method:: Contract.adjust_request_args(args)
 
         This receives a ``dict`` as an argument containing default arguments
-        for request object. :class:`~scrapy.http.Request` is used
-        if ``request_cls`` is not set on ``args``.
+        for request object. :class:`~scrapy.http.Request` is used by default,
+        but this can be changed with the ``request_cls`` attribute.
+        If multiple contracts in chain have this attribute defined, the last one is used.
 
         Must return the same or a modified version of it.
 

--- a/tests/test_contracts.py
+++ b/tests/test_contracts.py
@@ -27,9 +27,9 @@ class ResponseMock(object):
 
 class CustomFormContract(Contract):
     name = 'custom_form'
+    request_cls = FormRequest
 
     def adjust_request_args(self, args):
-        args['request_cls'] = FormRequest
         args['formdata'] = {'name': 'scrapy'}
         return args
 


### PR DESCRIPTION
With current implementation of contracts, it is basically not possible to create a generic `@form` contract, but I think we should at least allow to add `formdata` in custom contracts.

Closes #3382.