### PR TITLE
[MRG+1] doc: update configure_logging docs to discourage use with CrawlerProcess

### DIFF
--- a/docs/topics/logging.rst
+++ b/docs/topics/logging.rst
@@ -238,9 +238,10 @@ scrapy.utils.log module
 
 .. autofunction:: configure_logging
 
-    ``configure_logging`` is automatically called when using Scrapy commands,
-    but needs to be called explicitly when running custom scripts. In that
-    case, its usage is not required but it's recommended.
+    ``configure_logging`` is automatically called when using Scrapy commands
+    or :class:`~scrapy.crawler.CrawlerProcess`, but needs to be called explicitly
+    when running custom scripts using :class:`~scrapy.crawler.CrawlerRunner`.
+    In that case, its usage is not required but it's recommended.
 
     If you plan on configuring the handlers yourself is still recommended you
     call this function, passing ``install_root_handler=False``. Bear in mind


### PR DESCRIPTION
Update to the `configure_logging` docs in order to prevent users from using this function with `CrawlerProcess` as this produces unexpected behavior.

Fixes #1347 

