### PR TITLE
Disallow media extensions unregistered with IANA 

### DIFF
--- a/scrapy/pipelines/files.py
+++ b/scrapy/pipelines/files.py
@@ -12,7 +12,7 @@ import time
 import logging
 from email.utils import parsedate_tz, mktime_tz
 from six.moves.urllib.parse import urlparse
-
+from collections import defaultdict
 import six
 
 

--- a/scrapy/pipelines/files.py
+++ b/scrapy/pipelines/files.py
@@ -5,15 +5,16 @@ See documentation in topics/media-pipeline.rst
 """
 import functools
 import hashlib
+import mimetypes
 import os
 import os.path
 import time
 import logging
 from email.utils import parsedate_tz, mktime_tz
 from six.moves.urllib.parse import urlparse
-from collections import defaultdict
+
 import six
-import mimetypes
+
 
 try:
     from cStringIO import StringIO as BytesIO

--- a/scrapy/pipelines/files.py
+++ b/scrapy/pipelines/files.py
@@ -460,4 +460,11 @@ class FilesPipeline(MediaPipeline):
     def file_path(self, request, response=None, info=None):
         media_guid = hashlib.sha1(to_bytes(request.url)).hexdigest()
         media_ext = os.path.splitext(request.url)[1]
+        # Handles empty and wild extensions by trying to guess the
+        # mime type then extension or default to empty string otherwise
+        if media_ext not in mimetypes.types_map.keys():
+            media_ext = ''
+            media_type = mimetypes.guess_type(request.url)[0]
+            if media_type:
+                media_ext = mimetypes.guess_extension(media_type)
         return 'full/%s%s' % (media_guid, media_ext)

--- a/scrapy/pipelines/files.py
+++ b/scrapy/pipelines/files.py
@@ -13,6 +13,7 @@ from email.utils import parsedate_tz, mktime_tz
 from six.moves.urllib.parse import urlparse
 from collections import defaultdict
 import six
+import mimetypes
 
 try:
     from cStringIO import StringIO as BytesIO

--- a/scrapy/pipelines/files.py
+++ b/scrapy/pipelines/files.py
@@ -464,7 +464,7 @@ class FilesPipeline(MediaPipeline):
         media_ext = os.path.splitext(request.url)[1]
         # Handles empty and wild extensions by trying to guess the
         # mime type then extension or default to empty string otherwise
-        if media_ext not in mimetypes.types_map.keys():
+        if media_ext not in mimetypes.types_map:
             media_ext = ''
             media_type = mimetypes.guess_type(request.url)[0]
             if media_type:

--- a/tests/test_pipeline_files.py
+++ b/tests/test_pipeline_files.py
@@ -57,6 +57,8 @@ class FilesPipelineTestCase(unittest.TestCase):
                                    response=Response("http://www.dorma.co.uk/images/product_details/2532"),
                                    info=object()),
                          'full/244e0dd7d96a3b7b01f54eded250c9e272577aa1')
+        self.assertEqual(file_path(Request("http://www.dfsonline.co.uk/get_prod_image.php?img=status_0907_mdm.jpg.bohaha")),
+                         'full/76c00cef2ef669ae65052661f68d451162829507')
 
     def test_fs_store(self):
         assert isinstance(self.pipeline.store, FSFilesStore)

--- a/tests/test_pipeline_files.py
+++ b/tests/test_pipeline_files.py
@@ -59,6 +59,10 @@ class FilesPipelineTestCase(unittest.TestCase):
                          'full/244e0dd7d96a3b7b01f54eded250c9e272577aa1')
         self.assertEqual(file_path(Request("http://www.dfsonline.co.uk/get_prod_image.php?img=status_0907_mdm.jpg.bohaha")),
                          'full/76c00cef2ef669ae65052661f68d451162829507')
+        self.assertEqual(file_path(Request("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAR0AAACxCAMAAADOHZloAAACClBMVEX/\
+                                    //+F0tzCwMK76ZKQ21AMqr7oAAC96JvD5aWM2kvZ78J0N7fmAAC46Y4Ap7y")),
+                         'full/178059cbeba2e34120a67f2dc1afc3ecc09b61cb.png')
+                         
 
     def test_fs_store(self):
         assert isinstance(self.pipeline.store, FSFilesStore)


### PR DESCRIPTION
If a media extension is empty string or is unregistered with [IANA](http://www.iana.org/assignments/media-types), then try to guess the MIME type from the url then the extension from MIME type using built-in `mimetypes` lib..

Fixes #3953, fixes #1287