### PR TITLE
Fix [#3553] Add_http_if_no_scheme in domain in genspider

### DIFF
--- a/scrapy/commands/genspider.py
+++ b/scrapy/commands/genspider.py
@@ -9,6 +9,7 @@ from os.path import join, dirname, abspath, exists, splitext
 import scrapy
 from scrapy.commands import ScrapyCommand
 from scrapy.utils.template import render_templatefile, string_camelcase
+from scrapy.utils.url import add_http_if_no_scheme
 from scrapy.exceptions import UsageError
 
 
@@ -62,6 +63,7 @@ class Command(ScrapyCommand):
 
         name, domain = args[0:2]
         module = sanitize_module_name(name)
+        domain = add_http_if_no_scheme(domain)
 
         if self.settings.get('BOT_NAME') == module:
             print("Cannot create a spider with the same name as your project")

--- a/scrapy/commands/genspider.py
+++ b/scrapy/commands/genspider.py
@@ -30,9 +30,12 @@ def normalize_domain_name(domain):
         domain = re.findall(r'http.?://(.*)/?', domain)[0]
     else:
         start_url = add_http_if_no_scheme(domain)
+        
     if not start_url.endswith('/'):
         start_url = start_url + '/'
+
     return start_url, domain
+
 
 class Command(ScrapyCommand):
 

--- a/scrapy/commands/genspider.py
+++ b/scrapy/commands/genspider.py
@@ -25,6 +25,11 @@ def sanitize_module_name(module_name):
     return module_name
 
 def normalize_domain_name(domain):
+    """
+    Normalize Domain. if http is added, remove for the domain name,
+    But keep for the start_urls, else make start_urls equals to 
+    domain by adding http.
+    """
     start_url = domain
     if 'http' in domain:
         domain = re.findall(r'http.?://(.*)/?', domain)[0]
@@ -94,7 +99,8 @@ class Command(ScrapyCommand):
                 return
         template_file = self._find_template(opts.template)
         if template_file:
-            self._genspider(module, name, start_url, domain, opts.template, template_file)
+            self._genspider(module, name, start_url, \
+                domain, opts.template, template_file)
             if opts.edit:
                 self.exitcode = os.system('scrapy edit "%s"' % name)
 

--- a/scrapy/templates/spiders/basic.tmpl
+++ b/scrapy/templates/spiders/basic.tmpl
@@ -5,7 +5,7 @@ import scrapy
 class $classname(scrapy.Spider):
     name = '$name'
     allowed_domains = ['$domain']
-    start_urls = ['$domain/']
+    start_urls = ['$start_url']
 
     def parse(self, response):
         pass

--- a/scrapy/templates/spiders/basic.tmpl
+++ b/scrapy/templates/spiders/basic.tmpl
@@ -5,7 +5,7 @@ import scrapy
 class $classname(scrapy.Spider):
     name = '$name'
     allowed_domains = ['$domain']
-    start_urls = ['http://$domain/']
+    start_urls = ['$domain/']
 
     def parse(self, response):
         pass

--- a/scrapy/templates/spiders/crawl.tmpl
+++ b/scrapy/templates/spiders/crawl.tmpl
@@ -7,7 +7,7 @@ from scrapy.spiders import CrawlSpider, Rule
 class $classname(CrawlSpider):
     name = '$name'
     allowed_domains = ['$domain']
-    start_urls = ['$domain/']
+    start_urls = ['$start_url']
 
     rules = (
         Rule(LinkExtractor(allow=r'Items/'), callback='parse_item', follow=True),

--- a/scrapy/templates/spiders/crawl.tmpl
+++ b/scrapy/templates/spiders/crawl.tmpl
@@ -7,7 +7,7 @@ from scrapy.spiders import CrawlSpider, Rule
 class $classname(CrawlSpider):
     name = '$name'
     allowed_domains = ['$domain']
-    start_urls = ['http://$domain/']
+    start_urls = ['$domain/']
 
     rules = (
         Rule(LinkExtractor(allow=r'Items/'), callback='parse_item', follow=True),

--- a/scrapy/templates/spiders/csvfeed.tmpl
+++ b/scrapy/templates/spiders/csvfeed.tmpl
@@ -5,7 +5,7 @@ from scrapy.spiders import CSVFeedSpider
 class $classname(CSVFeedSpider):
     name = '$name'
     allowed_domains = ['$domain']
-    start_urls = ['http://$domain/feed.csv']
+    start_urls = ['$domain/feed.csv']
     # headers = ['id', 'name', 'description', 'image_link']
     # delimiter = '\t'
 

--- a/scrapy/templates/spiders/csvfeed.tmpl
+++ b/scrapy/templates/spiders/csvfeed.tmpl
@@ -5,7 +5,7 @@ from scrapy.spiders import CSVFeedSpider
 class $classname(CSVFeedSpider):
     name = '$name'
     allowed_domains = ['$domain']
-    start_urls = ['$domain/feed.csv']
+    start_urls = ['$start_url/feed.csv']
     # headers = ['id', 'name', 'description', 'image_link']
     # delimiter = '\t'
 

--- a/scrapy/templates/spiders/xmlfeed.tmpl
+++ b/scrapy/templates/spiders/xmlfeed.tmpl
@@ -5,7 +5,7 @@ from scrapy.spiders import XMLFeedSpider
 class $classname(XMLFeedSpider):
     name = '$name'
     allowed_domains = ['$domain']
-    start_urls = ['$domain/feed.xml']
+    start_urls = ['$start_url/feed.xml']
     iterator = 'iternodes' # you can change this; see the docs
     itertag = 'item' # change it accordingly
 

--- a/scrapy/templates/spiders/xmlfeed.tmpl
+++ b/scrapy/templates/spiders/xmlfeed.tmpl
@@ -5,7 +5,7 @@ from scrapy.spiders import XMLFeedSpider
 class $classname(XMLFeedSpider):
     name = '$name'
     allowed_domains = ['$domain']
-    start_urls = ['http://$domain/feed.xml']
+    start_urls = ['$domain/feed.xml']
     iterator = 'iternodes' # you can change this; see the docs
     itertag = 'item' # change it accordingly
 


### PR DESCRIPTION
Fixed [#3553] 
before passing the domain, use built-in function from utils.url.add_http_if_no_scheme to add the http:// before the domain.
Updated template files by removing hard coded values.