### PR TITLE
Use (default) secure connections in botocore / S3

### DIFF
--- a/scrapy/pipelines/files.py
+++ b/scrapy/pipelines/files.py
@@ -127,9 +127,7 @@ class S3FilesStore(object):
         return self._get_boto_key(path).addCallback(_onsuccess)
 
     def _get_boto_bucket(self):
-        # disable ssl (is_secure=False) because of this python bug:
-        # https://bugs.python.org/issue5103
-        c = self.S3Connection(self.AWS_ACCESS_KEY_ID, self.AWS_SECRET_ACCESS_KEY, is_secure=False)
+        c = self.S3Connection(self.AWS_ACCESS_KEY_ID, self.AWS_SECRET_ACCESS_KEY)
         return c.get_bucket(self.bucket, validate=False)
 
     def _get_boto_key(self, path):

--- a/scrapy/utils/boto.py
+++ b/scrapy/utils/boto.py
@@ -1,9 +1,11 @@
 """Boto/botocore helpers"""
 
 from __future__ import absolute_import
+import warnings
 import six
 
 from scrapy.exceptions import NotConfigured
+from scrapy.exceptions import ScrapyDeprecationWarning
 
 
 def is_botocore():
@@ -14,6 +16,11 @@ def is_botocore():
         if six.PY2:
             try:
                 import boto
+                message = (
+                    'Usage of boto in Scrapy is deprecated. '
+                    'Consider installing botocore for a stable and recommended way to access AWS.'
+                )
+                warnings.warn(message, category=ScrapyDeprecationWarning, stacklevel=2)
                 return False
             except ImportError:
                 raise NotConfigured('missing botocore or boto library')


### PR DESCRIPTION
This pull requests tends to resolve these stale pull requests:

https://github.com/scrapy/scrapy/pull/2085
https://github.com/scrapy/scrapy/pull/2372

The reason for explicitly setting `is_secure=False` was long gone, since the related Python bug had been fixed years ago (Scrapy does not even support that Python version now). There is absolutely no reason to use insecure connections now.

This pull request just removes the comment and restores the default behavior of botocore.