### PR TITLE
Write the 1.7 release notes

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -30,6 +30,7 @@ extensions = [
     'scrapydocs',
     'sphinx.ext.autodoc',
     'sphinx.ext.coverage',
+    'sphinx.ext.intersphinx',
 ]
 
 # Add any paths that contain templates here, relative to this directory.
@@ -73,6 +74,8 @@ language = 'en'
 
 # List of documents that shouldn't be included in the build.
 #unused_docs = []
+
+exclude_patterns = ['build']
 
 # List of directories, relative to source directory, that shouldn't be searched
 # for source files.
@@ -250,3 +253,11 @@ coverage_ignore_pyobjects = [
     # Private exception used by the command-line interface implementation.
     r'^scrapy\.exceptions\.UsageError',
 ]
+
+
+# Options for the InterSphinx extension
+# -------------------------------------
+
+intersphinx_mapping = {
+    'python': ('https://docs.python.org/3', None),
+}

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -171,6 +171,8 @@ Scrapy:
   See https://help.github.com/articles/setting-your-username-in-git/ for
   setup instructions.
 
+.. _documentation-policies:
+
 Documentation policies
 ======================
 
@@ -195,6 +197,8 @@ Tests
 
 Tests are implemented using the `Twisted unit-testing framework`_, running
 tests requires `tox`_.
+
+.. _running-tests:
 
 Running tests
 -------------

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -329,6 +329,8 @@ I'm scraping a XML document and my XPath selector doesn't return any items
 
 You may need to remove namespaces. See :ref:`removing-namespaces`.
 
+.. _faq-split-item:
+
 How to split an item into multiple items in an item pipeline?
 -------------------------------------------------------------
 

--- a/docs/topics/contracts.rst
+++ b/docs/topics/contracts.rst
@@ -126,6 +126,7 @@ response received::
                 if header not in response.headers:
                     raise ContractFail('X-CustomHeader not present')
 
+.. _detecting-contract-check-runs:
 
 Detecting check runs
 ====================

--- a/docs/topics/downloader-middleware.rst
+++ b/docs/topics/downloader-middleware.rst
@@ -52,6 +52,8 @@ as its value.  For example, if you want to disable the user-agent middleware::
 Finally, keep in mind that some middlewares may need to be enabled through a
 particular setting. See each middleware documentation for more info.
 
+.. _topics-downloader-middleware-custom:
+
 Writing your own downloader middleware
 ======================================
 

--- a/docs/topics/feed-exports.rst
+++ b/docs/topics/feed-exports.rst
@@ -164,9 +164,9 @@ The feeds are stored in a FTP server.
  * Example URI: ``ftp://user:pass@ftp.example.com/path/to/export.csv``
  * Required external libraries: none
 
-FTP supports two different connection modes: [active or passive](
-https://stackoverflow.com/a/1699163). Scrapy uses the passive connection mode
-by default. To use the active connection mode instead, set the
+FTP supports two different connection modes: `active or passive
+<https://stackoverflow.com/a/1699163>`_. Scrapy uses the passive connection
+mode by default. To use the active connection mode instead, set the
 :setting:`FEED_STORAGE_FTP_ACTIVE` setting to ``True``.
 
 .. _topics-feed-storage-s3:
@@ -320,8 +320,11 @@ FEED_STORAGE_FTP_ACTIVE
 
 Default: ``False``
 
-Whether to use [active mode](https://stackoverflow.com/a/1699163) when exporting feeds
-to a FTP server.
+Whether to use the active connection mode when exporting feeds to an FTP server
+(``True``) or use the passive connection mode instead (``False``, default).
+
+For information about FTP connection modes, see `What is the difference between
+active and passive FTP? <https://stackoverflow.com/a/1699163>`_.
 
 .. setting:: FEED_STORAGE_S3_ACL
 

--- a/docs/topics/items.rst
+++ b/docs/topics/items.rst
@@ -157,6 +157,8 @@ To access all populated values, just use the typical `dict API`_::
     [('price', 1000), ('name', 'Desktop PC')]
 
 
+.. _copying-items:
+
 Copying items
 -------------
 

--- a/docs/topics/settings.rst
+++ b/docs/topics/settings.rst
@@ -30,6 +30,8 @@ Python `import search path`_.
 
 .. _import search path: https://docs.python.org/2/tutorial/modules.html#the-module-search-path
 
+.. _populating-settings:
+
 Populating the settings
 =======================
 
@@ -537,6 +539,8 @@ amount of time between requests, but uses a random interval between 0.5 * :setti
 
 When :setting:`CONCURRENT_REQUESTS_PER_IP` is non-zero, delays are enforced
 per ip address instead of per domain.
+
+.. _spider-download_delay-attribute:
 
 You can also change this setting per spider by setting ``download_delay``
 spider attribute.


### PR DESCRIPTION
Current coverage: https://github.com/scrapy/scrapy/commit/44eb21aa51cc0212e68dc0709aaa5c10bfe64e7e

Includes a note about dropping Python 2 support in Scrapy 2.0.

Fixes #3872.