### PR TITLE
Add `host_ip` property to response

### DIFF
--- a/scrapy/http/response/__init__.py
+++ b/scrapy/http/response/__init__.py
@@ -4,7 +4,8 @@ responses in Scrapy.
 
 See documentation in docs/topics/request-response.rst
 """
-from six.moves.urllib.parse import urljoin
+from six.moves.urllib.parse import urljoin, urlparse
+from socket import gethostbyname
 
 from scrapy.http.request import Request
 from scrapy.http.headers import Headers
@@ -12,6 +13,7 @@ from scrapy.link import Link
 from scrapy.utils.trackref import object_ref
 from scrapy.http.common import obsolete_setter
 from scrapy.exceptions import NotSupported
+
 
 
 class Response(object_ref):
@@ -33,6 +35,10 @@ class Response(object_ref):
                 "Response.meta not available, this response "
                 "is not tied to any request"
             )
+
+    @property
+    def host_ip(self):
+        return gethostbyname(urlparse(self.url).netloc)
 
     def _get_url(self):
         return self._url


### PR DESCRIPTION
This PR adds support to get the host IP address from a response as proposed in #3903 .
Will write tests once approved