### PR TITLE
#833 Encoding Resolved

### DIFF
--- a/docs/topics/request-response.rst
+++ b/docs/topics/request-response.rst
@@ -100,7 +100,7 @@ Request objects
 
     :param encoding: the encoding of this request (defaults to ``'utf-8'``).
        This encoding will be used to percent-encode the URL and to convert the
-       body to ``str`` (if given as ``unicode``).
+       body to ``str`` (if given as ``unicode``).To use the url in raw form use ``encoding='None'`` in the param list.
     :type encoding: string
 
     :param priority: the priority of this request (defaults to ``0``).

--- a/scrapy/__init__.py
+++ b/scrapy/__init__.py
@@ -1,4 +1,4 @@
-pi"""
+"""
 Scrapy - a web crawling and web scraping framework written for Python
 """
 

--- a/scrapy/__init__.py
+++ b/scrapy/__init__.py
@@ -1,4 +1,4 @@
-"""
+pi"""
 Scrapy - a web crawling and web scraping framework written for Python
 """
 

--- a/scrapy/http/request/__init__.py
+++ b/scrapy/http/request/__init__.py
@@ -55,8 +55,11 @@ class Request(object_ref):
         if not isinstance(url, six.string_types):
             raise TypeError('Request url must be str or unicode, got %s:' % type(url).__name__)
         if(self.encoding=='None'):
+
             s=url
+            self._url= escape_ajax(s)
         else:
+
             s = safe_url_string(url, self.encoding)
             self._url = escape_ajax(s)
 

--- a/scrapy/http/request/__init__.py
+++ b/scrapy/http/request/__init__.py
@@ -54,9 +54,11 @@ class Request(object_ref):
     def _set_url(self, url):
         if not isinstance(url, six.string_types):
             raise TypeError('Request url must be str or unicode, got %s:' % type(url).__name__)
-
-        s = safe_url_string(url, self.encoding)
-        self._url = escape_ajax(s)
+        if(self.encoding=='None'):
+            s=url
+        else:
+            s = safe_url_string(url, self.encoding)
+            self._url = escape_ajax(s)
 
         if ':' not in self._url:
             raise ValueError('Missing scheme in request url: %s' % self._url)


### PR DESCRIPTION
Use encoding='None' while calling Request Objects to solve the issue with encoding of urls. Doc has been updated.