### PR TITLE
Log cipher, certificate and temp key info on establishing an SSL connection

### DIFF
--- a/docs/topics/settings.rst
+++ b/docs/topics/settings.rst
@@ -438,9 +438,10 @@ or even enable client-side authentication (and various other things).
     which uses the platform's certificates to validate remote endpoints.
     **This is only available if you use Twisted>=14.0.**
 
-If you do use a custom ContextFactory, make sure it accepts a ``method``
-parameter at init (this is the ``OpenSSL.SSL`` method mapping
-:setting:`DOWNLOADER_CLIENT_TLS_METHOD`).
+If you do use a custom ContextFactory, make sure its ``__init__` method accepts
+a ``method`` parameter (this is the ``OpenSSL.SSL`` method mapping
+:setting:`DOWNLOADER_CLIENT_TLS_METHOD`) and a ``settings`` parameter (this is
+the Scrapy settings object).
 
 .. setting:: DOWNLOADER_CLIENT_TLS_METHOD
 
@@ -467,6 +468,20 @@ This setting must be one of these string values:
 
     We recommend that you use PyOpenSSL>=0.13 and Twisted>=0.13
     or above (Twisted>=14.0 if you can).
+
+.. setting:: DOWNLOADER_CLIENT_TLS_VERBOSE_LOGGING
+
+DOWNLOADER_CLIENT_TLS_VERBOSE_LOGGING
+-------------------------------------
+
+Default: ``False``
+
+Setting this to ``True`` will enable DEBUG level messages about TLS connection
+parameters after establishing HTTPS connections. The kind of information logged
+depends on the versions of OpenSSL and pyOpenSSL.
+
+This setting is only used for the default
+:setting:`DOWNLOADER_CLIENTCONTEXTFACTORY`.
 
 .. setting:: DOWNLOADER_MIDDLEWARES
 

--- a/docs/topics/settings.rst
+++ b/docs/topics/settings.rst
@@ -440,8 +440,8 @@ or even enable client-side authentication (and various other things).
 
 If you do use a custom ContextFactory, make sure its ``__init__`` method
 accepts a ``method`` parameter (this is the ``OpenSSL.SSL`` method mapping
-:setting:`DOWNLOADER_CLIENT_TLS_METHOD`) and a ``settings`` parameter (this is
-the Scrapy :class:`~scrapy.settings.Settings` object).
+:setting:`DOWNLOADER_CLIENT_TLS_METHOD`) and a ``tls_verbose_logging``
+parameter (``bool``).
 
 .. setting:: DOWNLOADER_CLIENT_TLS_METHOD
 

--- a/docs/topics/settings.rst
+++ b/docs/topics/settings.rst
@@ -438,10 +438,10 @@ or even enable client-side authentication (and various other things).
     which uses the platform's certificates to validate remote endpoints.
     **This is only available if you use Twisted>=14.0.**
 
-If you do use a custom ContextFactory, make sure its ``__init__` method accepts
-a ``method`` parameter (this is the ``OpenSSL.SSL`` method mapping
+If you do use a custom ContextFactory, make sure its ``__init__`` method
+accepts a ``method`` parameter (this is the ``OpenSSL.SSL`` method mapping
 :setting:`DOWNLOADER_CLIENT_TLS_METHOD`) and a ``settings`` parameter (this is
-the Scrapy settings object).
+the Scrapy :class:`~scrapy.settings.Settings` object).
 
 .. setting:: DOWNLOADER_CLIENT_TLS_METHOD
 

--- a/scrapy/core/downloader/contextfactory.py
+++ b/scrapy/core/downloader/contextfactory.py
@@ -29,17 +29,18 @@ if twisted_version >= (14, 0, 0):
          understand the SSLv3, TLSv1, TLSv1.1 and TLSv1.2 protocols.'
         """
 
-        def __init__(self, method=SSL.SSLv23_METHOD, settings=None, *args, **kwargs):
+        def __init__(self, method=SSL.SSLv23_METHOD, tls_verbose_logging=False, *args, **kwargs):
             super(ScrapyClientContextFactory, self).__init__(*args, **kwargs)
             self._ssl_method = method
-            if settings:
-                self.tls_verbose_logging = settings['DOWNLOADER_CLIENT_TLS_VERBOSE_LOGGING']
-            else:
-                self.tls_verbose_logging = False
+            self.tls_verbose_logging = tls_verbose_logging
 
         @classmethod
         def from_settings(cls, settings, method=SSL.SSLv23_METHOD, *args, **kwargs):
-            return cls(method=method, settings=settings, *args, **kwargs)
+            if settings:
+                tls_verbose_logging = settings.getbool('DOWNLOADER_CLIENT_TLS_VERBOSE_LOGGING')
+            else:
+                tls_verbose_logging = False
+            return cls(method=method, tls_verbose_logging=tls_verbose_logging, *args, **kwargs)
 
         def getCertificateOptions(self):
             # setting verify=True will require you to provide CAs

--- a/scrapy/core/downloader/contextfactory.py
+++ b/scrapy/core/downloader/contextfactory.py
@@ -2,7 +2,6 @@ from OpenSSL import SSL
 from twisted.internet.ssl import ClientContextFactory
 
 from scrapy import twisted_version
-from scrapy.utils.misc import create_instance
 
 if twisted_version >= (14, 0, 0):
 

--- a/scrapy/core/downloader/contextfactory.py
+++ b/scrapy/core/downloader/contextfactory.py
@@ -35,10 +35,7 @@ if twisted_version >= (14, 0, 0):
 
         @classmethod
         def from_settings(cls, settings, method=SSL.SSLv23_METHOD, *args, **kwargs):
-            if settings:
-                tls_verbose_logging = settings.getbool('DOWNLOADER_CLIENT_TLS_VERBOSE_LOGGING')
-            else:
-                tls_verbose_logging = False
+            tls_verbose_logging = settings.getbool('DOWNLOADER_CLIENT_TLS_VERBOSE_LOGGING')
             return cls(method=method, tls_verbose_logging=tls_verbose_logging, *args, **kwargs)
 
         def getCertificateOptions(self):

--- a/scrapy/core/downloader/handlers/http10.py
+++ b/scrapy/core/downloader/handlers/http10.py
@@ -1,7 +1,7 @@
 """Download handlers for http and https schemes
 """
 from twisted.internet import reactor
-from scrapy.utils.misc import load_object
+from scrapy.utils.misc import load_object, create_instance
 from scrapy.utils.python import to_unicode
 
 
@@ -11,6 +11,7 @@ class HTTP10DownloadHandler(object):
     def __init__(self, settings):
         self.HTTPClientFactory = load_object(settings['DOWNLOADER_HTTPCLIENTFACTORY'])
         self.ClientContextFactory = load_object(settings['DOWNLOADER_CLIENTCONTEXTFACTORY'])
+        self._settings = settings
 
     def download_request(self, request, spider):
         """Return a deferred for the HTTP download"""
@@ -21,7 +22,7 @@ class HTTP10DownloadHandler(object):
     def _connect(self, factory):
         host, port = to_unicode(factory.host), factory.port
         if factory.scheme == b'https':
-            return reactor.connectSSL(host, port, factory,
-                                      self.ClientContextFactory())
+            client_context_factory = create_instance(self.ClientContextFactory, settings=self._settings, crawler=None)
+            return reactor.connectSSL(host, port, factory, client_context_factory)
         else:
             return reactor.connectTCP(host, port, factory)

--- a/scrapy/core/downloader/handlers/http11.py
+++ b/scrapy/core/downloader/handlers/http11.py
@@ -25,7 +25,7 @@ from scrapy.http import Headers
 from scrapy.responsetypes import responsetypes
 from scrapy.core.downloader.webclient import _parse
 from scrapy.core.downloader.tls import openssl_methods
-from scrapy.utils.misc import load_object
+from scrapy.utils.misc import load_object, create_instance
 from scrapy.utils.python import to_bytes, to_unicode
 from scrapy import twisted_version
 
@@ -44,14 +44,15 @@ class HTTP11DownloadHandler(object):
         self._contextFactoryClass = load_object(settings['DOWNLOADER_CLIENTCONTEXTFACTORY'])
         # try method-aware context factory
         try:
-            self._contextFactory = self._contextFactoryClass(method=self._sslMethod)
+            self._contextFactory = create_instance(self._contextFactoryClass, settings=settings, crawler=None,
+                                                   method=self._sslMethod)
         except TypeError:
             # use context factory defaults
-            self._contextFactory = self._contextFactoryClass()
+            self._contextFactory = create_instance(self._contextFactoryClass, settings=settings, crawler=None)
             msg = """
  '%s' does not accept `method` argument (type OpenSSL.SSL method,\
- e.g. OpenSSL.SSL.SSLv23_METHOD).\
- Please upgrade your context factory class to handle it or ignore it.""" % (
+ e.g. OpenSSL.SSL.SSLv23_METHOD) and/or `settings` argument.\
+ Please upgrade your context factory class to handle them or ignore them.""" % (
                 settings['DOWNLOADER_CLIENTCONTEXTFACTORY'],)
             warnings.warn(msg)
         self._default_maxsize = settings.getint('DOWNLOAD_MAXSIZE')

--- a/scrapy/core/downloader/handlers/http11.py
+++ b/scrapy/core/downloader/handlers/http11.py
@@ -51,7 +51,7 @@ class HTTP11DownloadHandler(object):
             self._contextFactory = create_instance(self._contextFactoryClass, settings=settings, crawler=None)
             msg = """
  '%s' does not accept `method` argument (type OpenSSL.SSL method,\
- e.g. OpenSSL.SSL.SSLv23_METHOD) and/or `settings` argument.\
+ e.g. OpenSSL.SSL.SSLv23_METHOD) and/or `tls_verbose_logging` argument.\
  Please upgrade your context factory class to handle them or ignore them.""" % (
                 settings['DOWNLOADER_CLIENTCONTEXTFACTORY'],)
             warnings.warn(msg)

--- a/scrapy/core/downloader/tls.py
+++ b/scrapy/core/downloader/tls.py
@@ -74,11 +74,18 @@ if twisted_version >= (14, 0, 0):
             if where & SSL_CB_HANDSHAKE_START:
                 set_tlsext_host_name(connection, self._hostnameBytes)
             elif where & SSL_CB_HANDSHAKE_DONE:
-                logger.debug('SSL connection to %s using protocol %s, cipher %s',
-                             self._hostnameASCII,
-                             connection.get_protocol_version_name(),
-                             connection.get_cipher_name(),
-                             )
+                if hasattr(connection, 'get_cipher_name'):  # requires pyOPenSSL 0.15
+                    if hasattr(connection, 'get_protocol_version_name'):  # requires pyOPenSSL 16.0.0
+                        logger.debug('SSL connection to %s using protocol %s, cipher %s',
+                                     self._hostnameASCII,
+                                     connection.get_protocol_version_name(),
+                                     connection.get_cipher_name(),
+                                     )
+                    else:
+                        logger.debug('SSL connection to %s using cipher %s',
+                                     self._hostnameASCII,
+                                     connection.get_cipher_name(),
+                                     )
                 server_cert = connection.get_peer_certificate()
                 logger.debug('SSL connection certificate: issuer "%s", subject "%s"',
                              x509name_to_string(server_cert.get_issuer()),

--- a/scrapy/core/downloader/tls.py
+++ b/scrapy/core/downloader/tls.py
@@ -71,7 +71,7 @@ if twisted_version >= (14, 0, 0):
         """
 
         def __init__(self, hostname, ctx, verbose_logging=False):
-            super().__init__(hostname, ctx)
+            super(ScrapyClientTLSOptions, self).__init__(hostname, ctx)
             self.verbose_logging = verbose_logging
 
         def _identityVerifyingInfoCallback(self, connection, where, ret):

--- a/scrapy/core/downloader/tls.py
+++ b/scrapy/core/downloader/tls.py
@@ -70,30 +70,35 @@ if twisted_version >= (14, 0, 0):
         logging warnings. Also, HTTPS connection parameters logging is added.
         """
 
+        def __init__(self, hostname, ctx, verbose_logging=False):
+            super().__init__(hostname, ctx)
+            self.verbose_logging = verbose_logging
+
         def _identityVerifyingInfoCallback(self, connection, where, ret):
             if where & SSL_CB_HANDSHAKE_START:
                 set_tlsext_host_name(connection, self._hostnameBytes)
             elif where & SSL_CB_HANDSHAKE_DONE:
-                if hasattr(connection, 'get_cipher_name'):  # requires pyOPenSSL 0.15
-                    if hasattr(connection, 'get_protocol_version_name'):  # requires pyOPenSSL 16.0.0
-                        logger.debug('SSL connection to %s using protocol %s, cipher %s',
-                                     self._hostnameASCII,
-                                     connection.get_protocol_version_name(),
-                                     connection.get_cipher_name(),
-                                     )
-                    else:
-                        logger.debug('SSL connection to %s using cipher %s',
-                                     self._hostnameASCII,
-                                     connection.get_cipher_name(),
-                                     )
-                server_cert = connection.get_peer_certificate()
-                logger.debug('SSL connection certificate: issuer "%s", subject "%s"',
-                             x509name_to_string(server_cert.get_issuer()),
-                             x509name_to_string(server_cert.get_subject()),
-                             )
-                key_info = get_temp_key_info(connection._ssl)
-                if key_info:
-                    logger.debug('SSL temp key: %s', key_info)
+                if self.verbose_logging:
+                    if hasattr(connection, 'get_cipher_name'):  # requires pyOPenSSL 0.15
+                        if hasattr(connection, 'get_protocol_version_name'):  # requires pyOPenSSL 16.0.0
+                            logger.debug('SSL connection to %s using protocol %s, cipher %s',
+                                         self._hostnameASCII,
+                                         connection.get_protocol_version_name(),
+                                         connection.get_cipher_name(),
+                                         )
+                        else:
+                            logger.debug('SSL connection to %s using cipher %s',
+                                         self._hostnameASCII,
+                                         connection.get_cipher_name(),
+                                         )
+                    server_cert = connection.get_peer_certificate()
+                    logger.debug('SSL connection certificate: issuer "%s", subject "%s"',
+                                 x509name_to_string(server_cert.get_issuer()),
+                                 x509name_to_string(server_cert.get_subject()),
+                                 )
+                    key_info = get_temp_key_info(connection._ssl)
+                    if key_info:
+                        logger.debug('SSL temp key: %s', key_info)
 
                 try:
                     verifyHostname(connection, self._hostnameASCII)

--- a/scrapy/settings/default_settings.py
+++ b/scrapy/settings/default_settings.py
@@ -87,6 +87,7 @@ DOWNLOADER_HTTPCLIENTFACTORY = 'scrapy.core.downloader.webclient.ScrapyHTTPClien
 DOWNLOADER_CLIENTCONTEXTFACTORY = 'scrapy.core.downloader.contextfactory.ScrapyClientContextFactory'
 DOWNLOADER_CLIENT_TLS_METHOD = 'TLS' # Use highest TLS/SSL protocol version supported by the platform,
                                      # also allowing negotiation
+DOWNLOADER_CLIENT_TLS_VERBOSE_LOGGING = False
 
 DOWNLOADER_MIDDLEWARES = {}
 

--- a/scrapy/utils/ssl.py
+++ b/scrapy/utils/ssl.py
@@ -1,0 +1,50 @@
+# -*- coding: utf-8 -*-
+
+import OpenSSL._util as pyOpenSSLutil
+
+from scrapy.utils.python import to_native_str
+
+
+def ffi_buf_to_string(buf):
+    return to_native_str(pyOpenSSLutil.ffi.string(buf))
+
+
+def x509name_to_string(x509name):
+    # from OpenSSL.crypto.X509Name.__repr__
+    result_buffer = pyOpenSSLutil.ffi.new("char[]", 512)
+    pyOpenSSLutil.lib.X509_NAME_oneline(x509name._name, result_buffer, len(result_buffer))
+
+    return ffi_buf_to_string(result_buffer)
+
+
+def get_temp_key_info(ssl_object):
+    if not hasattr(pyOpenSSLutil.lib, 'SSL_get_server_tmp_key'):  # requires OpenSSL 1.0.2
+        return None
+
+    # adapted from OpenSSL apps/s_cb.c::ssl_print_tmp_key()
+    temp_key_p = pyOpenSSLutil.ffi.new("EVP_PKEY **")
+    pyOpenSSLutil.lib.SSL_get_server_tmp_key(ssl_object, temp_key_p)
+    if temp_key_p == pyOpenSSLutil.ffi.NULL:
+        return None
+
+    temp_key = temp_key_p[0]
+    pyOpenSSLutil.ffi.gc(temp_key, pyOpenSSLutil.lib.EVP_PKEY_free)
+    key_info = []
+    key_type = pyOpenSSLutil.lib.EVP_PKEY_id(temp_key)
+    if key_type == pyOpenSSLutil.lib.EVP_PKEY_RSA:
+        key_info.append('RSA')
+    elif key_type == pyOpenSSLutil.lib.EVP_PKEY_DH:
+        key_info.append('DH')
+    elif key_type == pyOpenSSLutil.lib.EVP_PKEY_EC:
+        key_info.append('ECDH')
+        ec_key = pyOpenSSLutil.lib.EVP_PKEY_get1_EC_KEY(temp_key)
+        pyOpenSSLutil.ffi.gc(ec_key, pyOpenSSLutil.lib.EC_KEY_free)
+        nid = pyOpenSSLutil.lib.EC_GROUP_get_curve_name(pyOpenSSLutil.lib.EC_KEY_get0_group(ec_key))
+        cname = pyOpenSSLutil.lib.EC_curve_nid2nist(nid)
+        if cname == pyOpenSSLutil.ffi.NULL:
+            cname = pyOpenSSLutil.lib.OBJ_nid2sn(nid)
+        key_info.append(ffi_buf_to_string(cname))
+    else:
+        key_info.append(ffi_buf_to_string(pyOpenSSLutil.lib.OBJ_nid2sn(key_type)))
+    key_info.append('%s bits' % pyOpenSSLutil.lib.EVP_PKEY_bits(temp_key))
+    return ', '.join(key_info)


### PR DESCRIPTION
Fix #2111. Also related to #2726, though that ticket most likely asks for a programmatical access to all of this (I don't know if it's easily doable).

Output example:

> 2018-10-05 20:08:36 [scrapy.core.downloader.tls] DEBUG: SSL connection to market.yandex.ru using protocol TLSv1.2, cipher ECDHE-RSA-AES128-GCM-SHA256
> 2018-10-05 20:08:36 [scrapy.core.downloader.tls] DEBUG: SSL connection certificate: issuer "/C=RU/O=Yandex LLC/OU=Yandex Certification Authority/CN=Yandex CA", subject "/C=RU/O=Yandex LLC/OU=ITO/L=Moscow/ST=Russian Federation/CN=market.yandex.ru"
> 2018-10-05 20:08:36 [scrapy.core.downloader.tls] DEBUG: SSL temp key: ECDH, P-256, 256 bits

I'm not sure this should be enabled by default as a lot of websites are now HTTPS and this will be printed on all requests including redirects, but I don't know how to access settings in this class.

Note that there is a lot of direct FFI code to access the temporary key params, I hope it works correctly and doesn't cause memleaks. It also requires OpenSSL 1.0.2, but I couldn't test the check with an older OpenSSL, as I couldn't run tests on an actual jessie system.

There is other info that can be added, look at the `Connection` methods (easy) and at the `openssl s_client` output (may be harder, like with the temp key info).