### PR TITLE
Avoid URL Encoding as an option

### DIFF
--- a/scrapy/http/request/__init__.py
+++ b/scrapy/http/request/__init__.py
@@ -16,13 +16,13 @@ from scrapy.http.common import obsolete_setter
 
 class Request(object_ref):
 
-    def __init__(self, url, escape_URL=None, callback=None, method='GET', headers=None, body=None,
+    def __init__(self, url, quote_path=True, callback=None, method='GET', headers=None, body=None,
                  cookies=None, meta=None, encoding='utf-8', priority=0,
                  dont_filter=False, errback=None, flags=None):
 
         self._encoding = encoding  # this one has to be set first
         self.method = str(method).upper()
-        self.escape_URL = escape_URL
+        self.quote_path = quote_path
         self._set_url(url)
         self._set_body(body)
         assert isinstance(priority, int), "Request priority not an integer: %r" % priority
@@ -56,7 +56,7 @@ class Request(object_ref):
         if not isinstance(url, six.string_types):
             raise TypeError('Request url must be str or unicode, got %s:' % type(url).__name__)
 
-        s = safe_url_string(url, self.encoding, self.escape_URL)
+        s = safe_url_string(url, self.encoding, self.quote_path)
         self._url = escape_ajax(s)
 
         if ':' not in self._url:

--- a/scrapy/http/request/__init__.py
+++ b/scrapy/http/request/__init__.py
@@ -56,7 +56,7 @@ class Request(object_ref):
         if not isinstance(url, six.string_types):
             raise TypeError('Request url must be str or unicode, got %s:' % type(url).__name__)
 
-        s = safe_url_string(url, self.encoding, self.quote_path)
+        s = safe_url_string(url, encoding=self.encoding, quote_path=self.quote_path)
         self._url = escape_ajax(s)
 
         if ':' not in self._url:

--- a/scrapy/http/request/__init__.py
+++ b/scrapy/http/request/__init__.py
@@ -16,13 +16,13 @@ from scrapy.http.common import obsolete_setter
 
 class Request(object_ref):
 
-    def __init__(self, url, safeURL=None, callback=None, method='GET', headers=None, body=None,
+    def __init__(self, url, escape_URL=None, callback=None, method='GET', headers=None, body=None,
                  cookies=None, meta=None, encoding='utf-8', priority=0,
                  dont_filter=False, errback=None, flags=None):
 
         self._encoding = encoding  # this one has to be set first
         self.method = str(method).upper()
-        self.safeURL = safeURL
+        self.escape_URL = escape_URL
         self._set_url(url)
         self._set_body(body)
         assert isinstance(priority, int), "Request priority not an integer: %r" % priority
@@ -56,7 +56,7 @@ class Request(object_ref):
         if not isinstance(url, six.string_types):
             raise TypeError('Request url must be str or unicode, got %s:' % type(url).__name__)
 
-        s = safe_url_string(url, self.encoding, self.safeURL)
+        s = safe_url_string(url, self.encoding, self.escape_URL)
         self._url = escape_ajax(s)
 
         if ':' not in self._url:

--- a/scrapy/http/request/__init__.py
+++ b/scrapy/http/request/__init__.py
@@ -16,9 +16,9 @@ from scrapy.http.common import obsolete_setter
 
 class Request(object_ref):
 
-    def __init__(self, url, quote_path=True, callback=None, method='GET', headers=None, body=None,
+    def __init__(self, url, callback=None, method='GET', headers=None, body=None,
                  cookies=None, meta=None, encoding='utf-8', priority=0,
-                 dont_filter=False, errback=None, flags=None):
+                 dont_filter=False, errback=None, flags=None, quote_path=True):
 
         self._encoding = encoding  # this one has to be set first
         self.method = str(method).upper()

--- a/scrapy/http/request/__init__.py
+++ b/scrapy/http/request/__init__.py
@@ -16,12 +16,13 @@ from scrapy.http.common import obsolete_setter
 
 class Request(object_ref):
 
-    def __init__(self, url, callback=None, method='GET', headers=None, body=None,
+    def __init__(self, url, safeURL=None, callback=None, method='GET', headers=None, body=None,
                  cookies=None, meta=None, encoding='utf-8', priority=0,
                  dont_filter=False, errback=None, flags=None):
 
         self._encoding = encoding  # this one has to be set first
         self.method = str(method).upper()
+        self.safeURL = safeURL
         self._set_url(url)
         self._set_body(body)
         assert isinstance(priority, int), "Request priority not an integer: %r" % priority
@@ -55,7 +56,7 @@ class Request(object_ref):
         if not isinstance(url, six.string_types):
             raise TypeError('Request url must be str or unicode, got %s:' % type(url).__name__)
 
-        s = safe_url_string(url, self.encoding)
+        s = safe_url_string(url, self.encoding, self.safeURL)
         self._url = escape_ajax(s)
 
         if ':' not in self._url:


### PR DESCRIPTION
Fixes https://github.com/scrapy/scrapy/issues/833.
Case (i):-
```In [3]: from scrapy import Request

In [4]: Request('http://google.com/"hello"',True)
Out[4]: <GET http://google.com/%22hello%22>

In [5]: Request('http://google.com/"hello"',False)
Out[5]: <GET http://google.com/"hello">

In [6]: Request('http://google.com/"hello"')
Out[6]: <GET http://google.com/%22hello%22>
```

In the above case I am able to add quote_path as an argument in the Request constructor. This is set to ```True (default)``` if the user wants to quote the URL.

Case (ii):-

 I want to add an option to the command ``` scrapy shell "http://google.com/\"hello\"" ``` which when set to True, we get <GET http://google.com/%22hello%22> , if it is set to False, we get<GET http://google.com/"hello">

I dont have idea how to add option for that (Case-(ii)) command. Any suggestions?
Mentors please guide me @kmike @cathalgarvey @lopuhin :)

(PS:- I used \ for each " of hello as escape sequence in order to include it in the URL)
At present I had opened a PR for Case (i), ideas for Case (ii) are welcome :)

I opened a PR for w3lib to modify safe_url_string method. Please look into this https://github.com/scrapy/w3lib/pull/119

Thanks :)
