### PR TITLE
Fix JSONRequest naming

### DIFF
--- a/docs/news.rst
+++ b/docs/news.rst
@@ -64,8 +64,8 @@ New features
     provides a cleaner way to pass keyword arguments to callback methods
     (:issue:`1138`, :issue:`3563`)
 
-*   A new :class:`~scrapy.http.JsonRequest` class offers a more convenient way
-    to build JSON requests (:issue:`3504`, :issue:`3505`)
+*   A new :class:`JSONRequest <scrapy.http.JsonRequest>` class offers a more
+    convenient way to build JSON requests (:issue:`3504`, :issue:`3505`)
 
 *   A ``process_request`` callback passed to the :class:`~scrapy.spiders.Rule`
     constructor now receives the :class:`~scrapy.http.Response` object that

--- a/docs/news.rst
+++ b/docs/news.rst
@@ -64,7 +64,7 @@ New features
     provides a cleaner way to pass keyword arguments to callback methods
     (:issue:`1138`, :issue:`3563`)
 
-*   A new :class:`~scrapy.http.JSONRequest` class offers a more convenient way
+*   A new :class:`~scrapy.http.JsonRequest` class offers a more convenient way
     to build JSON requests (:issue:`3504`, :issue:`3505`)
 
 *   A ``process_request`` callback passed to the :class:`~scrapy.spiders.Rule`

--- a/docs/topics/request-response.rst
+++ b/docs/topics/request-response.rst
@@ -533,19 +533,19 @@ method for this job. Here's an example spider which uses it::
 
             # continue scraping with authenticated session...
 
-JSONRequest
+JsonRequest
 -----------
 
-The JSONRequest class extends the base :class:`Request` class with functionality for
+The JsonRequest class extends the base :class:`Request` class with functionality for
 dealing with JSON requests.
 
-.. class:: JSONRequest(url, [... data, dumps_kwargs])
+.. class:: JsonRequest(url, [... data, dumps_kwargs])
 
-   The :class:`JSONRequest` class adds two new argument to the constructor. The
+   The :class:`JsonRequest` class adds two new argument to the constructor. The
    remaining arguments are the same as for the :class:`Request` class and are
    not documented here.
 
-   Using the :class:`JSONRequest` will set the ``Content-Type`` header to ``application/json``
+   Using the :class:`JsonRequest` will set the ``Content-Type`` header to ``application/json``
    and ``Accept`` header to ``application/json, text/javascript, */*; q=0.01``
 
    :param data: is any JSON serializable object that needs to be JSON encoded and assigned to body.
@@ -560,7 +560,7 @@ dealing with JSON requests.
 
 .. _json.dumps: https://docs.python.org/3/library/json.html#json.dumps
 
-JSONRequest usage example
+JsonRequest usage example
 -------------------------
 
 Sending a JSON POST request with a JSON payload::
@@ -569,7 +569,7 @@ Sending a JSON POST request with a JSON payload::
        'name1': 'value1',
        'name2': 'value2',
    }
-   yield JSONRequest(url='http://www.example.com/post/action', data=data)
+   yield JsonRequest(url='http://www.example.com/post/action', data=data)
 
 
 Response objects

--- a/scrapy/http/__init__.py
+++ b/scrapy/http/__init__.py
@@ -10,7 +10,7 @@ from scrapy.http.headers import Headers
 from scrapy.http.request import Request
 from scrapy.http.request.form import FormRequest
 from scrapy.http.request.rpc import XmlRpcRequest
-from scrapy.http.request.json_request import JSONRequest
+from scrapy.http.request.json_request import JsonRequest
 
 from scrapy.http.response import Response
 from scrapy.http.response.html import HtmlResponse

--- a/scrapy/http/request/json_request.py
+++ b/scrapy/http/request/json_request.py
@@ -1,5 +1,5 @@
 """
-This module implements the JSONRequest class which is a more convenient class
+This module implements the JsonRequest class which is a more convenient class
 (than Request) to generate JSON Requests.
 
 See documentation in docs/topics/request-response.rst
@@ -12,7 +12,7 @@ import warnings
 from scrapy.http.request import Request
 
 
-class JSONRequest(Request):
+class JsonRequest(Request):
     def __init__(self, *args, **kwargs):
         dumps_kwargs = copy.deepcopy(kwargs.pop('dumps_kwargs', {}))
         dumps_kwargs.setdefault('sort_keys', True)
@@ -31,7 +31,7 @@ class JSONRequest(Request):
             if 'method' not in kwargs:
                 kwargs['method'] = 'POST'
 
-        super(JSONRequest, self).__init__(*args, **kwargs)
+        super(JsonRequest, self).__init__(*args, **kwargs)
         self.headers.setdefault('Content-Type', 'application/json')
         self.headers.setdefault('Accept', 'application/json, text/javascript, */*; q=0.01')
 
@@ -46,7 +46,7 @@ class JSONRequest(Request):
         elif not body_passed and data_passed:
             kwargs['body'] = self._dumps(data)
 
-        return super(JSONRequest, self).replace(*args, **kwargs)
+        return super(JsonRequest, self).replace(*args, **kwargs)
 
     def _dumps(self, data):
         """Convert to JSON """

--- a/scrapy/http/request/json_request.py
+++ b/scrapy/http/request/json_request.py
@@ -10,6 +10,7 @@ import json
 import warnings
 
 from scrapy.http.request import Request
+from scrapy.utils.deprecate import create_deprecated_class
 
 
 class JsonRequest(Request):
@@ -51,3 +52,6 @@ class JsonRequest(Request):
     def _dumps(self, data):
         """Convert to JSON """
         return json.dumps(data, **self._dumps_kwargs)
+
+
+JSONRequest = create_deprecated_class("JSONRequest", JsonRequest)

--- a/tests/test_http_request.py
+++ b/tests/test_http_request.py
@@ -11,7 +11,7 @@ from six.moves.urllib.parse import urlparse, parse_qs, unquote
 if six.PY3:
     from urllib.parse import unquote_to_bytes
 
-from scrapy.http import Request, FormRequest, XmlRpcRequest, JSONRequest, Headers, HtmlResponse
+from scrapy.http import Request, FormRequest, XmlRpcRequest, JsonRequest, Headers, HtmlResponse
 from scrapy.utils.python import to_bytes, to_native_str
 
 from tests import mock
@@ -1170,14 +1170,14 @@ class XmlRpcRequestTest(RequestTest):
         self._test_request(params=(u'pas£',), encoding='latin1')
 
 
-class JSONRequestTest(RequestTest):
-    request_class = JSONRequest
+class JsonRequestTest(RequestTest):
+    request_class = JsonRequest
     default_method = 'GET'
     default_headers = {b'Content-Type': [b'application/json'], b'Accept': [b'application/json, text/javascript, */*; q=0.01']}
 
     def setUp(self):
         warnings.simplefilter("always")
-        super(JSONRequestTest, self).setUp()
+        super(JsonRequestTest, self).setUp()
 
     def test_data(self):
         r1 = self.request_class(url="http://www.example.com/")
@@ -1331,7 +1331,7 @@ class JSONRequestTest(RequestTest):
 
     def tearDown(self):
         warnings.resetwarnings()
-        super(JSONRequestTest, self).tearDown()
+        super(JsonRequestTest, self).tearDown()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Change `JSONRequest` to `JsonRequest` to follow the same format/style as the other JSON classes (`JsonLinesItemExporter`, `JsonItemExporter` and `JsonWriterPipeline`) and the other response/request classes (`HtmlResponse`, `XmlResponse`, `XmlRpcRequest`)

fixes:
* issue: https://github.com/scrapy/scrapy/issues/3929
* old PR: https://github.com/scrapy/scrapy/pull/3930