### PR TITLE
[MRG+1] FIX: Remove redundant string function

### DIFF
--- a/docs/topics/xpath-tutorial.rst
+++ b/docs/topics/xpath-tutorial.rst
@@ -762,7 +762,7 @@ What happens when you apply ``string()`` on the document ``<body>`` for example?
 You get a text representation of the document, without the tags:
 
 
-.. xpathdemo:: string(string(//body))
+.. xpathdemo:: string(//body)
 
     <html>
     <head>


### PR DESCRIPTION
string(string(//body)) is equivalent to string(//body) in the example provided