### PR TITLE
[MRG+1] Update Scrapy Tutorial docs 

### DIFF
--- a/docs/intro/tutorial.rst
+++ b/docs/intro/tutorial.rst
@@ -23,7 +23,7 @@ start by getting an idea of what the language is like, to get the most out of
 Scrapy.
 
 If you're already familiar with other languages, and want to learn Python
-quickly, we recommend reading through `Dive Into Python 3`_.  Alternatively,
+quickly, we recommend reading through `Crash into Python`_.  Alternatively,
 you can follow the `Python Tutorial`_.
 
 If you're new to programming and want to start with Python, the following books
@@ -40,7 +40,7 @@ as well as the `suggested resources in the learnpython-subreddit`_.
 
 .. _Python: https://www.python.org/
 .. _this list of Python resources for non-programmers: https://wiki.python.org/moin/BeginnersGuide/NonProgrammers
-.. _Dive Into Python 3: http://www.diveintopython3.net
+.. _Crash into Python: https://stephensugden.com/crash_into_python/
 .. _Python Tutorial: https://docs.python.org/3/tutorial
 .. _Automate the Boring Stuff With Python: https://automatetheboringstuff.com/
 .. _How To Think Like a Computer Scientist: http://openbookproject.net/thinkcs/python/english3e/

--- a/docs/intro/tutorial.rst
+++ b/docs/intro/tutorial.rst
@@ -22,9 +22,7 @@ Scrapy is written in Python_. If you're new to the language you might want to
 start by getting an idea of what the language is like, to get the most out of
 Scrapy.
 
-If you're already familiar with other languages, and want to learn Python
-quickly, we recommend reading through `Crash into Python`_.  Alternatively,
-you can follow the `Python Tutorial`_.
+If you're already familiar with other languages, and want to learn Python quickly, the `Python Tutorial`_ is a good resource.
 
 If you're new to programming and want to start with Python, the following books
 may be useful to you: 
@@ -40,7 +38,6 @@ as well as the `suggested resources in the learnpython-subreddit`_.
 
 .. _Python: https://www.python.org/
 .. _this list of Python resources for non-programmers: https://wiki.python.org/moin/BeginnersGuide/NonProgrammers
-.. _Crash into Python: https://stephensugden.com/crash_into_python/
 .. _Python Tutorial: https://docs.python.org/3/tutorial
 .. _Automate the Boring Stuff With Python: https://automatetheboringstuff.com/
 .. _How To Think Like a Computer Scientist: http://openbookproject.net/thinkcs/python/english3e/


### PR DESCRIPTION
Hi there!

This is my pull request referencing the issue #3464.

I've removed the ad link "Dive into Python 3", and replaced it with [Crash into Python](https://stephensugden.com/crash_into_python/). It seems like a good resource for people to get up to speed with Python quickly.

Alternatively, I can just remove the link as well and point people to [The Python Tutorial](https://docs.python.org/3/tutorial). 

Thanks!

