### PR TITLE
[MRG+1] Scheduler: better priority handling in next_request method

### DIFF
--- a/docs/topics/settings.rst
+++ b/docs/topics/settings.rst
@@ -1243,6 +1243,15 @@ Type of priority queue used by the scheduler. Another available type is
 domains in parallel. But currently ``scrapy.pqueues.DownloaderAwarePriorityQueue``
 does not work together with :setting:`CONCURRENT_REQUESTS_PER_IP`.
 
+.. setting:: SCHEDULER_PREFER_MEMORY_QUEUE
+
+SCHEDULER_PREFER_MEMORY_QUEUE
+-----------------------------
+Default: ``True``
+
+Whether or not the scheduler will try to get the next request from the memory queue even if there
+are higher priority requests in the disk queue. Defaults to ``True`` for backwards compatibility.
+
 .. setting:: SPIDER_CONTRACTS
 
 SPIDER_CONTRACTS

--- a/scrapy/core/scheduler.py
+++ b/scrapy/core/scheduler.py
@@ -40,7 +40,8 @@ class Scheduler(object):
     Also, it handles dupefilters.
     """
     def __init__(self, dupefilter, jobdir=None, dqclass=None, mqclass=None,
-                 logunser=False, stats=None, pqclass=None, crawler=None):
+                 logunser=False, stats=None, pqclass=None, crawler=None,
+                 prefer_memory_queue=True):
         self.df = dupefilter
         self.dqdir = self._dqdir(jobdir)
         self.pqclass = pqclass
@@ -49,6 +50,7 @@ class Scheduler(object):
         self.logunser = logunser
         self.stats = stats
         self.crawler = crawler
+        self.prefer_memory_queue = prefer_memory_queue
 
     @classmethod
     def from_crawler(cls, crawler):
@@ -68,9 +70,11 @@ class Scheduler(object):
         mqclass = load_object(settings['SCHEDULER_MEMORY_QUEUE'])
         logunser = settings.getbool('LOG_UNSERIALIZABLE_REQUESTS',
                                     settings.getbool('SCHEDULER_DEBUG'))
-        return cls(dupefilter, jobdir=job_dir(settings), logunser=logunser,
+        prefer_memory_queue = settings.getbool('SCHEDULER_PREFER_MEMORY_QUEUE')
+        return cls(dupefilter=dupefilter, jobdir=job_dir(settings), logunser=logunser,
                    stats=crawler.stats, pqclass=pqclass, dqclass=dqclass,
-                   mqclass=mqclass, crawler=crawler)
+                   mqclass=mqclass, crawler=crawler,
+                   prefer_memory_queue=prefer_memory_queue)
 
     def has_pending_requests(self):
         return len(self) > 0
@@ -101,15 +105,21 @@ class Scheduler(object):
         return True
 
     def next_request(self):
-        request = self.mqs.pop()
-        if request:
-            self.stats.inc_value('scheduler/dequeued/memory', spider=self.spider)
+        """
+        Return the next request, according to the preference set by SCHEDULER_PREFER_MEMORY_QUEUE.
+        Note: From the queue's point of view, a lower value means a higher priority.
+        """
+        mprio = self.mqs.curprio
+        dprio = self.dqs.curprio if self.dqs else None
+        if mprio is not None and (self.prefer_memory_queue or dprio is None or mprio <= dprio):
+            request = self.mqs.pop()
+            queue_name = 'memory'
         else:
             request = self._dqpop()
-            if request:
-                self.stats.inc_value('scheduler/dequeued/disk', spider=self.spider)
+            queue_name = 'disk'
         if request:
             self.stats.inc_value('scheduler/dequeued', spider=self.spider)
+            self.stats.inc_value('scheduler/dequeued/{}'.format(queue_name), spider=self.spider)
         return request
 
     def __len__(self):

--- a/scrapy/settings/default_settings.py
+++ b/scrapy/settings/default_settings.py
@@ -253,6 +253,7 @@ SCHEDULER = 'scrapy.core.scheduler.Scheduler'
 SCHEDULER_DISK_QUEUE = 'scrapy.squeues.PickleLifoDiskQueue'
 SCHEDULER_MEMORY_QUEUE = 'scrapy.squeues.LifoMemoryQueue'
 SCHEDULER_PRIORITY_QUEUE = 'scrapy.pqueues.ScrapyPriorityQueue'
+SCHEDULER_PREFER_MEMORY_QUEUE = True
 
 SPIDER_LOADER_CLASS = 'scrapy.spiderloader.SpiderLoader'
 SPIDER_LOADER_WARN_ONLY = False

--- a/scrapy/squeues.py
+++ b/scrapy/squeues.py
@@ -34,13 +34,25 @@ def _pickle_serialize(obj):
         raise ValueError(str(e))
 
 
-PickleFifoDiskQueue = _serializable_queue(queue.FifoDiskQueue,
-    _pickle_serialize, pickle.loads)
-PickleLifoDiskQueue = _serializable_queue(queue.LifoDiskQueue,
-    _pickle_serialize, pickle.loads)
-MarshalFifoDiskQueue = _serializable_queue(queue.FifoDiskQueue,
-    marshal.dumps, marshal.loads)
-MarshalLifoDiskQueue = _serializable_queue(queue.LifoDiskQueue,
-    marshal.dumps, marshal.loads)
+PickleFifoDiskQueue = _serializable_queue(
+    queue_class=queue.FifoDiskQueue,
+    serialize=_pickle_serialize,
+    deserialize=pickle.loads
+)
+PickleLifoDiskQueue = _serializable_queue(
+    queue_class=queue.LifoDiskQueue,
+    serialize=_pickle_serialize,
+    deserialize=pickle.loads
+)
+MarshalFifoDiskQueue = _serializable_queue(
+    queue_class=queue.FifoDiskQueue,
+    serialize=marshal.dumps,
+    deserialize=marshal.loads
+)
+MarshalLifoDiskQueue = _serializable_queue(
+    queue_class=queue.LifoDiskQueue,
+    serialize=marshal.dumps,
+    deserialize=marshal.loads
+)
 FifoMemoryQueue = queue.FifoMemoryQueue
 LifoMemoryQueue = queue.LifoMemoryQueue

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -1,14 +1,15 @@
+from random import shuffle
+import collections
 import shutil
 import tempfile
 import unittest
-import collections
 
 from twisted.internet import defer
-from twisted.trial.unittest import TestCase
+from twisted.trial.unittest import TestCase as TwistedTestCase
 
-from scrapy.crawler import Crawler
 from scrapy.core.downloader import Downloader
 from scrapy.core.scheduler import Scheduler
+from scrapy.crawler import Crawler
 from scrapy.http import Request
 from scrapy.spiders import Spider
 from scrapy.utils.httpobj import urlparse_cached
@@ -302,7 +303,7 @@ class StartUrlsSpider(Spider):
         pass
 
 
-class TestIntegrationWithDownloaderAwareInMemory(TestCase):
+class TestIntegrationWithDownloaderAwareInMemory(TwistedTestCase):
     def setUp(self):
         self.crawler = get_crawler(
                     StartUrlsSpider,
@@ -340,3 +341,119 @@ class TestIncompatibility(unittest.TestCase):
     def test_incompatibility(self):
         with self.assertRaises(ValueError):
             self._incompatible()
+
+
+class _TestSpider(Spider):
+    name = 'testspider'
+
+
+class _WontPickle(object):
+    def __getstate__(self):
+        raise ValueError('Nope')
+
+
+def _get_open_scheduler(crawler):
+    scheduler = Scheduler.from_crawler(crawler)
+    spider = _TestSpider.from_crawler(crawler)
+    scheduler.open(spider)
+    return scheduler
+
+
+class MemoryOrDiskPreferenceTest(TwistedTestCase):
+
+    maxDiff = None
+
+    def test_request_only_memory(self):
+        """
+        Only use a memory queue
+        """
+        crawler = get_crawler(settings_dict=dict(JOBDIR=None, SCHEDULER_PREFER_MEMORY_QUEUE=True))
+        scheduler = _get_open_scheduler(crawler)
+        # push requests with different priorities in a random order
+        priorities = list(range(20))
+        priorities.extend(range(10, 30))
+        shuffle(priorities)
+        for prio in priorities:
+            req = Request('https://example.org/memory-{}'.format(prio), priority=prio, dont_filter=True)
+            scheduler.enqueue_request(req)
+        # check all requests are retrieved in the intended order
+        # expected priorities are reversed to put the highest one first
+        expected = sorted(priorities, reverse=True)
+        retrieved = []
+        while scheduler.has_pending_requests():
+            req = scheduler.next_request()
+            retrieved.append(req.priority)
+        self.assertEqual(retrieved, expected)
+        self.assertEqual(crawler.stats.get_value('scheduler/enqueued'), len(priorities))
+        self.assertEqual(crawler.stats.get_value('scheduler/enqueued/memory'), len(priorities))
+        self.assertEqual(crawler.stats.get_value('scheduler/enqueued/disk'), None)
+        self.assertEqual(crawler.stats.get_value('scheduler/dequeued'), len(priorities))
+        self.assertEqual(crawler.stats.get_value('scheduler/dequeued/memory'), len(priorities))
+        self.assertEqual(crawler.stats.get_value('scheduler/dequeued/disk'), None)
+
+    def test_request_prefer_memory(self):
+        """
+        Memory-enqueued requests should be retrieved first
+        """
+        jobdir = tempfile.mkdtemp()
+        crawler = get_crawler(settings_dict=dict(JOBDIR=jobdir, SCHEDULER_PREFER_MEMORY_QUEUE=True))
+        scheduler = _get_open_scheduler(crawler)
+        # push requests with different priorities in a random order
+        memory_priorities = [('memory', i) for i in range(20)]
+        disk_priorities = [('disk', i) for i in range(10, 30)]
+        priorities = memory_priorities + disk_priorities
+        shuffle(priorities)
+        for queue, prio in priorities:
+            url = 'https://example.org/{}-{}'.format(queue, prio)
+            req = Request(url=url, meta={'queue': queue}, priority=prio, dont_filter=True)
+            if queue == 'memory':
+                req.meta['pickle'] = _WontPickle()  # make sure the request goes to memory
+            scheduler.enqueue_request(req)
+        # check all requests are retrieved in the intended order
+        # expected priorities are reversed to put the highest one first
+        expected = sorted(priorities, key=lambda x: (1 if x[0] == 'memory' else 0, x[1]), reverse=True)
+        retrieved = []
+        while scheduler.has_pending_requests():
+            req = scheduler.next_request()
+            retrieved.append((req.meta['queue'], req.priority))
+        self.assertEqual(retrieved, expected)
+        self.assertEqual(crawler.stats.get_value('scheduler/enqueued'), len(priorities))
+        self.assertEqual(crawler.stats.get_value('scheduler/enqueued/memory'), len(memory_priorities))
+        self.assertEqual(crawler.stats.get_value('scheduler/enqueued/disk'), len(disk_priorities))
+        self.assertEqual(crawler.stats.get_value('scheduler/dequeued'), len(priorities))
+        self.assertEqual(crawler.stats.get_value('scheduler/dequeued/memory'), len(memory_priorities))
+        self.assertEqual(crawler.stats.get_value('scheduler/dequeued/disk'), len(disk_priorities))
+        shutil.rmtree(jobdir, ignore_errors=True)
+
+    def test_request_global_priorities(self):
+        """
+        No preference for memory-enqueued requests, only priority is considered
+        """
+        jobdir = tempfile.mkdtemp()
+        crawler = get_crawler(settings_dict=dict(JOBDIR=jobdir, SCHEDULER_PREFER_MEMORY_QUEUE=False))
+        scheduler = _get_open_scheduler(crawler)
+        # push requests with different priorities in a random order
+        memory_priorities = [('memory', i) for i in range(20)]
+        disk_priorities = [('disk', i) for i in range(10, 30)]
+        priorities = memory_priorities + disk_priorities
+        shuffle(priorities)
+        for queue, prio in priorities:
+            url = 'https://example.org/{}-{}'.format(queue, prio)
+            req = Request(url=url, meta={'queue': queue}, priority=prio, dont_filter=True)
+            if queue == 'memory':
+                req.meta['pickle'] = _WontPickle()  # make sure the request goes to memory
+            scheduler.enqueue_request(req)
+        # check all requests are retrieved in the intended order
+        expected = sorted(priorities, key=lambda x: (x[1], 1 if x[0] == 'memory' else 0), reverse=True)
+        retrieved = []
+        while scheduler.has_pending_requests():
+            req = scheduler.next_request()
+            retrieved.append((req.meta['queue'], req.priority))
+        self.assertEqual(retrieved, expected)
+        self.assertEqual(crawler.stats.get_value('scheduler/enqueued'), len(priorities))
+        self.assertEqual(crawler.stats.get_value('scheduler/enqueued/memory'), len(memory_priorities))
+        self.assertEqual(crawler.stats.get_value('scheduler/enqueued/disk'), len(disk_priorities))
+        self.assertEqual(crawler.stats.get_value('scheduler/dequeued'), len(priorities))
+        self.assertEqual(crawler.stats.get_value('scheduler/dequeued/memory'), len(memory_priorities))
+        self.assertEqual(crawler.stats.get_value('scheduler/dequeued/disk'), len(disk_priorities))
+        shutil.rmtree(jobdir, ignore_errors=True)


### PR DESCRIPTION
Fixes #3666

With this change, the scheduler will return the next request based on priority, not on storage location (memory vs. disk). If the next requests from memory and disk both have the same priority, the memory one is returned first.

~Currently lacking tests, I'll add them shortly. In the meantime,~ a slightly modified version of the original snippet:
```python
$ scrapy shell -s JOBDIR=/tmp/scrapytmp -s LOG_UNSERIALIZABLE_REQUESTS=0
(...)
In [1]: s = scrapy.core.scheduler.Scheduler.from_crawler(crawler)
   ...: s.open(spider)
   ...: s.enqueue_request(scrapy.Request('http://a.com/mqs-0', priority=0, meta={'foo': lambda: 'bar'}))
   ...: s.enqueue_request(scrapy.Request('http://a.com/dqs-8', priority=8))
   ...: s.enqueue_request(scrapy.Request('http://a.com/dqs-2', priority=2))
   ...: s.enqueue_request(scrapy.Request('http://a.com/dqs-1', priority=1))
   ...: s.enqueue_request(scrapy.Request('http://a.com/mqs-1', priority=1, meta={'foo': lambda: 'bar'}))
   ...: s.enqueue_request(scrapy.Request('http://a.com/mqs-6', priority=6, meta={'foo': lambda: 'bar'}))
   ...: while s.has_pending_requests():
   ...:     print(s.next_request())
   ...:
<GET http://a.com/dqs-8>
<GET http://a.com/mqs-6>
<GET http://a.com/dqs-2>
<GET http://a.com/mqs-1>
<GET http://a.com/dqs-1>
<GET http://a.com/mqs-0>
```

**Update**: Introduced a new boolean setting (`SCHEDULER_PREFER_MEMORY_QUEUE`, `True` by default) to control whether or not memory-enqueued requests have preference over disk-enqueued ones.