### PR TITLE
[MRG+1] Add SCRAPY_CHECK environment variable

### DIFF
--- a/docs/topics/contracts.rst
+++ b/docs/topics/contracts.rst
@@ -122,13 +122,12 @@ get the failures pretty printed::
                     raise ContractFail('X-CustomHeader not present')
 
 
-Detecting check run
-===================
-It is not encouraged to created different behaviour when running test.
-However, sometimes it is useful to know when a spider is started by scrapy check.
-It can for example be needed to enforce less settings to be set, or to disable some
-uploading of result data. When scrapy check is runned the ``SCRAPY_CHECK`` environment
-variable is set. This can be retrieved via ``os.environ``::
+Detecting check runs
+====================
+
+When ``scrapy check`` is running, the ``SCRAPY_CHECK`` environment variable is
+set to the ``true`` string. You can use `os.environ`_ to perform any change to
+your spiders or your settings when ``scrapy check`` is used::
 
     import os
     import scrapy
@@ -138,4 +137,6 @@ variable is set. This can be retrieved via ``os.environ``::
 
         def __init__(self):
             if os.environ.get('SCRAPY_CHECK'):
-                # Do some scraper adjustments when check is running
+                pass  # Do some scraper adjustments when a check is running
+
+.. _os.environ: https://docs.python.org/3/library/os.html#os.environ

--- a/docs/topics/contracts.rst
+++ b/docs/topics/contracts.rst
@@ -120,3 +120,22 @@ get the failures pretty printed::
             for header in self.args:
                 if header not in response.headers:
                     raise ContractFail('X-CustomHeader not present')
+
+
+Detecting check run
+===================
+It is not encouraged to created different behaviour when running test.
+However, sometimes it is useful to know when a spider is started by scrapy check.
+It can for example be needed to enforce less settings to be set, or to disable some
+uploading of result data. When scrapy check is runned the ``SCRAPY_CHECK`` environment
+variable is set. This can be retrieved via ``os.environ``::
+
+    import os
+    import scrapy
+
+    class ExampleSpider(scrapy.Spider):
+        name = 'example'
+
+        def __init__(self):
+            if os.environ.get('SCRAPY_CHECK'):
+                # Do some scraper adjustments when check is running

--- a/scrapy/commands/check.py
+++ b/scrapy/commands/check.py
@@ -6,7 +6,7 @@ from unittest import TextTestRunner, TextTestResult as _TextTestResult
 
 from scrapy.commands import ScrapyCommand
 from scrapy.contracts import ContractsManager
-from scrapy.utils.misc import load_object
+from scrapy.utils.misc import load_object, set_environ
 from scrapy.utils.conf import build_component_list
 
 
@@ -68,16 +68,17 @@ class Command(ScrapyCommand):
 
         spider_loader = self.crawler_process.spider_loader
 
-        for spidername in args or spider_loader.list():
-            spidercls = spider_loader.load(spidername)
-            spidercls.start_requests = lambda s: conman.from_spider(s, result)
+        with set_environ(SCRAPY_CHECK=True):
+            for spidername in args or spider_loader.list():
+                spidercls = spider_loader.load(spidername)
+                spidercls.start_requests = lambda s: conman.from_spider(s, result)
 
-            tested_methods = conman.tested_methods_from_spidercls(spidercls)
-            if opts.list:
-                for method in tested_methods:
-                    contract_reqs[spidercls.name].append(method)
-            elif tested_methods:
-                self.crawler_process.crawl(spidercls)
+                tested_methods = conman.tested_methods_from_spidercls(spidercls)
+                if opts.list:
+                    for method in tested_methods:
+                        contract_reqs[spidercls.name].append(method)
+                elif tested_methods:
+                    self.crawler_process.crawl(spidercls)
 
         # start checks
         if opts.list:

--- a/scrapy/commands/check.py
+++ b/scrapy/commands/check.py
@@ -68,7 +68,7 @@ class Command(ScrapyCommand):
 
         spider_loader = self.crawler_process.spider_loader
 
-        with set_environ(SCRAPY_CHECK=True):
+        with set_environ(SCRAPY_CHECK='true'):
             for spidername in args or spider_loader.list():
                 spidercls = spider_loader.load(spidername)
                 spidercls.start_requests = lambda s: conman.from_spider(s, result)

--- a/scrapy/utils/misc.py
+++ b/scrapy/utils/misc.py
@@ -156,7 +156,7 @@ def set_environ(**kwargs):
     try:
         yield
     finally:
-        for k, v in original_env:
+        for k, v in original_env.items():
             if v is None:
                 del os.environ[k]
             else:

--- a/scrapy/utils/misc.py
+++ b/scrapy/utils/misc.py
@@ -88,7 +88,7 @@ def extract_regex(regex, text, encoding='utf-8'):
     try:
         strings = [regex.search(text).group('extract')]   # named group
     except Exception:
-        strings = regex.findall(text)   # full regex or numbered groups
+        strings = regex.findall(text)    # full regex or numbered groups
     strings = flatten(strings)
 
     if isinstance(text, six.text_type):

--- a/scrapy/utils/misc.py
+++ b/scrapy/utils/misc.py
@@ -41,7 +41,7 @@ def load_object(path):
     except ValueError:
         raise ValueError("Error loading object '%s': not a full path" % path)
 
-    module, name = path[:dot], path[dot + 1:]
+    module, name = path[:dot], path[dot+1:]
     mod = import_module(module)
 
     try:
@@ -86,9 +86,9 @@ def extract_regex(regex, text, encoding='utf-8'):
         regex = re.compile(regex, re.UNICODE)
 
     try:
-        strings = [regex.search(text).group('extract')]  # named group
+        strings = [regex.search(text).group('extract')]   # named group
     except Exception:
-        strings = regex.findall(text)  # full regex or numbered groups
+        strings = regex.findall(text)   # full regex or numbered groups
     strings = flatten(strings)
 
     if isinstance(text, six.text_type):

--- a/scrapy/utils/misc.py
+++ b/scrapy/utils/misc.py
@@ -12,6 +12,7 @@ from w3lib.html import replace_entities
 from scrapy.utils.python import flatten, to_unicode
 from scrapy.item import BaseItem
 
+
 _ITERABLE_SINGLE_VALUES = dict, BaseItem, six.text_type, bytes
 
 

--- a/tests/test_utils_misc/__init__.py
+++ b/tests/test_utils_misc/__init__.py
@@ -3,7 +3,7 @@ import os
 import unittest
 
 from scrapy.item import Item, Field
-from scrapy.utils.misc import arg_to_iter, create_instance, load_object, walk_modules
+from scrapy.utils.misc import arg_to_iter, create_instance, load_object, walk_modules, set_environ
 
 from tests import mock
 
@@ -129,6 +129,13 @@ class UtilsMiscTestCase(unittest.TestCase):
 
         with self.assertRaises(ValueError):
             create_instance(m, None, None)
+
+    def test_set_environ(self):
+        assert os.environ.get('some_test_environ') is None
+        with set_environ(some_test_environ='test_value'):
+            assert os.environ.get('some_test_environ') == 'test_value'
+        assert os.environ.get('some_test_environ') is None
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_utils_misc/__init__.py
+++ b/tests/test_utils_misc/__init__.py
@@ -136,6 +136,12 @@ class UtilsMiscTestCase(unittest.TestCase):
             assert os.environ.get('some_test_environ') == 'test_value'
         assert os.environ.get('some_test_environ') is None
 
+        os.environ['some_test_environ'] = 'test'
+        assert os.environ.get('some_test_environ') == 'test'
+        with set_environ(some_test_environ='test_value'):
+            assert os.environ.get('some_test_environ') == 'test_value'
+        assert os.environ.get('some_test_environ') == 'test'
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_utils_misc/__init__.py
+++ b/tests/test_utils_misc/__init__.py
@@ -3,11 +3,12 @@ import os
 import unittest
 
 from scrapy.item import Item, Field
-from scrapy.utils.misc import arg_to_iter, create_instance, load_object, walk_modules, set_environ
+from scrapy.utils.misc import arg_to_iter, create_instance, load_object, set_environ, walk_modules
 
 from tests import mock
 
 __doctests__ = ['scrapy.utils.misc']
+
 
 class UtilsMiscTestCase(unittest.TestCase):
 


### PR DESCRIPTION
This PR implements the environment variable when running `scrapy check` as asked in #3704 . This way it is possible to have different behaviour in the scraper when running the check (like requiring less settings to be set)

fixes #3704 