### PR TITLE
scrapy view <url> for local files

### DIFF
--- a/scrapy/commands/parse.py
+++ b/scrapy/commands/parse.py
@@ -26,7 +26,7 @@ class Command(ScrapyCommand):
     first_response = None
 
     def syntax(self):
-        return "[options] <url>"
+        return "<url> [options]"
 
     def short_desc(self):
         return "Parse URL (using its spider) and print the results"

--- a/scrapy/commands/view.py
+++ b/scrapy/commands/view.py
@@ -7,8 +7,8 @@ class Command(fetch.Command):
         return "Open URL in browser, as seen by Scrapy"
 
     def long_desc(self):
-        return "Fetch a URL using the Scrapy downloader and show its " \
-            "contents in a browser"
+        return "Fetch a URL using the Scrapy downloader and show its contents in a browser. " \
+               "For local file, concatenate 'file:///' with the full path of local file and type this string in place of <url> in 'scrapy view <url>'"
 
     def add_options(self, parser):
         super(Command, self).add_options(parser)


### PR DESCRIPTION
This patch documents ``scrapy view --help`` output. To view local ``html`` files in a browser, we can use ``scrapy view "file:///C:\Users\Name\Desktop\scrape.html"`` (example), which is a syntax to access local files.