### PR TITLE
Fix boto import error under Jessie testing environment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,6 +43,11 @@ install:
         virtualenv --python="$PYPY_VERSION/bin/pypy3" "$HOME/virtualenvs/$PYPY_VERSION"
         source "$HOME/virtualenvs/$PYPY_VERSION/bin/activate"
       fi
+      if [ "$TOXENV" = "jessie" ]; then
+        # Not used directly but allows boto GCE plugins to load.
+        # https://github.com/GoogleCloudPlatform/compute-image-packages/issues/262
+        pip install google-compute-engine
+      fi
   - pip install -U tox twine wheel codecov
 
 script: tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,11 +43,6 @@ install:
         virtualenv --python="$PYPY_VERSION/bin/pypy3" "$HOME/virtualenvs/$PYPY_VERSION"
         source "$HOME/virtualenvs/$PYPY_VERSION/bin/activate"
       fi
-      if [ "$TOXENV" = "jessie" ]; then
-        # Not used directly but allows boto GCE plugins to load.
-        # https://github.com/GoogleCloudPlatform/compute-image-packages/issues/262
-        pip install google-compute-engine
-      fi
   - pip install -U tox twine wheel codecov
 
 script: tox

--- a/tox.ini
+++ b/tox.ini
@@ -51,6 +51,9 @@ deps =
     cssselect==0.9.1
     zope.interface==4.1.1
     -rtests/requirements-py2.txt
+# Not used directly but allows boto GCE plugins to load.
+# https://github.com/GoogleCloudPlatform/compute-image-packages/issues/262
+    google-compute-engine==2.8.12
 
 [testenv:trunk]
 basepython = python2.7


### PR DESCRIPTION
Our builds are failing for `TOXENV=jessie` with the following error

<img width="1008" alt="image" src="https://user-images.githubusercontent.com/37369/50314289-0ad2d580-048d-11e9-9279-f9f56547f83a.png">

Related to https://github.com/GoogleCloudPlatform/compute-image-packages/issues/262
 