### PR TITLE
Docs - Item Pipeline - Add filenames to code snippets

### DIFF
--- a/docs/intro/tutorial.rst
+++ b/docs/intro/tutorial.rst
@@ -511,7 +511,7 @@ We can try extracting it in the shell::
     '<a href="/page/2/">Next <span aria-hidden="true">→</span></a>'
 
 This gets the anchor element, but we want the attribute ``href``. For that,
-Scrapy supports a CSS extension that let's you select the attribute contents,
+Scrapy supports a CSS extension that lets you select the attribute contents,
 like this::
 
     >>> response.css('li.next a::attr(href)').get()

--- a/docs/intro/tutorial.rst
+++ b/docs/intro/tutorial.rst
@@ -296,7 +296,7 @@ expressions`_::
 
 In order to find the proper CSS selectors to use, you might find useful opening
 the response page from the shell in your web browser using ``view(response)``.
-You can use your browser developer tools to inspect the HTML and come up
+You can use your browser's developer tools to inspect the HTML and come up
 with a selector (see section about :ref:`topics-developer-tools`).
 
 `Selector Gadget`_ is also a nice tool to quickly find CSS selector for

--- a/docs/intro/tutorial.rst
+++ b/docs/intro/tutorial.rst
@@ -205,7 +205,7 @@ Extracting data
 ---------------
 
 The best way to learn how to extract data with Scrapy is trying selectors
-using the shell :ref:`Scrapy shell <topics-shell>`. Run::
+using the :ref:`Scrapy shell <topics-shell>`. Run::
 
     scrapy shell 'http://quotes.toscrape.com/page/1/'
 

--- a/docs/intro/tutorial.rst
+++ b/docs/intro/tutorial.rst
@@ -297,7 +297,7 @@ expressions`_::
 In order to find the proper CSS selectors to use, you might find useful opening
 the response page from the shell in your web browser using ``view(response)``.
 You can use your browser's developer tools to inspect the HTML and come up
-with a selector (see section about :ref:`topics-developer-tools`).
+with a selector (see :ref:`topics-developer-tools`).
 
 `Selector Gadget`_ is also a nice tool to quickly find CSS selector for
 visually selected elements, which works in many browsers.


### PR DESCRIPTION
I'm new to Scrapy, and the tutorial is great, but beyond that I got lost very fast.

I think it would be really helpful for all code blocks in all docs to mention the filename that they belong in. 

For example, in the Item Pipeline ```docs/topics/item-pipeline.rst```, I figured out that the very last code snippet goes in the ```settings.py``` file. (I eventually realized there's a link to the doc for settings, but writing it explicitly in addition would be helpful). 

Similarly, for Item Loaders ```docs/topics/loaders.rst``` it's not immediately clear that the Item Loader declaration goes in the ```items.py``` file while the parsing code stays in the spider files.

I'm also new to Sphinx/.rst format, so stylistically, what is a good way to do this? Is it possible to add a caption to the bottom of a code block, with the file name?