### PR TITLE
Fix a memory leak on the Media Pipeline (Files and Images)

### DIFF
--- a/scrapy/pipelines/media.py
+++ b/scrapy/pipelines/media.py
@@ -156,7 +156,10 @@ class MediaPipeline(object):
             # objects on the Media Pipeline cache, we should wipe the context of
             # the exception encapsulated by the Twisted Failure when its a
             # _DefGen_Return instance.
-            if isinstance(result.value.__context__, _DefGen_Return):
+            #
+            # This problem does not occur in Python 2.7 since we don't have
+            # Exception Chaining (https://www.python.org/dev/peps/pep-3134/).
+            if isinstance(getattr(result.value, '__context__'), _DefGen_Return):
                 result.value.__context__ = None
 
         info.downloading.remove(fp)

--- a/scrapy/pipelines/media.py
+++ b/scrapy/pipelines/media.py
@@ -3,7 +3,7 @@ from __future__ import print_function
 import functools
 import logging
 from collections import defaultdict
-from twisted.internet.defer import Deferred, DeferredList
+from twisted.internet.defer import Deferred, DeferredList, _DefGen_Return
 from twisted.python.failure import Failure
 
 from scrapy.settings import Settings
@@ -139,6 +139,11 @@ class MediaPipeline(object):
             result.cleanFailure()
             result.frames = []
             result.stack = None
+
+            # See twisted.internet.defer.returnValue docstring
+            if isinstance(result.value.__context__, _DefGen_Return):
+                result.value.__context__ = None
+
         info.downloading.remove(fp)
         info.downloaded[fp] = result  # cache result
         for wad in info.waiting.pop(fp):

--- a/scrapy/pipelines/media.py
+++ b/scrapy/pipelines/media.py
@@ -159,8 +159,9 @@ class MediaPipeline(object):
             #
             # This problem does not occur in Python 2.7 since we don't have
             # Exception Chaining (https://www.python.org/dev/peps/pep-3134/).
-            if isinstance(getattr(result.value, '__context__'), _DefGen_Return):
-                result.value.__context__ = None
+            context = getattr(result.value, '__context__', None)
+            if isinstance(context, _DefGen_Return):
+                setattr(result.value, '__context__', None)
 
         info.downloading.remove(fp)
         info.downloaded[fp] = result  # cache result

--- a/tests/test_pipeline_media.py
+++ b/tests/test_pipeline_media.py
@@ -129,7 +129,7 @@ class BaseMediaPipelineTestCase(unittest.TestCase):
             try:
                 # Simulate the media_downloaded callback raising a FileException
                 # This usually happens when the status code is not 200 OK
-                raise FileException('download-error') from def_gen_return_exc
+                raise FileException('download-error')
             except Exception as exc:
                 file_exc = exc
                 # Simulate Twisted capturing the FileException

--- a/tests/test_pipeline_media.py
+++ b/tests/test_pipeline_media.py
@@ -162,7 +162,8 @@ class BaseMediaPipelineTestCase(unittest.TestCase):
         # ... encapsulating the original FileException ...
         self.assertEqual(info.downloaded[fp].value, file_exc)
         # ... but it should not store the returnValue exception on its context
-        self.assertIsNone(getattr(info.downloaded[fp].value, '__context__'))
+        context = getattr(info.downloaded[fp].value, '__context__', None)
+        self.assertIsNone(context)
 
 
 class MockedMediaPipeline(MediaPipeline):


### PR DESCRIPTION
We're storing exceptions captured by Twisted on the media pipeline
cache, but we're also using the defer.returnValue method with our
own methods decorated with @defer.inlineCallbacks.

The defer.returnValue method passes returned values forward by
throwing a defer._DefGen_Return exception, which in its turn
extends the BaseException class and is captured by Twisted.

This way, the latest exception stored in the Failure's object may
also have an HtmlResponse object in its `__context__` attribute. As
the Response object also keeps track of the Request object that
has originated it, you could figure it out how many RAM we're
wasting here.

This could easily lead to a Memory Leak problem when running
spiders with Media Pipeline enabled and a particular Request set
that tends to raise a significant number of exceptions.

Example triggers:
- media requests with 404 status responses
- userland exceptions coming from custom middlewares
- etc.