### PR TITLE
Deprecate scrapy.utils.datatypes.MergeDict in favor of collections.ChainMap

### DIFF
--- a/scrapy/loader/processors.py
+++ b/scrapy/loader/processors.py
@@ -3,10 +3,13 @@ This module provides some commonly used processors for Item Loaders.
 
 See documentation in docs/topics/loaders.rst
 """
+try:
+    from collections import ChainMap
+except ImportError:
+    from scrapy.utils.datatypes import MergeDict as ChainMap
 
 from scrapy.utils.misc import arg_to_iter
-from scrapy.utils.datatypes import MergeDict
-from .common import wrap_loader_context
+from scrapy.loader.common import wrap_loader_context
 
 
 class MapCompose(object):
@@ -18,7 +21,7 @@ class MapCompose(object):
     def __call__(self, value, loader_context=None):
         values = arg_to_iter(value)
         if loader_context:
-            context = MergeDict(loader_context, self.default_loader_context)
+            context = ChainMap(loader_context, self.default_loader_context)
         else:
             context = self.default_loader_context
         wrapped_funcs = [wrap_loader_context(f, context) for f in self.functions]
@@ -45,7 +48,7 @@ class Compose(object):
 
     def __call__(self, value, loader_context=None):
         if loader_context:
-            context = MergeDict(loader_context, self.default_loader_context)
+            context = ChainMap(loader_context, self.default_loader_context)
         else:
             context = self.default_loader_context
         wrapped_funcs = [wrap_loader_context(f, context) for f in self.functions]

--- a/scrapy/utils/datatypes.py
+++ b/scrapy/utils/datatypes.py
@@ -245,6 +245,13 @@ class MergeDict(object):
     first occurrence will be used.
     """
     def __init__(self, *dicts):
+        if six.PY3:
+            warnings.warn(
+                "scrapy.utils.datatypes.MergeDict is deprecated in favor "
+                "of collections.ChainMap (introduced in Python 3.3)",
+                category=ScrapyDeprecationWarning,
+                stacklevel=2,
+            )
         self.dicts = dicts
 
     def __getitem__(self, key):

--- a/scrapy/utils/datatypes.py
+++ b/scrapy/utils/datatypes.py
@@ -245,7 +245,7 @@ class MergeDict(object):
     first occurrence will be used.
     """
     def __init__(self, *dicts):
-        if six.PY3:
+        if not six.PY2:
             warnings.warn(
                 "scrapy.utils.datatypes.MergeDict is deprecated in favor "
                 "of collections.ChainMap (introduced in Python 3.3)",


### PR DESCRIPTION
Use `collections.ChainMap` when available, fall back to `scrapy.utils.datatypes.MergeDict` (currently in use only in `scrapy.loader.processors.MapCompose`)