### PR TITLE
Make lazy loading Download Handlers optional

### DIFF
--- a/scrapy/core/downloader/handlers/datauri.py
+++ b/scrapy/core/downloader/handlers/datauri.py
@@ -6,6 +6,8 @@ from scrapy.utils.decorators import defers
 
 
 class DataURIDownloadHandler(object):
+    lazy = False
+
     def __init__(self, settings):
         super(DataURIDownloadHandler, self).__init__()
 

--- a/scrapy/core/downloader/handlers/file.py
+++ b/scrapy/core/downloader/handlers/file.py
@@ -2,7 +2,9 @@ from w3lib.url import file_uri_to_path
 from scrapy.responsetypes import responsetypes
 from scrapy.utils.decorators import defers
 
+
 class FileDownloadHandler(object):
+    lazy = False
 
     def __init__(self, settings):
         pass

--- a/scrapy/core/downloader/handlers/ftp.py
+++ b/scrapy/core/downloader/handlers/ftp.py
@@ -60,7 +60,10 @@ class ReceivedDataProtocol(Protocol):
         self.body.close() if self.filename else self.body.seek(0)
 
 _CODE_RE = re.compile("\d+")
+
+
 class FTPDownloadHandler(object):
+    lazy = False
 
     CODE_MAPPING = {
         "550": 404,

--- a/scrapy/core/downloader/handlers/http10.py
+++ b/scrapy/core/downloader/handlers/http10.py
@@ -6,6 +6,7 @@ from scrapy.utils.python import to_unicode
 
 
 class HTTP10DownloadHandler(object):
+    lazy = False
 
     def __init__(self, settings):
         self.HTTPClientFactory = load_object(settings['DOWNLOADER_HTTPCLIENTFACTORY'])

--- a/scrapy/core/downloader/handlers/http11.py
+++ b/scrapy/core/downloader/handlers/http11.py
@@ -33,6 +33,7 @@ logger = logging.getLogger(__name__)
 
 
 class HTTP11DownloadHandler(object):
+    lazy = False
 
     def __init__(self, settings):
         self._pool = HTTPConnectionPool(reactor, persistent=True)

--- a/scrapy/core/downloader/handlers/s3.py
+++ b/scrapy/core/downloader/handlers/s3.py
@@ -31,7 +31,6 @@ def _get_boto_connection():
 
 
 class S3DownloadHandler(object):
-    lazy = True
 
     def __init__(self, settings, aws_access_key_id=None, aws_secret_access_key=None, \
             httpdownloadhandler=HTTPDownloadHandler, **kw):

--- a/scrapy/core/downloader/handlers/s3.py
+++ b/scrapy/core/downloader/handlers/s3.py
@@ -31,6 +31,7 @@ def _get_boto_connection():
 
 
 class S3DownloadHandler(object):
+    lazy = True
 
     def __init__(self, settings, aws_access_key_id=None, aws_secret_access_key=None, \
             httpdownloadhandler=HTTPDownloadHandler, **kw):

--- a/tests/test_downloader_handlers.py
+++ b/tests/test_downloader_handlers.py
@@ -43,19 +43,21 @@ from tests.spiders import SingleRequestSpider
 
 
 class DummyDH(object):
+    lazy = False
 
     def __init__(self, crawler):
         pass
 
 
 class DummyLazyDH(object):
-    lazy = True
+    # Default is lazy for backwards compatibility
 
     def __init__(self, crawler):
         pass
 
 
 class OffDH(object):
+    lazy = False
 
     def __init__(self, crawler):
         raise NotConfigured

--- a/tests/test_downloader_handlers.py
+++ b/tests/test_downloader_handlers.py
@@ -41,7 +41,15 @@ from scrapy.exceptions import NotConfigured
 from tests.mockserver import MockServer, ssl_context_factory, Echo
 from tests.spiders import SingleRequestSpider
 
+
 class DummyDH(object):
+
+    def __init__(self, crawler):
+        pass
+
+
+class DummyLazyDH(object):
+    lazy = True
 
     def __init__(self, crawler):
         pass
@@ -60,8 +68,6 @@ class LoadTestCase(unittest.TestCase):
         crawler = get_crawler(settings_dict={'DOWNLOAD_HANDLERS': handlers})
         dh = DownloadHandlers(crawler)
         self.assertIn('scheme', dh._schemes)
-        for scheme in handlers: # force load handlers
-            dh._get_handler(scheme)
         self.assertIn('scheme', dh._handlers)
         self.assertNotIn('scheme', dh._notconfigured)
 
@@ -70,8 +76,6 @@ class LoadTestCase(unittest.TestCase):
         crawler = get_crawler(settings_dict={'DOWNLOAD_HANDLERS': handlers})
         dh = DownloadHandlers(crawler)
         self.assertIn('scheme', dh._schemes)
-        for scheme in handlers: # force load handlers
-            dh._get_handler(scheme)
         self.assertNotIn('scheme', dh._handlers)
         self.assertIn('scheme', dh._notconfigured)
 
@@ -80,10 +84,21 @@ class LoadTestCase(unittest.TestCase):
         crawler = get_crawler(settings_dict={'DOWNLOAD_HANDLERS': handlers})
         dh = DownloadHandlers(crawler)
         self.assertNotIn('scheme', dh._schemes)
-        for scheme in handlers: # force load handlers
+        for scheme in handlers:  # force load handlers
             dh._get_handler(scheme)
         self.assertNotIn('scheme', dh._handlers)
         self.assertIn('scheme', dh._notconfigured)
+
+    def test_lazy_handlers(self):
+        handlers = {'scheme': 'tests.test_downloader_handlers.DummyLazyDH'}
+        crawler = get_crawler(settings_dict={'DOWNLOAD_HANDLERS': handlers})
+        dh = DownloadHandlers(crawler)
+        self.assertIn('scheme', dh._schemes)
+        self.assertNotIn('scheme', dh._handlers)
+        for scheme in handlers:  # force load lazy handler
+            dh._get_handler(scheme)
+        self.assertIn('scheme', dh._handlers)
+        self.assertNotIn('scheme', dh._notconfigured)
 
 
 class FileTestCase(unittest.TestCase):


### PR DESCRIPTION
Download Handlers load only when first request for a scheme is needed, this was put in place because s3 download handler used to be very slow to create.

This makes it optional for Download Handlers to be lazy loaded which is relevant when writing custom handlers that have required settings and wants to raise `NotConfiguredException` during instantiation.