### PR TITLE
s3 file store persist_file should accept all supported headers

### DIFF
--- a/scrapy/pipelines/files.py
+++ b/scrapy/pipelines/files.py
@@ -189,6 +189,19 @@ class S3FilesStore(object):
             'X-Amz-Grant-Read': 'GrantRead',
             'X-Amz-Grant-Read-ACP': 'GrantReadACP',
             'X-Amz-Grant-Write-ACP': 'GrantWriteACP',
+            'X-Amz-Object-Lock-Legal-Hold': 'ObjectLockLegalHoldStatus',
+            'X-Amz-Object-Lock-Mode': 'ObjectLockMode',
+            'X-Amz-Object-Lock-Retain-Until-Date': 'ObjectLockRetainUntilDate',
+            'X-Amz-Request-Payer': 'RequestPayer',
+            'X-Amz-Server-Side-Encryption': 'ServerSideEncryption',
+            'X-Amz-Server-Side-Encryption-Aws-Kms-Key-Id': 'SSEKMSKeyId',
+            'X-Amz-Server-Side-Encryption-Context': 'SSEKMSEncryptionContext',
+            'X-Amz-Server-Side-Encryption-Customer-Algorithm': 'SSECustomerAlgorithm',
+            'X-Amz-Server-Side-Encryption-Customer-Key': 'SSECustomerKey',
+            'X-Amz-Server-Side-Encryption-Customer-Key-Md5': 'SSECustomerKeyMD5',
+            'X-Amz-Storage-Class': 'StorageClass',
+            'X-Amz-Tagging': 'Tagging',
+            'X-Amz-Website-Redirect-Location': 'WebsiteRedirectLocation',
         })
         extra = {}
         for key, value in six.iteritems(headers):


### PR DESCRIPTION
Fix https://github.com/scrapy/scrapy/issues/3904.

The new headers mapping are read from botocore service json file:
```python
import requests, json
r = requests.get('https://raw.githubusercontent.com/boto/botocore/master/botocore/data/s3/2006-03-01/service-2.json')
s3_service_json = r.json()
members = s3_service_json['shapes']['PutObjectRequest']['members']

def to_camel_case(s):
    return '-'.join(x.upper() if x.lower() in ('acp', 'md5') else x.capitalize() for x in s.split('-'))

print({
    to_camel_case(v['locationName'].encode()): k.encode()  
    for k, v in members.items()
    if v.get('location') == 'header' and k.lower() not in ('meta', 'acl' )
})
```

Tested manually with:

```python
import os
from twisted.internet import reactor

os.environ['AWS_ACCESS_KEY_ID'] = 'xxx'
os.environ['AWS_SECRET_ACCESS_KEY'] = 'xxx'

from scrapy.pipelines.files import S3FilesStore
from io import BytesIO

s3_file_store = S3FilesStore('s3://bucket/')
dfd = s3_file_store.persist_file('test.txt', BytesIO(b'test'), None, None, {'x-amz-storage-class': 'STANDARD_IA'})

reactor.callLater(2, reactor.stop)
reactor.run()
print(dfd.result)
```
The result is:
```python
{'ResponseMetadata': {'RequestId': '...',
  'HostId': '...',
  'HTTPStatusCode': 200,
  'HTTPHeaders': {'x-amz-id-2': '...',
   'x-amz-request-id': '...',
   'date': 'Fri, 26 Jul 2019 01:24:08 GMT',
   'etag': '"..."',
   'x-amz-storage-class': 'STANDARD_IA',
   'content-length': '0',
   'server': 'AmazonS3'},
  'RetryAttempts': 0},
 'ETag': '"..."'}
```