### PR TITLE
Update file_path() example in media-pipeline.rst

### DIFF
--- a/docs/topics/media-pipeline.rst
+++ b/docs/topics/media-pipeline.rst
@@ -529,7 +529,7 @@ See here the methods that you can override in your custom Images Pipeline:
 
         class MyImagesPipeline(ImagesPipeline):
 
-            def file_path(self, request, response, info):
+            def file_path(self, request, response = None, info = None):
                 return 'files/' + os.path.basename(urlparse(request.url).path)
 
       By default the :meth:`file_path` method returns


### PR DESCRIPTION
`def file_path(self, request, response, info):` throws error `Failure instance: Traceback (failure with no frames): <class 'TypeError'>: file_path() missing 1 required positional argument: 'response'` under item_completed() results. Setting default arguments fixes the issue.