### PR TITLE
ValueError workaround

### DIFF
--- a/scrapy/crawler.py
+++ b/scrapy/crawler.py
@@ -255,7 +255,10 @@ class CrawlerProcess(CrawlerRunner):
     The CrawlerProcess object must be instantiated with a
     :class:`~scrapy.settings.Settings` object.
 
-    :param install_root_handler: whether to install root logging handler
+    :param is_install_root_handler: whether to install root logging handler
+        (default: True)
+
+    :param is_install_shutdown_handlers: whether to install shutdown signal handlers
         (default: True)
 
     This class shouldn't be needed (since Scrapy is responsible of using it
@@ -263,10 +266,11 @@ class CrawlerProcess(CrawlerRunner):
     process. See :ref:`run-from-script` for an example.
     """
 
-    def __init__(self, settings=None, install_root_handler=True):
+    def __init__(self, settings=None, is_install_root_handler=True, is_install_shutdown_handlers=True):
         super(CrawlerProcess, self).__init__(settings)
-        install_shutdown_handlers(self._signal_shutdown)
-        configure_logging(self.settings, install_root_handler)
+        if is_install_shutdown_handlers:
+            install_shutdown_handlers(self._signal_shutdown)
+        configure_logging(self.settings, is_install_root_handler)
         log_scrapy_info(self.settings)
 
     def _signal_shutdown(self, signum, _):


### PR DESCRIPTION
When we're scheduling scrapy jobs from other threads we're getting twisted ValueError

	from apscheduler.schedulers.blocking import BlockingScheduler
	from scrapy.crawler import CrawlerProcess

    def crawl():
        process = CrawlerProcess(settings)
        process.start()

    scheduler = BlockingScheduler()
    scheduler.add_job(crawl, trigger='interval', hours=1, next_run_time=datetime.now())
    scheduler.start()


	ERROR:apscheduler.executors.default:Job "crawl (trigger: interval[1:00:00], next run at: 2019-07-30 13:23:38 MSK)" raised an exception
	Traceback (most recent call last):
	  File "C:\Users\vyacheslav.raskulin\AppData\Local\Programs\Python\Python37-32\lib\site-packages\apscheduler\executors\base.py", line 125, in run_job
		retval = job.func(*job.args, **job.kwargs)
	  File "C:/Users/user/PycharmProjects/python_avito_buddy/project/run.py", line 24, in crawl
		process = CrawlerProcess(settings)
	  File "C:\Users\user\AppData\Local\Programs\Python\Python37-32\lib\site-packages\scrapy\crawler.py", line 268, in __init__
		install_shutdown_handlers(self._signal_shutdown)
	  File "C:\Users\user\AppData\Local\Programs\Python\Python37-32\lib\site-packages\scrapy\utils\ossignal.py", line 22, in install_shutdown_handlers
		reactor._handleSignals()
	  File "C:\Users\user\AppData\Local\Programs\Python\Python37-32\lib\site-packages\twisted\internet\posixbase.py", line 295, in _handleSignals
		_SignalReactorMixin._handleSignals(self)
	  File "C:\Users\user\AppData\Local\Programs\Python\Python37-32\lib\site-packages\twisted\internet\base.py", line 1232, in _handleSignals
		signal.signal(signal.SIGINT, self.sigInt)
	  File "C:\Users\user\AppData\Local\Programs\Python\Python37-32\lib\signal.py", line 47, in signal
		handler = _signal.signal(_enum_to_int(signalnum), _enum_to_int(handler))
	ValueError: signal only works in main thread


In [official Twisted documentation](https://twistedmatrix.com/trac/wiki/FrequentlyAskedQuestions#Igetexceptions.ValueError:signalonlyworksinmainthreadwhenItrytorunmyTwistedprogramWhatswrong) we can find a solution for this problem

	I get exceptions.ValueError: signal only works in main thread when I try to run my Twisted program! What's wrong?

	The default reactor, by default, will install signal handlers to catch events like Ctrl-C, SIGTERM, and so on. However, you can't install signal handlers from non-main threads in Python, which means that reactor.run() will cause an error. Pass the installSignalHandlers=0 keyword argument to reactor.run to work around this.

So if we're installing signals from non-main thread we can't start an twisted reactor.
Can we please make this installation optional? 
