### PR TITLE
add TextResponse.re() and .re_first()

### DIFF
--- a/docs/news.rst
+++ b/docs/news.rst
@@ -5,6 +5,11 @@ Release notes
 
 .. _release-1.6.0:
 
+Scrapy 1.6.1 (2019-MM-DD)
+-------------------------
+
+*   `TextResponse.re()` and `TextResponse.re_first()` added
+
 Scrapy 1.6.0 (2019-01-30)
 -------------------------
 

--- a/docs/topics/request-response.rst
+++ b/docs/topics/request-response.rst
@@ -530,7 +530,7 @@ dealing with JSON requests.
 
    :param data: is any JSON serializable object that needs to be JSON encoded and assigned to body.
       if :attr:`Request.body` argument is provided this parameter will be ignored.
-      if :attr:`Request.body` argument is not provided and data argument is provided :attr:`Request.method` will be 
+      if :attr:`Request.body` argument is not provided and data argument is provided :attr:`Request.method` will be
       set to ``'POST'`` automatically.
    :type data: JSON serializable object
 
@@ -761,6 +761,18 @@ TextResponse objects
         A shortcut to ``TextResponse.selector.css(query)``::
 
             response.css('p')
+
+    .. method:: TextResponse.re(self, regex, replace_entities=True)
+
+        A shortcut to ``TextResponse.selector.re(regex, replace_entities=True)``::
+
+            response.re(r'-(\w+)')
+
+    .. method:: TextResponse.re_first(self, regex, default=None, replace_entities=True)
+
+        A shortcut to ``TextResponse.selector.re_first(regex, default=None, replace_entities=True)``::
+
+            response.re_first(r'-(\w+)', default='')
 
     .. automethod:: TextResponse.follow
 

--- a/docs/topics/selectors.rst
+++ b/docs/topics/selectors.rst
@@ -69,9 +69,10 @@ constructed by passing either :class:`~scrapy.http.TextResponse` object or
 markup as an unicode string (in ``text`` argument).
 Usually there is no need to construct Scrapy selectors manually:
 ``response`` object is available in Spider callbacks, so in most cases
-it is more convenient to use ``response.css()`` and ``response.xpath()``
-shortcuts. By using ``response.selector`` or one of these shortcuts
-you can also ensure the response body is parsed only once.
+it is more convenient to use ``response.css()``, ``response.xpath()``,
+``response.re()``, and ``response.re_first()`` shortcuts. By using
+``response.selector`` or one of these shortcuts you can also ensure the
+response body is parsed only once.
 
 But if required, it is possible to use ``Selector`` directly.
 Constructing from text::

--- a/scrapy/http/response/text.py
+++ b/scrapy/http/response/text.py
@@ -121,6 +121,18 @@ class TextResponse(Response):
     def css(self, query):
         return self.selector.css(query)
 
+    def re(self, regex, replace_entities=True):
+        # type: (Pattern) -> list
+        return self.selector.re(regex, replace_entities=replace_entities)
+
+    def re_first(self, regex, default=None, replace_entities=True):
+        # type: (Pattern) -> str
+        return self.selector.re_first(
+            regex,
+            default=default,
+            replace_entities=replace_entities
+        )
+
     def follow(self, url, callback=None, method='GET', headers=None, body=None,
                cookies=None, meta=None, encoding=None, priority=0,
                dont_filter=False, errback=None):
@@ -129,7 +141,7 @@ class TextResponse(Response):
         Return a :class:`~.Request` instance to follow a link ``url``.
         It accepts the same arguments as ``Request.__init__`` method,
         but ``url`` can be not only an absolute URL, but also
-        
+
         * a relative URL;
         * a scrapy.link.Link object (e.g. a link extractor result);
         * an attribute Selector (not SelectorList) - e.g.
@@ -137,7 +149,7 @@ class TextResponse(Response):
           ``response.xpath('//img/@src')[0]``.
         * a Selector for ``<a>`` or ``<link>`` element, e.g.
           ``response.css('a.my_link')[0]``.
-          
+
         See :ref:`response-follow-example` for usage examples.
         """
         if isinstance(url, parsel.Selector):

--- a/tests/test_http_response.py
+++ b/tests/test_http_response.py
@@ -360,9 +360,18 @@ class TextResponseTest(BaseResponseTest):
             response.css("title::text").getall(),
             response.selector.css("title::text").getall(),
         )
+        self.assertEqual(
+            response.re(r'Some\s+(\w+)<'),
+            response.selector.re(r'Some\s+(\w+)<')
+        )
+
+        self.assertEqual(
+            response.re_first(r'Some\s+(\w+)<'),
+            response.selector.re_first(r'Some\s+(\w+)<')
+        )
 
     def test_selector_shortcuts_kwargs(self):
-        body = b"<html><head><title>Some page</title><body><p class=\"content\">A nice paragraph.</p></body></html>"
+        body = b"<html><head><title>Some page &gt;</title><body><p class=\"content\">A nice paragraph.</p></body></html>"
         response = self.response_class("http://www.example.com", body=body)
 
         self.assertEqual(
@@ -373,6 +382,21 @@ class TextResponseTest(BaseResponseTest):
             response.xpath("//title[count(following::p[@class=$pclass])=$pcount]/text()",
                 pclass="content", pcount=1).getall(),
             response.xpath("//title[count(following::p[@class=\"content\"])=1]/text()").getall(),
+        )
+
+        self.assertEqual(
+            response.re(r'Some\s+(.+?)<'),
+            ['page >']
+        )
+
+        self.assertEqual(
+            response.re(r'Some\s+(.+?)<', replace_entities=False),
+            ['page &gt;']
+        )
+
+        self.assertEqual(
+            response.re_first(r'a(xxx)b<', default='not present'),
+            'not present'
         )
 
     def test_urljoin_with_base_url(self):


### PR DESCRIPTION
The `.re()` and `.re_first()` methods were left out of `TextResponse` when `.xpath()` and `.css()`  were added in #690. The reasons for leaving them out at the last minute (they were in the original pull request) are undocumented.

This pull requests adds the two methods.