### PR TITLE
Update reactor.py, updated 'if' sequencing .

### DIFF
--- a/scrapy/utils/reactor.py
+++ b/scrapy/utils/reactor.py
@@ -3,10 +3,10 @@ from twisted.internet import reactor, error
 def listen_tcp(portrange, host, factory):
     """Like reactor.listenTCP but tries different ports in a range."""
     assert len(portrange) <= 2, "invalid portrange: %s" % portrange
-    if not hasattr(portrange, '__iter__'):
-        return reactor.listenTCP(portrange, factory, interface=host)
     if not portrange:
         return reactor.listenTCP(0, factory, interface=host)
+    if not hasattr(portrange, '__iter__'):
+        return reactor.listenTCP(portrange, factory, interface=host)
     if len(portrange) == 1:
         return reactor.listenTCP(portrange[0], factory, interface=host)
     for x in range(portrange[0], portrange[1]+1):


### PR DESCRIPTION

This should be the proper ordering.This is the explanation.
  If `'not portrange'` is True ,it is guaranteed that `not hasattr(portrange, '__iter__')`  is also True  the converse of this is not always true.(for example, consider portrange=None, for such case we were executing the logic for `not hasattr(portrange, '__iter__')` . ).Such case is eliminated by this PR.