### PR TITLE
[MRG+1] Simplify version reporting

### DIFF
--- a/scrapy/utils/ssl.py
+++ b/scrapy/utils/ssl.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+import OpenSSL
 import OpenSSL._util as pyOpenSSLutil
 
 from scrapy.utils.python import to_native_str
@@ -48,3 +49,10 @@ def get_temp_key_info(ssl_object):
         key_info.append(ffi_buf_to_string(pyOpenSSLutil.lib.OBJ_nid2sn(key_type)))
     key_info.append('%s bits' % pyOpenSSLutil.lib.EVP_PKEY_bits(temp_key))
     return ', '.join(key_info)
+
+
+def get_openssl_version():
+    system_openssl = OpenSSL.SSL.SSLeay_version(
+        OpenSSL.SSL.SSLEAY_VERSION
+    ).decode('ascii', errors='replace')
+    return '{} ({})'.format(OpenSSL.version.__version__, system_openssl)

--- a/scrapy/utils/versions.py
+++ b/scrapy/utils/versions.py
@@ -4,12 +4,12 @@ import sys
 import cryptography
 import cssselect
 import lxml.etree
-import OpenSSL
 import parsel
 import twisted
 import w3lib
 
 import scrapy
+from scrapy.utils.ssl import get_openssl_version
 
 
 def scrapy_components_versions():
@@ -25,14 +25,7 @@ def scrapy_components_versions():
         ("w3lib", w3lib.__version__),
         ("Twisted", twisted.version.short()),
         ("Python", sys.version.replace("\n", "- ")),
-        ("pyOpenSSL", _get_openssl_version()),
+        ("pyOpenSSL", get_openssl_version()),
         ("cryptography", cryptography.__version__),
         ("Platform",  platform.platform()),
     ]
-
-
-def _get_openssl_version():
-    openssl = OpenSSL.SSL.SSLeay_version(
-        OpenSSL.SSL.SSLEAY_VERSION
-    ).decode('ascii', errors='replace')
-    return '{} ({})'.format(OpenSSL.version.__version__, openssl)

--- a/scrapy/utils/versions.py
+++ b/scrapy/utils/versions.py
@@ -1,8 +1,10 @@
 import platform
 import sys
 
+import cryptography
 import cssselect
 import lxml.etree
+import OpenSSL
 import parsel
 import twisted
 import w3lib
@@ -13,15 +15,6 @@ import scrapy
 def scrapy_components_versions():
     lxml_version = ".".join(map(str, lxml.etree.LXML_VERSION))
     libxml2_version = ".".join(map(str, lxml.etree.LIBXML_VERSION))
-    try:
-        w3lib_version = w3lib.__version__
-    except AttributeError:
-        w3lib_version = "<1.14.3"
-    try:
-        import cryptography
-        cryptography_version = cryptography.__version__
-    except ImportError:
-        cryptography_version = "unknown"
 
     return [
         ("Scrapy", scrapy.__version__),
@@ -29,22 +22,17 @@ def scrapy_components_versions():
         ("libxml2", libxml2_version),
         ("cssselect", cssselect.__version__),
         ("parsel", parsel.__version__),
-        ("w3lib", w3lib_version),
+        ("w3lib", w3lib.__version__),
         ("Twisted", twisted.version.short()),
         ("Python", sys.version.replace("\n", "- ")),
         ("pyOpenSSL", _get_openssl_version()),
-        ("cryptography", cryptography_version),
+        ("cryptography", cryptography.__version__),
         ("Platform",  platform.platform()),
     ]
 
 
 def _get_openssl_version():
-    try:
-        import OpenSSL
-        openssl = OpenSSL.SSL.SSLeay_version(OpenSSL.SSL.SSLEAY_VERSION)\
-            .decode('ascii', errors='replace')
-    # pyOpenSSL 0.12 does not expose openssl version
-    except AttributeError:
-        openssl = 'Unknown OpenSSL version'
-
+    openssl = OpenSSL.SSL.SSLeay_version(
+        OpenSSL.SSL.SSLEAY_VERSION
+    ).decode('ascii', errors='replace')
     return '{} ({})'.format(OpenSSL.version.__version__, openssl)


### PR DESCRIPTION
After the recent updates of #3892 the minimum package versions for `w3lib` and `pyOpenSSL` were upgraded beyond the cases considered in the existing checks, I think those checks are not needed anymore.

Also, I'm sure there is a historical reason for catching `ImportError` on `cryptography`, but it is also required in `setup.py` so it should always be available for import.