### PR TITLE
CallbackKeywordArgumentsContract

### DIFF
--- a/docs/topics/contracts.rst
+++ b/docs/topics/contracts.rst
@@ -35,11 +35,19 @@ This callback is tested using three built-in contracts:
 
 .. class:: UrlContract
 
-    This contract (``@url``) sets the sample url used when checking other
+    This contract (``@url``) sets the sample URL used when checking other
     contract conditions for this spider. This contract is mandatory. All
     callbacks lacking this contract are ignored when running the checks::
 
     @url url
+
+.. class:: CallbackKeywordArgumentsContract
+
+    This contract (``@cb_kwargs``) sets the :attr:`cb_kwargs <scrapy.http.Request.cb_kwargs>`
+    attribute for the sample request. It must be a valid JSON dictionary.
+    ::
+
+    @cb_kwargs {"arg1": "value1", "arg2": "value2", ...}
 
 .. class:: ReturnsContract
 

--- a/scrapy/contracts/__init__.py
+++ b/scrapy/contracts/__init__.py
@@ -90,9 +90,9 @@ class ContractsManager(object):
         cb = request.callback
 
         @wraps(cb)
-        def cb_wrapper(response):
+        def cb_wrapper(response, **cb_kwargs):
             try:
-                output = cb(response, **request.cb_kwargs)
+                output = cb(response, **cb_kwargs)
                 output = list(iterate_spider_output(output))
             except Exception:
                 case = _create_testcase(method, 'callback')
@@ -121,7 +121,7 @@ class Contract(object):
             cb = request.callback
 
             @wraps(cb)
-            def wrapper(response):
+            def wrapper(response, **cb_kwargs):
                 try:
                     results.startTest(self.testcase_pre)
                     self.pre_process(response)
@@ -133,7 +133,7 @@ class Contract(object):
                 else:
                     results.addSuccess(self.testcase_pre)
                 finally:
-                    return list(iterate_spider_output(cb(response, **request.cb_kwargs)))
+                    return list(iterate_spider_output(cb(response, **cb_kwargs)))
 
             request.callback = wrapper
 
@@ -144,8 +144,8 @@ class Contract(object):
             cb = request.callback
 
             @wraps(cb)
-            def wrapper(response):
-                output = list(iterate_spider_output(cb(response, **request.cb_kwargs)))
+            def wrapper(response, **cb_kwargs):
+                output = list(iterate_spider_output(cb(response, **cb_kwargs)))
                 try:
                     results.startTest(self.testcase_post)
                     self.post_process(output)

--- a/scrapy/contracts/__init__.py
+++ b/scrapy/contracts/__init__.py
@@ -92,7 +92,7 @@ class ContractsManager(object):
         @wraps(cb)
         def cb_wrapper(response):
             try:
-                output = cb(response)
+                output = cb(response, **request.cb_kwargs)
                 output = list(iterate_spider_output(output))
             except Exception:
                 case = _create_testcase(method, 'callback')
@@ -133,7 +133,7 @@ class Contract(object):
                 else:
                     results.addSuccess(self.testcase_pre)
                 finally:
-                    return list(iterate_spider_output(cb(response)))
+                    return list(iterate_spider_output(cb(response, **request.cb_kwargs)))
 
             request.callback = wrapper
 
@@ -145,7 +145,7 @@ class Contract(object):
 
             @wraps(cb)
             def wrapper(response):
-                output = list(iterate_spider_output(cb(response)))
+                output = list(iterate_spider_output(cb(response, **request.cb_kwargs)))
                 try:
                     results.startTest(self.testcase_post)
                     self.post_process(output)

--- a/scrapy/contracts/default.py
+++ b/scrapy/contracts/default.py
@@ -1,3 +1,5 @@
+import json
+
 from scrapy.item import BaseItem
 from scrapy.http import Request
 from scrapy.exceptions import ContractFail
@@ -15,6 +17,20 @@ class UrlContract(Contract):
 
     def adjust_request_args(self, args):
         args['url'] = self.args[0]
+        return args
+
+
+class CallbackKeywordArgumentsContract(Contract):
+    """ Contract to set the keyword arguments for the request.
+        The value should be a JSON-encoded dictionary, e.g.:
+
+        @cb_kwargs {"arg1": "some value"}
+    """
+
+    name = 'cb_kwargs'
+
+    def adjust_request_args(self, args):
+        args['cb_kwargs'] = json.loads(' '.join(self.args))
         return args
 
 

--- a/scrapy/settings/default_settings.py
+++ b/scrapy/settings/default_settings.py
@@ -291,6 +291,7 @@ TELNETCONSOLE_PASSWORD = None
 SPIDER_CONTRACTS = {}
 SPIDER_CONTRACTS_BASE = {
     'scrapy.contracts.default.UrlContract': 1,
-    'scrapy.contracts.default.ReturnsContract': 2,
-    'scrapy.contracts.default.ScrapesContract': 3,
+    'scrapy.contracts.default.CallbackKeywordArgumentsContract': 2,
+    'scrapy.contracts.default.ReturnsContract': 3,
+    'scrapy.contracts.default.ScrapesContract': 4,
 }

--- a/scrapy/settings/default_settings.py
+++ b/scrapy/settings/default_settings.py
@@ -291,7 +291,7 @@ TELNETCONSOLE_PASSWORD = None
 SPIDER_CONTRACTS = {}
 SPIDER_CONTRACTS_BASE = {
     'scrapy.contracts.default.UrlContract': 1,
-    'scrapy.contracts.default.CallbackKeywordArgumentsContract': 2,
-    'scrapy.contracts.default.ReturnsContract': 3,
-    'scrapy.contracts.default.ScrapesContract': 4,
+    'scrapy.contracts.default.CallbackKeywordArgumentsContract': 1,
+    'scrapy.contracts.default.ReturnsContract': 2,
+    'scrapy.contracts.default.ScrapesContract': 3,
 }


### PR DESCRIPTION
Fixes #3985

~This patch works _partially_, in the sense that it prevents the reported `TypeError` (I checked, for instance by adding a simple `print(request.cb_kwargs)` to https://github.com/scrapy/scrapy/blob/1.7.3/scrapy/core/scheduler.py#L90, and the generated request does include a valid `cb_kwargs` attribute). However, adding the `@cb_kwargs` contract causes the whole callback to be excluded from the tests, and I can't for the life of me figure out why.~

Update: Working now, thanks to @victor-torres :rocket: 
 
Remaining tasks:

- [x] Docs
- [x] Tests
- [x] Figure out why it doesn't work