### PR TITLE
Fix itemloader cannot process zero

### DIFF
--- a/scrapy/loader/__init__.py
+++ b/scrapy/loader/__init__.py
@@ -89,7 +89,7 @@ class ItemLoader(object):
     def _add_value(self, field_name, value):
         value = arg_to_iter(value)
         processed_value = self._process_input_value(field_name, value)
-        if processed_value:
+        if processed_value or processed_value == 0:
             self._values[field_name] += arg_to_iter(processed_value)
 
     def _replace_value(self, field_name, value):

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -262,6 +262,13 @@ class BasicItemLoaderTest(unittest.TestCase):
         il.add_value('name', u'marta')
         self.assertEqual(il.get_output_value('name'), [u'mARTA'])
 
+        class ChildItemLoader(TestItemLoader):
+            name_in = Compose(TakeFirst(), int)
+
+        il = ChildItemLoader()
+        il.add_value('name', u'0')
+        self.assertEqual(il.get_output_value('name'), [0])
+
     def test_extend_default_input_processors(self):
         class ChildDefaultedItemLoader(DefaultedItemLoader):
             name_in = MapCompose(DefaultedItemLoader.default_input_processor, six.text_type.swapcase)


### PR DESCRIPTION
When we use extend custom input processors, if we input a zero value, it will output only a `[]`, like this:
```Python
from scrapy.loader import ItemLoader
from scrapy.loader.processors import TakeFirst, Compose
from scrapy.item import Item, Field


class TestItem(Item):
    name = Field()


class TestItemLoader(ItemLoader):
    default_item_class = TestItem
    name_in = Compose(TakeFirst(), int)


il = TestItemLoader()
il.add_value('name', u'0')
assert il.get_output_value('name') == []
assert il.get_output_value('name') == [0]
```
And we will get:
```
Traceback (most recent call last):
  File "xxx.py", line 18, in <module>
    assert il.get_output_value('name') == [0]
AssertionError
```