### PR TITLE
Skip scrapy.contracts private APIs in the documentation coverage report

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -224,4 +224,17 @@ linkcheck_ignore = [
 # Options for the Coverage extension
 # ----------------------------------
 coverage_ignore_pyobjects = [
+    # Contract’s add_pre_hook and add_post_hook are not documented because
+    # they should be transparent to contract developers, for whom pre_hook and
+    # post_hook should be the actual concern.
+    r'\bContract\.add_(pre|post)_hook$',
+
+    # ContractsManager is an internal class, developers are not expected to
+    # interact with it directly in any way.
+    r'\bContractsManager\b$',
+
+    # For default contracts we only want to document their general purpose in
+    # their constructor, the methods they reimplement to achieve that purpose
+    # should be irrelevant to developers using those contracts.
+    r'\w+Contract\.(adjust_request_args|(pre|post)_process)$',
 ]


### PR DESCRIPTION
I made the following assumptions:
- `Contract`’s `add_pre_hook` and `add_post_hook` are not documented because they should be transparent to contract developers, for whom `pre_hook` and `post_hook` should be the actual concern.
- `ContractsManager` is an internal class, developers are not expected to interact with it directly in any way.
- For default contracts we only want to document their general purpose in their constructor, the methods they reimplement to achieve that purpose should be irrelevant to developers using those contracts.