### PR TITLE
Add text sitemap support

### DIFF
--- a/scrapy/spiders/sitemap.py
+++ b/scrapy/spiders/sitemap.py
@@ -49,6 +49,13 @@ class SitemapSpider(Spider):
                 logger.warning("Ignoring invalid sitemap: %(response)s",
                                {'response': response}, extra={'spider': self})
                 return
+            if response.url.endswith('.txt'):
+                for loc in iterloc_text_sitemap(response.text):
+                    for r, c in self._cbs:
+                        if r.search(loc):
+                            yield Request(loc, callback=c)
+                            break
+                return
 
             s = Sitemap(body)
             it = self.sitemap_filter(s)
@@ -74,14 +81,16 @@ class SitemapSpider(Spider):
             return gunzip(response.body)
         # actual gzipped sitemap files are decompressed above ;
         # if we are here (response body is not gzipped)
-        # and have a response for .xml.gz,
+        # and have a response for .xml.gz or .txt.gz,
         # it usually means that it was already gunzipped
         # by HttpCompression middleware,
         # the HTTP response being sent with "Content-Encoding: gzip"
-        # without actually being a .xml.gz file in the first place,
-        # merely XML gzip-compressed on the fly,
-        # in other word, here, we have plain XML
+        # without actually being a .gz file in the first place,
+        # merely gzip-compressed on the fly,
+        # in other word, here, we have plain XML or TXT
         elif response.url.endswith('.xml') or response.url.endswith('.xml.gz'):
+            return response.body
+        elif response.url.endswith('.txt') or response.url.endswith('.txt.gz'):
             return response.body
 
 
@@ -99,3 +108,8 @@ def iterloc(it, alt=False):
         if alt and 'alternate' in d:
             for l in d['alternate']:
                 yield l
+
+
+def iterloc_text_sitemap(text):
+    for l in text.splitlines():
+        yield l

--- a/scrapy/spiders/sitemap.py
+++ b/scrapy/spiders/sitemap.py
@@ -87,7 +87,7 @@ class SitemapSpider(Spider):
         # the HTTP response being sent with "Content-Encoding: gzip"
         # without actually being a .gz file in the first place,
         # merely gzip-compressed on the fly,
-        # in other word, here, we have plain XML or TXT
+        # in other word, here, we have plain XML or text
         elif response.url.endswith('.xml') or response.url.endswith('.xml.gz'):
             return response.body
         elif response.url.endswith('.txt') or response.url.endswith('.txt.gz'):

--- a/tests/test_spider.py
+++ b/tests/test_spider.py
@@ -354,7 +354,7 @@ Sitemap: /sitemap-relative-url.xml
                           'http://www.example.com/sitemap-relative-url.xml'])
 
     def test_iterloc_text_sitemap(self):
-        text = b"""http://example.com/1
+        text = """http://example.com/1
 http://example.com/2
 """
         self.assertEqual(list(iterloc_text_sitemap(text)),


### PR DESCRIPTION
I have added some changes to support text sitemaps that are part of the standard based on https://www.sitemaps.org/protocol.html

When generating myself a sitemap for some sites I am crawling I find it easier to pass to a spider a `.txt` file that contains one URL per line than generating a `.xml` file.

For example in https://www.xml-sitemaps.com/urllist.txt:
```
https://www.xml-sitemaps.com/
https://www.xml-sitemaps.com/standalone-google-sitemap-generator.html
https://www.xml-sitemaps.com/about-sitemaps.html
...
```

I could then do:

```
class MySitemapSpider(SitemapSpider):
     name = 'mysitemapspider'
     sitemap_urls = ('https://www.xml-sitemaps.com/urllist.txt',)
```

Is that something that you would be interested to add support for?