### PR TITLE
[Discussion] Don’t retry response status codes from handle_httpstatus_list

### DIFF
--- a/scrapy/downloadermiddlewares/retry.py
+++ b/scrapy/downloadermiddlewares/retry.py
@@ -48,7 +48,10 @@ class RetryMiddleware(object):
         return cls(crawler.settings)
 
     def process_response(self, request, response, spider):
-        if request.meta.get('dont_retry', False):
+        if (request.meta.get('dont_retry', False) or
+                response.status in getattr(spider, 'handle_httpstatus_list', []) or
+                response.status in request.meta.get('handle_httpstatus_list', []) or
+                request.meta.get('handle_httpstatus_all', False)):
             return response
         if response.status in self.retry_http_codes:
             reason = response_status_message(response.status)


### PR DESCRIPTION
Given a request with `'handle_httpstatus_list': [404]` in a project with `RETRY_HTTP_CODES = […, 404, …]`, there is currently no way to prevent retries of that specific request only for 404 responses.

These changes solve that issue by copying some code from the Redirect middleware into the Retry middleware, making the latter take `handle_httpstatus_list` and `handle_httpstatus_all` into account for retries.

These changes are *backward incompatible*. Not only do they change the current behavior, but they also make the previous behavior impossible without replacing the built-in Redirect middleware.

What are your thoughts? Should I go ahead and complete the pull request as is (add docs and tests)? Should we follow a backward-compatible approach, such as supporting a new `dont_retry_httpstatus_list`? Can you think of a better approach? Or is it better for people to rewrite the Redirect middleware when they need this behavior?