### PR TITLE
request_fingerprint should return bytes

### DIFF
--- a/scrapy/dupefilters.py
+++ b/scrapy/dupefilters.py
@@ -1,5 +1,6 @@
 import os
 import logging
+from binascii import hexlify
 
 from scrapy.utils.job import job_dir
 from scrapy.utils.request import referer_str, request_fingerprint
@@ -36,7 +37,8 @@ class RFPDupeFilter(BaseDupeFilter):
         if path:
             self.file = open(os.path.join(path, 'requests.seen'), 'a+')
             self.file.seek(0)
-            self.fingerprints.update(x.rstrip() for x in self.file)
+            self.fingerprints.update(bytes(bytearray.fromhex(x.rstrip()))
+                                     for x in self.file)
 
     @classmethod
     def from_settings(cls, settings):
@@ -49,7 +51,7 @@ class RFPDupeFilter(BaseDupeFilter):
             return True
         self.fingerprints.add(fp)
         if self.file:
-            self.file.write(fp + '\n')
+            self.file.write(hexlify(fp).decode('ascii') + '\n')
 
     def request_fingerprint(self, request):
         return request_fingerprint(request)

--- a/scrapy/extensions/httpcache.py
+++ b/scrapy/extensions/httpcache.py
@@ -267,7 +267,7 @@ class DbmCacheStorage(object):
         return pickle.loads(db['%s_data' % key])
 
     def _request_key(self, request):
-        return request_fingerprint(request)
+        return request_fingerprint(request, as_string=True)
 
 
 class FilesystemCacheStorage(object):
@@ -328,7 +328,7 @@ class FilesystemCacheStorage(object):
             f.write(request.body)
 
     def _get_request_path(self, spider, request):
-        key = request_fingerprint(request)
+        key = request_fingerprint(request, as_string=True)
         return os.path.join(self.cachedir, spider.name, key[0:2], key)
 
     def _read_meta(self, spider, request):

--- a/scrapy/utils/request.py
+++ b/scrapy/utils/request.py
@@ -17,7 +17,8 @@ from scrapy.utils.python import to_bytes, to_unicode
 _fingerprint_cache = weakref.WeakKeyDictionary()
 
 
-def request_fingerprint(request, include_headers=None, keep_fragments=False):
+def request_fingerprint(request, include_headers=None, keep_fragments=False,
+                        as_string=False):
     """
     Return the request fingerprint.
 
@@ -40,13 +41,17 @@ def request_fingerprint(request, include_headers=None, keep_fragments=False):
     the fingerprint.
 
     For this reason, request headers are ignored by default when calculating
-    the fingeprint. If you want to include specific headers use the
+    the fingerprint. If you want to include specific headers use the
     include_headers argument, which is a list of Request headers to include.
 
     Also, servers usually ignore fragments in urls when handling requests,
     so they are also ignored by default when calculating the fingerprint.
     If you want to include them, set the keep_fragments argument to True
     (for instance when handling requests with a headless browser).
+
+    With the as_string argument set tot True, a hex representation of the
+    fingerprint will be returned (legacy behaviour) instead of the raw bytes
+    value.
 
     """
     if include_headers:
@@ -65,7 +70,9 @@ def request_fingerprint(request, include_headers=None, keep_fragments=False):
                     fp.update(hdr)
                     for v in request.headers.getlist(hdr):
                         fp.update(v)
-        cache[cache_key] = fp.hexdigest()
+        cache[cache_key] = fp.digest()
+    if as_string:
+        return cache[cache_key].hex()
     return cache[cache_key]
 
 

--- a/tests/test_dupefilters.py
+++ b/tests/test_dupefilters.py
@@ -82,6 +82,7 @@ class RFPDupeFilterTest(unittest.TestCase):
     def test_dupefilter_path(self):
         r1 = Request('http://scrapytest.org/1')
         r2 = Request('http://scrapytest.org/2')
+        r3 = Request('http://scrapytest.org/3')
 
         path = tempfile.mkdtemp()
         try:
@@ -90,6 +91,8 @@ class RFPDupeFilterTest(unittest.TestCase):
                 df.open()
                 assert not df.request_seen(r1)
                 assert df.request_seen(r1)
+                assert not df.request_seen(r2)
+                assert df.request_seen(r2)
             finally:
                 df.close('finished')
 
@@ -97,8 +100,9 @@ class RFPDupeFilterTest(unittest.TestCase):
             try:
                 df2.open()
                 assert df2.request_seen(r1)
-                assert not df2.request_seen(r2)
                 assert df2.request_seen(r2)
+                assert not df2.request_seen(r3)
+                assert df2.request_seen(r3)
             finally:
                 df2.close('finished')
         finally:

--- a/tests/test_utils_request.py
+++ b/tests/test_utils_request.py
@@ -11,6 +11,8 @@ class UtilsRequestTest(unittest.TestCase):
         r2 = Request("http://www.example.com/query?cat=222&id=111")
         self.assertEqual(request_fingerprint(r1), request_fingerprint(r1))
         self.assertEqual(request_fingerprint(r1), request_fingerprint(r2))
+        self.assertEqual(request_fingerprint(r1, as_string=True), request_fingerprint(r2, as_string=True))
+        self.assertNotEqual(request_fingerprint(r1, as_string=True), request_fingerprint(r2, as_string=False))
 
         r1 = Request('http://www.example.com/hnnoticiaj1.aspx?78132,199')
         r2 = Request('http://www.example.com/hnnoticiaj1.aspx?78160,199')
@@ -18,6 +20,7 @@ class UtilsRequestTest(unittest.TestCase):
 
         # make sure caching is working
         self.assertEqual(request_fingerprint(r1), _fingerprint_cache[r1][(None, False)])
+        self.assertNotEqual(request_fingerprint(r1, as_string=True), _fingerprint_cache[r1][(None, False)])
 
         r1 = Request("http://www.example.com/members/offers.html")
         r2 = Request("http://www.example.com/members/offers.html")


### PR DESCRIPTION
In my opinion `request_fingerprint` (`scrapy.utils.request`) would be more sensible to return `bytes`; as returned by `hashlib.sha1().digest()` (versus `.hexdigest()`).

A hash as returned by this function is usually used for comparison only (duplicate detection) and being kept in memory (rfp cache) -- except for the cache middleware where it's used as a unique storage key.

Since this is happening mostly under the hood, comparing between bytes-objects is just as good; but storing the 20 bytes SHA1, over a 40 byte hexadecimal string-representation, is a theoretical 200% improvement in memory usage.
(In reality `sys.getsizeof()` makes the `bytes` object *53* bytes worth and the `str` (unicode) *89*, not quite double the size.)

The only place where I can see a hex representation used, is as a unique filename for the `FilesystemCacheStorage`; even the DB storages could save some by storing the plain binary representation; they do `to_bytes()` the hexstring instead. This is of course not the inverse of turning bytes into a hex string (that would be `bytes(bytearray.fromhex())`).

Alas, this is a behavior breaking change which could impact 3rd party code, so I don't have much hope of seeing the current functionality changing. But perhaps it could still return bytes when passing a flag - and be used with that internally. It's much easier to ask for that, than turning the hex string back to "binary".