### PR TITLE
Retry request from spider callback

### DIFF
--- a/docs/topics/request-response.rst
+++ b/docs/topics/request-response.rst
@@ -636,6 +636,8 @@ Response objects
 
     .. automethod:: Response.follow
 
+    .. automethod:: Response.retry_request
+
 
 .. _urlparse.urljoin: https://docs.python.org/2/library/urlparse.html#urlparse.urljoin
 

--- a/docs/topics/spider-middleware.rst
+++ b/docs/topics/spider-middleware.rst
@@ -443,3 +443,9 @@ UrlLengthMiddleware
 
       * :setting:`URLLENGTH_LIMIT` - The maximum URL length to allow for crawled URLs.
 
+RetryMiddleware
+---------------
+.. module:: scrapy.spidermiddlewares.retry
+   :synopsis: Retry Spider Middleware
+
+.. autoclass:: scrapy.spidermiddlewares.retry.RetryMiddleware

--- a/scrapy/downloadermiddlewares/retry.py
+++ b/scrapy/downloadermiddlewares/retry.py
@@ -22,7 +22,7 @@ from twisted.web.client import ResponseFailed
 from scrapy.exceptions import NotConfigured
 from scrapy.utils.response import response_status_message
 from scrapy.core.downloader.handlers.http11 import TunnelError
-from scrapy.utils.python import global_object_name
+from scrapy.utils.retry import RetryHandler
 
 logger = logging.getLogger(__name__)
 
@@ -39,6 +39,7 @@ class RetryMiddleware(object):
     def __init__(self, settings):
         if not settings.getbool('RETRY_ENABLED'):
             raise NotConfigured
+
         self.max_retry_times = settings.getint('RETRY_TIMES')
         self.retry_http_codes = set(int(x) for x in settings.getlist('RETRY_HTTP_CODES'))
         self.priority_adjust = settings.getint('RETRY_PRIORITY_ADJUST')
@@ -48,7 +49,7 @@ class RetryMiddleware(object):
         return cls(crawler.settings)
 
     def process_response(self, request, response, spider):
-        if request.meta.get('dont_retry', False):
+        if not request.is_retrying_enabled():
             return response
         if response.status in self.retry_http_codes:
             reason = response_status_message(response.status)
@@ -57,35 +58,15 @@ class RetryMiddleware(object):
 
     def process_exception(self, request, exception, spider):
         if isinstance(exception, self.EXCEPTIONS_TO_RETRY) \
-                and not request.meta.get('dont_retry', False):
+                and request.is_retrying_enabled():
             return self._retry(request, exception, spider)
 
     def _retry(self, request, reason, spider):
-        retries = request.meta.get('retry_times', 0) + 1
+        retry_handler = RetryHandler(spider, request)
+        if retry_handler.is_exhausted():
+            retry_handler.record_retry_failure(reason)
+            return None
 
-        retry_times = self.max_retry_times
-
-        if 'max_retry_times' in request.meta:
-            retry_times = request.meta['max_retry_times']
-
-        stats = spider.crawler.stats
-        if retries <= retry_times:
-            logger.debug("Retrying %(request)s (failed %(retries)d times): %(reason)s",
-                         {'request': request, 'retries': retries, 'reason': reason},
-                         extra={'spider': spider})
-            retryreq = request.copy()
-            retryreq.meta['retry_times'] = retries
-            retryreq.dont_filter = True
-            retryreq.priority = request.priority + self.priority_adjust
-
-            if isinstance(reason, Exception):
-                reason = global_object_name(reason.__class__)
-
-            stats.inc_value('retry/count')
-            stats.inc_value('retry/reason_count/%s' % reason)
-            return retryreq
-        else:
-            stats.inc_value('retry/max_reached')
-            logger.debug("Gave up retrying %(request)s (failed %(retries)d times): %(reason)s",
-                         {'request': request, 'retries': retries, 'reason': reason},
-                         extra={'spider': spider})
+        new_req = retry_handler.make_retry_request()
+        retry_handler.record_retry(new_req, reason)
+        return new_req

--- a/scrapy/http/response/__init__.py
+++ b/scrapy/http/response/__init__.py
@@ -113,8 +113,8 @@ class Response(object_ref):
         It accepts the same arguments as ``Request.__init__`` method,
         but ``url`` can be a relative URL or a ``scrapy.link.Link`` object,
         not only an absolute URL.
-        
-        :class:`~.TextResponse` provides a :meth:`~.TextResponse.follow` 
+
+        :class:`~.TextResponse` provides a :meth:`~.TextResponse.follow`
         method which supports selectors in addition to absolute/relative URLs
         and Link objects.
         """
@@ -133,3 +133,23 @@ class Response(object_ref):
                        priority=priority,
                        dont_filter=dont_filter,
                        errback=errback)
+
+    def retry_request(self, reason=None, **kwargs):
+        """Retry the request tied to this response.
+
+        This returns a new :class:`~.Request` instance that is marked to be retried
+        which is as same as the request tied to this response except attributes
+        provided as keyword arguments. Scrapy will schedule this new request if request retrying
+        is `enabled <https://docs.scrapy.org/en/latest/topics/downloader-middleware.html#retry-enabled>`_
+        and maximum number of
+        `allowed retries <https://docs.scrapy.org/en/latest/topics/downloader-middleware.html#retry-times>`_
+        are not reached.
+
+        :param reason: Reason for retrying. Optional, defaults to None.
+        :type reason: str
+        """
+        request = self.request
+        if not request:
+            raise NotSupported('This response is not tied to any request')
+
+        return request.mark_for_retry(reason, **kwargs)

--- a/scrapy/settings/default_settings.py
+++ b/scrapy/settings/default_settings.py
@@ -258,6 +258,7 @@ SPIDER_MIDDLEWARES_BASE = {
     'scrapy.spidermiddlewares.referer.RefererMiddleware': 700,
     'scrapy.spidermiddlewares.urllength.UrlLengthMiddleware': 800,
     'scrapy.spidermiddlewares.depth.DepthMiddleware': 900,
+    'scrapy.spidermiddlewares.retry.RetryMiddleware': 950,
     # Spider side
 }
 

--- a/scrapy/spidermiddlewares/retry.py
+++ b/scrapy/spidermiddlewares/retry.py
@@ -1,0 +1,50 @@
+"""
+RetryMiddleware is used to retry temporary issues or bans where the response has to be
+processed by spider before been retried.
+
+You can issue a retry request by calling :meth:`scrapy.http.response.Response.retry_request` method on a
+:class:`scrapy.http.response.Response` instance.
+"""
+import logging
+
+from scrapy import Request
+from scrapy.utils.retry import RetryHandler
+
+
+logger = logging.getLogger(__name__)
+
+
+class RetryMiddleware(object):
+
+    def __init__(self, settings):
+        self.enabled = settings.getbool('RETRY_ENABLED')
+
+    @classmethod
+    def from_crawler(cls, crawler):
+        return cls(crawler.settings)
+
+    def process_spider_output(self, response, result, spider):
+        for x in result:
+            if isinstance(x, Request):
+                if x.is_marked_for_retry():
+                    if not self.enabled:
+                        logger.debug(
+                            "Dropping retry request because request retrying is disabled: %(request)s",
+                            {'request': x},
+                            extra={'spider': spider}
+                        )
+                        continue
+
+                    reason = x.get_retry_reason() or 'Retry Requested'
+                    retry_handler = RetryHandler(spider, x)
+                    if retry_handler.is_exhausted():
+                        retry_handler.record_retry_failure(reason)
+                    else:
+                        new_req = retry_handler.make_retry_request()
+                        retry_handler.record_retry(new_req, reason)
+                        new_req.unmark_as_retry()
+                        yield new_req
+                else:
+                    yield x
+            else:
+                yield x

--- a/scrapy/spidermiddlewares/retry.py
+++ b/scrapy/spidermiddlewares/retry.py
@@ -1,10 +1,3 @@
-"""
-RetryMiddleware is used to retry temporary issues or bans where the response has to be
-processed by spider before been retried.
-
-You can issue a retry request by calling :meth:`scrapy.http.response.Response.retry_request` method on a
-:class:`scrapy.http.response.Response` instance.
-"""
 import logging
 
 from scrapy import Request
@@ -15,6 +8,27 @@ logger = logging.getLogger(__name__)
 
 
 class RetryMiddleware(object):
+    """
+    RetryMiddleware is used to retry requests that have temporary issues or bans where the response has to be
+    processed by spider before been retried.
+
+    You can retry a request by calling :meth:`retry_request <scrapy.http.Response.retry_request>` method on a
+    :class:`Response <scrapy.http.Response>` instance and yielding the returned :class:`Request <scrapy.http.Request>`
+    that is marked to be retried.
+
+    example::
+
+        def parse(self, response):
+            if self.needs_to_be_retried(response):
+                yield response.retry_request('Invalid response')
+
+    RetryMiddleware can be configured through the following settings which are
+    also used in :class:`RetryDownloaderMiddleware <scrapy.downloadermiddlewares.retry.RetryMiddleware>`.
+
+    * :setting:`RETRY_ENABLED`
+    * :setting:`RETRY_TIMES`
+    * :setting:`RETRY_PRIORITY_ADJUST`
+    """
 
     def __init__(self, settings):
         self.enabled = settings.getbool('RETRY_ENABLED')

--- a/scrapy/utils/retry.py
+++ b/scrapy/utils/retry.py
@@ -1,0 +1,54 @@
+from scrapy.utils.python import global_object_name
+
+
+class RetryHandler(object):
+    """utilities to handle retries"""
+
+    def __init__(self, spider, request):
+        self.spider = spider
+        self.request = request
+        self.max_retry_times = spider.settings.getint('RETRY_TIMES')
+        self.priority_adjust = spider.settings.getint('RETRY_PRIORITY_ADJUST')
+
+    def is_exhausted(self):
+        """return whether current request has failed
+           all allowed retry attempts"""
+        max_retries = int(self.request.meta.get('max_retry_times', self.max_retry_times))
+        retries = self.request.meta.get('retry_times', 0)
+        return retries >= max_retries
+
+    def make_retry_request(self):
+        """create a new retrying request out of current request"""
+        retries = self.request.meta.get('retry_times', 0) + 1
+        retryreq = self.request.copy()
+        retryreq.meta['retry_times'] = retries
+        retryreq.dont_filter = True
+        retryreq.priority = self.request.priority + self.priority_adjust
+        return retryreq
+
+    def record_retry(self, retry_request, reason):
+        if isinstance(reason, Exception):
+            reason = global_object_name(reason.__class__)
+
+        stats = self.spider.crawler.stats
+        retries = retry_request.meta.get('retry_times')
+        self.spider.logger.debug(
+            "Retrying %(request)s (failed %(retries)d times): %(reason)s",
+            {'request': self.request, 'retries': retries, 'reason': reason},
+            extra={'spider': self.spider}
+        )
+        stats.inc_value('retry/count')
+        stats.inc_value('retry/reason_count/%s' % reason)
+
+    def record_retry_failure(self, reason):
+        if isinstance(reason, Exception):
+            reason = global_object_name(reason.__class__)
+
+        stats = self.spider.crawler.stats
+        retries = self.request.meta.get('retry_times')
+        stats.inc_value('retry/max_reached')
+        self.spider.logger.debug(
+            "Gave up retrying %(request)s (failed %(retries)d times): %(reason)s",
+            {'request': self.request, 'retries': retries, 'reason': reason},
+            extra={'spider': self.spider}
+        )

--- a/tests/test_http_request.py
+++ b/tests/test_http_request.py
@@ -260,6 +260,43 @@ class RequestTest(unittest.TestCase):
         with self.assertRaises(TypeError):
             self.request_class('http://example.com', a_function, errback='a_function')
 
+    def test_mark_for_retry(self):
+        r = self.request_class('http://example.com')
+        self.assertFalse(r.is_marked_for_retry())
+
+        r2 = r.mark_for_retry('Empty content')
+        self.assertTrue(r2.is_marked_for_retry())
+
+        new_body = 'new body'
+        r3 = r.mark_for_retry('Empty content', body=new_body)
+        self.assertTrue(r3.is_marked_for_retry())
+        self.assertEqual(r3.body, to_bytes(new_body))
+
+    def test_unmark_as_retry(self):
+        r = self.request_class('http://example.com')
+        r2 = r.mark_for_retry('Empty content')
+        self.assertTrue(r2.is_marked_for_retry())
+        r2.unmark_as_retry()
+        self.assertFalse(r2.is_marked_for_retry())
+
+    def test_get_retry_reason(self):
+        r = self.request_class('http://example.com')
+        self.assertEqual(r.get_retry_reason(), None)
+
+        reason = 'Empty content'
+        r2 = r.mark_for_retry(reason)
+        self.assertEqual(r2.get_retry_reason(), reason)
+
+    def test_is_retrying_enabled(self):
+        r = self.request_class('http://example.com')
+        self.assertTrue(r.is_retrying_enabled())
+
+        new_meta = {
+            'dont_retry': True,
+        }
+        r2 = r.replace(meta=new_meta)
+        self.assertFalse(r2.is_retrying_enabled())
+
 
 class FormRequestTest(RequestTest):
 

--- a/tests/test_http_response.py
+++ b/tests/test_http_response.py
@@ -178,6 +178,17 @@ class BaseResponseTest(unittest.TestCase):
         resp = self.response_class('http://example.com/index', body=body)
         return resp
 
+    def test_retry_request(self):
+        reason = 'No content'
+        body = b'New body'
+        req = Request("http://www.example.com")
+        response = self.response_class("http://www.example.com", request=req)
+        self.assertFalse(req.is_marked_for_retry())
+
+        new_req = response.retry_request(reason, body=body)
+        self.assertTrue(new_req.is_marked_for_retry())
+        self.assertEqual(new_req.body, body)
+
 
 class TextResponseTest(BaseResponseTest):
 

--- a/tests/test_spidermiddleware_retry.py
+++ b/tests/test_spidermiddleware_retry.py
@@ -1,0 +1,142 @@
+from unittest import TestCase
+
+from scrapy.item import Item, Field
+from scrapy.spiders import Spider
+from scrapy.utils.test import get_crawler
+from scrapy.http import Response, Request
+from scrapy.spidermiddlewares.retry import RetryMiddleware
+
+
+class TestItem(Item):
+    name = Field()
+
+
+class TestRetryMiddleware(TestCase):
+
+    spider_settings = {
+        'name': 'foo',
+    }
+
+    def setUp(self):
+        crawler = self._get_crawler()
+        self.spider = self._get_spider(crawler)
+        self.mw = self._get_middleware(crawler)
+
+    def _get_crawler(self, spider_settings=None):
+        return get_crawler(Spider, spider_settings)
+
+    def _get_spider(self, crawler):
+        return crawler._create_spider(**self.spider_settings)
+
+    def _get_middleware(self, crawler):
+        return RetryMiddleware.from_crawler(crawler)
+
+    def _assert_retry(self, original_request, output):
+        """assert that output of the middleware is a retrying request of a original request"""
+        self.assertIsNotNone(output)
+        self.assertEqual(original_request.url, output.url)
+        self.assertTrue(output.dont_filter)
+
+    def test_retry_request(self):
+        response = Response('http://scrapytest.org')
+        request = Request('http://scrapytest.org/1').mark_for_retry('No content')
+        reqs = [request]
+
+        out = list(self.mw.process_spider_output(response, reqs, self.spider))[0]
+        self._assert_retry(request, out)
+
+    def test_retry_times(self):
+        response = Response('http://scrapytest.org')
+        request = Request('http://scrapytest.org/1').mark_for_retry('No content')
+        reqs = [request]
+        for attempt in range(1, 3):
+            out = list(self.mw.process_spider_output(response, reqs, self.spider))
+            self.assertEqual(out[0].meta['retry_times'], attempt)
+            reqs = [r.mark_for_retry('No content') for r in out]
+
+    def test_is_marked_for_retry(self):
+        response = Response('http://scrapytest.org')
+        request = Request('http://scrapytest.org/1').mark_for_retry('No content')
+        self.assertTrue(request.is_marked_for_retry())
+        out = list(self.mw.process_spider_output(response, [request], self.spider))[0]
+        self._assert_retry(request, out)
+        self.assertFalse(out.is_marked_for_retry())
+
+    def test_retry_reason(self):
+        reason = 'No content'
+        response = Response('http://scrapytest.org')
+        request = Request('http://scrapytest.org/1').mark_for_retry(reason)
+        self.assertEqual(request.get_retry_reason(), reason)
+        out = list(self.mw.process_spider_output(response, [request], self.spider))[0]
+        self._assert_retry(request, out)
+        self.assertIsNone(out.get_retry_reason())
+
+    def test_unmarked_requests(self):
+        """middleware should return unmarked requests as is"""
+        response = Response('http://scrapytest.org')
+        url = 'https://scrapytest.org/{}'
+        reqs = [Request(url.format(i + 1)) for i in range(5)]
+        out = list(self.mw.process_spider_output(response, reqs, self.spider))
+        self.assertEqual(reqs, out)
+
+    def test_non_requests(self):
+        """middleware should return non Request objects as is"""
+        response = Response('http://scrapytest.org')
+        items = [TestItem({'name': 'name{}'.format(i)}) for i in range(5)]
+        out = list(self.mw.process_spider_output(response, items, self.spider))
+        self.assertEqual(items, out)
+
+        items = [{'Address': 'add{}'.format(i)} for i in range(5)]
+        out = list(self.mw.process_spider_output(response, items, self.spider))
+        self.assertEqual(items, out)
+
+    def test_max_retry_times(self):
+        """if a request has reached maximum retry times it should be dropped"""
+        max_retry_setting = 5
+        max_retry_meta = 3
+
+        crawler = self._get_crawler({'RETRY_TIMES': max_retry_setting})
+        spider = self._get_spider(crawler)
+        mw = self._get_middleware(crawler)
+
+        response = Response('http://scrapytest.org')
+        request = Request('http://scrapytest.org/1').mark_for_retry('No content')
+        reqs = [request]
+        for attempt in range(1, max_retry_setting + 2):
+            out = list(mw.process_spider_output(response, reqs, spider))
+            if attempt < max_retry_setting + 1:
+                self._assert_retry(request, out[0])
+            else:
+                self.assertEqual(out, [])
+
+            reqs = [r.mark_for_retry('No content') for r in out]
+
+
+        # setting max retry times in meta
+        meta = {
+            'max_retry_times': max_retry_meta,
+        }
+        response2 = Response('http://scrapytest.org')
+        request2 = Request('http://scrapytest.org/1', meta=meta).mark_for_retry('No content')
+        reqs2 = [request2]
+
+        for attempt in range(1, max_retry_meta + 2):
+            out2 = list(mw.process_spider_output(response2, reqs2, spider))
+            if attempt < max_retry_meta + 1:
+                self._assert_retry(request2, out2[0])
+            else:
+                self.assertEqual(out2, [])
+
+            reqs2 = [r.mark_for_retry('No content') for r in out2]
+
+    def test_disabled(self):
+        """if retrying is disabled requests marked for retrying should be dropped"""
+        crawler = self._get_crawler({'RETRY_ENABLED': False})
+        spider = self._get_spider(crawler)
+        mw = self._get_middleware(crawler)
+
+        response = Response('http://scrapytest.org')
+        request = Request('http://scrapytest.org/1').mark_for_retry('No content')
+        reqs = [request]
+        out = list(mw.process_spider_output(response, reqs, spider))
+        self.assertEqual(out, [])


### PR DESCRIPTION
New approach for #3590

This,
1) provides a method retry_request() in response class that will return a request instance that is marked as to be retried
2) A spidermiddleware (RetryMiddleware) will check whether this request can be retried, do the necessary modifications and retry the request

Resolves #3590