### PR TITLE
[MRG+1] Update project.py removed one 'hack', seems irrelevant.

### DIFF
--- a/scrapy/utils/project.py
+++ b/scrapy/utils/project.py
@@ -73,7 +73,7 @@ def get_project_settings():
     if pickled_settings:
         warnings.warn("Use of environment variable "
                       "'SCRAPY_PICKLED_SETTINGS_TO_OVERRIDE' "
-                      " is deprecated.",ScrapyDeprecationWarning)
+                      "is deprecated.", ScrapyDeprecationWarning)
         settings.setdict(pickle.loads(pickled_settings), priority='project')
 
     # XXX: deprecate and remove this functionality

--- a/scrapy/utils/project.py
+++ b/scrapy/utils/project.py
@@ -66,7 +66,13 @@ def get_project_settings():
     settings_module_path = os.environ.get(ENVVAR)
     if settings_module_path:
         settings.setmodule(settings_module_path, priority='project')
-    
+
+    # XXX: remove this hack
+    pickled_settings = os.environ.get("SCRAPY_PICKLED_SETTINGS_TO_OVERRIDE")
+    if pickled_settings:
+        warnings.warn("Use of environmental variable 'SCRAPY_PICKLED_SETTINGS_TO_OVERRIDE' is deprecated",DeprecationWarning)
+        settings.setdict(pickle.loads(pickled_settings), priority='project')
+
     # XXX: deprecate and remove this functionality
     env_overrides = {k[7:]: v for k, v in os.environ.items() if
                      k.startswith('SCRAPY_')}

--- a/scrapy/utils/project.py
+++ b/scrapy/utils/project.py
@@ -66,8 +66,6 @@ def get_project_settings():
     settings_module_path = os.environ.get(ENVVAR)
     if settings_module_path:
         settings.setmodule(settings_module_path, priority='project')
-
-    # XXX: remove this hack
     
     # XXX: deprecate and remove this functionality
     env_overrides = {k[7:]: v for k, v in os.environ.items() if

--- a/scrapy/utils/project.py
+++ b/scrapy/utils/project.py
@@ -68,10 +68,7 @@ def get_project_settings():
         settings.setmodule(settings_module_path, priority='project')
 
     # XXX: remove this hack
-    pickled_settings = os.environ.get("SCRAPY_PICKLED_SETTINGS_TO_OVERRIDE")
-    if pickled_settings:
-        settings.setdict(pickle.loads(pickled_settings), priority='project')
-
+    
     # XXX: deprecate and remove this functionality
     env_overrides = {k[7:]: v for k, v in os.environ.items() if
                      k.startswith('SCRAPY_')}

--- a/scrapy/utils/project.py
+++ b/scrapy/utils/project.py
@@ -71,9 +71,9 @@ def get_project_settings():
     # XXX: remove this hack
     pickled_settings = os.environ.get("SCRAPY_PICKLED_SETTINGS_TO_OVERRIDE")
     if pickled_settings:
-        warnings.warn("Use of environment variable \
-        'SCRAPY_PICKLED_SETTINGS_TO_OVERRIDE' \
-        is deprecated",ScrapyDeprecationWarning)
+        warnings.warn("Use of environment variable "
+                      "'SCRAPY_PICKLED_SETTINGS_TO_OVERRIDE'"
+                      " is deprecated.",ScrapyDeprecationWarning)
         settings.setdict(pickle.loads(pickled_settings), priority='project')
 
     # XXX: deprecate and remove this functionality

--- a/scrapy/utils/project.py
+++ b/scrapy/utils/project.py
@@ -1,6 +1,7 @@
 import os
 from six.moves import cPickle as pickle
 import warnings
+from scrapy.exceptions import ScrapyDeprecationWarning
 
 from importlib import import_module
 from os.path import join, dirname, abspath, isabs, exists
@@ -70,7 +71,9 @@ def get_project_settings():
     # XXX: remove this hack
     pickled_settings = os.environ.get("SCRAPY_PICKLED_SETTINGS_TO_OVERRIDE")
     if pickled_settings:
-        warnings.warn("Use of environmental variable 'SCRAPY_PICKLED_SETTINGS_TO_OVERRIDE' is deprecated",DeprecationWarning)
+        warnings.warn("Use of environment variable \
+        'SCRAPY_PICKLED_SETTINGS_TO_OVERRIDE' \
+        is deprecated",ScrapyDeprecationWarning)
         settings.setdict(pickle.loads(pickled_settings), priority='project')
 
     # XXX: deprecate and remove this functionality

--- a/scrapy/utils/project.py
+++ b/scrapy/utils/project.py
@@ -72,7 +72,7 @@ def get_project_settings():
     pickled_settings = os.environ.get("SCRAPY_PICKLED_SETTINGS_TO_OVERRIDE")
     if pickled_settings:
         warnings.warn("Use of environment variable "
-                      "'SCRAPY_PICKLED_SETTINGS_TO_OVERRIDE'"
+                      "'SCRAPY_PICKLED_SETTINGS_TO_OVERRIDE' "
                       " is deprecated.",ScrapyDeprecationWarning)
         settings.setdict(pickle.loads(pickled_settings), priority='project')
 

--- a/scrapy/utils/project.py
+++ b/scrapy/utils/project.py
@@ -1,7 +1,6 @@
 import os
 from six.moves import cPickle as pickle
 import warnings
-from scrapy.exceptions import ScrapyDeprecationWarning
 
 from importlib import import_module
 from os.path import join, dirname, abspath, isabs, exists
@@ -9,6 +8,7 @@ from os.path import join, dirname, abspath, isabs, exists
 from scrapy.utils.conf import closest_scrapy_cfg, get_config, init_env
 from scrapy.settings import Settings
 from scrapy.exceptions import NotConfigured
+from scrapy.exceptions import ScrapyDeprecationWarning
 
 ENVVAR = 'SCRAPY_SETTINGS_MODULE'
 DATADIR_CFG_SECTION = 'datadir'


### PR DESCRIPTION
As mentioned by @Gallaecio in issue #3871, the 'hack'  is cleared. I also  double checked whether the environment variable "SCRAPY_PICKLED_SETTINGS_TO_OVERRIDE" was ever set in our codebase and it turns out we didn't set it or used it anywhere else.So I guess the 'hack' was not used in the current version.