### PR TITLE
[MRG+1] Itemloader errors #3836

### DIFF
--- a/scrapy/loader/__init__.py
+++ b/scrapy/loader/__init__.py
@@ -106,17 +106,17 @@ class ItemLoader(object):
             value = arg_to_iter(value)
             value = flatten(extract_regex(regex, x) for x in value)
 
-        for _proc in processors:
+        for proc in processors:
             if value is None:
                 break
-            proc = wrap_loader_context(_proc, self.context)
+            _proc = proc
+            proc = wrap_loader_context(proc, self.context)
             try:
                 value = proc(value)
             except Exception as e:
-                raise ValueError(
-                    "Error with processor %s value=%r error='%s: %s'" %
-                    (_proc.__class__.__name__, value, type(e).__name__,
-                     str(e)))
+                raise ValueError("Error with processor %s value=%r error='%s: %s'" %
+                                 (_proc.__class__.__name__, value,
+                                  type(e).__name__, str(e)))
         return value
 
     def load_item(self):
@@ -155,8 +155,9 @@ class ItemLoader(object):
         return proc
 
     def _process_input_value(self, field_name, value):
-        _proc = self.get_input_processor(field_name)
-        proc = wrap_loader_context(_proc, self.context)
+        proc = self.get_input_processor(field_name)
+        _proc = proc
+        proc = wrap_loader_context(proc, self.context)
         try:
             return proc(value)
         except Exception as e:

--- a/scrapy/loader/__init__.py
+++ b/scrapy/loader/__init__.py
@@ -128,14 +128,6 @@ class ItemLoader(object):
 
         return item
 
-    def get_output_value(self, field_name):
-        proc = self.get_output_processor(field_name)
-        proc = wrap_loader_context(proc, self.context)
-        try:
-            return proc(self._values[field_name])
-        except Exception as e:
-            raise ValueError("Error with output processor: field=%r value=%r error='%s: %s'" % \
-                (field_name, self._values[field_name], type(e).__name__, str(e)))
 
     def get_collected_values(self, field_name):
         return self._values[field_name]
@@ -145,6 +137,14 @@ class ItemLoader(object):
         if not proc:
             proc = self._get_item_field_attr(field_name, 'input_processor', \
                 self.default_input_processor)
+    def get_output_value(self, field_name):
+        proc = self.get_output_processor(field_name)
+        proc = wrap_loader_context(proc, self.context)
+        try:
+            return proc(self._values[field_name])
+        except Exception as e:
+            raise ValueError("Error with output processor: field=%r value=%r error='%s: %s'" % \
+                (field_name, self._values[field_name], type(e).__name__, str(e)))
         return proc
 
     def get_output_processor(self, field_name):

--- a/scrapy/loader/__init__.py
+++ b/scrapy/loader/__init__.py
@@ -162,7 +162,7 @@ class ItemLoader(object):
             return proc(value)
         except Exception as e:
             raise ValueError(
-                "Error with inputput processor %s: field=%r value=%r "
+                "Error with input processor %s: field=%r value=%r "
                 "error='%s: %s'" % (_proc.__class__.__name__, field_name,
                                     value, type(e).__name__, str(e)))
 

--- a/scrapy/loader/__init__.py
+++ b/scrapy/loader/__init__.py
@@ -155,9 +155,15 @@ class ItemLoader(object):
         return proc
 
     def _process_input_value(self, field_name, value):
-        proc = self.get_input_processor(field_name)
-        proc = wrap_loader_context(proc, self.context)
-        return proc(value)
+        _proc = self.get_input_processor(field_name)
+        proc = wrap_loader_context(_proc, self.context)
+        try:
+            return proc(value)
+        except Exception as e:
+            raise ValueError(
+                "Error with inputput processor %s: field=%r value=%r "
+                "error='%s: %s'" % (_proc.__class__.__name__, field_name,
+                                    value, type(e).__name__, str(e)))
 
     def _get_item_field_attr(self, field_name, key, default=None):
         if isinstance(self.item, Item):

--- a/scrapy/loader/__init__.py
+++ b/scrapy/loader/__init__.py
@@ -136,7 +136,6 @@ class ItemLoader(object):
         except Exception as e:
             raise ValueError("Error with output processor: field=%r value=%r error='%s: %s'" % \
                 (field_name, self._values[field_name], type(e).__name__, str(e)))
-        return proc
 
     def get_collected_values(self, field_name):
         return self._values[field_name]

--- a/scrapy/loader/__init__.py
+++ b/scrapy/loader/__init__.py
@@ -106,11 +106,17 @@ class ItemLoader(object):
             value = arg_to_iter(value)
             value = flatten(extract_regex(regex, x) for x in value)
 
-        for proc in processors:
+        for _proc in processors:
             if value is None:
                 break
-            proc = wrap_loader_context(proc, self.context)
-            value = proc(value)
+            proc = wrap_loader_context(_proc, self.context)
+            try:
+                value = proc(value)
+            except Exception as e:
+                raise ValueError(
+                    "Error with processor %s value=%r error='%s: %s'" %
+                    (_proc.__class__.__name__, value, type(e).__name__,
+                     str(e)))
         return value
 
     def load_item(self):

--- a/scrapy/loader/__init__.py
+++ b/scrapy/loader/__init__.py
@@ -128,6 +128,15 @@ class ItemLoader(object):
 
         return item
 
+    def get_output_value(self, field_name):
+        proc = self.get_output_processor(field_name)
+        proc = wrap_loader_context(proc, self.context)
+        try:
+            return proc(self._values[field_name])
+        except Exception as e:
+            raise ValueError("Error with output processor: field=%r value=%r error='%s: %s'" % \
+                (field_name, self._values[field_name], type(e).__name__, str(e)))
+        return proc
 
     def get_collected_values(self, field_name):
         return self._values[field_name]
@@ -137,14 +146,6 @@ class ItemLoader(object):
         if not proc:
             proc = self._get_item_field_attr(field_name, 'input_processor', \
                 self.default_input_processor)
-    def get_output_value(self, field_name):
-        proc = self.get_output_processor(field_name)
-        proc = wrap_loader_context(proc, self.context)
-        try:
-            return proc(self._values[field_name])
-        except Exception as e:
-            raise ValueError("Error with output processor: field=%r value=%r error='%s: %s'" % \
-                (field_name, self._values[field_name], type(e).__name__, str(e)))
         return proc
 
     def get_output_processor(self, field_name):

--- a/scrapy/loader/processors.py
+++ b/scrapy/loader/processors.py
@@ -28,10 +28,12 @@ class MapCompose(object):
                 try:
                     next_values += arg_to_iter(func(v))
                 except Exception as e:
+                    type_name = type(func).__name__
+                    _name = (func.__name__ if type_name == 'function'
+                             else type_name)
                     raise ValueError("Error in MapCompose with "
                                      "function %s value=%r error='%s: %s'" %
-                                     (func.__name__, value,
-                                      type(e).__name__, str(e)))
+                                     (_name, value, type(e).__name__, str(e)))
             values = next_values
         return values
 
@@ -55,10 +57,12 @@ class Compose(object):
             try:
                 value = func(value)
             except Exception as e:
+                type_name = type(func).__name__
+                _name = (func.__name__ if type_name == 'function' 
+                         else type_name)
                 raise ValueError("Error in Compose with "
                                  "function %s value=%r error='%s: %s'" %
-                                 (func.__name__, value,
-                                  type(e).__name__, str(e)))
+                                 (_name, value, type(e).__name__, str(e)))
         return value
 
 

--- a/scrapy/loader/processors.py
+++ b/scrapy/loader/processors.py
@@ -32,6 +32,7 @@ class MapCompose(object):
                                      "function %s value=%r error='%s: %s'" %
                                      (func.__name__, value,
                                       type(e).__name__, str(e)))
+            values = next_values
         return values
 
 

--- a/scrapy/loader/processors.py
+++ b/scrapy/loader/processors.py
@@ -28,12 +28,10 @@ class MapCompose(object):
                 try:
                     next_values += arg_to_iter(func(v))
                 except Exception as e:
-                    type_name = type(func).__name__
-                    _name = (func.__name__ if type_name == 'function'
-                             else type_name)
                     raise ValueError("Error in MapCompose with "
-                                     "function %s value=%r error='%s: %s'" %
-                                     (_name, value, type(e).__name__, str(e)))
+                                     "%s value=%r error='%s: %s'" %
+                                     (str(func), value, type(e).__name__,
+                                      str(e)))
             values = next_values
         return values
 
@@ -57,12 +55,9 @@ class Compose(object):
             try:
                 value = func(value)
             except Exception as e:
-                type_name = type(func).__name__
-                _name = (func.__name__ if type_name == 'function' 
-                         else type_name)
                 raise ValueError("Error in Compose with "
-                                 "function %s value=%r error='%s: %s'" %
-                                 (_name, value, type(e).__name__, str(e)))
+                                 "%s value=%r error='%s: %s'" %
+                                 (str(func), value, type(e).__name__, str(e)))
         return value
 
 

--- a/scrapy/loader/processors.py
+++ b/scrapy/loader/processors.py
@@ -25,8 +25,13 @@ class MapCompose(object):
         for func in wrapped_funcs:
             next_values = []
             for v in values:
-                next_values += arg_to_iter(func(v))
-            values = next_values
+                try:
+                    next_values += arg_to_iter(func(v))
+                except Exception as e:
+                    raise ValueError("Error in MapCompose with "
+                                     "function %s value=%r error='%s: %s'" %
+                                     (func.__name__, value,
+                                      type(e).__name__, str(e)))
         return values
 
 
@@ -46,7 +51,13 @@ class Compose(object):
         for func in wrapped_funcs:
             if value is None and self.stop_on_none:
                 break
-            value = func(value)
+            try:
+                value = func(value)
+            except Exception as e:
+                raise ValueError("Error in Compose with "
+                                 "function %s value=%r error='%s: %s'" %
+                                 (func.__name__, value,
+                                  type(e).__name__, str(e)))
         return value
 
 

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -482,7 +482,7 @@ class ProcessorsTest(unittest.TestCase):
         proc = Compose(str.upper)
         self.assertEqual(proc(None), None)
         proc = Compose(str.upper, stop_on_none=False)
-        self.assertRaises(TypeError, proc, None)
+        self.assertRaises(ValueError, proc, None)
 
     def test_mapcompose(self):
         filter_world = lambda x: None if x == 'world' else x

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -483,12 +483,21 @@ class ProcessorsTest(unittest.TestCase):
         self.assertEqual(proc(None), None)
         proc = Compose(str.upper, stop_on_none=False)
         self.assertRaises(ValueError, proc, None)
+        proc = Compose(str.upper, lambda x: x + 1)
+        self.assertRaises(ValueError, proc, 'hello')
 
     def test_mapcompose(self):
         filter_world = lambda x: None if x == 'world' else x
         proc = MapCompose(filter_world, six.text_type.upper)
         self.assertEqual(proc([u'hello', u'world', u'this', u'is', u'scrapy']),
                          [u'HELLO', u'THIS', u'IS', u'SCRAPY'])
+        proc = MapCompose(filter_world, six.text_type.upper)
+        self.assertEqual(proc(None), [])
+        proc = MapCompose(filter_world, six.text_type.upper)
+        self.assertRaises(ValueError, proc, [1])
+        proc = MapCompose(filter_world, lambda x: x + 1)
+        self.assertRaises(ValueError, proc, 'hello')
+
 
 
 class SelectortemLoaderTest(unittest.TestCase):

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -456,6 +456,42 @@ class BasicItemLoaderTest(unittest.TestCase):
             'title': [u'Test item title 3', u'Test item 4'],
         })
 
+    def test_error_input_processor(self):
+        class TestItem(Item):
+            name = Field()
+
+        class TestItemLoader(ItemLoader):
+            default_item_class = TestItem
+            name_in = MapCompose(float)
+
+        il = TestItemLoader()
+        self.assertRaises(ValueError, il.add_value, 'name',
+                          [u'marta', u'other'])
+
+    def test_error_output_processor(self):
+        class TestItem(Item):
+            name = Field()
+
+        class TestItemLoader(ItemLoader):
+            default_item_class = TestItem
+            name_out = Compose(Join(), float)
+
+        il = TestItemLoader()
+        il.add_value('name', u'marta')
+        with self.assertRaises(ValueError):
+            il.load_item()
+
+    def test_error_processor_as_argument(self):
+        class TestItem(Item):
+            name = Field()
+
+        class TestItemLoader(ItemLoader):
+            default_item_class = TestItem
+
+        il = TestItemLoader()
+        self.assertRaises(ValueError, il.add_value, 'name',
+                          [u'marta', u'other'], Compose(float))
+
 
 class ProcessorsTest(unittest.TestCase):
 


### PR DESCRIPTION
Added error messages to ItemLoader (for input processor, and processor as argument) and also for MapCompose and Compose. 

For MapCompose and Compose, I'm not sure though if the format is correct, since these errors will be displayed when processing the input/out processors and they will be nested to these ones, example:
```
ValueError: Error with processor MapCompose value=['change,deep-thoughts,thinking,world'] 
error='ValueError: Error in MapCompose with function _strip 
value=['change,deep-thoughts,thinking,world'] error='TypeError: must be str, not int''
```

I would appreciate some suggestions here.

Fixes #3836