### PR TITLE
Fixed wrong name of attachment when use non-ascii filename

### DIFF
--- a/scrapy/mail.py
+++ b/scrapy/mail.py
@@ -82,8 +82,7 @@ class MailSender(object):
                 part = MIMEBase(*mimetype.split('/'))
                 part.set_payload(f.read())
                 Encoders.encode_base64(part)
-                part.add_header('Content-Disposition', 'attachment; filename="%s"' \
-                    % attach_name)
+                part.add_header('Content-Disposition', 'attachment', filename=attach_name)
                 msg.attach(part)
         else:
             msg.set_payload(body)


### PR DESCRIPTION
If parameter `attachs` of the  function `send` use non-ascii filename like below, the attachment filename can not display correctly.

```attachs=[(u'更新条目.json', 'text/json', open('/tmp/update.json'))]```

This was solved by updated code as I put below:

```part.add_header('Content-Disposition', 'attachment', filename=attach_name)```