### PR TITLE
Updated pytest and fixed Python 3.7 DeprecationWarnings when importing from collections

### DIFF
--- a/scrapy/item.py
+++ b/scrapy/item.py
@@ -5,7 +5,10 @@ See documentation in docs/topics/item.rst
 """
 
 from pprint import pformat
-from collections import MutableMapping
+try:
+    from collections.abc import MutableMapping
+except ImportError:
+    from collections import MutableMapping
 
 from abc import ABCMeta
 import six

--- a/scrapy/settings/__init__.py
+++ b/scrapy/settings/__init__.py
@@ -1,7 +1,10 @@
 import six
 import json
 import copy
-from collections import MutableMapping
+try:
+    from collections.abc import MutableMapping
+except ImportError:
+    from collections import MutableMapping
 from importlib import import_module
 from pprint import pformat
 

--- a/scrapy/utils/datatypes.py
+++ b/scrapy/utils/datatypes.py
@@ -8,7 +8,11 @@ This module must not depend on any module outside the Standard Library.
 import copy
 import six
 import warnings
-from collections import OrderedDict, Mapping
+try:
+    from collections.abc import Mapping
+except ImportError:
+    from collections import Mapping
+from collections import OrderedDict
 
 from scrapy.exceptions import ScrapyDeprecationWarning
 

--- a/tests/requirements-py3.txt
+++ b/tests/requirements-py3.txt
@@ -1,6 +1,6 @@
-pytest==3.6.3
+pytest==4.3.0
 pytest-twisted
-pytest-cov==2.5.1
+pytest-cov==2.6.1
 testfixtures
 jmespath
 leveldb; sys_platform != "win32"

--- a/tests/test_utils_datatypes.py
+++ b/tests/test_utils_datatypes.py
@@ -1,6 +1,9 @@
 import copy
 import unittest
-from collections import Mapping, MutableMapping
+try:
+    from collections.abc import Mapping, MutableMapping
+except ImportError:
+    from collections import Mapping, MutableMapping
 
 from scrapy.utils.datatypes import CaselessDict, SequenceExclude
 


### PR DESCRIPTION
I was using the latest pytest to test some of my own code and it flagged some DeprecationWarnings in Scrapy about importing from collections. These warnings were introduced in Python 3.7: https://docs.python.org/3/whatsnew/3.7.html#id3

The version of pytest currently used by tox (3.6.3) is old and does not flag the warnings. Pytest 3.8/3.9 introduced the flagging of DeprecatedWarning: https://docs.pytest.org/en/latest/warnings.html#deprecationwarning-and-pendingdeprecationwarning

I updated the versions of pytest and pytest-cov for Python 3 environments in tox. Along with that I fixed the imports.

The first commit will cause the warnings to show up. The second one fixes them.

Here are the first warnings I got when running tox with `py37`:
```
scrapy/utils/datatypes.py:11
  .../scrapy/utils/datatypes.py:11: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated, and in 3.8 it will stop working
    from collections import OrderedDict, Mapping

scrapy/item.py:8
  .../scrapy/item.py:8: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated, and in 3.8 it will stop working
    from collections import MutableMapping
```

And after fixing those I got these:
```
scrapy/settings/__init__.py:4
  .../scrapy/settings/__init__.py:4: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated, and in 3.8 it will stop working
    from collections import MutableMapping

tests/test_utils_datatypes.py:3
  .../tests/test_utils_datatypes.py:3: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated, and in 3.8 it will stop working
    from collections import Mapping, MutableMapping
```

The other imports from collections in the Scrapy code are not considered abstract classes as per the warning.

I ran tox tests on this PR using Python 2.7.15, 3.4.9, 3.5.6, 3.6.8 and 3.7.2.

A side-effect of this DeprecationWarning flagging is that there are a lot more warnings now. Currently tox reports 18 warnings, with this PR it reports 343. Many of those are within Scrapy, but unrelated to this specific PR. The third party deprecations can be muted as per the pytest documentation. I did not touch any of the other warnings since they don't get raised when I run pytest with my own code. 

Would this be acceptable as a standalone PR? I can start looking at some of the others separately. Or should this be one big PR?