### PR TITLE
[WIP] Base support for asyncio

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -29,3 +29,8 @@ if six.PY3:
 def chdir(tmpdir):
     """Change to pytest-provided temporary directory"""
     tmpdir.chdir()
+
+
+@pytest.fixture()
+def reactor_pytest(request):
+    request.cls.reactor_pytest = request.config.getoption("--reactor")

--- a/pytest.ini
+++ b/pytest.ini
@@ -2,5 +2,5 @@
 usefixtures = chdir
 python_files=test_*.py __init__.py
 python_classes=
-addopts = --doctest-modules --assert=plain
+addopts = --doctest-modules --assert=plain --reactor=asyncio
 twisted = 1

--- a/scrapy/__init__.py
+++ b/scrapy/__init__.py
@@ -23,28 +23,6 @@ import warnings
 warnings.filterwarnings('ignore', category=DeprecationWarning, module='twisted')
 del warnings
 
-# Install twisted asyncio loop
-def _install_asyncio_reactor():
-    global asyncio_supported
-    try:
-        import asyncio
-        from twisted.internet import asyncioreactor
-    except ImportError:
-        pass
-    else:
-        from twisted.internet.error import ReactorAlreadyInstalledError
-        try:
-            asyncioreactor.install(asyncio.get_event_loop())
-            asyncio_supported = True
-        except ReactorAlreadyInstalledError:
-            import twisted.internet.reactor
-            if isinstance(twisted.internet.reactor,
-                              asyncioreactor.AsyncioSelectorReactor):
-                asyncio_supported = True
-asyncio_supported = False
-_install_asyncio_reactor()
-del _install_asyncio_reactor
-
 # Apply monkey patches to fix issues in external libraries
 from . import _monkeypatches
 del _monkeypatches

--- a/scrapy/__init__.py
+++ b/scrapy/__init__.py
@@ -23,6 +23,28 @@ import warnings
 warnings.filterwarnings('ignore', category=DeprecationWarning, module='twisted')
 del warnings
 
+# Install twisted asyncio loop
+def _install_asyncio_reactor():
+    global asyncio_supported
+    try:
+        import asyncio
+        from twisted.internet import asyncioreactor
+    except ImportError:
+        pass
+    else:
+        from twisted.internet.error import ReactorAlreadyInstalledError
+        try:
+            asyncioreactor.install(asyncio.get_event_loop())
+            asyncio_supported = True
+        except ReactorAlreadyInstalledError:
+            import twisted.internet.reactor
+            if isinstance(twisted.internet.reactor,
+                              asyncioreactor.AsyncioSelectorReactor):
+                asyncio_supported = True
+asyncio_supported = False
+_install_asyncio_reactor()
+del _install_asyncio_reactor
+
 # Apply monkey patches to fix issues in external libraries
 from . import _monkeypatches
 del _monkeypatches

--- a/scrapy/cmdline.py
+++ b/scrapy/cmdline.py
@@ -7,9 +7,9 @@ import inspect
 import pkg_resources
 
 import scrapy
-from scrapy.crawler import CrawlerProcess
 from scrapy.commands import ScrapyCommand
 from scrapy.exceptions import UsageError
+from scrapy.utils.asyncio import install_asyncio_reactor, is_asyncio_supported
 from scrapy.utils.misc import walk_modules
 from scrapy.utils.project import inside_project, get_project_settings
 from scrapy.utils.python import garbage_collect
@@ -121,6 +121,10 @@ def execute(argv=None, settings=None):
             settings['EDITOR'] = editor
     check_deprecated_settings(settings)
 
+    # needs to be before _get_commands_dict() as that imports the command modules
+    # which may import twisted.internet.reactor
+    install_asyncio_reactor()
+
     inproject = inside_project()
     cmds = _get_commands_dict(settings, inproject)
     cmdname = _pop_command_name(argv)
@@ -142,6 +146,8 @@ def execute(argv=None, settings=None):
     opts, args = parser.parse_args(args=argv[1:])
     _run_print_help(parser, cmd.process_options, args, opts)
 
+    # needs to be after install_asyncio_reactor() as it imports twisted.internet.reactor
+    from scrapy.crawler import CrawlerProcess
     cmd.crawler_process = CrawlerProcess(settings)
     _run_print_help(parser, _run_command, cmd, args, opts)
     sys.exit(cmd.exitcode)

--- a/scrapy/utils/asyncio.py
+++ b/scrapy/utils/asyncio.py
@@ -1,0 +1,26 @@
+#coding: utf-8
+
+
+def install_asyncio_reactor():
+    """ Tries to install AsyncioSelectorReactor
+    """
+    try:
+        import asyncio
+        from twisted.internet import asyncioreactor
+    except ImportError:
+        pass
+    else:
+        from twisted.internet.error import ReactorAlreadyInstalledError
+        try:
+            asyncioreactor.install(asyncio.get_event_loop())
+        except ReactorAlreadyInstalledError:
+            pass
+
+
+def is_asyncio_supported():
+    try:
+        import twisted.internet.reactor
+        from twisted.internet import asyncioreactor
+        return isinstance(twisted.internet.reactor, asyncioreactor.AsyncioSelectorReactor)
+    except ImportError:
+        return False

--- a/scrapy/utils/defer.py
+++ b/scrapy/utils/defer.py
@@ -1,10 +1,14 @@
 """
 Helper functions for dealing with Twisted deferreds
 """
+import asyncio
+import asyncio.futures
+import inspect
 
 from twisted.internet import defer, reactor, task
 from twisted.python import failure
 
+from scrapy import asyncio_supported
 from scrapy.exceptions import IgnoreRequest
 
 def defer_fail(_failure):
@@ -104,3 +108,21 @@ def iter_errback(iterable, errback, *a, **kw):
             break
         except Exception:
             errback(failure.Failure(), *a, **kw)
+
+
+def isfuture(o):
+    # workaround for Python before 3.5.3 not having asyncio.isfuture
+    if hasattr(asyncio, 'isfuture'):
+        return asyncio.isfuture(o)
+    return isinstance(o, asyncio.futures.Future)
+
+
+def deferred_from_coro(o):
+    """Converts a coroutine into a Deferred, or returns the object as is if it isn't a coroutine"""
+    if isinstance(o, defer.Deferred):
+        return o
+    if asyncio.iscoroutine(o) or isfuture(o) or inspect.isawaitable(o):
+        if not asyncio_supported:
+            raise TypeError('Using coroutines requires installing AsyncioSelectorReactor')
+        return defer.Deferred.fromFuture(asyncio.ensure_future(o))
+    return o

--- a/scrapy/utils/defer.py
+++ b/scrapy/utils/defer.py
@@ -8,8 +8,9 @@ import inspect
 from twisted.internet import defer, reactor, task
 from twisted.python import failure
 
-from scrapy import asyncio_supported
 from scrapy.exceptions import IgnoreRequest
+from scrapy.utils.asyncio import is_asyncio_supported
+
 
 def defer_fail(_failure):
     """Same as twisted.internet.defer.fail but delay calling errback until
@@ -122,7 +123,7 @@ def deferred_from_coro(o):
     if isinstance(o, defer.Deferred):
         return o
     if asyncio.iscoroutine(o) or isfuture(o) or inspect.isawaitable(o):
-        if not asyncio_supported:
+        if not is_asyncio_supported():
             raise TypeError('Using coroutines requires installing AsyncioSelectorReactor')
         return defer.Deferred.fromFuture(asyncio.ensure_future(o))
     return o

--- a/scrapy/utils/log.py
+++ b/scrapy/utils/log.py
@@ -11,6 +11,7 @@ from twisted.python import log as twisted_log
 import scrapy
 from scrapy.settings import Settings
 from scrapy.exceptions import ScrapyDeprecationWarning
+from scrapy.utils.asyncio import is_asyncio_supported
 from scrapy.utils.versions import scrapy_components_versions
 
 
@@ -148,6 +149,8 @@ def log_scrapy_info(settings):
                 {'versions': ", ".join("%s %s" % (name, version)
                     for name, version in scrapy_components_versions()
                     if name != "Scrapy")})
+    if is_asyncio_supported():
+        logger.debug("Asyncio support enabled")
 
 
 class StreamLogger(object):

--- a/tests/mockserver.py
+++ b/tests/mockserver.py
@@ -4,6 +4,9 @@ from six.moves.urllib.parse import urlencode
 from subprocess import Popen, PIPE
 
 from OpenSSL import SSL
+
+import scrapy  # needed before importing twisted.internet.reactor
+
 from twisted.web.server import Site, NOT_DONE_YET
 from twisted.web.resource import Resource
 from twisted.web.static import File

--- a/tests/mockserver.py
+++ b/tests/mockserver.py
@@ -5,8 +5,6 @@ from subprocess import Popen, PIPE
 
 from OpenSSL import SSL
 
-import scrapy  # needed before importing twisted.internet.reactor
-
 from twisted.web.server import Site, NOT_DONE_YET
 from twisted.web.resource import Resource
 from twisted.web.static import File

--- a/tests/requirements-py3.txt
+++ b/tests/requirements-py3.txt
@@ -3,7 +3,8 @@ jmespath
 leveldb; sys_platform != "win32"
 pytest
 pytest-cov
-pytest-twisted
+#pytest-twisted
+-e git+https://github.com/pytest-dev/pytest-twisted@81b91f17#egg=pytest-twisted
 pytest-xdist
 testfixtures
 

--- a/tests/requirements-py3.txt
+++ b/tests/requirements-py3.txt
@@ -3,8 +3,7 @@ jmespath
 leveldb; sys_platform != "win32"
 pytest
 pytest-cov
-#pytest-twisted
--e git+https://github.com/pytest-dev/pytest-twisted@81b91f17#egg=pytest-twisted
+pytest-twisted >= 1.11
 pytest-xdist
 testfixtures
 

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -9,6 +9,7 @@ from tempfile import mkdtemp
 from contextlib import contextmanager
 from threading import Timer
 
+from pytest import mark
 from twisted.trial import unittest
 from twisted.internet import defer
 
@@ -181,6 +182,7 @@ class MiscCommandsTest(CommandTest):
         self.assertEqual(0, self.call('list'))
 
 
+@mark.usefixtures('reactor_pytest')
 class RunSpiderCommandTest(CommandTest):
 
     debug_log_spider = """
@@ -297,6 +299,11 @@ class BadSpider(scrapy.Spider):
         print(log)
         self.assertIn("start_requests", log)
         self.assertIn("badspider.py", log)
+
+    def test_asyncio_supported(self):
+        if self.reactor_pytest == 'asyncio':
+            log = self.get_log(self.debug_log_spider)
+            self.assertIn("DEBUG: Asyncio support enabled", log)
 
 
 class BenchCommandTest(CommandTest):

--- a/tests/test_downloadermiddleware.py
+++ b/tests/test_downloadermiddleware.py
@@ -1,3 +1,4 @@
+from twisted.internet.defer import Deferred
 from twisted.trial.unittest import TestCase
 from twisted.python.failure import Failure
 
@@ -176,3 +177,31 @@ class ProcessExceptionInvalidOutput(ManagerTestCase):
         dfd.addBoth(results.append)
         self.assertIsInstance(results[0], Failure)
         self.assertIsInstance(results[0].value, _InvalidOutput)
+
+
+class MiddlewareUsingDeferreds(ManagerTestCase):
+    """Middlewares using Deferreds should work"""
+
+    def test_deferred(self):
+        resp = Response('http://example.com/index.html')
+
+        class DeferredMiddleware:
+            def cb(self, result):
+                return result
+
+            def process_request(self, request, spider):
+                d = Deferred()
+                d.addCallback(self.cb)
+                d.callback(resp)
+                return d
+
+        self.mwman._add_middleware(DeferredMiddleware())
+        req = Request('http://example.com/index.html')
+        download_func = mock.MagicMock()
+        dfd = self.mwman.download(download_func, req, self.spider)
+        results = []
+        dfd.addBoth(results.append)
+        self._wait(dfd)
+
+        self.assertIs(results[0], resp)
+        self.assertFalse(download_func.called)

--- a/tests/test_utils_asyncio.py
+++ b/tests/test_utils_asyncio.py
@@ -1,0 +1,17 @@
+from unittest import TestCase
+
+from pytest import mark
+
+from scrapy.utils.asyncio import is_asyncio_supported, install_asyncio_reactor
+
+
+@mark.usefixtures('reactor_pytest')
+class AsyncioTest(TestCase):
+
+    def test_is_asyncio_supported(self):
+        # the result should depend only on the pytest --reactor argument
+        self.assertEquals(is_asyncio_supported(), self.reactor_pytest == 'asyncio')
+
+    def test_install_asyncio_reactor(self):
+        # this should do nothing
+        install_asyncio_reactor()

--- a/tox.ini
+++ b/tox.ini
@@ -90,6 +90,12 @@ deps = {[testenv:py35]deps}
 basepython = python3.7
 deps = {[testenv:py35]deps}
 
+[testenv:py37-no-asyncio]
+basepython = python3.7
+deps = {[testenv:py35]deps}
+commands =
+    py.test --cov=scrapy --cov-report= --reactor=default {posargs:scrapy tests}
+
 [testenv:pypy3]
 basepython = pypy3
 deps = {[testenv:py35]deps}


### PR DESCRIPTION
This is the first PR that is required for any other asyncio-related changes. It assumes no Python 2 support exists so it shouldn't be merged before the 1.8 release and removing Python 2 tests and other support.

Related issues and PRs: #3485, #3148, #3362, #3446, and probably others.

This PR adds installing the asyncio reactor in `scrapy.cmdline` and in tests, a test env that uses the default reactor, and some related tests. It also adds some helper functions which are not currently useful but will be useful in the future changes.