### PR TITLE
Extend ItemLoader processors

### DIFF
--- a/docs/topics/loaders.rst
+++ b/docs/topics/loaders.rst
@@ -223,11 +223,35 @@ metadata. Here is an example::
     >>> il.load_item()
     {'name': u'Welcome to my website', 'price': u'1000'}
 
+If you use a custom ItemLoader which specifies: :meth:`ItemLoader.default_input_processor` and/or :meth:`ItemLoader.default_output_processor` you can extend those on field basis. It is not allowed to specify ``add_input`` and ``input_processor`` on the same field. Example::
+
+    import scrapy
+    from scrapy.loader.processors import Join, MapCompose
+    from scrapy.loader import ItemLoader
+    from w3lib.html import remove_tags
+
+    def CustomItemLoader(ItemLoader):
+        default_input_processor = remove_tags
+
+    class Product(scrapy.Item):
+        name = scrapy.Field(
+            add_input=MapCompose(str.upper),
+            output_processor=Join(),
+        )
+
+::
+
+    >>> il = CustomItemLoader(item=Product())
+    >>> il.add_value('name', [u'Welcome to my', u'<strong>website</strong>'])
+    >>> il.load_item()
+    {'name': u'WELCOME TO MY WEBSITE'}
+
+
 The precedence order, for both input and output processors, is as follows:
 
 1. Item Loader field-specific attributes: ``field_in`` and ``field_out`` (most
    precedence)
-2. Field metadata (``input_processor`` and ``output_processor`` key)
+2. Field metadata (``input_processor`` or ``add_input`` and ``output_processor`` or ``add_output`` key)
 3. Item Loader defaults: :meth:`ItemLoader.default_input_processor` and
    :meth:`ItemLoader.default_output_processor` (least precedence)
 

--- a/scrapy/loader/__init__.py
+++ b/scrapy/loader/__init__.py
@@ -136,7 +136,7 @@ class ItemLoader(object):
             override_proc = self._get_item_field_attr(field_name, 'input_processor')
             extend_proc = self._get_item_field_attr(field_name, 'add_input')
             if override_proc and extend_proc:
-                raise ValueError(f'Not allowed to define input_processor and add_input for {field_name}')
+                raise ValueError('Not allowed to define input_processor and add_input for %s', field_name)
             if override_proc:
                 return override_proc
             elif extend_proc:
@@ -150,7 +150,7 @@ class ItemLoader(object):
             override_proc = self._get_item_field_attr(field_name, 'output_processor')
             extend_proc = self._get_item_field_attr(field_name, 'add_output')
             if override_proc and extend_proc:
-                raise ValueError(f'Not allowed to define out_processor and add_output for {field_name}')
+                raise ValueError('Not allowed to define out_processor and add_output for %s', field_name)
             if override_proc:
                 return override_proc
             elif extend_proc:

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -271,6 +271,14 @@ class BasicItemLoaderTest(unittest.TestCase):
         il.add_value('name', u'marta')
         self.assertEqual(il.get_output_value('name'), [u'MART'])
 
+    def test_input_processor_via_field(self):
+        class OverrideItem(Item):
+            name = Field(input_processor=MapCompose(six.text_type.swapcase))
+
+        il = DefaultedItemLoader(OverrideItem())
+        il.add_value('name', u'marta')
+        self.assertEqual(il.get_collected_values('name'), [u'MARTA'])
+
     def test_extend_default_input_processor_via_field(self):
         class ExtendItem(Item):
             name = Field(add_input=MapCompose(six.text_type.swapcase))
@@ -286,6 +294,15 @@ class BasicItemLoaderTest(unittest.TestCase):
 
         il = DefaultedItemLoader(ExtendItem())
         self.assertRaises(ValueError, il.add_value, 'name', u'marta')
+
+    def test_output_processor_via_field(self):
+        class OverrideItem(Item):
+            name = Field(output_processor=u" ".join)
+
+        il = DefaultedItemLoader(OverrideItem())
+        il.add_value('name', u'marn')
+        il.add_value('name', u'tan')
+        self.assertEqual(il.get_output_value('name'), "mar ta")
 
     def test_extend_default_output_processor_via_field(self):
         class ExtendItemLoader(DefaultedItemLoader):


### PR DESCRIPTION
The implementation to make the ItemLoader processors more extendable as proposed in #3576.

With this implementation it is possible to extend the default ItemLoader input or output processors without referencing them. This makes the use of ItemLoaders more flexible. 

I am interested in what you all think about this idea/implementation.