### PR TITLE
[MRG+1] Add 429 to RETRY_HTTP_CODES

### DIFF
--- a/scrapy/settings/default_settings.py
+++ b/scrapy/settings/default_settings.py
@@ -238,7 +238,7 @@ REFERRER_POLICY = 'scrapy.spidermiddlewares.referer.DefaultReferrerPolicy'
 
 RETRY_ENABLED = True
 RETRY_TIMES = 2  # initial response + 2 retries = 3 requests
-RETRY_HTTP_CODES = [500, 502, 503, 504, 522, 524, 408]
+RETRY_HTTP_CODES = [500, 502, 503, 504, 522, 524, 408, 429]
 RETRY_PRIORITY_ADJUST = -1
 
 ROBOTSTXT_OBEY = False


### PR DESCRIPTION
I believe 429 should be added to RETRY_HTTP_CODES. It literally means to be retried after a certain while.