### PR TITLE
Fixes Python 3.4 support incompatibility with twisted

### DIFF
--- a/scrapy/__init__.py
+++ b/scrapy/__init__.py
@@ -29,6 +29,8 @@ del _monkeypatches
 
 from twisted import version as _txv
 twisted_version = (_txv.major, _txv.minor, _txv.micro)
+import platform
+python_version = tuple(map(int, platform.python_version_tuple()))
 
 # Declare top-level shortcuts
 from scrapy.spiders import Spider

--- a/scrapy/core/downloader/contextfactory.py
+++ b/scrapy/core/downloader/contextfactory.py
@@ -1,9 +1,10 @@
 from OpenSSL import SSL
 from twisted.internet.ssl import ClientContextFactory
 
-from scrapy import twisted_version
+from scrapy import twisted_version, python_version
 
-if twisted_version >= (14, 0, 0):
+if twisted_version >= (14, 0, 0) and (python_version < (3, 0, 0) or
+                                      python_version >= (3, 5, 0)):
 
     from zope.interface.declarations import implementer
 


### PR DESCRIPTION
Twisted doesn't support Python 3.4 at the moment and the test suite fails because of the latest patch to twisted. This pull request fixes #3821 