### PR TITLE
FIX rewrite invalid user-agent middleware method

### DIFF
--- a/scrapy/downloadermiddlewares/useragent.py
+++ b/scrapy/downloadermiddlewares/useragent.py
@@ -20,4 +20,4 @@ class UserAgentMiddleware(object):
 
     def process_request(self, request, spider):
         if self.user_agent:
-            request.headers.setdefault(b'User-Agent', self.user_agent)
+            request.headers[b'User-Agent'] = self.user_agent


### PR DESCRIPTION
because headers does not actually has the setdefault method, here if we directly give value to the [‘user-agent’], things work out fine