### PR TITLE
[MRG+1] A different S3 Endpoint URL is now possible when uploading images

### DIFF
--- a/scrapy/pipelines/images.py
+++ b/scrapy/pipelines/images.py
@@ -90,6 +90,9 @@ class ImagesPipeline(FilesPipeline):
         s3store.AWS_ACCESS_KEY_ID = settings['AWS_ACCESS_KEY_ID']
         s3store.AWS_SECRET_ACCESS_KEY = settings['AWS_SECRET_ACCESS_KEY']
         s3store.AWS_ENDPOINT_URL = settings['AWS_ENDPOINT_URL']
+        s3store.AWS_REGION_NAME = settings['AWS_REGION_NAME']
+        s3store.AWS_USE_SSL = settings['AWS_USE_SSL']
+        s3store.AWS_VERIFY = settings['AWS_VERIFY']
         s3store.POLICY = settings['IMAGES_STORE_S3_ACL']
 
         gcs_store = cls.STORE_SCHEMES['gs']

--- a/scrapy/pipelines/images.py
+++ b/scrapy/pipelines/images.py
@@ -89,6 +89,7 @@ class ImagesPipeline(FilesPipeline):
         s3store = cls.STORE_SCHEMES['s3']
         s3store.AWS_ACCESS_KEY_ID = settings['AWS_ACCESS_KEY_ID']
         s3store.AWS_SECRET_ACCESS_KEY = settings['AWS_SECRET_ACCESS_KEY']
+        s3store.AWS_ENDPOINT_URL = settings['AWS_ENDPOINT_URL']
         s3store.POLICY = settings['IMAGES_STORE_S3_ACL']
 
         gcs_store = cls.STORE_SCHEMES['gs']


### PR DESCRIPTION
AWS_ENDPOINT_URL in Settings was read by files.py but not by images.py. I don't know if it was intentionally but i couldn't connect to my local minio S3 Server when uploading images with ImagesPipeline