### PR TITLE
Support for overriding OpenSSL ciphers

### DIFF
--- a/docs/topics/settings.rst
+++ b/docs/topics/settings.rst
@@ -445,6 +445,24 @@ accepts a ``method`` parameter (this is the ``OpenSSL.SSL`` method mapping
 :setting:`DOWNLOADER_CLIENT_TLS_METHOD`) and a ``tls_verbose_logging``
 parameter (``bool``).
 
+.. setting:: DOWNLOADER_CLIENT_TLS_CIPHERS
+
+DOWNLOADER_CLIENT_TLS_CIPHERS
+-----------------------------
+
+Default: ``'DEFAULT'``
+
+Use  this setting to customize the TLS/SSL ciphers used by the default
+HTTP/1.1 downloader.
+
+The setting should contain a string in the `OpenSSL cipher list format`_,
+these ciphers will be used as client ciphers. Changing this setting may be
+necessary to access certain HTTPS websites: for example, you may need to use
+``'DEFAULT:!DH'`` for a website with weak DH parameters or enable a
+specific cipher that is not included in ``DEFAULT`` if a website requires it.
+
+.. _OpenSSL cipher list format: https://www.openssl.org/docs/manmaster/man1/ciphers.html#CIPHER-LIST-FORMAT
+
 .. setting:: DOWNLOADER_CLIENT_TLS_METHOD
 
 DOWNLOADER_CLIENT_TLS_METHOD

--- a/docs/topics/settings.rst
+++ b/docs/topics/settings.rst
@@ -442,8 +442,9 @@ or even enable client-side authentication (and various other things).
 
 If you do use a custom ContextFactory, make sure its ``__init__`` method
 accepts a ``method`` parameter (this is the ``OpenSSL.SSL`` method mapping
-:setting:`DOWNLOADER_CLIENT_TLS_METHOD`) and a ``tls_verbose_logging``
-parameter (``bool``).
+:setting:`DOWNLOADER_CLIENT_TLS_METHOD`), a ``tls_verbose_logging``
+parameter (``bool``) and a ``tls_ciphers`` parameter (see
+:setting:`DOWNLOADER_CLIENT_TLS_CIPHERS`).
 
 .. setting:: DOWNLOADER_CLIENT_TLS_CIPHERS
 

--- a/scrapy/core/downloader/handlers/http11.py
+++ b/scrapy/core/downloader/handlers/http11.py
@@ -54,7 +54,7 @@ class HTTP11DownloadHandler(object):
             )
             msg = """
  '%s' does not accept `method` argument (type OpenSSL.SSL method,\
- e.g. OpenSSL.SSL.SSLv23_METHOD) and/or `tls_verbose_logging` argument.\
+ e.g. OpenSSL.SSL.SSLv23_METHOD) and/or `tls_verbose_logging` argument and/or `tls_ciphers` argument.\
  Please upgrade your context factory class to handle them or ignore them.""" % (
                 settings['DOWNLOADER_CLIENTCONTEXTFACTORY'],)
             warnings.warn(msg)

--- a/scrapy/settings/default_settings.py
+++ b/scrapy/settings/default_settings.py
@@ -85,6 +85,7 @@ DOWNLOADER = 'scrapy.core.downloader.Downloader'
 
 DOWNLOADER_HTTPCLIENTFACTORY = 'scrapy.core.downloader.webclient.ScrapyHTTPClientFactory'
 DOWNLOADER_CLIENTCONTEXTFACTORY = 'scrapy.core.downloader.contextfactory.ScrapyClientContextFactory'
+DOWNLOADER_CLIENT_TLS_CIPHERS = 'DEFAULT'
 DOWNLOADER_CLIENT_TLS_METHOD = 'TLS' # Use highest TLS/SSL protocol version supported by the platform,
                                      # also allowing negotiation
 DOWNLOADER_CLIENT_TLS_VERBOSE_LOGGING = False

--- a/scrapy/utils/ssl.py
+++ b/scrapy/utils/ssl.py
@@ -6,6 +6,11 @@ import OpenSSL._util as pyOpenSSLutil
 from scrapy.utils.python import to_native_str
 
 
+# The OpenSSL symbol is present since 1.1.1 but it's not currently supported in any version of pyOpenSSL.
+# Using the binding directly, as this code does, requires cryptography 2.4.
+SSL_OP_NO_TLSv1_3 = getattr(pyOpenSSLutil.lib, 'SSL_OP_NO_TLSv1_3', 0)
+
+
 def ffi_buf_to_string(buf):
     return to_native_str(pyOpenSSLutil.ffi.string(buf))
 

--- a/tests/mockserver.py
+++ b/tests/mockserver.py
@@ -3,6 +3,8 @@ import sys, time, random, os, json
 from six.moves.urllib.parse import urlencode
 from subprocess import Popen, PIPE
 
+from OpenSSL import SSL
+
 from twisted.web.server import Site, NOT_DONE_YET
 from twisted.web.resource import Resource
 from twisted.web.static import File
@@ -220,6 +222,14 @@ def ssl_context_factory(keyfile='keys/localhost.key', certfile='keys/localhost.c
          os.path.join(os.path.dirname(__file__), keyfile),
          os.path.join(os.path.dirname(__file__), certfile),
          )
+
+
+def broken_ssl_context_factory(keyfile='keys/localhost.key', certfile='keys/localhost.crt', cipher_string='DEFAULT'):
+    factory = ssl_context_factory(keyfile, certfile)
+    ctx = factory.getContext()
+    ctx.set_options(SSL.OP_CIPHER_SERVER_PREFERENCE | SSL.OP_NO_TLSv1_2)
+    ctx.set_cipher_list(cipher_string)
+    return factory
 
 
 if __name__ == "__main__":

--- a/tests/test_downloader_handlers.py
+++ b/tests/test_downloader_handlers.py
@@ -39,7 +39,7 @@ from scrapy.utils.test import get_crawler, skip_if_no_boto
 from scrapy.utils.python import to_bytes
 from scrapy.exceptions import NotConfigured
 
-from tests.mockserver import MockServer, ssl_context_factory, Echo
+from tests.mockserver import MockServer, ssl_context_factory, Echo, broken_ssl_context_factory
 from tests.spiders import SingleRequestSpider
 
 
@@ -551,6 +551,47 @@ class Https11InvalidDNSPattern(Https11TestCase):
             raise unittest.SkipTest("cryptography lib is too old")
         self.tls_log_message = 'SSL connection certificate: issuer "/C=IE/O=Scrapy/CN=127.0.0.1", subject "/C=IE/O=Scrapy/CN=127.0.0.1"'
         super(Https11InvalidDNSPattern, self).setUp()
+
+
+class Https11BadCiphers(unittest.TestCase):
+    scheme = 'https'
+    download_handler_cls = HTTP11DownloadHandler
+
+    keyfile = 'keys/localhost.key'
+    certfile = 'keys/localhost.crt'
+
+    def setUp(self):
+        self.tmpname = self.mktemp()
+        os.mkdir(self.tmpname)
+        FilePath(self.tmpname).child("file").setContent(b"0123456789")
+        r = static.File(self.tmpname)
+        self.site = server.Site(r, timeout=None)
+        self.wrapper = WrappingFactory(self.site)
+        self.host = 'localhost'
+        self.port = reactor.listenSSL(
+            0, self.wrapper, broken_ssl_context_factory(self.keyfile, self.certfile, cipher_string='CAMELLIA256-SHA'),
+            interface=self.host)
+        self.portno = self.port.getHost().port
+        self.download_handler = self.download_handler_cls(
+            Settings({'DOWNLOADER_CLIENT_TLS_CIPHERS': 'CAMELLIA256-SHA'}))
+        self.download_request = self.download_handler.download_request
+
+    @defer.inlineCallbacks
+    def tearDown(self):
+        yield self.port.stopListening()
+        if hasattr(self.download_handler, 'close'):
+            yield self.download_handler.close()
+        shutil.rmtree(self.tmpname)
+
+    def getURL(self, path):
+        return "%s://%s:%d/%s" % (self.scheme, self.host, self.portno, path)
+
+    def test_download(self):
+        request = Request(self.getURL('file'))
+        d = self.download_request(request, Spider('foo'))
+        d.addCallback(lambda r: r.body)
+        d.addCallback(self.assertEqual, b"0123456789")
+        return d
 
 
 class Http11MockServerTestCase(unittest.TestCase):

--- a/tests/test_downloader_handlers.py
+++ b/tests/test_downloader_handlers.py
@@ -39,7 +39,7 @@ from scrapy.utils.test import get_crawler, skip_if_no_boto
 from scrapy.utils.python import to_bytes
 from scrapy.exceptions import NotConfigured
 
-from tests.mockserver import MockServer, ssl_context_factory, Echo, broken_ssl_context_factory
+from tests.mockserver import MockServer, ssl_context_factory, Echo
 from tests.spiders import SingleRequestSpider
 
 
@@ -553,7 +553,7 @@ class Https11InvalidDNSPattern(Https11TestCase):
         super(Https11InvalidDNSPattern, self).setUp()
 
 
-class Https11BadCiphers(unittest.TestCase):
+class Https11CustomCiphers(unittest.TestCase):
     scheme = 'https'
     download_handler_cls = HTTP11DownloadHandler
 
@@ -569,7 +569,7 @@ class Https11BadCiphers(unittest.TestCase):
         self.wrapper = WrappingFactory(self.site)
         self.host = 'localhost'
         self.port = reactor.listenSSL(
-            0, self.wrapper, broken_ssl_context_factory(self.keyfile, self.certfile, cipher_string='CAMELLIA256-SHA'),
+            0, self.wrapper, ssl_context_factory(self.keyfile, self.certfile, cipher_string='CAMELLIA256-SHA'),
             interface=self.host)
         self.portno = self.port.getHost().port
         self.download_handler = self.download_handler_cls(


### PR DESCRIPTION
This adds the `DOWNLOADER_CLIENT_TLS_CIPHERS` setting which is then used in `ScrapyClientContextFactory`. There is a real-world example of when it may be needed in #3392 (the server offers a cipher that is rejected by the client so we need to not advertise it), there are other theoretical  problems e.g. a server supports only ciphers that are supported by the client but disabled. I've constructed the second case in the tests because constructing the first case seems to be impossible with a modern OpenSSL.
There are two tests, the one in `tests/test_webclient.py` uses `ScrapyClientContextFactory` directly (its base class also just tests the default context factory with the default SSL server) and the one in `tests/test_downloader_handlers.py` uses the setting and the download handler. I don't know if the first one is worth keeping. I also don't like the amount of duplicated code in the added test cases, maybe some reshuffling of base HTTP(S) test classes will be useful.