### PR TITLE
Check command verbose

### DIFF
--- a/scrapy/commands/check.py
+++ b/scrapy/commands/check.py
@@ -59,7 +59,7 @@ class Command(ScrapyCommand):
     def run(self, args, opts):
         # load contracts
         contracts = build_component_list(self.settings.getwithbase('SPIDER_CONTRACTS'))
-        conman = ContractsManager(load_object(c) for c in contracts)
+        conman = ContractsManager([load_object(c) for c in contracts], opts.verbose)
         runner = TextTestRunner(verbosity=2 if opts.verbose else 1)
         result = TextTestResult(runner.stream, runner.descriptions, runner.verbosity)
 

--- a/scrapy/commands/check.py
+++ b/scrapy/commands/check.py
@@ -73,6 +73,7 @@ class Command(ScrapyCommand):
             spidercls.start_requests = lambda s: conman.from_spider(s, result)
 
             tested_methods = conman.tested_methods_from_spidercls(spidercls)
+            print('Checking spider %s...' % spidername)
             if opts.list:
                 for method in tested_methods:
                     contract_reqs[spidercls.name].append(method)

--- a/scrapy/contracts/__init__.py
+++ b/scrapy/contracts/__init__.py
@@ -40,9 +40,11 @@ class ContractsManager(object):
 
     def from_spider(self, spider, results):
         requests = []
+        print('Testing Methods:')
         for method in self.tested_methods_from_spidercls(type(spider)):
             bound_method = spider.__getattribute__(method)
             try:
+                print('-- %s' % bound_method.__name__)
                 requests.append(self.from_method(bound_method, results))
             except Exception:
                 case = _create_testcase(bound_method, 'contract')

--- a/scrapy/contracts/__init__.py
+++ b/scrapy/contracts/__init__.py
@@ -12,9 +12,10 @@ from scrapy.utils.python import get_spec
 class ContractsManager(object):
     contracts = {}
 
-    def __init__(self, contracts):
+    def __init__(self, contracts, verbose=None):
         for contract in contracts:
             self.contracts[contract.name] = contract
+        self.verbose = verbose
 
     def tested_methods_from_spidercls(self, spidercls):
         methods = []
@@ -33,18 +34,16 @@ class ContractsManager(object):
             if line.startswith('@'):
                 name, args = re.match(r'@(\w+)\s*(.*)', line).groups()
                 args = re.split(r'\s+', args)
-
-                contracts.append(self.contracts[name](method, *args))
-
+                contracts.append(self.contracts[name](method, self.verbose, *args))
         return contracts
 
     def from_spider(self, spider, results):
         requests = []
-        print('Testing Methods:')
+        if self.verbose: print('Testing Methods:')
         for method in self.tested_methods_from_spidercls(type(spider)):
             bound_method = spider.__getattribute__(method)
             try:
-                print('-- %s' % bound_method.__name__)
+                if self.verbose: print('-- %s' % bound_method.__name__)
                 requests.append(self.from_method(bound_method, results))
             except Exception:
                 case = _create_testcase(bound_method, 'contract')
@@ -113,10 +112,11 @@ class Contract(object):
     """ Abstract class for contracts """
     request_cls = None
 
-    def __init__(self, method, *args):
+    def __init__(self, method, verbose=None, *args):
         self.testcase_pre = _create_testcase(method, '@%s pre-hook' % self.name)
         self.testcase_post = _create_testcase(method, '@%s post-hook' % self.name)
         self.args = args
+        self.verbose = verbose
 
     def add_pre_hook(self, request, results):
         if hasattr(self, 'pre_process'):

--- a/scrapy/contracts/default.py
+++ b/scrapy/contracts/default.py
@@ -73,7 +73,7 @@ class ReturnsContract(Contract):
             raise ContractFail("Returned %s %s, expected %s" % \
                 (occurrences, self.obj_name, expected))
         else:
-            print('Returned %s %s, expected %s. OK.' % (occurrences, self.obj_name, expected))
+            if self.verbose: print('Returned %s %s, expected %s.' % (occurrences, self.obj_name, expected))
 
 
 class ScrapesContract(Contract):
@@ -91,4 +91,4 @@ class ScrapesContract(Contract):
                     if not arg in x:
                         raise ContractFail("'%s' field is missing" % arg)
                     found_args.append(arg)
-                print('Fields found: %s' % (found_args))
+                if self.verbose: print('Fields found: %s' % (found_args))

--- a/scrapy/contracts/default.py
+++ b/scrapy/contracts/default.py
@@ -64,14 +64,16 @@ class ReturnsContract(Contract):
 
         assertion = (self.min_bound <= occurrences <= self.max_bound)
 
-        if not assertion:
-            if self.min_bound == self.max_bound:
-                expected = self.min_bound
-            else:
-                expected = '%s..%s' % (self.min_bound, self.max_bound)
+        if self.min_bound == self.max_bound:
+            expected = self.min_bound
+        else:
+            expected = '%s..%s' % (self.min_bound, self.max_bound)
 
+        if not assertion:
             raise ContractFail("Returned %s %s, expected %s" % \
                 (occurrences, self.obj_name, expected))
+        else:
+            print('Returned %s %s, expected %s. OK.' % (occurrences, self.obj_name, expected))
 
 
 class ScrapesContract(Contract):
@@ -82,8 +84,11 @@ class ScrapesContract(Contract):
     name = 'scrapes'
 
     def post_process(self, output):
+        found_args = []
         for x in output:
             if isinstance(x, (BaseItem, dict)):
                 for arg in self.args:
                     if not arg in x:
                         raise ContractFail("'%s' field is missing" % arg)
+                    found_args.append(arg)
+                print('Fields found: %s' % (found_args))


### PR DESCRIPTION
Scrapy check has been a great tool for me to check how my spider works, however, this unittest tool doesn't provide too much useful information when it's running. Specifically, even if the --verbose option is on, it only tells you if each individual test works, rather than the actual result of the test. I think it would be better if the check command can print out more useful info for the users. 

In this PR, I added some information when -v is on. It prints out the spider and function to be checked, and tells the user when a test passed, how the test works (how many requests/ what kind of fields have been found). I think this can help users to debug a spider. 

