### PR TITLE
Improve ability to find templates

### DIFF
--- a/scrapy/commands/genspider.py
+++ b/scrapy/commands/genspider.py
@@ -109,9 +109,15 @@ class Command(ScrapyCommand):
             print("in module:\n  %s.%s" % (spiders_module.__name__, module))
 
     def _find_template(self, template):
-        template_file = join(self.templates_dir, '%s.tmpl' % template)
-        if exists(template_file):
-            return template_file
+        if not '.tmpl' in template:
+            template = '%s.tmpl' % template
+        if exists(template):
+            return template
+
+        global_template = join(self.templates_dir, template)
+        if exists(global_template):
+            return global_template
+
         print("Unable to find template: %s\n" % template)
         print('Use "scrapy genspider --list" to see all available templates.')
 


### PR DESCRIPTION
Currently template searching requires the templates to be in a
specifically configured directory (settings['TEMPLATES_DIR']).

If you change the setting for `TEMPLATES_DIR`, you no longer have
access to the standard, generic Scrapy templates unless those are copied in.

This change first searches for a template using the path given,
and if not found, falls back to the TEMPLATES_DIR. This allows us to
maintain templates in more versatile ways, and creates less friction when trying to use spider templates for the first time.

Additionally, the `.tmpl` suffix was being added regardless of what was
passed in. So if you wrote `-t my_template.tmpl` it would raise an
error. Instead, this will now check if you've already included `.tmpl`
and not add it an additional time.


Some notes:
- This does not affect the listing of templates when running `genspider -l`, this list still comes from `TEMPLATES_DIR`: This only allows the ability to find a template with the given path, potentially outside of that directory.
- I only recently started using Python, and only have used Py3. I tried to stick to the existing code conventions to ensure Py2 compatibility, but I don't have experience there.
- I wasn't able to get the original test suite to pass in the first place, so I need help with adding an appropriate test. My issue looked like it may have been related to py2 compatibility, as I saw a lot of `py27` output. I don't really understand how to work with this.

Fixes #3680