### PR TITLE
Fix #3771: Add fallback css and xpath selectors

### DIFF
--- a/docs/topics/loaders.rst
+++ b/docs/topics/loaders.rst
@@ -391,6 +391,8 @@ ItemLoader objects
             loader.add_xpath('name', '//p[@class="product-name"]')
             # HTML snippet: <p id="price">the price is $1200</p>
             loader.add_xpath('price', '//p[@id="price"]', re='the price is (.*)')
+            # HTML snippet: <p class="product-name1">Color</p><p class="product-name2">TV</p>
+            loader.add_xpath('name', ['//p[@class="product-name1"]', '//p[@class="product-name2"]'])
 
     .. method:: replace_xpath(field_name, xpath, \*processors, \**kwargs)
 
@@ -434,6 +436,8 @@ ItemLoader objects
             loader.add_css('name', 'p.product-name')
             # HTML snippet: <p id="price">the price is $1200</p>
             loader.add_css('price', 'p#price', re='the price is (.*)')
+            # HTML snippet: <p class="product-name1">Color</p><p class="product-name2">TV</p>
+            loader.add_css('name', ['p.product-name1', 'p.product-name2'])
 
     .. method:: replace_css(field_name, css, \*processors, \**kwargs)
 

--- a/docs/topics/loaders.rst
+++ b/docs/topics/loaders.rst
@@ -385,6 +385,10 @@ ItemLoader objects
         :param xpath: the XPath to extract data from
         :type xpath: str
 
+        :param stop_on_first_match: when ``xpath`` is a list of selectors, should it
+            get only the first match or all? Defaults to ``False``.
+        :type stop_on_first_match: bool
+
         Examples::
 
             # HTML snippet: <p class="product-name">Color TV</p>
@@ -392,7 +396,15 @@ ItemLoader objects
             # HTML snippet: <p id="price">the price is $1200</p>
             loader.add_xpath('price', '//p[@id="price"]', re='the price is (.*)')
             # HTML snippet: <p class="product-name1">Color</p><p class="product-name2">TV</p>
-            loader.add_xpath('name', ['//p[@class="product-name1"]', '//p[@class="product-name2"]'])
+            loader.add_xpath('name', [
+                '//p[@class="product-name1"]',
+                '//p[@class="product-name2"]'
+            ])
+            # HTML snippet: <p class="product-name1">Color</p><p class="product-name2">TV</p>
+            loader.add_xpath('name', [
+                '//p[@class="product-name1"]',
+                '//p[@class="product-name2"]'
+            ], stop_on_first_match=True)
 
     .. method:: replace_xpath(field_name, xpath, \*processors, \**kwargs)
 
@@ -430,6 +442,10 @@ ItemLoader objects
         :param css: the CSS selector to extract data from
         :type css: str
 
+        :param stop_on_first_match: when ``css`` is a list of selectors, should it
+            get only the first match or all? Defaults to ``False``.
+        :type stop_on_first_match: bool
+
         Examples::
 
             # HTML snippet: <p class="product-name">Color TV</p>
@@ -438,6 +454,11 @@ ItemLoader objects
             loader.add_css('price', 'p#price', re='the price is (.*)')
             # HTML snippet: <p class="product-name1">Color</p><p class="product-name2">TV</p>
             loader.add_css('name', ['p.product-name1', 'p.product-name2'])
+            # HTML snippet: <p class="product-name1">Color</p><p class="product-name2">TV</p>
+            loader.add_css('name', [
+                'p.product-name1',
+                'p.product-name2'
+            ], stop_on_first_match=True)
 
     .. method:: replace_css(field_name, css, \*processors, \**kwargs)
 

--- a/scrapy/loader/__init__.py
+++ b/scrapy/loader/__init__.py
@@ -181,7 +181,8 @@ class ItemLoader(object):
     def _get_xpathvalues(self, xpaths, **kw):
         self._check_selector_method()
         xpaths = arg_to_iter(xpaths)
-        return flatten(self.selector.xpath(xpath).getall() for xpath in xpaths)
+        gen = (self.selector.xpath(xpath).getall() for xpath in xpaths)
+        return self._first_or_flatten(gen, **kw)
 
     def add_css(self, field_name, css, *processors, **kw):
         values = self._get_cssvalues(css, **kw)
@@ -198,6 +199,14 @@ class ItemLoader(object):
     def _get_cssvalues(self, csss, **kw):
         self._check_selector_method()
         csss = arg_to_iter(csss)
-        return flatten(self.selector.css(css).getall() for css in csss)
+        gen = (self.selector.css(css).getall() for css in csss)
+        return self._first_or_flatten(gen, **kw)
+
+    def _first_or_flatten(self, values, **kw):
+        if kw.get('stop_on_first_match', False):
+            values = filter(None, values)
+            return next(values, None)
+
+        return flatten(values)
 
 XPathItemLoader = create_deprecated_class('XPathItemLoader', ItemLoader)

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -612,6 +612,50 @@ class SelectortemLoaderTest(unittest.TestCase):
         l.replace_css('url', 'a::attr(href)', re='http://www\.(.+)')
         self.assertEqual(l.get_output_value('url'), [u'scrapy.org'])
 
+    def test_fallback_css_selector(self):
+        sel = Selector(text=u"""
+        <html>
+            <body>
+                <span class="selector1">bruce</span>
+                <span class="selector2">wayne</span>
+                <span class="selector3">batman</span>
+            </body>
+        </html>
+        """)
+        l = TestItemLoader(selector=sel)
+        
+        l.add_css('name', [
+            '.selector1::text',
+            '.selector2::text',
+            '.selector3::text',
+        ])
+        self.assertEqual(
+            l.get_output_value('name'),
+            [u'Bruce', u'Wayne', u'Batman']
+        )
+
+    def test_fallback_xpath_selector(self):
+        sel = Selector(text=u"""
+        <html>
+            <body>
+                <span class="selector1">bruce</span>
+                <span class="selector2">batman</span>
+                <span class="selector3">wayne</span>
+            </body>
+        </html>
+        """)
+        l = TestItemLoader(selector=sel)
+        
+        l.add_xpath('name', [
+            u'//span[contains(@class, "selector1")]/text()',
+            u'//span[contains(@class, "selector2")]/text()',
+            u'//span[contains(@class, "selector3")]/text()',
+        ])
+        self.assertEqual(
+            l.get_output_value('name'),
+            [u'Bruce', u'Batman', u'Wayne']
+        )
+
 
 class SubselectorLoaderTest(unittest.TestCase):
     response = HtmlResponse(url="", encoding='utf-8', body=b"""


### PR DESCRIPTION
Fixes #3771 

So, scrapy already handled `loader.add_css('my_field', ['selector1', 'selector2'])`.
Though, I added this behavior to the docs.

I added a new _kwarg_ called `stop_on_first_match` to both `add_css` and `add_xpath`.
This way we can control if the field is a composite of various selectors or if it is a set of fallbacks.

I'm not sure about the name `stop_on_first_match`.
`processor.Compose` has a `stop_on_none` argument (https://docs.scrapy.org/en/latest/topics/loaders.html#scrapy.loader.processors.Compose).
Maybe we can use another that is similar, or even `stop_on_none` it is checking explicitly for `None` right now.