### PR TITLE
[MRG+1] Add ability to change max_active_size by setting

### DIFF
--- a/docs/topics/settings.rst
+++ b/docs/topics/settings.rst
@@ -1266,7 +1266,7 @@ does not work together with :setting:`CONCURRENT_REQUESTS_PER_IP`.
 
 SCRAPER_SLOT_MAX_ACTIVE_SIZE
 ----------------------------
-Default: ``5000000``
+Default: ``5_000_000``
 
 Soft limit (in bytes) for response data being processed.
 

--- a/docs/topics/settings.rst
+++ b/docs/topics/settings.rst
@@ -1262,6 +1262,17 @@ Type of priority queue used by the scheduler. Another available type is
 domains in parallel. But currently ``scrapy.pqueues.DownloaderAwarePriorityQueue``
 does not work together with :setting:`CONCURRENT_REQUESTS_PER_IP`.
 
+.. setting:: SCRAPER_SLOT_MAX_ACTIVE_SIZE
+
+SCRAPER_SLOT_MAX_ACTIVE_SIZE
+----------------------------
+Default: ``5000000``
+
+Soft limit (in bytes) for response data being processed.
+
+While the sum of the sizes of all responses being processed is above this value,
+Scrapy does not process new requests.
+
 .. setting:: SPIDER_CONTRACTS
 
 SPIDER_CONTRACTS

--- a/scrapy/core/scraper.py
+++ b/scrapy/core/scraper.py
@@ -78,7 +78,7 @@ class Scraper(object):
     @defer.inlineCallbacks
     def open_spider(self, spider):
         """Open the given spider for scraping and allocate resources for it"""
-        self.slot = Slot()
+        self.slot = Slot(self.crawler.settings.getint('SCRAPER_SLOT_MAX_ACTIVE_SIZE'))
         yield self.itemproc.open_spider(spider)
 
     def close_spider(self, spider):

--- a/scrapy/settings/default_settings.py
+++ b/scrapy/settings/default_settings.py
@@ -254,6 +254,8 @@ SCHEDULER_DISK_QUEUE = 'scrapy.squeues.PickleLifoDiskQueue'
 SCHEDULER_MEMORY_QUEUE = 'scrapy.squeues.LifoMemoryQueue'
 SCHEDULER_PRIORITY_QUEUE = 'scrapy.pqueues.ScrapyPriorityQueue'
 
+SCRAPER_SLOT_MAX_ACTIVE_SIZE = 5000000
+
 SPIDER_LOADER_CLASS = 'scrapy.spiderloader.SpiderLoader'
 SPIDER_LOADER_WARN_ONLY = False
 


### PR DESCRIPTION
This PR fixes https://github.com/scrapy/scrapy/issues/1410

In our setup we had urls that were bigger than 5Mb (the default value) and we were reaching a deadlock scenario.
These changes allow for configuration of the `max_active_size` by setting the `SCRAPER_SLOT_MAX_ACTIVE_SIZE` configuration.

Thanks!