### PR TITLE
More deprecations

### DIFF
--- a/scrapy/utils/http.py
+++ b/scrapy/utils/http.py
@@ -4,8 +4,19 @@ Transitional module for moving to the w3lib library.
 For new code, always import from w3lib.http instead of this module
 """
 
+import warnings
+
+from scrapy.exceptions import ScrapyDeprecationWarning
+from scrapy.utils.decorators import deprecated
 from w3lib.http import *
 
+
+warnings.warn("Module `scrapy.utils.http` is deprecated, "
+              "Please import from `w3lib.http` instead.",
+              ScrapyDeprecationWarning, stacklevel=2)
+
+
+@deprecated
 def decode_chunked_transfer(chunked_body):
     """Parsed body received with chunked transfer encoding, and return the
     decoded body.

--- a/scrapy/utils/markup.py
+++ b/scrapy/utils/markup.py
@@ -3,5 +3,12 @@ Transitional module for moving to the w3lib library.
 
 For new code, always import from w3lib.html instead of this module
 """
+import warnings
 
+from scrapy.exceptions import ScrapyDeprecationWarning
 from w3lib.html import *
+
+
+warnings.warn("Module `scrapy.utils.markup` is deprecated. "
+              "Please import from `w3lib.html` instead.",
+              ScrapyDeprecationWarning, stacklevel=2)

--- a/scrapy/utils/multipart.py
+++ b/scrapy/utils/multipart.py
@@ -3,5 +3,13 @@ Transitional module for moving to the w3lib library.
 
 For new code, always import from w3lib.form instead of this module
 """
+import warnings
 
+from scrapy.exceptions import ScrapyDeprecationWarning
 from w3lib.form import *
+
+
+warnings.warn("Module `scrapy.utils.multipart` is deprecated. "
+              "If you're using `encode_multipart` function, please use "
+              "`urllib3.filepost.encode_multipart_formdata` instead",
+              ScrapyDeprecationWarning, stacklevel=2)


### PR DESCRIPTION
I noticed that there are 2 import-only modules in scrapy.utils, and one which is almost import-only. It looks like we should start sending deprecation warnings for them all, and this should have been done a while ago.