### PR TITLE
PEP8-ify comments on templates

### DIFF
--- a/scrapy/templates/project/module/settings.py.tmpl
+++ b/scrapy/templates/project/module/settings.py.tmpl
@@ -16,75 +16,75 @@ NEWSPIDER_MODULE = '$project_name.spiders'
 
 
 # Crawl responsibly by identifying yourself (and your website) on the user-agent
-#USER_AGENT = '$project_name (+http://www.yourdomain.com)'
+# USER_AGENT = '$project_name (+http://www.yourdomain.com)'
 
 # Obey robots.txt rules
 ROBOTSTXT_OBEY = True
 
 # Configure maximum concurrent requests performed by Scrapy (default: 16)
-#CONCURRENT_REQUESTS = 32
+# CONCURRENT_REQUESTS = 32
 
 # Configure a delay for requests for the same website (default: 0)
 # See https://docs.scrapy.org/en/latest/topics/settings.html#download-delay
 # See also autothrottle settings and docs
-#DOWNLOAD_DELAY = 3
+# DOWNLOAD_DELAY = 3
 # The download delay setting will honor only one of:
-#CONCURRENT_REQUESTS_PER_DOMAIN = 16
-#CONCURRENT_REQUESTS_PER_IP = 16
+# CONCURRENT_REQUESTS_PER_DOMAIN = 16
+# CONCURRENT_REQUESTS_PER_IP = 16
 
 # Disable cookies (enabled by default)
-#COOKIES_ENABLED = False
+# COOKIES_ENABLED = False
 
 # Disable Telnet Console (enabled by default)
-#TELNETCONSOLE_ENABLED = False
+# TELNETCONSOLE_ENABLED = False
 
 # Override the default request headers:
-#DEFAULT_REQUEST_HEADERS = {
-#   'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
-#   'Accept-Language': 'en',
-#}
+# DEFAULT_REQUEST_HEADERS = {
+#     'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
+#     'Accept-Language': 'en',
+# }
 
 # Enable or disable spider middlewares
 # See https://docs.scrapy.org/en/latest/topics/spider-middleware.html
-#SPIDER_MIDDLEWARES = {
-#    '$project_name.middlewares.${ProjectName}SpiderMiddleware': 543,
-#}
+# SPIDER_MIDDLEWARES = {
+#     '$project_name.middlewares.${ProjectName}SpiderMiddleware': 543,
+# }
 
 # Enable or disable downloader middlewares
 # See https://docs.scrapy.org/en/latest/topics/downloader-middleware.html
-#DOWNLOADER_MIDDLEWARES = {
-#    '$project_name.middlewares.${ProjectName}DownloaderMiddleware': 543,
-#}
+# DOWNLOADER_MIDDLEWARES = {
+#     '$project_name.middlewares.${ProjectName}DownloaderMiddleware': 543,
+# }
 
 # Enable or disable extensions
 # See https://docs.scrapy.org/en/latest/topics/extensions.html
-#EXTENSIONS = {
-#    'scrapy.extensions.telnet.TelnetConsole': None,
-#}
+# EXTENSIONS = {
+#     'scrapy.extensions.telnet.TelnetConsole': None,
+# }
 
 # Configure item pipelines
 # See https://docs.scrapy.org/en/latest/topics/item-pipeline.html
-#ITEM_PIPELINES = {
-#    '$project_name.pipelines.${ProjectName}Pipeline': 300,
-#}
+# ITEM_PIPELINES = {
+#     '$project_name.pipelines.${ProjectName}Pipeline': 300,
+# }
 
 # Enable and configure the AutoThrottle extension (disabled by default)
 # See https://docs.scrapy.org/en/latest/topics/autothrottle.html
-#AUTOTHROTTLE_ENABLED = True
+# AUTOTHROTTLE_ENABLED = True
 # The initial download delay
-#AUTOTHROTTLE_START_DELAY = 5
+# AUTOTHROTTLE_START_DELAY = 5
 # The maximum download delay to be set in case of high latencies
-#AUTOTHROTTLE_MAX_DELAY = 60
+# AUTOTHROTTLE_MAX_DELAY = 60
 # The average number of requests Scrapy should be sending in parallel to
 # each remote server
-#AUTOTHROTTLE_TARGET_CONCURRENCY = 1.0
+# AUTOTHROTTLE_TARGET_CONCURRENCY = 1.0
 # Enable showing throttling stats for every response received:
-#AUTOTHROTTLE_DEBUG = False
+# AUTOTHROTTLE_DEBUG = False
 
 # Enable and configure HTTP caching (disabled by default)
 # See https://docs.scrapy.org/en/latest/topics/downloader-middleware.html#httpcache-middleware-settings
-#HTTPCACHE_ENABLED = True
-#HTTPCACHE_EXPIRATION_SECS = 0
-#HTTPCACHE_DIR = 'httpcache'
-#HTTPCACHE_IGNORE_HTTP_CODES = []
-#HTTPCACHE_STORAGE = 'scrapy.extensions.httpcache.FilesystemCacheStorage'
+# HTTPCACHE_ENABLED = True
+# HTTPCACHE_EXPIRATION_SECS = 0
+# HTTPCACHE_DIR = 'httpcache'
+# HTTPCACHE_IGNORE_HTTP_CODES = []
+# HTTPCACHE_STORAGE = 'scrapy.extensions.httpcache.FilesystemCacheStorage'

--- a/scrapy/templates/spiders/crawl.tmpl
+++ b/scrapy/templates/spiders/crawl.tmpl
@@ -15,7 +15,7 @@ class $classname(CrawlSpider):
 
     def parse_item(self, response):
         item = {}
-        #item['domain_id'] = response.xpath('//input[@id="sid"]/@value').get()
-        #item['name'] = response.xpath('//div[@id="name"]').get()
-        #item['description'] = response.xpath('//div[@id="description"]').get()
+        # item['domain_id'] = response.xpath('//input[@id="sid"]/@value').get()
+        # item['name'] = response.xpath('//div[@id="name"]').get()
+        # item['description'] = response.xpath('//div[@id="description"]').get()
         return item

--- a/scrapy/templates/spiders/csvfeed.tmpl
+++ b/scrapy/templates/spiders/csvfeed.tmpl
@@ -10,12 +10,12 @@ class $classname(CSVFeedSpider):
     # delimiter = '\t'
 
     # Do any adaptations you need here
-    #def adapt_response(self, response):
-    #    return response
+    # def adapt_response(self, response):
+    #     return response
 
     def parse_row(self, response, row):
         i = {}
-        #i['url'] = row['url']
-        #i['name'] = row['name']
-        #i['description'] = row['description']
+        # i['url'] = row['url']
+        # i['name'] = row['name']
+        # i['description'] = row['description']
         return i

--- a/scrapy/templates/spiders/xmlfeed.tmpl
+++ b/scrapy/templates/spiders/xmlfeed.tmpl
@@ -6,12 +6,12 @@ class $classname(XMLFeedSpider):
     name = '$name'
     allowed_domains = ['$domain']
     start_urls = ['http://$domain/feed.xml']
-    iterator = 'iternodes' # you can change this; see the docs
-    itertag = 'item' # change it accordingly
+    iterator = 'iternodes'  # you can change this; see the docs
+    itertag = 'item'  # change it accordingly
 
     def parse_node(self, response, selector):
         item = {}
-        #item['url'] = selector.select('url').get()
-        #item['name'] = selector.select('name').get()
-        #item['description'] = selector.select('description').get()
+        # item['url'] = selector.select('url').get()
+        # item['name'] = selector.select('name').get()
+        # item['description'] = selector.select('description').get()
         return item


### PR DESCRIPTION
There are still a few warnings reported by `flake8`, which I think can be safely ignored: `scrapy.cfg` is not a Python file, the other `SyntaxError`s come from the `$` sign needed by the template engine, and `E501 line too long (81 > 79 characters)` is not a big deal IMHO (everyone has screens with more than 80 chars these days).


For reference, these are the remaining warnings:
```
scrapy/templates/project/scrapy.cfg:7:11: E999 SyntaxError: invalid syntax
scrapy/templates/project/scrapy.cfg:10:1: E265 block comment should start with '# '
scrapy/templates/spiders/basic.tmpl:5:7: E999 SyntaxError: invalid syntax
scrapy/templates/spiders/crawl.tmpl:7:7: E999 SyntaxError: invalid syntax
scrapy/templates/spiders/crawl.tmpl:13:80: E501 line too long (81 > 79 characters)
scrapy/templates/spiders/crawl.tmpl:20:80: E501 line too long (80 > 79 characters)
scrapy/templates/spiders/csvfeed.tmpl:5:7: E999 SyntaxError: invalid syntax
scrapy/templates/spiders/xmlfeed.tmpl:5:7: E999 SyntaxError: invalid syntax
````