### PR TITLE
Bash completion via setuptools

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,8 +33,11 @@ def install_bash_completion_inside_virtualenv():
     if environ.get('VIRTUAL_ENV'):
         activate_path = join(environ['VIRTUAL_ENV'], 'bin/activate')
         with open('extras/scrapy_bash_completion') as src, open(activate_path, 'a') as dest:
-            dest.write('\n\n\n')
-            dest.write(src.read())
+            dest.write("\n\n\n")
+            dest.write("shell=`echo $0 | awk -F/ '{print $NF}'`\n")
+            dest.write("if [ $shell = 'bash' ] ; then\n")
+            dest.write(''.join(['    ' + line for line in src.readlines()]))
+            dest.write("fi")
 
 
 class PostDevelopCommand(develop):

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,5 @@
-from os import environ
+import os
+import shutil
 from os.path import dirname, join
 from pkg_resources import parse_version
 from setuptools import setup, find_packages, __version__ as setuptools_version
@@ -30,14 +31,13 @@ if has_environment_marker_platform_impl_support():
 
 
 def install_bash_completion_inside_virtualenv():
-    if environ.get('VIRTUAL_ENV'):
-        activate_path = join(environ['VIRTUAL_ENV'], 'bin/activate')
-        with open('extras/scrapy_bash_completion') as src, open(activate_path, 'a') as dest:
-            dest.write("\n\n\n")
-            dest.write("shell=`echo $0 | awk -F/ '{print $NF}'`\n")
-            dest.write("if [ $shell = 'bash' ] ; then\n")
-            dest.write(''.join(['    ' + line for line in src.readlines()]))
-            dest.write("fi")
+    if os.environ.get('VIRTUAL_ENV'):
+        bin_dir = join(os.environ['VIRTUAL_ENV'], 'bin')
+        shutil.copy('extras/scrapy_bash_completion', bin_dir)
+        with open(join(bin_dir, 'activate'), 'a') as dest:
+            dest.write('\n\n')
+            dest.write('# bash completion for the Scrapy command-line tool (added by Scrapy)\n')
+            dest.write('[ -n "${BASH-}" ] && [ -f scrapy_bash_completion ] && source scrapy_bash_completion\n')
 
 
 class PostDevelopCommand(develop):


### PR DESCRIPTION
**System-wide**
I'm using the `data_files` argument to copy the file. This is probably not that useful, it applies only if Scrapy is installed system-wide, which I hope it's not done often.

**Inside a virtualenv**
I must admit this feels a bit like a hack, I don't love this text-appending approach. I wish there were some kind of post-activate hook :man_shrugging:

**About other shells**
There is also a ZSH completion script in the `extras` directory, I didn't include it here because it didn't work in my tests. Perhaps it's outdated, or perhaps I just couldn't make it work properly.

As usual, I look forward to reading your comments :rocket: 