### PR TITLE
[ItemLoader] add remove_value method to loader

### DIFF
--- a/scrapy/loader/__init__.py
+++ b/scrapy/loader/__init__.py
@@ -109,6 +109,15 @@ class ItemLoader(object):
             value = proc(value)
         return value
 
+    def remove_value(self, field_name):
+        """Remove value of field_name from loader and from underlying item.
+
+        :param field_name: string with field name
+        :return:
+        """
+        self._values.pop(field_name, None)
+        self.item.pop(field_name, None)
+
     def load_item(self):
         item = self.item
         for field_name in tuple(self._values):

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -136,6 +136,22 @@ class BasicItemLoaderTest(unittest.TestCase):
         il.add_value(None, u'Jim', lambda x: {'name': x})
         self.assertEqual(il.get_collected_values('name'), [u'Marta', u'Pepe', u'Jim'])
 
+    def test_remove_value(self):
+        il = TestItemLoader()
+        il.add_value('name', 'Pepe')
+        self.assertEqual(il.get_collected_values('name'), [u'Pepe'])
+        self.assertEqual(il.get_output_value('name'), [u'Pepe'])
+        il.remove_value('name')
+        self.assertEqual(il.get_collected_values('name'), [])
+
+    def test_remove_value_in_item(self):
+        item = TestItem()
+        item['name'] = ['Marta']
+        il = TestItemLoader(item)
+        self.assertEqual(il.load_item().get('name'), ['Marta'])
+        il.remove_value('name')
+        self.assertEqual(il.load_item().get('name'), None)
+
     def test_add_zero(self):
         il = NameItemLoader()
         il.add_value('name', 0)


### PR DESCRIPTION
You pass field name as argument and loader will smartly remove values from loader and item.

This is needed because now when you want to remove something from loader you need to write code like this:

```python
# coding: utf-8
from scrapy.loader import ItemLoader, Item
from scrapy.item import Field


class TestItem(Item):
    name = Field()


class TestLoader(ItemLoader):
    default_item_class = TestItem


loader = TestLoader()
loader.add_value('name', 'pepe')
item = loader.load_item()
item.pop('name')
new_loader = TestLoader(item)
```

This is not very convenient and it also works badly with some of loader behaviors. For example scrapy loader allows you to do something like this. 

```python
# coding: utf-8
from scrapy.loader import ItemLoader, Item
from scrapy.item import Field


class TestItem(Item):
    name = Field()
    location = Field()


class TestLoader(ItemLoader):
    default_item_class = TestItem


class Spider(object):
    def do_something(self):
        loader = TestLoader()
        self.add_something_to_loader(loader)
        item = loader.load_item()
        assert 'location' not in item
        assert 'name' in item
        print("end {}".format(item))
        return item

    def add_something_to_loader(self, loader):
        loader.add_value('location', 'NY')
        # 20 lines later
        some_condition = True
        if some_condition:
            # Now you are doing something bad!!!
            item = loader.load_item()
            item.pop('location')
            loader = TestLoader(item)
        
        # Someone thinks he will get name in do_something,
        # but it is not true, he now has different loader from one that was
        # initially passed to function.
        loader.add_value('name', 'Frank')
        print(loader.load_item())


s = Spider()
r = s.do_something()```
```

## Solution
adds method remove_value that will remove value from both:
- loader
- item

Removing field_name from loader item will remove it from parent item passed to loader.

```python
# coding: utf-8
from scrapy.loader import ItemLoader, Item
from scrapy.item import Field
import random


class TestItem(Item):
    name = Field()
    location = Field()


class TestLoader(ItemLoader):
    default_item_class = TestItem

item = TestItem()
item['name'] = 'Frank'
loader = TestLoader(item)
loader.remove_value('name')

# Note: no name in item! Loader removes it from item too.
print(item)

```

I opted for this option because that's what I would expect. When I use loader I usually treat "item" passed to loader as something that is useful only for loader and not needed outside it. So if I want to remove something from loader I usually want to remove it from item. This is because I want to do loader.load_item() at some point and I dont want to have field removed in output of load_item(). 

Not sure if this is universal though. This is something that could be discussed.