### PR TITLE
Default encoding 'utf-8'

### DIFF
--- a/scrapy/http/response/text.py
+++ b/scrapy/http/response/text.py
@@ -24,7 +24,7 @@ class TextResponse(Response):
     _DEFAULT_ENCODING = 'ascii'
 
     def __init__(self, *args, **kwargs):
-        self._encoding = kwargs.pop('encoding', None)
+        self._encoding = kwargs.pop('encoding', 'utf-8')
         self._cached_benc = None
         self._cached_ubody = None
         self._cached_selector = None


### PR DESCRIPTION
```from scrapy.http import HtmlResponse```
```response = HtmlResponse(body='', url='http://foo.com/')```

Getting error:-
        ````TypeError: Cannot convert unicode body - HtmlResponse has no encoding````

Whereas,   ```response = HtmlResponse(body='', url='http://foo.com/', encoding='utf-8')``` will execute the program correctly.

Shouldn't the default encoding be changed to ```'utf-8'``` instead of ```None```?
 
