### PR TITLE
[MRG+1] Account for mangling when serializing requests with private callbacks

### DIFF
--- a/scrapy/utils/reqser.py
+++ b/scrapy/utils/reqser.py
@@ -2,14 +2,10 @@
 Helper functions for serializing (and deserializing) requests.
 """
 import six
-import re
 
 from scrapy.http import Request
 from scrapy.utils.python import to_unicode, to_native_str
 from scrapy.utils.misc import load_object
-
-
-private_name_regex = re.compile('^__.*[^_]_?$')
 
 
 def request_to_dict(request, spider=None):
@@ -71,6 +67,10 @@ def request_from_dict(d, spider=None):
         flags=d.get('flags'))
 
 
+def _is_private_method(name):
+    return name.startswith('__') and not name.endswith('__')
+
+
 def _find_method(obj, func):
     if obj:
         try:
@@ -80,7 +80,7 @@ def _find_method(obj, func):
         else:
             if func_self is obj:
                 name = six.get_method_function(func).__name__
-                if private_name_regex.search(name):
+                if _is_private_method(name):
                     classname = obj.__class__.__name__.lstrip('_')
                     name = '_%s%s' % (classname, name)
                 return name

--- a/scrapy/utils/reqser.py
+++ b/scrapy/utils/reqser.py
@@ -2,10 +2,14 @@
 Helper functions for serializing (and deserializing) requests.
 """
 import six
+import re
 
 from scrapy.http import Request
 from scrapy.utils.python import to_unicode, to_native_str
 from scrapy.utils.misc import load_object
+
+
+private_name_regex = re.compile('^__[^_](.*[^_])?_?$')
 
 
 def request_to_dict(request, spider=None):
@@ -76,7 +80,7 @@ def _find_method(obj, func):
         else:
             if func_self is obj:
                 name = six.get_method_function(func).__name__
-                if name.startswith('__'):
+                if private_name_regex.search(name):
                     classname = obj.__class__.__name__.lstrip('_')
                     name = '_%s%s' % (classname, name)
                 return name

--- a/scrapy/utils/reqser.py
+++ b/scrapy/utils/reqser.py
@@ -9,7 +9,7 @@ from scrapy.utils.python import to_unicode, to_native_str
 from scrapy.utils.misc import load_object
 
 
-private_name_regex = re.compile('^__[^_](.*[^_])?_?$')
+private_name_regex = re.compile('^__.*[^_]_?$')
 
 
 def request_to_dict(request, spider=None):

--- a/scrapy/utils/reqser.py
+++ b/scrapy/utils/reqser.py
@@ -71,6 +71,16 @@ def _is_private_method(name):
     return name.startswith('__') and not name.endswith('__')
 
 
+def _mangle_private_name(obj, func, name):
+    qualname = getattr(func, '__qualname__', None)
+    if qualname is None:
+        classname = obj.__class__.__name__.lstrip('_')
+        return '_%s%s' % (classname, name)
+    else:
+        splits = qualname.split('.')
+        return '_%s%s' % (splits[-2], splits[-1])
+
+
 def _find_method(obj, func):
     if obj:
         try:
@@ -81,13 +91,7 @@ def _find_method(obj, func):
             if func_self is obj:
                 name = six.get_method_function(func).__name__
                 if _is_private_method(name):
-                    qualname = getattr(func, '__qualname__', None)
-                    if qualname is None:
-                        classname = obj.__class__.__name__.lstrip('_')
-                        name = '_%s%s' % (classname, name)
-                    else:
-                        splits = qualname.split('.')
-                        name = '_%s%s' % (splits[-2], splits[-1])
+                    return _mangle_private_name(obj, func, name)
                 return name
     raise ValueError("Function %s is not a method of: %s" % (func, obj))
 

--- a/scrapy/utils/reqser.py
+++ b/scrapy/utils/reqser.py
@@ -75,7 +75,11 @@ def _find_method(obj, func):
             pass
         else:
             if func_self is obj:
-                return six.get_method_function(func).__name__
+                name = six.get_method_function(func).__name__
+                if name.startswith('__'):
+                    classname = obj.__class__.__name__.lstrip('_')
+                    name = '_%s%s' % (classname, name)
+                return name
     raise ValueError("Function %s is not a method of: %s" % (func, obj))
 
 

--- a/scrapy/utils/reqser.py
+++ b/scrapy/utils/reqser.py
@@ -81,8 +81,13 @@ def _find_method(obj, func):
             if func_self is obj:
                 name = six.get_method_function(func).__name__
                 if _is_private_method(name):
-                    classname = obj.__class__.__name__.lstrip('_')
-                    name = '_%s%s' % (classname, name)
+                    qualname = getattr(func, '__qualname__', None)
+                    if qualname is None:
+                        classname = obj.__class__.__name__.lstrip('_')
+                        name = '_%s%s' % (classname, name)
+                    else:
+                        splits = qualname.split('.')
+                        name = '_%s%s' % (splits[-2], splits[-1])
                 return name
     raise ValueError("Function %s is not a method of: %s" % (func, obj))
 

--- a/tests/test_utils_reqser.py
+++ b/tests/test_utils_reqser.py
@@ -68,6 +68,12 @@ class RequestSerializationTest(unittest.TestCase):
                     errback=self.spider.handle_error)
         self._assert_serializes_ok(r, spider=self.spider)
 
+    def test_private_callback_serialization(self):
+        r = Request("http://www.example.com",
+                    callback=self.spider._TestSpider__parse_item_private,
+                    errback=self.spider.handle_error)
+        self._assert_serializes_ok(r, spider=self.spider)
+
     def test_unserializable_callback1(self):
         r = Request("http://www.example.com", callback=lambda x: x)
         self.assertRaises(ValueError, request_to_dict, r)
@@ -85,6 +91,9 @@ class TestSpider(Spider):
         pass
 
     def handle_error(self, failure):
+        pass
+
+    def __parse_item_private(self, response):
         pass
 
 

--- a/tests/test_utils_reqser.py
+++ b/tests/test_utils_reqser.py
@@ -3,7 +3,7 @@ import unittest
 
 from scrapy.http import Request, FormRequest
 from scrapy.spiders import Spider
-from scrapy.utils.reqser import request_to_dict, request_from_dict, private_name_regex
+from scrapy.utils.reqser import request_to_dict, request_from_dict, _is_private_method
 
 
 class RequestSerializationTest(unittest.TestCase):
@@ -75,26 +75,26 @@ class RequestSerializationTest(unittest.TestCase):
         self._assert_serializes_ok(r, spider=self.spider)
 
     def test_private_callback_name_matching(self):
-        self.assertTrue(private_name_regex.search('__a'))
-        self.assertTrue(private_name_regex.search('__a_'))
-        self.assertTrue(private_name_regex.search('__a_a'))
-        self.assertTrue(private_name_regex.search('__a_a_'))
-        self.assertTrue(private_name_regex.search('__a__a'))
-        self.assertTrue(private_name_regex.search('__a__a_'))
-        self.assertTrue(private_name_regex.search('__a___a'))
-        self.assertTrue(private_name_regex.search('__a___a_'))
-        self.assertTrue(private_name_regex.search('___a'))
-        self.assertTrue(private_name_regex.search('___a_'))
-        self.assertTrue(private_name_regex.search('___a_a'))
-        self.assertTrue(private_name_regex.search('___a_a_'))
-        self.assertTrue(private_name_regex.search('____a_a_'))
+        self.assertTrue(_is_private_method('__a'))
+        self.assertTrue(_is_private_method('__a_'))
+        self.assertTrue(_is_private_method('__a_a'))
+        self.assertTrue(_is_private_method('__a_a_'))
+        self.assertTrue(_is_private_method('__a__a'))
+        self.assertTrue(_is_private_method('__a__a_'))
+        self.assertTrue(_is_private_method('__a___a'))
+        self.assertTrue(_is_private_method('__a___a_'))
+        self.assertTrue(_is_private_method('___a'))
+        self.assertTrue(_is_private_method('___a_'))
+        self.assertTrue(_is_private_method('___a_a'))
+        self.assertTrue(_is_private_method('___a_a_'))
+        self.assertTrue(_is_private_method('____a_a_'))
 
-        self.assertFalse(private_name_regex.search('_a'))
-        self.assertFalse(private_name_regex.search('_a_'))
-        self.assertFalse(private_name_regex.search('__a__'))
-        self.assertFalse(private_name_regex.search('__'))
-        self.assertFalse(private_name_regex.search('___'))
-        self.assertFalse(private_name_regex.search('____'))
+        self.assertFalse(_is_private_method('_a'))
+        self.assertFalse(_is_private_method('_a_'))
+        self.assertFalse(_is_private_method('__a__'))
+        self.assertFalse(_is_private_method('__'))
+        self.assertFalse(_is_private_method('___'))
+        self.assertFalse(_is_private_method('____'))
 
     def test_unserializable_callback1(self):
         r = Request("http://www.example.com", callback=lambda x: x)

--- a/tests/test_utils_reqser.py
+++ b/tests/test_utils_reqser.py
@@ -3,7 +3,7 @@ import unittest
 
 from scrapy.http import Request, FormRequest
 from scrapy.spiders import Spider
-from scrapy.utils.reqser import request_to_dict, request_from_dict
+from scrapy.utils.reqser import request_to_dict, request_from_dict, private_name_regex
 
 
 class RequestSerializationTest(unittest.TestCase):
@@ -73,6 +73,28 @@ class RequestSerializationTest(unittest.TestCase):
                     callback=self.spider._TestSpider__parse_item_private,
                     errback=self.spider.handle_error)
         self._assert_serializes_ok(r, spider=self.spider)
+
+    def test_private_callback_name_matching(self):
+        self.assertTrue(private_name_regex.search('__a'))
+        self.assertTrue(private_name_regex.search('__a_'))
+        self.assertTrue(private_name_regex.search('__a_a'))
+        self.assertTrue(private_name_regex.search('__a_a_'))
+        self.assertTrue(private_name_regex.search('__a__a'))
+        self.assertTrue(private_name_regex.search('__a__a_'))
+        self.assertTrue(private_name_regex.search('__a___a'))
+        self.assertTrue(private_name_regex.search('__a___a_'))
+        self.assertTrue(private_name_regex.search('___a'))
+        self.assertTrue(private_name_regex.search('___a_'))
+        self.assertTrue(private_name_regex.search('___a_a'))
+        self.assertTrue(private_name_regex.search('___a_a_'))
+        self.assertTrue(private_name_regex.search('____a_a_'))
+
+        self.assertFalse(private_name_regex.search('_a'))
+        self.assertFalse(private_name_regex.search('_a_'))
+        self.assertFalse(private_name_regex.search('__a__'))
+        self.assertFalse(private_name_regex.search('__'))
+        self.assertFalse(private_name_regex.search('___'))
+        self.assertFalse(private_name_regex.search('____'))
 
     def test_unserializable_callback1(self):
         r = Request("http://www.example.com", callback=lambda x: x)

--- a/tests/test_utils_reqser.py
+++ b/tests/test_utils_reqser.py
@@ -108,8 +108,9 @@ class RequestSerializationTest(unittest.TestCase):
         self.assertFalse(_is_private_method('____'))
 
     def _assert_mangles_to(self, obj, name):
+        func = getattr(obj, name)
         self.assertEqual(
-            _mangle_private_name(obj, getattr(obj, name), name),
+            _mangle_private_name(obj, func, func.__name__),
             name
         )
 

--- a/tests/test_utils_reqser.py
+++ b/tests/test_utils_reqser.py
@@ -116,8 +116,9 @@ class RequestSerializationTest(unittest.TestCase):
     def test_private_name_mangling(self):
         self._assert_mangles_to(
             self.spider, '_TestSpider__parse_item_private')
-        self._assert_mangles_to(
-            self.spider, '_TestSpiderMixin__mixin_callback')
+        if sys.version_info[0] >= 3:
+            self._assert_mangles_to(
+                self.spider, '_TestSpiderMixin__mixin_callback')
 
     def test_unserializable_callback1(self):
         r = Request("http://www.example.com", callback=lambda x: x)

--- a/tests/test_utils_reqser.py
+++ b/tests/test_utils_reqser.py
@@ -2,9 +2,11 @@
 import unittest
 import sys
 
+import six
+
 from scrapy.http import Request, FormRequest
 from scrapy.spiders import Spider
-from scrapy.utils.reqser import request_to_dict, request_from_dict, _is_private_method
+from scrapy.utils.reqser import request_to_dict, request_from_dict, _is_private_method, _mangle_private_name
 
 
 class RequestSerializationTest(unittest.TestCase):
@@ -104,6 +106,18 @@ class RequestSerializationTest(unittest.TestCase):
         self.assertFalse(_is_private_method('__'))
         self.assertFalse(_is_private_method('___'))
         self.assertFalse(_is_private_method('____'))
+
+    def _assert_mangles_to(self, obj, name):
+        self.assertEqual(
+            _mangle_private_name(obj, getattr(obj, name), name),
+            name
+        )
+
+    def test_private_name_mangling(self):
+        self._assert_mangles_to(
+            self.spider, '_TestSpider__parse_item_private')
+        self._assert_mangles_to(
+            self.spider, '_TestSpiderMixin__mixin_callback')
 
     def test_unserializable_callback1(self):
         r = Request("http://www.example.com", callback=lambda x: x)

--- a/tests/test_utils_reqser.py
+++ b/tests/test_utils_reqser.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import unittest
+import sys
 
 from scrapy.http import Request, FormRequest
 from scrapy.spiders import Spider
@@ -74,6 +75,14 @@ class RequestSerializationTest(unittest.TestCase):
                     errback=self.spider.handle_error)
         self._assert_serializes_ok(r, spider=self.spider)
 
+    def test_mixin_private_callback_serialization(self):
+        if sys.version_info[0] < 3:
+            return
+        r = Request("http://www.example.com",
+                    callback=self.spider._TestSpiderMixin__mixin_callback,
+                    errback=self.spider.handle_error)
+        self._assert_serializes_ok(r, spider=self.spider)
+
     def test_private_callback_name_matching(self):
         self.assertTrue(_is_private_method('__a'))
         self.assertTrue(_is_private_method('__a_'))
@@ -106,7 +115,12 @@ class RequestSerializationTest(unittest.TestCase):
         self.assertRaises(ValueError, request_to_dict, r)
 
 
-class TestSpider(Spider):
+class TestSpiderMixin(object):
+    def __mixin_callback(self, response):
+        pass
+
+
+class TestSpider(Spider, TestSpiderMixin):
     name = 'test'
 
     def parse_item(self, response):


### PR DESCRIPTION
Sorry for making a PR without an issue~ just hit an issue where mixins with similarly named methods used private names to prevent method conflicts.  The spider worked properly in memory but had errors when requests were serialized to a disk queue.

The Python documentation specifically documents the mangling convention so I think it's reasonable to assume it works in other implementations, but I haven't tested except with CPython.