### PR TITLE
Fixing FilePipeline file extensions

### DIFF
--- a/tests/test_pipeline_files.py
+++ b/tests/test_pipeline_files.py
@@ -48,9 +48,19 @@ class FilesPipelineTestCase(unittest.TestCase):
         self.assertEqual(file_path(Request("https://dev.mydeco.com/two/dirs/with%20spaces%2Bsigns.doc")),
                          'full/94ccc495a17b9ac5d40e3eabf3afcb8c2c9b9e1a.doc')
         self.assertEqual(file_path(Request("http://www.dfsonline.co.uk/get_prod_image.php?img=status_0907_mdm.jpg")),
+                         'full/4507be485f38b0da8a0be9eb2e1dfab8a19223f2.php')
+        self.assertEqual(file_path(Request("http://www.dfsonline.co.uk/get_prod_image.php?img=status_0907_mdm.jpg", ),
+                                   response=Response("http://www.dfsonline.co.uk/get_prod_image.php?img=status_0907_mdm.jpg",
+                                                     headers={'Content-Disposition': 'attachment; filename="status_0907_mdm.jpg"'})),
                          'full/4507be485f38b0da8a0be9eb2e1dfab8a19223f2.jpg')
+        self.assertEqual(file_path(Request("http://www.dfsonline.co.uk/get_prod_image.php?img=status_0907_mdm.jpg", ),
+                                   response=Response("http://www.dfsonline.co.uk/get_prod_image.php?img=status_0907_mdm.jpg",
+                                                     headers={'Content-Type': 'application/octet-stream .gz'})),
+                          'full/4507be485f38b0da8a0be9eb2e1dfab8a19223f2.gz')
+        self.assertEqual(file_path(Request("http://www.dfsonline.co.uk/profile")),
+                          'full/3732b7922e62dcf74b0956f6c4021e20cd83ea06')
         self.assertEqual(file_path(Request("http://www.dfsonline.co.uk/get_prod_image.php?img=status_0907_mdm.jpg&length=10")),
-                          'full/35981d262ddc8b7a927cbd6d1cb97fa7457c5f3d.jpg')
+                          'full/35981d262ddc8b7a927cbd6d1cb97fa7457c5f3d.php')
         self.assertEqual(file_path(Request("http://www.dorma.co.uk/images/product_details/2532/")),
                          'full/97ee6f8a46cbbb418ea91502fd24176865cf39b2')
         self.assertEqual(file_path(Request("http://www.dorma.co.uk/images/product_details/2532")),

--- a/tests/test_pipeline_files.py
+++ b/tests/test_pipeline_files.py
@@ -49,6 +49,8 @@ class FilesPipelineTestCase(unittest.TestCase):
                          'full/94ccc495a17b9ac5d40e3eabf3afcb8c2c9b9e1a.doc')
         self.assertEqual(file_path(Request("http://www.dfsonline.co.uk/get_prod_image.php?img=status_0907_mdm.jpg")),
                          'full/4507be485f38b0da8a0be9eb2e1dfab8a19223f2.jpg')
+        self.assertEqual(file_path(Request("http://www.dfsonline.co.uk/get_prod_image.php?img=status_0907_mdm.jpg&length=10")),
+                          'full/35981d262ddc8b7a927cbd6d1cb97fa7457c5f3d.jpg')
         self.assertEqual(file_path(Request("http://www.dorma.co.uk/images/product_details/2532/")),
                          'full/97ee6f8a46cbbb418ea91502fd24176865cf39b2')
         self.assertEqual(file_path(Request("http://www.dorma.co.uk/images/product_details/2532")),


### PR DESCRIPTION
This is a proposed fix for #2997 and #1199, since #2809 has not been merged or updated in a some time now.

I've also seen @idgarcia's [approach](https://github.com/ldgarcia/scrapy/commit/a01f24900b3a454f4b09f594a6d529da14394367), but in using mimetype, but in my tests that produced some uncommon extensions, such as `.jpe` for `image/jpeg` content type. 

I do can implement a control flag if you deem necessary.