### PR TITLE
Fix configparser import for python2

### DIFF
--- a/scrapy/utils/conf.py
+++ b/scrapy/utils/conf.py
@@ -1,7 +1,7 @@
 import os
 import sys
 import numbers
-import configparser
+from six.moves import configparser
 from operator import itemgetter
 
 import six


### PR DESCRIPTION
The latest release breaks scrapy on python2
Closes https://github.com/scrapy/scrapy/issues/3889