### PR TITLE
Resolve IPs before applying IP-based concurrency

### DIFF
--- a/scrapy/pqueues.py
+++ b/scrapy/pqueues.py
@@ -126,7 +126,7 @@ class DownloaderInterface(object):
                 for slot in possible_slots]
 
     def get_slot_key(self, request):
-        return self.downloader._get_slot_key(request, None)
+        return self.downloader._get_slot_key(request)
 
     def _active_downloads(self, slot):
         """ Return a number of requests in a Downloader for a given slot """

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -24,7 +24,7 @@ class MockDownloader(object):
     def __init__(self):
         self.slots = dict()
 
-    def _get_slot_key(self, request, spider):
+    def _get_slot_key(self, request):
         if Downloader.DOWNLOAD_SLOT in request.meta:
             return request.meta[Downloader.DOWNLOAD_SLOT]
 
@@ -265,14 +265,14 @@ class DownloaderAwareSchedulerTestMixin(object):
         while self.scheduler.has_pending_requests():
             request = self.scheduler.next_request()
             # pylint: disable=protected-access
-            slot = downloader._get_slot_key(request, None)
+            slot = downloader._get_slot_key(request)
             dequeued_slots.append(slot)
             downloader.increment(slot)
             requests.append(request)
 
         for request in requests:
             # pylint: disable=protected-access
-            slot = downloader._get_slot_key(request, None)
+            slot = downloader._get_slot_key(request)
             downloader.decrement(slot)
 
         self.assertTrue(_is_scheduling_fair(list(s for u, s in _URLS_WITH_SLOTS),


### PR DESCRIPTION
Fixes #1659

Now, when IP-based concurrency is configured, DNS resolving is done before requests are assigned a slot.

I’ve run the test script from #1659 with these changes, and it seems to work as expected:
```
2019-09-17 14:01:17 [scrapy.core.engine] DEBUG: Crawled (200) <GET http://a.capybala.com/> (referer: None)
Download slot: 153.126.148.254
2019-09-17 14:01:18 [scrapy.core.engine] DEBUG: Crawled (200) <GET http://c.capybala.com/> (referer: None)
Download slot: 153.126.148.254
2019-09-17 14:01:19 [scrapy.core.engine] DEBUG: Crawled (200) <GET http://b.capybala.com/> (referer: None)
Download slot: 153.126.148.254
2019-09-17 14:01:20 [scrapy.core.engine] DEBUG: Crawled (200) <GET http://d.capybala.com/> (referer: None)
Download slot: 153.126.148.254
2019-09-17 14:01:21 [scrapy.core.engine] DEBUG: Crawled (200) <GET http://e.capybala.com/> (referer: None)
Download slot: 153.126.148.254
```

Regarding automated tests to cover this change: I don’t even know where to start, so any help is much appreciated.

Upon DNS errors, a special “unknown_ip_address” is used, instead of the domain name, as suggested in #1659. Should we make this configurable?