### PR TITLE
[MRG+1] Show elapsed time in statscollector

### DIFF
--- a/scrapy/extensions/corestats.py
+++ b/scrapy/extensions/corestats.py
@@ -27,8 +27,8 @@ class CoreStats(object):
         finish_time = datetime.datetime.utcnow()
         elapsed_time = finish_time - self.stats.get_value('start_time')
         elapsed_time_seconds = elapsed_time.seconds + elapsed_time.microseconds/1000000
-        self.stats.set_value('finish_time', finish_time, spider=spider)
         self.stats.set_value('elapsed_time_seconds', elapsed_time_seconds, spider=spider)
+        self.stats.set_value('finish_time', finish_time, spider=spider)
         self.stats.set_value('finish_reason', reason, spider=spider)
 
     def item_scraped(self, item, spider):

--- a/scrapy/extensions/corestats.py
+++ b/scrapy/extensions/corestats.py
@@ -6,7 +6,8 @@ import datetime
 from scrapy import signals
 
 class CoreStats(object):
-
+    start_time = 0
+    finish_time = 0
     def __init__(self, stats):
         self.stats = stats
 
@@ -21,10 +22,16 @@ class CoreStats(object):
         return o
 
     def spider_opened(self, spider):
-        self.stats.set_value('start_time', datetime.datetime.utcnow(), spider=spider)
+        start_time = datetime.datetime.now()
+        self.start_time = start_time
+        self.stats.set_value('start_time', start_time, spider=spider)
 
     def spider_closed(self, spider, reason):
-        self.stats.set_value('finish_time', datetime.datetime.utcnow(), spider=spider)
+        finish_time = datetime.datetime.now()
+        elapsed_time = finish_time - self.start_time
+        elapsed_time_seconds = elapsed_time.seconds + elapsed_time.microseconds/1000000
+        self.stats.set_value('finish_time', finish_time, spider=spider)
+        self.stats.set_value('elapsed_time_seconds', elapsed_time_seconds)
         self.stats.set_value('finish_reason', reason, spider=spider)
 
     def item_scraped(self, item, spider):

--- a/scrapy/extensions/corestats.py
+++ b/scrapy/extensions/corestats.py
@@ -6,8 +6,7 @@ import datetime
 from scrapy import signals
 
 class CoreStats(object):
-    start_time = 0
-    finish_time = 0
+
     def __init__(self, stats):
         self.stats = stats
 
@@ -22,16 +21,14 @@ class CoreStats(object):
         return o
 
     def spider_opened(self, spider):
-        start_time = datetime.datetime.now()
-        self.start_time = start_time
-        self.stats.set_value('start_time', start_time, spider=spider)
+        self.stats.set_value('start_time', datetime.datetime.utcnow(), spider=spider)
 
     def spider_closed(self, spider, reason):
-        finish_time = datetime.datetime.now()
-        elapsed_time = finish_time - self.start_time
+        finish_time = datetime.datetime.utcnow()
+        elapsed_time = finish_time - self.stats.get_value('start_time')
         elapsed_time_seconds = elapsed_time.seconds + elapsed_time.microseconds/1000000
         self.stats.set_value('finish_time', finish_time, spider=spider)
-        self.stats.set_value('elapsed_time_seconds', elapsed_time_seconds)
+        self.stats.set_value('elapsed_time_seconds', elapsed_time_seconds, spider=spider)
         self.stats.set_value('finish_reason', reason, spider=spider)
 
     def item_scraped(self, item, spider):

--- a/scrapy/extensions/corestats.py
+++ b/scrapy/extensions/corestats.py
@@ -26,7 +26,7 @@ class CoreStats(object):
     def spider_closed(self, spider, reason):
         finish_time = datetime.datetime.utcnow()
         elapsed_time = finish_time - self.stats.get_value('start_time')
-        elapsed_time_seconds = elapsed_time.seconds + elapsed_time.microseconds/1000000
+        elapsed_time_seconds = elapsed_time.total_seconds()
         self.stats.set_value('elapsed_time_seconds', elapsed_time_seconds, spider=spider)
         self.stats.set_value('finish_time', finish_time, spider=spider)
         self.stats.set_value('finish_reason', reason, spider=spider)

--- a/tests/test_closespider.py
+++ b/tests/test_closespider.py
@@ -53,9 +53,5 @@ class TestCloseSpider(TestCase):
         yield crawler.crawl(total=1000000, mockserver=self.mockserver)
         reason = crawler.spider.meta['close_reason']
         self.assertEqual(reason, 'closespider_timeout')
-        stats = crawler.stats
-        start = stats.get_value('start_time')
-        stop = stats.get_value('finish_time')
-        diff = stop - start
-        total_seconds = diff.seconds + diff.microseconds
+        total_seconds = crawler.stats.get_value('elapsed_time_seconds')
         self.assertTrue(total_seconds >= close_on)


### PR DESCRIPTION
Showing elapsed time in seconds in stats, also changing from utc to local time for better user experience.
(In my opinion time&date should be displayed based on the local time)