### PR TITLE
Refactor `open_in_browser`

### DIFF
--- a/scrapy/http/response/__init__.py
+++ b/scrapy/http/response/__init__.py
@@ -134,3 +134,8 @@ class Response(object_ref):
                        dont_filter=dont_filter,
                        errback=errback,
                        cb_kwargs=cb_kwargs)
+    
+    @property
+    def file_extension(self):
+        raise  TypeError("Unsupported response type: %s" %
+                        self.__class__.__name__)

--- a/scrapy/http/response/html.py
+++ b/scrapy/http/response/html.py
@@ -8,4 +8,6 @@ See documentation in docs/topics/request-response.rst
 from scrapy.http.response.text import TextResponse
 
 class HtmlResponse(TextResponse):
-    pass
+    @property
+    def file_extension(self):
+        return '.html'

--- a/scrapy/http/response/text.py
+++ b/scrapy/http/response/text.py
@@ -158,6 +158,9 @@ class TextResponse(Response):
             cb_kwargs=cb_kwargs,
         )
 
+    @property
+    def file_extension(self):
+        return '.txt'
 
 def _url_from_selector(sel):
     # type: (parsel.Selector) -> str

--- a/scrapy/utils/response.py
+++ b/scrapy/utils/response.py
@@ -57,19 +57,17 @@ def open_in_browser(response, _openfunc=webbrowser.open):
     """Open the given response in a local web browser, populating the <base>
     tag for external links to work
     """
-    from scrapy.http import HtmlResponse, TextResponse
-    # XXX: this implementation is a bit dirty and could be improved
-    body = response.body
-    if isinstance(response, HtmlResponse):
-        if b'<base' not in body:
-            repl = '<head><base href="%s">' % response.url
-            body = body.replace(b'<head>', to_bytes(repl))
-        ext = '.html'
-    elif isinstance(response, TextResponse):
-        ext = '.txt'
-    else:
-        raise TypeError("Unsupported response type: %s" %
-                        response.__class__.__name__)
+    def get_body(response):
+        from scrapy.http import HtmlResponse
+        body = response.body
+        if isinstance(response, HtmlResponse):
+            if b'<base' not in body:
+                repl = '<head><base href="%s">' % response.url
+                body = body.replace(b'<head>', to_bytes(repl))
+        return body
+    
+    ext = response.file_extension
+    body = get_body(response)
     fd, fname = tempfile.mkstemp(ext)
     os.write(fd, body)
     os.close(fd)


### PR DESCRIPTION
Refactor `open_in_browser` function by adding `file_extension` property to response classes, so to get the extension only use `response.file_extension`