### PR TITLE
Implement centralized, highly-configurable request fingerprinting

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -270,4 +270,5 @@ coverage_ignore_pyobjects = [
 
 intersphinx_mapping = {
     'python': ('https://docs.python.org/3', None),
+    'w3lib': ('https://w3lib.readthedocs.io/en/latest', None),
 }

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -165,6 +165,7 @@ Solving specific problems
    topics/autothrottle
    topics/benchmarking
    topics/jobs
+   topics/request-fingerprinting
 
 :doc:`faq`
     Get answers to most frequently asked questions.
@@ -204,6 +205,9 @@ Solving specific problems
 
 :doc:`topics/jobs`
     Learn how to pause and resume crawls for large spiders.
+
+:doc:`topics/request-fingerprinting`
+    Change how your requests are fingerprinted.
 
 .. _extending-scrapy:
 

--- a/docs/topics/request-fingerprinting.rst
+++ b/docs/topics/request-fingerprinting.rst
@@ -21,13 +21,23 @@ canonical version (:func:`w3lib.url.canonicalize_url`) of
 Continue reading to learn how to change request fingerprinting, for example to
 take into account some headers or compare URLs case-insensitively.
 
-Overriding the fingerprint of a request
-=======================================
+Using global request fingerprinting
+===================================
+
+Code that needs the fingerprint of a request based on global request
+fingerprinting must use :func:`scrapy.utils.request.request_fingerprint` to
+read the fingerprint of a request:
+
+.. autofunction:: scrapy.utils.request.request_fingerprint
+
+
+Overriding the fingerprint of a request manually
+================================================
 
 One way to override how request fingerprints are calculated is to manually
 define the fingerprint of a request::
 
     request.fingerprint = b'custom fingerprint'
 
-If :att:`request.fingerprint <scrapy.http.request.Request.fingerprint>` has a
+If :attr:`request.fingerprint <scrapy.http.Request.fingerprint>` has a
 value, it overrides global request fingerprinting.

--- a/docs/topics/request-fingerprinting.rst
+++ b/docs/topics/request-fingerprinting.rst
@@ -5,10 +5,10 @@ Request fingerprinting
 ======================
 
 Request fingerprinting is the mechanism of calculating the *fingerprint* of a
-request: a short array of :class:`bytes`, a *hash*, that is *likely* to
-uniquely identify that request. The fingerprint of a request can be used for
-tasks like ignoring duplicate requests (see :setting:`DUPEFILTER_CLASS`) or
-handling response caches (see
+request: a short array of :class:`bytes` that is expected to uniquely identify
+that request. The fingerprint of a request can be used for tasks like ignoring
+duplicate requests (see :setting:`DUPEFILTER_CLASS`) or handling response
+caches (see
 :class:`~scrapy.downloadermiddlewares.httpauth.HttpAuthMiddleware`).
 
 You often don’t need to worry about request fingerprinting, the default request
@@ -21,23 +21,115 @@ canonical version (:func:`w3lib.url.canonicalize_url`) of
 Continue reading to learn how to change request fingerprinting, for example to
 take into account some headers or compare URLs case-insensitively.
 
-Using global request fingerprinting
-===================================
 
-Code that needs the fingerprint of a request based on global request
-fingerprinting must use :func:`scrapy.utils.request.request_fingerprint` to
-read the fingerprint of a request:
+Configuring request fingerprinting
+==================================
+
+The process of generating a request fingerprint is split in three steps, all of
+which can be overriden through settings or their corresponding
+:attr:`request.meta <scrapy.http.Request.meta>` keys:
+
+1.  Select a subset of the request data that uniquely identifies the request
+    (:setting:`REQUEST_FINGERPRINT_PROCESSORS`)
+
+2.  Turn that subset of data into an equivalent byte string
+    (:setting:`REQUEST_FINGERPRINT_SERIALIZER`)
+
+3.  Generate a hash of that request-identifying byte string
+    (:setting:`REQUEST_FINGERPRINT_HASHER`)
+
+.. setting:: REQUEST_FINGERPRINT_PROCESSORS
+.. reqmeta:: fingerprint_processors
+
+REQUEST_FINGERPRINT_PROCESSORS
+------------------------------
+
+Default: ``[scrapy.utils.request.process_request_fingerprint]``
+
+Equivalent :attr:`Request.meta <scrapy.http.Request.meta>` key:
+``fingerprint_processors``
+
+A list of methods that receive two possitional parameters, ``request`` and
+``data`` (a :class:`dict`, empty unless filled by a previous processor), and
+must return a dictionary containing the data that must be used to generate a
+fingerprint for the target :class:`request <scrapy.http.Request>`.
+
+These methods are executed in a loop, in the provided order. They may add,
+modify or remove data from the input :class:`dict`.
+
+Most use cases can be covered by combining Python’s :func:`~functools.partial`
+with Scrapy’s :func:`~scrapy.utils.request.process_request_fingerprint`:
+
+.. autofunction:: scrapy.utils.request.process_request_fingerprint
+
+.. note:: There is technically no restriction on the type of data that each
+          :class:`dict` key may contain. In fact, it is technically possible to
+          return something other than a :class:`dict` if other request
+          fingerprinting settings are modified accordingly.
+
+.. setting:: REQUEST_FINGERPRINT_SERIALIZER
+.. reqmeta:: fingerprint_serializer
+
+REQUEST_FINGERPRINT_SERIALIZER
+------------------------------
+
+Default: ``scrapy.utils.request.json_serializer``
+
+Equivalent :attr:`Request.meta <scrapy.http.Request.meta>` key:
+``fingerprint_serializer``
+
+A method that received a :class:`dict` and serializer it into a :class:`bytes`
+representation of its data.
+
+The default value is :func:`~scrapy.utils.request.json_serializer`:
+
+.. autofunction:: scrapy.utils.request.json_serializer
+
+.. setting:: REQUEST_FINGERPRINT_HASHER
+.. reqmeta:: fingerprint_hasher
+
+REQUEST_FINGERPRINT_HASHER
+--------------------------
+
+Default: ``scrapy.utils.request.sha1_hasher``
+
+Equivalent :attr:`Request.meta <scrapy.http.Request.meta>` key:
+``fingerprint_hasher``
+
+A method that received a :class:`dict` and serializer it into a :class:`bytes`
+representation of its data.
+
+The default value is :func:`~scrapy.utils.request.sha1_hasher`:
+
+.. autofunction:: scrapy.utils.request.sha1_hasher
+
+
+Using request fingerprinting
+============================
+
+Code that needs the fingerprint of a request must use
+:func:`scrapy.utils.request.request_fingerprint` to read it:
 
 .. autofunction:: scrapy.utils.request.request_fingerprint
 
 
-Overriding the fingerprint of a request manually
-================================================
 
-One way to override how request fingerprints are calculated is to manually
-define the fingerprint of a request::
+.. _override-request-fingerprinting:
+
+Overriding the fingerprint of a request
+=======================================
+
+It’s technically possible to override how request fingerprints are calculated
+by manually defining the fingerprint of a request::
 
     request.fingerprint = b'custom fingerprint'
 
 If :attr:`request.fingerprint <scrapy.http.Request.fingerprint>` has a
-value, it overrides global request fingerprinting.
+value, it overrides request fingerprinting. This approach, however, has some
+drawbacks:
+
+-   It overrides all request fingerprinting settings.
+
+-   If done at a point where ``request.fingerprint`` already has a value, it
+    usually means that the previous fingerprint has already been used by one or
+    more Scrapy components that will not take the new value into account.

--- a/docs/topics/request-fingerprinting.rst
+++ b/docs/topics/request-fingerprinting.rst
@@ -21,7 +21,6 @@ canonical version (:func:`w3lib.url.canonicalize_url`) of
 Continue reading to learn how to change request fingerprinting, for example to
 take into account some headers or compare URLs case-insensitively.
 
-
 Configuring request fingerprinting
 ==================================
 
@@ -67,6 +66,7 @@ with Scrapy’s :func:`~scrapy.utils.request.process_request_fingerprint`:
           return something other than a :class:`dict` if other request
           fingerprinting settings are modified accordingly.
 
+
 .. setting:: REQUEST_FINGERPRINT_SERIALIZER
 .. reqmeta:: fingerprint_serializer
 
@@ -84,6 +84,7 @@ representation of its data.
 The default value is :func:`~scrapy.utils.request.json_serializer`:
 
 .. autofunction:: scrapy.utils.request.json_serializer
+
 
 .. setting:: REQUEST_FINGERPRINT_HASHER
 .. reqmeta:: fingerprint_hasher
@@ -111,7 +112,6 @@ Code that needs the fingerprint of a request must use
 :func:`scrapy.utils.request.request_fingerprint` to read it:
 
 .. autofunction:: scrapy.utils.request.request_fingerprint
-
 
 
 .. _override-request-fingerprinting:

--- a/docs/topics/request-fingerprinting.rst
+++ b/docs/topics/request-fingerprinting.rst
@@ -1,0 +1,33 @@
+.. _request-fingerprinting:
+
+======================
+Request fingerprinting
+======================
+
+Request fingerprinting is the mechanism of calculating the *fingerprint* of a
+request: a short array of :class:`bytes`, a *hash*, that is *likely* to
+uniquely identify that request. The fingerprint of a request can be used for
+tasks like ignoring duplicate requests (see :setting:`DUPEFILTER_CLASS`) or
+handling response caches (see
+:class:`~scrapy.downloadermiddlewares.httpauth.HttpAuthMiddleware`).
+
+You often don’t need to worry about request fingerprinting, the default request
+fingerprinting of Scrapy works for most projects. It takes into account a
+canonical version (:func:`w3lib.url.canonicalize_url`) of
+:attr:`request.url <scrapy.http.Request.url>` and the values of
+:attr:`request.method <scrapy.http.Request.method>` and
+:attr:`request.body <scrapy.http.Request.body>`.
+
+Continue reading to learn how to change request fingerprinting, for example to
+take into account some headers or compare URLs case-insensitively.
+
+Overriding the fingerprint of a request
+=======================================
+
+One way to override how request fingerprints are calculated is to manually
+define the fingerprint of a request::
+
+    request.fingerprint = b'custom fingerprint'
+
+If :att:`request.fingerprint <scrapy.http.request.Request.fingerprint>` has a
+value, it overrides global request fingerprinting.

--- a/docs/topics/request-response.rst
+++ b/docs/topics/request-response.rst
@@ -186,11 +186,8 @@ Request objects
 
     .. attribute:: fingerprint
 
-        A hash (:class:`bytes`) for request comparison.
-
-        Give it a value to override global request fingerprinting.
-
-        See :ref:`request-fingerprinting`.
+        A hash (:class:`bytes`) for request comparison. See
+        :ref:`request-fingerprinting`.
 
     .. method:: Request.copy()
 
@@ -330,26 +327,29 @@ are some special keys recognized by Scrapy and its built-in extensions.
 
 Those are:
 
-* :reqmeta:`dont_redirect`
-* :reqmeta:`dont_retry`
-* :reqmeta:`handle_httpstatus_list`
-* :reqmeta:`handle_httpstatus_all`
-* :reqmeta:`dont_merge_cookies`
+* :reqmeta:`bindaddress`
 * :reqmeta:`cookiejar`
 * :reqmeta:`dont_cache`
+* :reqmeta:`dont_merge_cookies`
+* :reqmeta:`dont_obey_robotstxt`
+* :reqmeta:`dont_redirect`
+* :reqmeta:`dont_retry`
+* :reqmeta:`download_fail_on_dataloss`
+* :reqmeta:`download_latency`
+* :reqmeta:`download_maxsize`
+* :reqmeta:`download_timeout`
+* :reqmeta:`fingerprint_hasher`
+* :reqmeta:`fingerprint_processors`
+* :reqmeta:`fingerprint_serializer`
+* :reqmeta:`ftp_password`
+* :reqmeta:`ftp_user`
+* :reqmeta:`handle_httpstatus_all`
+* :reqmeta:`handle_httpstatus_list`
+* :reqmeta:`max_retry_times`
+* :reqmeta:`proxy`
 * :reqmeta:`redirect_reasons`
 * :reqmeta:`redirect_urls`
-* :reqmeta:`bindaddress`
-* :reqmeta:`dont_obey_robotstxt`
-* :reqmeta:`download_timeout`
-* :reqmeta:`download_maxsize`
-* :reqmeta:`download_latency`
-* :reqmeta:`download_fail_on_dataloss`
-* :reqmeta:`proxy`
-* ``ftp_user`` (See :setting:`FTP_USER` for more info)
-* ``ftp_password`` (See :setting:`FTP_PASSWORD` for more info)
 * :reqmeta:`referrer_policy`
-* :reqmeta:`max_retry_times`
 
 .. reqmeta:: bindaddress
 

--- a/docs/topics/request-response.rst
+++ b/docs/topics/request-response.rst
@@ -24,7 +24,7 @@ below in :ref:`topics-request-response-ref-request-subclasses` and
 Request objects
 ===============
 
-.. class:: Request(url[, callback, method='GET', headers, body, cookies, meta, encoding='utf-8', priority=0, dont_filter=False, errback, flags, cb_kwargs])
+.. autoclass:: Request
 
     A :class:`Request` object represents an HTTP request, which is usually
     generated in the Spider and executed by the Downloader, and thus generating
@@ -129,6 +129,9 @@ Request objects
     :param cb_kwargs: A dict with arbitrary data that will be passed as keyword arguments to the Request's callback.
     :type cb_kwargs: dict
 
+    :param bytes fingerprint: A hash for request comparison. See
+        :attr:`fingerprint`.
+
     .. attribute:: Request.url
 
         A string containing the URL of this request. Keep in mind that this
@@ -181,6 +184,14 @@ Request objects
 
     .. _shallow copied: https://docs.python.org/2/library/copy.html
 
+    .. attribute:: fingerprint
+
+        A hash (:class:`bytes`) for request comparison.
+
+        Give it a value to override global request fingerprinting.
+
+        See :ref:`request-fingerprinting`.
+
     .. method:: Request.copy()
 
        Return a new Request which is a copy of this Request. See also:
@@ -189,10 +200,15 @@ Request objects
     .. method:: Request.replace([url, method, headers, body, cookies, meta, flags, encoding, priority, dont_filter, callback, errback, cb_kwargs])
 
        Return a Request object with the same members, except for those members
-       given new values by whichever keyword arguments are specified. The
-       :attr:`Request.cb_kwargs` and :attr:`Request.meta` attributes are shallow
-       copied by default (unless new values are given as arguments). See also
-       :ref:`topics-request-response-ref-request-callback-arguments`.
+       given new values by whichever keyword arguments are specified.
+
+       The :attr:`Request.cb_kwargs` and :attr:`Request.meta` attributes are
+       shallow copied by default (unless new values are given as arguments).
+       See also :ref:`topics-request-response-ref-request-callback-arguments`.
+
+       :attr:`fingerprint` is set to ``None`` unless no request attribute is
+       changed (:meth:`replace` used as :meth:`copy`) or a custom
+       ``fingerprint`` is given.
 
     .. automethod:: from_curl
 

--- a/docs/topics/settings.rst
+++ b/docs/topics/settings.rst
@@ -797,6 +797,7 @@ Default: ``True``
 Whether or not to use passive mode when initiating FTP transfers.
 
 .. setting:: FTP_PASSWORD
+.. reqmeta:: ftp_password
 
 FTP_PASSWORD
 ------------
@@ -815,6 +816,7 @@ in ``Request`` meta.
 .. _RFC 1635: https://tools.ietf.org/html/rfc1635
 
 .. setting:: FTP_USER
+.. reqmeta:: ftp_user
 
 FTP_USER
 --------

--- a/scrapy/http/request/__init__.py
+++ b/scrapy/http/request/__init__.py
@@ -19,7 +19,8 @@ class Request(object_ref):
 
     def __init__(self, url, callback=None, method='GET', headers=None, body=None,
                  cookies=None, meta=None, encoding='utf-8', priority=0,
-                 dont_filter=False, errback=None, flags=None, cb_kwargs=None):
+                 dont_filter=False, errback=None, flags=None, cb_kwargs=None,
+                 fingerprint=None):
 
         self._encoding = encoding  # this one has to be set first
         self.method = str(method).upper()
@@ -39,6 +40,7 @@ class Request(object_ref):
         self.cookies = cookies or {}
         self.headers = Headers(headers or {}, encoding=encoding)
         self.dont_filter = dont_filter
+        self.fingerprint = fingerprint
 
         self._meta = dict(meta) if meta else None
         self._cb_kwargs = dict(cb_kwargs) if cb_kwargs else None
@@ -99,8 +101,11 @@ class Request(object_ref):
         """Create a new Request with the same attributes except for those
         given new values.
         """
-        for x in ['url', 'method', 'headers', 'body', 'cookies', 'meta', 'flags',
-                  'encoding', 'priority', 'dont_filter', 'callback', 'errback', 'cb_kwargs']:
+        if not args and not kwargs:
+            kwargs['fingerprint'] = self.fingerprint
+        for x in ['url', 'method', 'headers', 'body', 'cookies', 'meta',
+                  'flags', 'encoding', 'priority', 'dont_filter', 'callback',
+                  'errback', 'cb_kwargs']:
             kwargs.setdefault(x, getattr(self, x))
         cls = kwargs.pop('cls', self.__class__)
         return cls(*args, **kwargs)

--- a/scrapy/utils/request.py
+++ b/scrapy/utils/request.py
@@ -43,6 +43,8 @@ def request_fingerprint(request, include_headers=None):
     include_headers argument, which is a list of Request headers to include.
 
     """
+    if request.fingerprint is not None:
+        return request.fingeprint.hex()
     if include_headers:
         include_headers = tuple(to_bytes(h.lower())
                                  for h in sorted(include_headers))

--- a/scrapy/utils/request.py
+++ b/scrapy/utils/request.py
@@ -15,14 +15,19 @@ from scrapy.utils.httpobj import urlparse_cached
 from scrapy.utils.python import to_bytes, to_native_str
 
 
-def request_fingerprint(request, include_headers=None, hexadecimal=True):
+def request_fingerprint(request, include_headers=None, hexadecimal=True,
+                        settings=None):
     """Fills :attr:`request.fingerprint <scrapy.http.Request.fingerprint>` if
     needed and returns the fingerprint of *request*.
 
     If :attr:`request.fingerprint <scrapy.http.Request.fingerprint>` is already
-    defined, its value is returned. Otherwise, a fingerprint of the request is
-    calculated, assigned to
+    defined, its value is returned. Otherwise, the fingerprint of the request
+    is calculated, assigned to
     :attr:`request.fingerprint <scrapy.http.Request.fingerprint>` and returned.
+
+    *settings* must be an instance of :class:`scrapy.settings.Settings`. Most
+    Scrapy components can get one from :attr:`crawler.settings
+    <scrapy.crawler.Crawler.settings>`.
 
     .. deprecated:: VERSION
 
@@ -49,6 +54,11 @@ def request_fingerprint(request, include_headers=None, hexadecimal=True):
         warn('`hexadecimal=True` is deprecated. Future versions will always '
              'return the fingerprint as `bytes`. Use `hexadecimal=False`.',
              ScrapyDeprecationWarning)
+    if settings is None:
+        warn('Calls omitting the `settings` parameter are deprecated. This '
+             'parameter will be required in future versions.',
+             ScrapyDeprecationWarning)
+
     if request.fingerprint is not None:
         return encoded_fingerprint(request)
     fp = hashlib.sha1()

--- a/scrapy/utils/request.py
+++ b/scrapy/utils/request.py
@@ -109,7 +109,8 @@ def request_fingerprint(request, include_headers=None, hexadecimal=True,
         >>> request = Request('https://example.com')
         >>> request.fingerprint is None
         True
-        >>> request_fingerprint(request, hexadecimal=False)
+        >>> from scrapy.settings import Settings
+        >>> request_fingerprint(request, hexadecimal=False, settings=Settings())
         b'\\x87\\xd9\\xb2q\\x8a\\xf8\\xdad%\\xc2i\\x06\\xc6\\x8f\\xbd<1i{\\xf5'
         >>> request.fingerprint
         b'\\x87\\xd9\\xb2q\\x8a\\xf8\\xdad%\\xc2i\\x06\\xc6\\x8f\\xbd<1i{\\xf5'

--- a/scrapy/utils/request.py
+++ b/scrapy/utils/request.py
@@ -15,7 +15,7 @@ from scrapy.utils.httpobj import urlparse_cached
 from scrapy.utils.python import to_bytes, to_native_str
 
 
-def request_fingerprint(request, include_headers=None):
+def request_fingerprint(request, include_headers=None, hexadecimal=True):
     """Fills :attr:`request.fingerprint <scrapy.http.Request.fingerprint>` if
     needed and returns the fingerprint of *request*.
 
@@ -24,19 +24,31 @@ def request_fingerprint(request, include_headers=None):
     calculated, assigned to
     :attr:`request.fingerprint <scrapy.http.Request.fingerprint>` and returned.
 
+    .. deprecated:: VERSION
+
+        ``hexadecimal=True`` is deprecated. Future versions will always return
+        the fingerprint as :class:`bytes`. Use ``hexadecimal=False``.
+
     Example::
 
         >>> from scrapy import Request
         >>> request = Request('https://example.com')
         >>> request.fingerprint is None
         True
-        >>> request_fingerprint(request)
-        '6d748741a927b10454c83ac285b002cd239964ea'
+        >>> request_fingerprint(request, hexadecimal=False)
+        b"mt\\x87A\\xa9'\\xb1\\x04T\\xc8:\\xc2\\x85\\xb0\\x02\\xcd#\\x99d\\xea"
         >>> request.fingerprint
-        '6d748741a927b10454c83ac285b002cd239964ea'
+        b"mt\\x87A\\xa9'\\xb1\\x04T\\xc8:\\xc2\\x85\\xb0\\x02\\xcd#\\x99d\\xea"
     """
     def encoded_fingerprint(request):
-        return request.fingerprint.hex()
+        if hexadecimal:
+            return request.fingerprint.hex()
+        return request.fingerprint
+
+    if hexadecimal:
+        warn('`hexadecimal=True` is deprecated. Future versions will always '
+             'return the fingerprint as `bytes`. Use `hexadecimal=False`.',
+             ScrapyDeprecationWarning)
     if request.fingerprint is not None:
         return encoded_fingerprint(request)
     fp = hashlib.sha1()

--- a/tests/test_crawler.py
+++ b/tests/test_crawler.py
@@ -170,9 +170,9 @@ class CrawlerRunnerTestCase(BaseCrawlerTest):
         with warnings.catch_warnings(record=True) as w:
             runner = CrawlerRunner(Settings())
             spiders = runner.spiders
-            self.assertEqual(len(w), 1)
-            self.assertIn("CrawlerRunner.spiders", str(w[0].message))
-            self.assertIn("CrawlerRunner.spider_loader", str(w[0].message))
+            message = ('CrawlerRunner.spiders attribute is renamed to '
+                       'CrawlerRunner.spider_loader.')
+            assert message in set(str(warning.message) for warning in w)
             sl_cls = load_object(runner.settings['SPIDER_LOADER_CLASS'])
             self.assertIsInstance(spiders, sl_cls)
 

--- a/tests/test_http_request.py
+++ b/tests/test_http_request.py
@@ -43,12 +43,20 @@ class RequestTest(unittest.TestCase):
 
         meta = {"lala": "lolo"}
         headers = {b"caca": b"coco"}
-        r = self.request_class("http://www.example.com", meta=meta, headers=headers, body="a body")
+        fingerprint = b'a'
+        r = self.request_class(
+            "http://www.example.com",
+            meta=meta,
+            headers=headers,
+            body="a body",
+            fingerprint=fingerprint,
+        )
 
         assert r.meta is not meta
         self.assertEqual(r.meta, meta)
         assert r.headers is not headers
         self.assertEqual(r.headers[b"caca"], b"coco")
+        assert r.fingerprint == fingerprint
 
     def test_url_no_scheme(self):
         self.assertRaises(ValueError, self.request_class, 'foo')

--- a/tests/test_utils_request.py
+++ b/tests/test_utils_request.py
@@ -16,9 +16,6 @@ class UtilsRequestTest(unittest.TestCase):
         r2 = Request('http://www.example.com/hnnoticiaj1.aspx?78160,199')
         self.assertNotEqual(request_fingerprint(r1), request_fingerprint(r2))
 
-        # make sure request.fingerprint is set
-        self.assertEqual(request_fingerprint(r1), r1.fingerprint.hex())
-
         r1 = Request("http://www.example.com/members/offers.html")
         r2 = Request("http://www.example.com/members/offers.html")
         r2.headers['SESSIONID'] = b"somehash"

--- a/tests/test_utils_request.py
+++ b/tests/test_utils_request.py
@@ -17,7 +17,7 @@ class UtilsRequestTest(unittest.TestCase):
         self.assertNotEqual(request_fingerprint(r1), request_fingerprint(r2))
 
         # make sure request.fingerprint is set
-        self.assertEqual(request_fingerprint(r1), r1.fingerprint)
+        self.assertEqual(request_fingerprint(r1), r1.fingerprint.hex())
 
         r1 = Request("http://www.example.com/members/offers.html")
         r2 = Request("http://www.example.com/members/offers.html")

--- a/tests/test_utils_request.py
+++ b/tests/test_utils_request.py
@@ -1,7 +1,7 @@
 from __future__ import print_function
 import unittest
 from scrapy.http import Request
-from scrapy.utils.request import request_fingerprint, _fingerprint_cache, \
+from scrapy.utils.request import request_fingerprint, \
     request_authenticate, request_httprepr
 
 class UtilsRequestTest(unittest.TestCase):
@@ -16,8 +16,8 @@ class UtilsRequestTest(unittest.TestCase):
         r2 = Request('http://www.example.com/hnnoticiaj1.aspx?78160,199')
         self.assertNotEqual(request_fingerprint(r1), request_fingerprint(r2))
 
-        # make sure caching is working
-        self.assertEqual(request_fingerprint(r1), _fingerprint_cache[r1][None])
+        # make sure request.fingerprint is set
+        self.assertEqual(request_fingerprint(r1), r1.fingerprint)
 
         r1 = Request("http://www.example.com/members/offers.html")
         r2 = Request("http://www.example.com/members/offers.html")

--- a/tests/test_utils_request.py
+++ b/tests/test_utils_request.py
@@ -14,10 +14,12 @@ from scrapy.utils.request import (
 )
 
 
-def test_json_serializer():
-    serialized = b'{"a": 1, "b": 2}'
-    assert json_serializer({'a': 1, 'b': 2}) == serialized
-    assert json_serializer({'b': 2, 'a': 1}) == serialized
+class JSONSerializerTests(unittest.TestCase):
+
+    def test_json_serializer(self):
+        serialized = b'{"a": 1, "b": 2}'
+        assert json_serializer({'a': 1, 'b': 2}) == serialized
+        assert json_serializer({'b': 2, 'a': 1}) == serialized
 
 
 class ProcessRequestFingerprintTests(unittest.TestCase):
@@ -342,9 +344,11 @@ class UtilsRequestTest(unittest.TestCase):
         request_httprepr(Request("ftp://localhost/tmp/foo.txt"))
 
 
-def test_sha1_hasher():
-    hashed = b'\x17D\xf5>\x00\xfc#\xbd>Q[)\x8eB\x93d\x85\x06\x1d\xba'
-    assert sha1_hasher(b'{"a": 1, "b": 2}') == hashed
+class SHA1HasherTests(unittest.TestCase):
+
+    def test_sha1_hasher(self):
+        hashed = b'\x17D\xf5>\x00\xfc#\xbd>Q[)\x8eB\x93d\x85\x06\x1d\xba'
+        assert sha1_hasher(b'{"a": 1, "b": 2}') == hashed
 
 
 if __name__ == "__main__":

--- a/tests/test_utils_request.py
+++ b/tests/test_utils_request.py
@@ -1,57 +1,230 @@
 from __future__ import print_function
+
 import unittest
+
 from scrapy.http import Request
-from scrapy.utils.request import request_fingerprint, \
-    request_authenticate, request_httprepr
+from scrapy.settings import Settings
+from scrapy.utils.request import (
+    json_serializer,
+    process_request_fingerprint,
+    request_fingerprint,
+    request_authenticate,
+    request_httprepr,
+    sha1_hasher,
+)
 
-class UtilsRequestTest(unittest.TestCase):
 
-    def test_request_fingerprint(self):
+def test_json_serializer():
+    serialized = b'{"a": 1, "b": 2}'
+    assert json_serializer({'a': 1, 'b': 2}) == serialized
+    assert json_serializer({'b': 2, 'a': 1}) == serialized
+
+
+class ProcessRequestFingerprintTests(unittest.TestCase):
+
+    def test_override_default_processor(self):
+        request = Request('https://example.com')
+        data = process_request_fingerprint(
+            request, {}, url_processor=str.upper)
+        assert data['url'] == 'HTTPS://EXAMPLE.COM'
+
+    def test_capture_request_header(self):
+        request = Request(
+            'https://example.com', headers={'Content-Type': 'json'})
+        data = process_request_fingerprint(
+            request, {}, headers={'content-type'})
+        assert data['headers']['content-type'] == ['json']
+
+    def test_capture_missing_request_header(self):
+        request = Request('https://example.com')
+        data = process_request_fingerprint(
+            request, {}, headers={'content-type'})
+        assert 'headers' not in data
+
+    def test_capture_request_metadata(self):
+        meta = {'page': 1}
+        request = Request('https://example.com', meta=meta)
+        data = process_request_fingerprint(request, {}, meta={'page'})
+        assert data['meta'] == meta
+        assert id(data['meta']) != id(meta)
+
+    def test_capture_missing_request_metadata(self):
+        request = Request('https://example.com')
+        data = process_request_fingerprint(request, {}, meta={'page'})
+        assert 'meta' not in data
+
+
+class RequestFingerprintTests(unittest.TestCase):
+
+    def test_different_query_string_order(self):
         r1 = Request("http://www.example.com/query?id=111&cat=222")
         r2 = Request("http://www.example.com/query?cat=222&id=111")
-        self.assertEqual(request_fingerprint(r1), request_fingerprint(r1))
         self.assertEqual(request_fingerprint(r1), request_fingerprint(r2))
 
+    def test_query_string_parameter_without_value(self):
         r1 = Request('http://www.example.com/hnnoticiaj1.aspx?78132,199')
         r2 = Request('http://www.example.com/hnnoticiaj1.aspx?78160,199')
         self.assertNotEqual(request_fingerprint(r1), request_fingerprint(r2))
 
+    def test_headers_are_ignored_by_default(self):
         r1 = Request("http://www.example.com/members/offers.html")
         r2 = Request("http://www.example.com/members/offers.html")
         r2.headers['SESSIONID'] = b"somehash"
         self.assertEqual(request_fingerprint(r1), request_fingerprint(r2))
 
+    def test_include_headers(self):
         r1 = Request("http://www.example.com/")
         r2 = Request("http://www.example.com/")
         r2.headers['Accept-Language'] = b'en'
         r3 = Request("http://www.example.com/")
         r3.headers['Accept-Language'] = b'en'
         r3.headers['SESSIONID'] = b"somehash"
-
         self.assertEqual(request_fingerprint(r1), request_fingerprint(r2), request_fingerprint(r3))
-
         self.assertEqual(request_fingerprint(r1),
                          request_fingerprint(r1, include_headers=['Accept-Language']))
-
         self.assertNotEqual(request_fingerprint(r1),
-                         request_fingerprint(r2, include_headers=['Accept-Language']))
-
+                            request_fingerprint(r2, include_headers=['Accept-Language']))
         self.assertEqual(request_fingerprint(r3, include_headers=['accept-language', 'sessionid']),
                          request_fingerprint(r3, include_headers=['SESSIONID', 'Accept-Language']))
 
+    def test_include_headers_and_request_fingerprint(self):
+        fingerprint = b'1'
+        request1 = Request("http://www.example.com/",
+                           headers={'Accept-Language': 'en'},
+                           fingerprint=fingerprint)
+        request2 = Request("http://www.example.com/",
+                           headers={'Accept-Language': 'en'})
+        fingerprint1 = request_fingerprint(
+            request1, include_headers=['Accept-Language'])
+        fingerprint2 = request_fingerprint(
+            request2, include_headers=['Accept-Language'])
+        assert fingerprint1 == fingerprint2
+        assert request1.fingerprint != fingerprint1
+        assert request1.fingerprint == fingerprint
+
+    def test_include_headers_ignores_overriders(self):
+        request1 = Request("http://www.example.com/")
+        fingerprint1 = request_fingerprint(request1, include_headers=['a'])
+        meta = {
+            'fingerprint_processors': [lambda x, y: x.url],
+            'fingerprint_serializer': lambda x: x,
+            'fingerprint_hasher': lambda x: x,
+        }
+        settings = Settings()
+        settings['REQUEST_FINGERPRINT_PROCESSORS'] = [lambda x, y: x.url]
+        settings['REQUEST_FINGERPRINT_SERIALIZER'] = lambda x: x
+        settings['REQUEST_FINGERPRINT_HASHER'] = lambda x: x
+        request2 = Request("http://www.example.com/", meta=meta)
+        fingerprint2 = request_fingerprint(
+            request2, include_headers=['a'], settings=settings)
+        assert request1.fingerprint is None
+        assert request2.fingerprint is None
+        assert fingerprint1 == fingerprint2
+
+    def test_method_and_body(self):
         r1 = Request("http://www.example.com")
         r2 = Request("http://www.example.com", method='POST')
         r3 = Request("http://www.example.com", method='POST', body=b'request body')
-
         self.assertNotEqual(request_fingerprint(r1), request_fingerprint(r2))
         self.assertNotEqual(request_fingerprint(r2), request_fingerprint(r3))
 
-        # cached fingerprint must be cleared on request copy
-        r1 = Request("http://www.example.com")
-        fp1 = request_fingerprint(r1)
-        r2 = r1.replace(url="http://www.example.com/other")
-        fp2 = request_fingerprint(r2)
-        self.assertNotEqual(fp1, fp2)
+    def test_return_predefined_fingerprint(self):
+        fingerprint = b'1'
+        fingerprint_string = fingerprint.hex()
+        request = Request("http://www.example.com", fingerprint=fingerprint)
+        output = request_fingerprint(request, settings=Settings())
+        assert output == fingerprint_string
+        assert request.fingerprint == fingerprint
+        output = request_fingerprint(
+            request, settings=Settings(), hexadecimal=False)
+        assert output == fingerprint
+        assert request.fingerprint == fingerprint
+
+    def test_fingerprint_is_updated(self):
+        request = Request("http://www.example.com")
+        assert request.fingerprint is None
+        output = request_fingerprint(
+            request, settings=Settings(), hexadecimal=False)
+        assert request.fingerprint == output
+
+    def test_no_settings_and_request_fingerprint(self):
+        fingerprint = b'1'
+        request1 = Request("http://www.example.com/", fingerprint=fingerprint)
+        request2 = Request("http://www.example.com/")
+        fingerprint1 = request_fingerprint(request1)
+        fingerprint2 = request_fingerprint(request2)
+        assert fingerprint1 == fingerprint2
+        assert request1.fingerprint != fingerprint1
+        assert request1.fingerprint == fingerprint
+
+    def test_no_settings_ignores_overriders(self):
+        request1 = Request("http://www.example.com/")
+        fingerprint1 = request_fingerprint(request1)
+        meta = {
+            'fingerprint_processors': [lambda x, y: x.url],
+            'fingerprint_serializer': lambda x: x,
+            'fingerprint_hasher': lambda x: x,
+        }
+        request2 = Request("http://www.example.com/", meta=meta)
+        fingerprint2 = request_fingerprint(request2)
+        assert request1.fingerprint is None
+        assert request2.fingerprint is None
+        assert fingerprint1 == fingerprint2
+
+    def test_meta_overriders(self):
+        meta = {
+            'fingerprint_processors': [lambda x, y: x.url],
+            'fingerprint_serializer': lambda x: x,
+            'fingerprint_hasher': lambda x: x,
+        }
+        request = Request("http://www.example.com/", meta=meta)
+        fingerprint = request_fingerprint(
+            request, settings=Settings(), hexadecimal=False)
+        assert fingerprint == request.url
+        assert request.fingerprint == fingerprint
+
+    def test_settings_overriders(self):
+        settings = Settings()
+        settings['REQUEST_FINGERPRINT_PROCESSORS'] = [lambda x, y: x.url]
+        settings['REQUEST_FINGERPRINT_SERIALIZER'] = lambda x: x
+        settings['REQUEST_FINGERPRINT_HASHER'] = lambda x: x
+        request = Request("http://www.example.com/")
+        fingerprint = request_fingerprint(
+            request, settings=settings, hexadecimal=False)
+        assert fingerprint == request.url
+        assert request.fingerprint == fingerprint
+
+    def test_meta_and_settings_overriders(self):
+        meta = {
+            'fingerprint_processors': [lambda x, y: x.method],
+            'fingerprint_serializer': lambda x: x,
+            'fingerprint_hasher': lambda x: x,
+        }
+        settings = Settings()
+        settings['REQUEST_FINGERPRINT_PROCESSORS'] = [lambda x, y: x.url]
+        settings['REQUEST_FINGERPRINT_SERIALIZER'] = lambda x: x
+        settings['REQUEST_FINGERPRINT_HASHER'] = lambda x: x
+        request = Request("http://www.example.com/", meta=meta)
+        fingerprint = request_fingerprint(
+            request, settings=settings, hexadecimal=False)
+        assert fingerprint == request.method
+        assert request.fingerprint == fingerprint
+
+    def test_multiple_processors(self):
+        meta = {
+            'fingerprint_processors': [lambda x, y: x.method,
+                                       lambda x, y: y+x.url],
+            'fingerprint_serializer': lambda x: x,
+            'fingerprint_hasher': lambda x: x,
+        }
+        request = Request("http://www.example.com/", meta=meta)
+        fingerprint = request_fingerprint(
+            request, settings=Settings(), hexadecimal=False)
+        assert fingerprint == request.method + request.url
+        assert request.fingerprint == fingerprint
+
+
+class UtilsRequestTest(unittest.TestCase):
 
     def test_request_authenticate(self):
         r = Request("http://www.example.com")
@@ -72,6 +245,12 @@ class UtilsRequestTest(unittest.TestCase):
         # the representation is not important but it must not fail.
         request_httprepr(Request("file:///tmp/foo.txt"))
         request_httprepr(Request("ftp://localhost/tmp/foo.txt"))
+
+
+def test_sha1_hasher():
+    hashed = b'\x17D\xf5>\x00\xfc#\xbd>Q[)\x8eB\x93d\x85\x06\x1d\xba'
+    assert sha1_hasher(b'{"a": 1, "b": 2}') == hashed
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Fixes #900, fixes #3420, fixes #3597. Closes #4113 (alternative implementation).

Things to look for during review:

- The proposed approach requires calling `request_fingerprint(request, settings)` every time you want to read the fingerprint of a request. It works, but it’s odd, so I’m more than open to architectural change requests.

-   It is OK for `REQUEST_FINGERPRINT_PROCESSORS` to be a list? Should it be
    something else, such as a dictionary like that of
    ``DOWNLOADER_MIDDLEWARES``?

-   Should we add PyYAML as a dependency to Scrapy and use a PyYAML-based
    serialization function, so that we support binary data (`bytes`, e.g.
    `request.body`) in the fingerprint data dictionary? (otherwise, since JSON
    does not support serializing bytes, `bytes.hex()` or similar must be used
    in processors)
