### PR TITLE
[MRG+1] Add documentation to `scrapy shell` command.

### DIFF
--- a/scrapy/commands/shell.py
+++ b/scrapy/commands/shell.py
@@ -28,7 +28,8 @@ class Command(ScrapyCommand):
         return "Interactive scraping console"
 
     def long_desc(self):
-        return "Interactive console for scraping the given url"
+        return ("Interactive console for scraping the given url or file. "
+                "Use ./file.html syntax or full path for local file.")
 
     def add_options(self, parser):
         ScrapyCommand.add_options(self, parser)


### PR DESCRIPTION
The special syntax required for local files (`./file.html`) is not documented as part of the `scrapy shell --help` output. This patch adds that.