### PR TITLE
Add missing '/' when the URL path is empty

### DIFF
--- a/scrapy/downloadermiddlewares/redirect.py
+++ b/scrapy/downloadermiddlewares/redirect.py
@@ -1,7 +1,7 @@
 import logging
 from six.moves.urllib.parse import urljoin
 
-from w3lib.url import safe_url_string
+from w3lib.url import canonicalize_url, safe_url_string
 
 from scrapy.http import HtmlResponse
 from scrapy.utils.response import get_meta_refresh
@@ -68,7 +68,7 @@ class RedirectMiddleware(BaseRedirectMiddleware):
         if 'Location' not in response.headers or response.status not in allowed_status:
             return response
 
-        location = safe_url_string(response.headers['location'])
+        location = canonicalize_url(safe_url_string(response.headers['location']))
 
         redirected_url = urljoin(request.url, location)
 

--- a/tests/test_downloadermiddleware_redirect.py
+++ b/tests/test_downloadermiddleware_redirect.py
@@ -133,11 +133,15 @@ class RedirectMiddlewareTest(unittest.TestCase):
         req2 = self.mw.process_response(req1, rsp1, self.spider)
         rsp2 = Response('http://scrapytest.org/redirected', headers={'Location': '/redirected2'}, status=302)
         req3 = self.mw.process_response(req2, rsp2, self.spider)
+        rsp3 = Response('http://scrapytest.org/redirected', headers={'Location': 'http://scrapytest.org?k=v'}, status=302)
+        req4 = self.mw.process_response(req3, rsp3, self.spider)
 
         self.assertEqual(req2.url, 'http://scrapytest.org/redirected')
         self.assertEqual(req2.meta['redirect_urls'], ['http://scrapytest.org/first'])
         self.assertEqual(req3.url, 'http://scrapytest.org/redirected2')
         self.assertEqual(req3.meta['redirect_urls'], ['http://scrapytest.org/first', 'http://scrapytest.org/redirected'])
+        self.assertEqual(req4.url, 'http://scrapytest.org/?k=v')
+        self.assertEqual(req4.meta['redirect_urls'], ['http://scrapytest.org/first', 'http://scrapytest.org/redirected', 'http://scrapytest.org/redirected2'])
 
     def test_spider_handling(self):
         smartspider = self.crawler._create_spider('smarty')


### PR DESCRIPTION
Fixes #1133

When performing redirects, scrapy creates a new request based on the URL from the response location header.

In some cases, the redirect URL that we receive in the response is not properly normalized.
When performing a HTTP GET request with this URL, we may receive a HTTP error.

However, when using an actual web browser, it works fine, because the browser normalizes the location URL before performing the next request.

For example, when querying https://www.watsons.com.sg, the response location header contains:

`https://queue.watsons.com.sg?c=aswatson&e=watsonprdsg&ver=v3-java-3.5.2&cver=55&cid=zh-CN&l=PoC+Layout+SG&t=https%3A%2F%2Fwww.watsons.com.sg%2F`

We can see that this part of the URL is not normalized: `queue.watsons.com.sg?c=aswatson`, it's missing a slash.
If you send a HTTP GET on this URL, you'll get some bad response code back (HTTP 400).

Firefox actually does the normalization to: `queue.watsons.com.sg/?c=aswatson` (notice the additional slash).

I've added a unit test to show the behavior.

More details in my answer in Stackoverflow: https://stackoverflow.com/a/53323565/869764