### PR TITLE
Fix item-pipeline example

### DIFF
--- a/docs/topics/item-pipeline.rst
+++ b/docs/topics/item-pipeline.rst
@@ -87,8 +87,8 @@ contain a price::
         vat_factor = 1.15
 
         def process_item(self, item, spider):
-            if item['price']:
-                if item['price_excludes_vat']:
+            if 'price' in item and item['price']:
+                if 'price_excludes_vat' in item and item['price_excludes_vat']:
                     item['price'] = item['price'] * self.vat_factor
                 return item
             else:

--- a/docs/topics/item-pipeline.rst
+++ b/docs/topics/item-pipeline.rst
@@ -87,8 +87,8 @@ contain a price::
         vat_factor = 1.15
 
         def process_item(self, item, spider):
-            if 'price' in item and item['price']:
-                if 'price_excludes_vat' in item and item['price_excludes_vat']:
+            if item.get('price'):
+                if item.get('price_excludes_vat'):
                     item['price'] = item['price'] * self.vat_factor
                 return item
             else:


### PR DESCRIPTION
`if item['price']:` and `if item['price_excludes_vat']:` could return `KeyError` exception, this patch aims to solve it.