### PR TITLE
Remove obsolete version checks

### DIFF
--- a/scrapy/core/downloader/contextfactory.py
+++ b/scrapy/core/downloader/contextfactory.py
@@ -1,112 +1,85 @@
 from OpenSSL import SSL
-from twisted.internet.ssl import ClientContextFactory
+from twisted.internet.ssl import optionsForClientTLS, CertificateOptions, platformTrust
+from twisted.web.client import BrowserLikePolicyForHTTPS
+from twisted.web.iweb import IPolicyForHTTPS
+from zope.interface.declarations import implementer
 
-from scrapy import twisted_version
-
-if twisted_version >= (14, 0, 0):
-
-    from zope.interface.declarations import implementer
-
-    from twisted.internet.ssl import (optionsForClientTLS,
-                                      CertificateOptions,
-                                      platformTrust)
-    from twisted.web.client import BrowserLikePolicyForHTTPS
-    from twisted.web.iweb import IPolicyForHTTPS
-
-    from scrapy.core.downloader.tls import ScrapyClientTLSOptions, DEFAULT_CIPHERS
+from scrapy.core.downloader.tls import ScrapyClientTLSOptions, DEFAULT_CIPHERS
 
 
-    @implementer(IPolicyForHTTPS)
-    class ScrapyClientContextFactory(BrowserLikePolicyForHTTPS):
-        """
-        Non-peer-certificate verifying HTTPS context factory
+@implementer(IPolicyForHTTPS)
+class ScrapyClientContextFactory(BrowserLikePolicyForHTTPS):
+    """
+    Non-peer-certificate verifying HTTPS context factory
 
-        Default OpenSSL method is TLS_METHOD (also called SSLv23_METHOD)
-        which allows TLS protocol negotiation
+    Default OpenSSL method is TLS_METHOD (also called SSLv23_METHOD)
+    which allows TLS protocol negotiation
 
-        'A TLS/SSL connection established with [this method] may
-         understand the SSLv3, TLSv1, TLSv1.1 and TLSv1.2 protocols.'
-        """
+    'A TLS/SSL connection established with [this method] may
+     understand the SSLv3, TLSv1, TLSv1.1 and TLSv1.2 protocols.'
+    """
 
-        def __init__(self, method=SSL.SSLv23_METHOD, tls_verbose_logging=False, *args, **kwargs):
-            super(ScrapyClientContextFactory, self).__init__(*args, **kwargs)
-            self._ssl_method = method
-            self.tls_verbose_logging = tls_verbose_logging
+    def __init__(self, method=SSL.SSLv23_METHOD, tls_verbose_logging=False, *args, **kwargs):
+        super(ScrapyClientContextFactory, self).__init__(*args, **kwargs)
+        self._ssl_method = method
+        self.tls_verbose_logging = tls_verbose_logging
 
-        @classmethod
-        def from_settings(cls, settings, method=SSL.SSLv23_METHOD, *args, **kwargs):
-            tls_verbose_logging = settings.getbool('DOWNLOADER_CLIENT_TLS_VERBOSE_LOGGING')
-            return cls(method=method, tls_verbose_logging=tls_verbose_logging, *args, **kwargs)
+    @classmethod
+    def from_settings(cls, settings, method=SSL.SSLv23_METHOD, *args, **kwargs):
+        tls_verbose_logging = settings.getbool('DOWNLOADER_CLIENT_TLS_VERBOSE_LOGGING')
+        return cls(method=method, tls_verbose_logging=tls_verbose_logging, *args, **kwargs)
 
-        def getCertificateOptions(self):
-            # setting verify=True will require you to provide CAs
-            # to verify against; in other words: it's not that simple
+    def getCertificateOptions(self):
+        # setting verify=True will require you to provide CAs
+        # to verify against; in other words: it's not that simple
 
-            # backward-compatible SSL/TLS method:
-            #
-            # * this will respect `method` attribute in often recommended
-            #   `ScrapyClientContextFactory` subclass
-            #   (https://github.com/scrapy/scrapy/issues/1429#issuecomment-131782133)
-            #
-            # * getattr() for `_ssl_method` attribute for context factories
-            #   not calling super(..., self).__init__
-            return CertificateOptions(verify=False,
-                        method=getattr(self, 'method',
-                                       getattr(self, '_ssl_method', None)),
-                        fixBrokenPeers=True,
-                        acceptableCiphers=DEFAULT_CIPHERS)
+        # backward-compatible SSL/TLS method:
+        #
+        # * this will respect `method` attribute in often recommended
+        #   `ScrapyClientContextFactory` subclass
+        #   (https://github.com/scrapy/scrapy/issues/1429#issuecomment-131782133)
+        #
+        # * getattr() for `_ssl_method` attribute for context factories
+        #   not calling super(..., self).__init__
+        return CertificateOptions(verify=False,
+                    method=getattr(self, 'method',
+                                   getattr(self, '_ssl_method', None)),
+                    fixBrokenPeers=True,
+                    acceptableCiphers=DEFAULT_CIPHERS)
 
-        # kept for old-style HTTP/1.0 downloader context twisted calls,
-        # e.g. connectSSL()
-        def getContext(self, hostname=None, port=None):
-            return self.getCertificateOptions().getContext()
+    # kept for old-style HTTP/1.0 downloader context twisted calls,
+    # e.g. connectSSL()
+    def getContext(self, hostname=None, port=None):
+        return self.getCertificateOptions().getContext()
 
-        def creatorForNetloc(self, hostname, port):
-            return ScrapyClientTLSOptions(hostname.decode("ascii"), self.getContext(),
-                                          verbose_logging=self.tls_verbose_logging)
+    def creatorForNetloc(self, hostname, port):
+        return ScrapyClientTLSOptions(hostname.decode("ascii"), self.getContext(),
+                                      verbose_logging=self.tls_verbose_logging)
 
 
-    @implementer(IPolicyForHTTPS)
-    class BrowserLikeContextFactory(ScrapyClientContextFactory):
-        """
-        Twisted-recommended context factory for web clients.
+@implementer(IPolicyForHTTPS)
+class BrowserLikeContextFactory(ScrapyClientContextFactory):
+    """
+    Twisted-recommended context factory for web clients.
 
-        Quoting https://twistedmatrix.com/documents/current/api/twisted.web.client.Agent.html:
-        "The default is to use a BrowserLikePolicyForHTTPS,
-        so unless you have special requirements you can leave this as-is."
+    Quoting https://twistedmatrix.com/documents/current/api/twisted.web.client.Agent.html:
+    "The default is to use a BrowserLikePolicyForHTTPS,
+    so unless you have special requirements you can leave this as-is."
 
-        creatorForNetloc() is the same as BrowserLikePolicyForHTTPS
-        except this context factory allows setting the TLS/SSL method to use.
+    creatorForNetloc() is the same as BrowserLikePolicyForHTTPS
+    except this context factory allows setting the TLS/SSL method to use.
 
-        Default OpenSSL method is TLS_METHOD (also called SSLv23_METHOD)
-        which allows TLS protocol negotiation.
-        """
-        def creatorForNetloc(self, hostname, port):
+    Default OpenSSL method is TLS_METHOD (also called SSLv23_METHOD)
+    which allows TLS protocol negotiation.
+    """
+    def creatorForNetloc(self, hostname, port):
 
-            # trustRoot set to platformTrust() will use the platform's root CAs.
-            #
-            # This means that a website like https://www.cacert.org will be rejected
-            # by default, since CAcert.org CA certificate is seldom shipped.
-            return optionsForClientTLS(hostname.decode("ascii"),
-                                       trustRoot=platformTrust(),
-                                       extraCertificateOptions={
-                                            'method': self._ssl_method,
-                                       })
-
-else:
-
-    class ScrapyClientContextFactory(ClientContextFactory):
-        "A SSL context factory which is more permissive against SSL bugs."
-        # see https://github.com/scrapy/scrapy/issues/82
-        # and https://github.com/scrapy/scrapy/issues/26
-        # and https://github.com/scrapy/scrapy/issues/981
-
-        def __init__(self, method=SSL.SSLv23_METHOD):
-            self.method = method
-
-        def getContext(self, hostname=None, port=None):
-            ctx = ClientContextFactory.getContext(self)
-            # Enable all workarounds to SSL bugs as documented by
-            # https://www.openssl.org/docs/manmaster/man3/SSL_CTX_set_options.html
-            ctx.set_options(SSL.OP_ALL)
-            return ctx
+        # trustRoot set to platformTrust() will use the platform's root CAs.
+        #
+        # This means that a website like https://www.cacert.org will be rejected
+        # by default, since CAcert.org CA certificate is seldom shipped.
+        return optionsForClientTLS(hostname.decode("ascii"),
+                                   trustRoot=platformTrust(),
+                                   extraCertificateOptions={
+                                        'method': self._ssl_method,
+                                   })

--- a/scrapy/core/downloader/handlers/http11.py
+++ b/scrapy/core/downloader/handlers/http11.py
@@ -13,12 +13,8 @@ from twisted.web.http_headers import Headers as TxHeaders
 from twisted.web.iweb import IBodyProducer, UNKNOWN_LENGTH
 from twisted.internet.error import TimeoutError
 from twisted.web.http import _DataLoss, PotentialDataLoss
-from twisted.web.client import Agent, ProxyAgent, ResponseDone, \
-    HTTPConnectionPool, ResponseFailed
-try:
-    from twisted.web.client import URI
-except ImportError:
-    from twisted.web.client import _URI as URI
+from twisted.web.client import (Agent, ProxyAgent, ResponseDone,
+                                HTTPConnectionPool, ResponseFailed, URI)
 from twisted.internet.endpoints import TCP4ClientEndpoint
 
 from scrapy.http import Headers

--- a/scrapy/core/downloader/handlers/http11.py
+++ b/scrapy/core/downloader/handlers/http11.py
@@ -141,14 +141,8 @@ class TunnelingTCP4ClientEndpoint(TCP4ClientEndpoint):
         self._protocol.dataReceived = self._protocolDataReceived
         respm = TunnelingTCP4ClientEndpoint._responseMatcher.match(self._connectBuffer)
         if respm and int(respm.group('status')) == 200:
-            try:
-                # this sets proper Server Name Indication extension
-                # but is only available for Twisted>=14.0
-                sslOptions = self._contextFactory.creatorForNetloc(
-                    self._tunneledHost, self._tunneledPort)
-            except AttributeError:
-                # fall back to non-SNI SSL context factory
-                sslOptions = self._contextFactory
+            # set proper Server Name Indication extension
+            sslOptions = self._contextFactory.creatorForNetloc(self._tunneledHost, self._tunneledPort)
             self._protocol.transport.startTLS(sslOptions,
                                               self._protocolFactory)
             self._tunnelReadyDeferred.callback(self._protocol)

--- a/scrapy/core/downloader/tls.py
+++ b/scrapy/core/downloader/tls.py
@@ -10,11 +10,13 @@ from scrapy.utils.ssl import x509name_to_string, get_temp_key_info
 
 logger = logging.getLogger(__name__)
 
+
 METHOD_SSLv3 = 'SSLv3'
 METHOD_TLS = 'TLS'
 METHOD_TLSv10 = 'TLSv1.0'
 METHOD_TLSv11 = 'TLSv1.1'
 METHOD_TLSv12 = 'TLSv1.2'
+
 
 openssl_methods = {
     METHOD_TLS:    SSL.SSLv23_METHOD,                   # protocol negotiation (recommended)
@@ -24,11 +26,6 @@ openssl_methods = {
     METHOD_TLSv12: getattr(SSL, 'TLSv1_2_METHOD', 6),   # TLS 1.2 only
 }
 
-
-# ClientTLSOptions requires a recent-enough version of Twisted (14.0.0+)
-# Not having ScrapyClientTLSOptions should not matter for older
-# Twisted versions because it is not used in the fallback
-# ScrapyClientContextFactory.
 
 try:
     # XXX: this import would fail on Debian jessie with system installed

--- a/scrapy/core/downloader/tls.py
+++ b/scrapy/core/downloader/tls.py
@@ -1,5 +1,8 @@
 import logging
+
 from OpenSSL import SSL
+from twisted.internet.ssl import AcceptableCiphers
+from twisted.internet._sslverify import ClientTLSOptions, verifyHostname, VerificationError
 
 from scrapy import twisted_version
 from scrapy.utils.ssl import x509name_to_string, get_temp_key_info
@@ -22,95 +25,90 @@ openssl_methods = {
 }
 
 
-if twisted_version >= (14, 0, 0):
-    # ClientTLSOptions requires a recent-enough version of Twisted.
-    # Not having ScrapyClientTLSOptions should not matter for older
-    # Twisted versions because it is not used in the fallback
-    # ScrapyClientContextFactory.
+# ClientTLSOptions requires a recent-enough version of Twisted (14.0.0+)
+# Not having ScrapyClientTLSOptions should not matter for older
+# Twisted versions because it is not used in the fallback
+# ScrapyClientContextFactory.
 
-    # taken from twisted/twisted/internet/_sslverify.py
+# taken from twisted/twisted/internet/_sslverify.py
 
-    try:
-        # XXX: this try-except is not needed in Twisted 17.0.0+ because
-        # it requires pyOpenSSL 0.16+.
-        from OpenSSL.SSL import SSL_CB_HANDSHAKE_DONE, SSL_CB_HANDSHAKE_START
-    except ImportError:
-        SSL_CB_HANDSHAKE_START = 0x10
-        SSL_CB_HANDSHAKE_DONE = 0x20
+try:
+    # XXX: this try-except is not needed in Twisted 17.0.0+ because
+    # it requires pyOpenSSL 0.16+.
+    from OpenSSL.SSL import SSL_CB_HANDSHAKE_DONE, SSL_CB_HANDSHAKE_START
+except ImportError:
+    SSL_CB_HANDSHAKE_START = 0x10
+    SSL_CB_HANDSHAKE_DONE = 0x20
 
-    from twisted.internet.ssl import AcceptableCiphers
-    from twisted.internet._sslverify import (ClientTLSOptions,
-                                             verifyHostname,
-                                             VerificationError)
-    try:
-        # XXX: this import would fail on Debian jessie with system installed
-        # service_identity library, due to lack of cryptography.x509 dependency
-        # See https://github.com/pyca/service_identity/issues/21
-        from service_identity.exceptions import CertificateError
-        verification_errors = (CertificateError, VerificationError)
-    except ImportError:
-        verification_errors = VerificationError
+try:
+    # XXX: this import would fail on Debian jessie with system installed
+    # service_identity library, due to lack of cryptography.x509 dependency
+    # See https://github.com/pyca/service_identity/issues/21
+    from service_identity.exceptions import CertificateError
+    verification_errors = (CertificateError, VerificationError)
+except ImportError:
+    verification_errors = VerificationError
 
-    if twisted_version < (17, 0, 0):
-        from twisted.internet._sslverify import _maybeSetHostNameIndication
-        set_tlsext_host_name = _maybeSetHostNameIndication
-    else:
-        def set_tlsext_host_name(connection, hostNameBytes):
-            connection.set_tlsext_host_name(hostNameBytes)
+if twisted_version < (17, 0, 0):
+    from twisted.internet._sslverify import _maybeSetHostNameIndication
+    set_tlsext_host_name = _maybeSetHostNameIndication
+else:
+    def set_tlsext_host_name(connection, hostNameBytes):
+        connection.set_tlsext_host_name(hostNameBytes)
 
 
-    class ScrapyClientTLSOptions(ClientTLSOptions):
-        """
-        SSL Client connection creator ignoring certificate verification errors
-        (for genuinely invalid certificates or bugs in verification code).
+class ScrapyClientTLSOptions(ClientTLSOptions):
+    """
+    SSL Client connection creator ignoring certificate verification errors
+    (for genuinely invalid certificates or bugs in verification code).
 
-        Same as Twisted's private _sslverify.ClientTLSOptions,
-        except that VerificationError, CertificateError and ValueError
-        exceptions are caught, so that the connection is not closed, only
-        logging warnings. Also, HTTPS connection parameters logging is added.
-        """
+    Same as Twisted's private _sslverify.ClientTLSOptions,
+    except that VerificationError, CertificateError and ValueError
+    exceptions are caught, so that the connection is not closed, only
+    logging warnings. Also, HTTPS connection parameters logging is added.
+    """
 
-        def __init__(self, hostname, ctx, verbose_logging=False):
-            super(ScrapyClientTLSOptions, self).__init__(hostname, ctx)
-            self.verbose_logging = verbose_logging
+    def __init__(self, hostname, ctx, verbose_logging=False):
+        super(ScrapyClientTLSOptions, self).__init__(hostname, ctx)
+        self.verbose_logging = verbose_logging
 
-        def _identityVerifyingInfoCallback(self, connection, where, ret):
-            if where & SSL_CB_HANDSHAKE_START:
-                set_tlsext_host_name(connection, self._hostnameBytes)
-            elif where & SSL_CB_HANDSHAKE_DONE:
-                if self.verbose_logging:
-                    if hasattr(connection, 'get_cipher_name'):  # requires pyOPenSSL 0.15
-                        if hasattr(connection, 'get_protocol_version_name'):  # requires pyOPenSSL 16.0.0
-                            logger.debug('SSL connection to %s using protocol %s, cipher %s',
-                                         self._hostnameASCII,
-                                         connection.get_protocol_version_name(),
-                                         connection.get_cipher_name(),
-                                         )
-                        else:
-                            logger.debug('SSL connection to %s using cipher %s',
-                                         self._hostnameASCII,
-                                         connection.get_cipher_name(),
-                                         )
-                    server_cert = connection.get_peer_certificate()
-                    logger.debug('SSL connection certificate: issuer "%s", subject "%s"',
-                                 x509name_to_string(server_cert.get_issuer()),
-                                 x509name_to_string(server_cert.get_subject()),
-                                 )
-                    key_info = get_temp_key_info(connection._ssl)
-                    if key_info:
-                        logger.debug('SSL temp key: %s', key_info)
+    def _identityVerifyingInfoCallback(self, connection, where, ret):
+        if where & SSL_CB_HANDSHAKE_START:
+            set_tlsext_host_name(connection, self._hostnameBytes)
+        elif where & SSL_CB_HANDSHAKE_DONE:
+            if self.verbose_logging:
+                if hasattr(connection, 'get_cipher_name'):  # requires pyOPenSSL 0.15
+                    if hasattr(connection, 'get_protocol_version_name'):  # requires pyOPenSSL 16.0.0
+                        logger.debug('SSL connection to %s using protocol %s, cipher %s',
+                                     self._hostnameASCII,
+                                     connection.get_protocol_version_name(),
+                                     connection.get_cipher_name(),
+                                     )
+                    else:
+                        logger.debug('SSL connection to %s using cipher %s',
+                                     self._hostnameASCII,
+                                     connection.get_cipher_name(),
+                                     )
+                server_cert = connection.get_peer_certificate()
+                logger.debug('SSL connection certificate: issuer "%s", subject "%s"',
+                             x509name_to_string(server_cert.get_issuer()),
+                             x509name_to_string(server_cert.get_subject()),
+                             )
+                key_info = get_temp_key_info(connection._ssl)
+                if key_info:
+                    logger.debug('SSL temp key: %s', key_info)
 
-                try:
-                    verifyHostname(connection, self._hostnameASCII)
-                except verification_errors as e:
-                    logger.warning(
-                        'Remote certificate is not valid for hostname "{}"; {}'.format(
-                            self._hostnameASCII, e))
+            try:
+                verifyHostname(connection, self._hostnameASCII)
+            except verification_errors as e:
+                logger.warning(
+                    'Remote certificate is not valid for hostname "{}"; {}'.format(
+                        self._hostnameASCII, e))
 
-                except ValueError as e:
-                    logger.warning(
-                        'Ignoring error while verifying certificate '
-                        'from host "{}" (exception: {})'.format(
-                            self._hostnameASCII, repr(e)))
+            except ValueError as e:
+                logger.warning(
+                    'Ignoring error while verifying certificate '
+                    'from host "{}" (exception: {})'.format(
+                        self._hostnameASCII, repr(e)))
 
-    DEFAULT_CIPHERS = AcceptableCiphers.fromOpenSSLCipherString('DEFAULT')
+DEFAULT_CIPHERS = AcceptableCiphers.fromOpenSSLCipherString('DEFAULT')

--- a/scrapy/core/downloader/tls.py
+++ b/scrapy/core/downloader/tls.py
@@ -30,16 +30,6 @@ openssl_methods = {
 # Twisted versions because it is not used in the fallback
 # ScrapyClientContextFactory.
 
-# taken from twisted/twisted/internet/_sslverify.py
-
-try:
-    # XXX: this try-except is not needed in Twisted 17.0.0+ because
-    # it requires pyOpenSSL 0.16+.
-    from OpenSSL.SSL import SSL_CB_HANDSHAKE_DONE, SSL_CB_HANDSHAKE_START
-except ImportError:
-    SSL_CB_HANDSHAKE_START = 0x10
-    SSL_CB_HANDSHAKE_DONE = 0x20
-
 try:
     # XXX: this import would fail on Debian jessie with system installed
     # service_identity library, due to lack of cryptography.x509 dependency
@@ -73,9 +63,9 @@ class ScrapyClientTLSOptions(ClientTLSOptions):
         self.verbose_logging = verbose_logging
 
     def _identityVerifyingInfoCallback(self, connection, where, ret):
-        if where & SSL_CB_HANDSHAKE_START:
+        if where & SSL.SSL_CB_HANDSHAKE_START:
             set_tlsext_host_name(connection, self._hostnameBytes)
-        elif where & SSL_CB_HANDSHAKE_DONE:
+        elif where & SSL.SSL_CB_HANDSHAKE_DONE:
             if self.verbose_logging:
                 if hasattr(connection, 'get_cipher_name'):  # requires pyOPenSSL 0.15
                     if hasattr(connection, 'get_protocol_version_name'):  # requires pyOPenSSL 16.0.0

--- a/scrapy/core/downloader/tls.py
+++ b/scrapy/core/downloader/tls.py
@@ -29,8 +29,7 @@ openssl_methods = {
 
 
 if twisted_version < (17, 0, 0):
-    from twisted.internet._sslverify import _maybeSetHostNameIndication
-    set_tlsext_host_name = _maybeSetHostNameIndication
+    from twisted.internet._sslverify import _maybeSetHostNameIndication as set_tlsext_host_name
 else:
     def set_tlsext_host_name(connection, hostNameBytes):
         connection.set_tlsext_host_name(hostNameBytes)


### PR DESCRIPTION
Removing more version checks after bumping minimum package versions in #3892 (Twisted, pyOpenSSL)

I must admit, in the last commit I might have got too excited about indentation and PEP8 (but not the 79-char limit), so feel free to disregard that one (hopefully you won't :crossed_fingers: :smile:) 