### PR TITLE
Fix url backslashes (invalid domains) like that in #3854 

### DIFF
--- a/scrapy/downloadermiddlewares/url.py
+++ b/scrapy/downloadermiddlewares/url.py
@@ -1,0 +1,19 @@
+""" This module implements the URLMiddleware which does any needed operations on the url 
+    like changing backslashes to forwardslashes
+"""
+
+from scrapy import signals
+
+
+class URLMiddleware(object):
+    """ This middleware does any needed operations on the url 
+    like changing backslashes to forwardslashes
+    """
+
+    def process_request(self, request, spider):
+        new_url = request.url.replace('\\','/')
+        if new_url == request.url:
+            return
+        return request.replace(url = new_url)
+        
+

--- a/scrapy/settings/default_settings.py
+++ b/scrapy/settings/default_settings.py
@@ -98,6 +98,7 @@ DOWNLOADER_MIDDLEWARES_BASE = {
     'scrapy.downloadermiddlewares.defaultheaders.DefaultHeadersMiddleware': 400,
     'scrapy.downloadermiddlewares.useragent.UserAgentMiddleware': 500,
     'scrapy.downloadermiddlewares.retry.RetryMiddleware': 550,
+    'scrapy.downloadermiddlewares.url.URLMiddleware': 555,
     'scrapy.downloadermiddlewares.ajaxcrawl.AjaxCrawlMiddleware': 560,
     'scrapy.downloadermiddlewares.redirect.MetaRefreshMiddleware': 580,
     'scrapy.downloadermiddlewares.httpcompression.HttpCompressionMiddleware': 590,


### PR DESCRIPTION
When trying to send a request, or even redirection, with url containing backslashes, it fails. You can see examples of that and how to reproduce the error in #3854. 

To fix that, I have added a downloader middleware called `URLMiddleware` that for now converts all backslashes in the url to forwardslashes, as this is the behavior of many browsers.

If confirmed, will immediately add tests and documentation