### PR TITLE
Add `item` to the extra kwargs when logging after processing an item

### DIFF
--- a/scrapy/core/scraper.py
+++ b/scrapy/core/scraper.py
@@ -224,20 +224,20 @@ class Scraper(object):
             ex = output.value
             if isinstance(ex, DropItem):
                 logkws = self.logformatter.dropped(item, ex, response, spider)
-                logger.log(*logformatter_adapter(logkws), extra={'spider': spider})
+                logger.log(*logformatter_adapter(logkws), extra={'spider': spider, 'item': item})
                 return self.signals.send_catch_log_deferred(
                     signal=signals.item_dropped, item=item, response=response,
                     spider=spider, exception=output.value)
             else:
                 logger.error('Error processing %(item)s', {'item': item},
                              exc_info=failure_to_exc_info(output),
-                             extra={'spider': spider})
+                             extra={'spider': spider, 'item': item})
                 return self.signals.send_catch_log_deferred(
                     signal=signals.item_error, item=item, response=response,
                     spider=spider, failure=output)
         else:
             logkws = self.logformatter.scraped(output, response, spider)
-            logger.log(*logformatter_adapter(logkws), extra={'spider': spider})
+            logger.log(*logformatter_adapter(logkws), extra={'spider': spider, 'item': item})
             return self.signals.send_catch_log_deferred(
                 signal=signals.item_scraped, item=output, response=response,
                 spider=spider)


### PR DESCRIPTION
The item is on the log message already, we might as well pass it as an extra kwarg.

We're using a custom log handler that is forwarding structured logs to an external service.
We are using the `extra` kwargs to add more useful information.
It currently contains the `spider` information, and we would like to use the `item` information as well if it is there.
