### PR TITLE
Per request delay implementation using request per_request_delay meta key #802

### DIFF
--- a/scrapy/core/downloader/__init__.py
+++ b/scrapy/core/downloader/__init__.py
@@ -34,6 +34,9 @@ class Slot(object):
         return self.concurrency - len(self.transferring)
 
     def download_delay(self):
+        if self.queue:
+            if "per_request_delay" in self.queue[0][0].meta.keys():
+                return self.queue[0][0].meta["per_request_delay"]
         if self.randomize_delay:
             return random.uniform(0.5 * self.delay, 1.5 * self.delay)
         return self.delay


### PR DESCRIPTION
Changes in this PR provide possibility to set per request delays (as it explained in this https://github.com/scrapy/scrapy/issues/802#issuecomment-500245345)

     ....
        next =  response.css("li.next a ::attr(href)").extract_first()
        if next:
            yield scrapy.Request(url=response.urljoin(next),
                                 callback=self.parse, meta={"per_request_delay": 3})