### PR TITLE
[MRG+1] fix: do not catch system exceptions like KeyboardInterrupt

### DIFF
--- a/scrapy/contracts/__init__.py
+++ b/scrapy/contracts/__init__.py
@@ -94,7 +94,7 @@ class ContractsManager(object):
             try:
                 output = cb(response)
                 output = list(iterate_spider_output(output))
-            except:
+            except Exception:
                 case = _create_testcase(method, 'callback')
                 results.addError(case, sys.exc_info())
 

--- a/scrapy/core/spidermw.py
+++ b/scrapy/core/spidermw.py
@@ -49,7 +49,7 @@ class SpiderMiddlewareManager(MiddlewareManager):
                                              .format(fname(method), type(result)))
                 except _InvalidOutput:
                     raise
-                except:
+                except Exception:
                     return scrape_func(Failure(), request, spider)
             return scrape_func(response, request, spider)
 

--- a/scrapy/utils/defer.py
+++ b/scrapy/utils/defer.py
@@ -48,7 +48,7 @@ def mustbe_deferred(f, *args, **kw):
     # exception in Scrapy - see #125
     except IgnoreRequest as e:
         return defer_fail(failure.Failure(e))
-    except:
+    except Exception:
         return defer_fail(failure.Failure())
     else:
         return defer_result(result)
@@ -102,5 +102,5 @@ def iter_errback(iterable, errback, *a, **kw):
             yield next(it)
         except StopIteration:
             break
-        except:
+        except Exception:
             errback(failure.Failure(), *a, **kw)

--- a/scrapy/utils/misc.py
+++ b/scrapy/utils/misc.py
@@ -86,7 +86,7 @@ def extract_regex(regex, text, encoding='utf-8'):
 
     try:
         strings = [regex.search(text).group('extract')]   # named group
-    except:
+    except Exception:
         strings = regex.findall(text)    # full regex or numbered groups
     strings = flatten(strings)
 

--- a/tests/mockserver.py
+++ b/tests/mockserver.py
@@ -177,7 +177,7 @@ class Root(Resource):
         try:
             from tests import tests_datadir
             self.putChild(b"files", File(os.path.join(tests_datadir, 'test_site/files/')))
-        except:
+        except Exception:
             pass
         self.putChild(b"redirect-to", RedirectTo())
 


### PR DESCRIPTION
I noticed that occasionally my **Ctrl+C** is ignored.  In general this happens when using plain `except:`. In this case, you probably do not want to catch system-exceptions like `KeyboardInterrupt`. 