### PR TITLE
Require Twisted<=19.2.0 for Python 3.4

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -65,7 +65,8 @@ setup(
     ],
     python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*',
     install_requires=[
-        'Twisted>=13.1.0',
+        'Twisted>=13.1.0;python_version!="3.4"',
+        'Twisted>=13.1.0,<=19.2.0;python_version=="3.4"',
         'w3lib>=1.17.0',
         'queuelib',
         'lxml',


### PR DESCRIPTION
[Twisted 19.2.0 is the final release with Python 3.4 support](https://github.com/twisted/twisted/blob/twisted-19.2.0/NEWS.rst).

These changes are based on the [setuptools documentation](https://setuptools.readthedocs.io/en/latest/setuptools.html#declaring-dependencies) and [PEP 508](https://www.python.org/dev/peps/pep-0508/#environment-markers).

Fixes #3821