### PR TITLE
Error 302 redirection with headers location starts with 3 slash #4032…

### DIFF
--- a/scrapy/downloadermiddlewares/redirect.py
+++ b/scrapy/downloadermiddlewares/redirect.py
@@ -70,8 +70,8 @@ class RedirectMiddleware(BaseRedirectMiddleware):
         if 'Location' not in response.headers or response.status not in allowed_status:
             return response
 
-        location = safe_url_string(response.headers['location'])
-        if response.headers['location'].startswith(b'//'):
+        location = safe_url_string(response.headers['Location'])
+        if response.headers['Location'].startswith(b'//'):
             request_scheme = urlparse(request.url).scheme
             location = request_scheme + '://' + location.lstrip('/')
 

--- a/scrapy/downloadermiddlewares/redirect.py
+++ b/scrapy/downloadermiddlewares/redirect.py
@@ -1,5 +1,7 @@
 import logging
+import re
 from six.moves.urllib.parse import urljoin
+from six.moves.urllib.parse import urlparse
 
 from w3lib.url import safe_url_string
 
@@ -71,6 +73,9 @@ class RedirectMiddleware(BaseRedirectMiddleware):
             return response
 
         location = safe_url_string(response.headers['location'])
+        if response.headers['location'].decode().startswith('/', 1):
+            request_scheme = urlparse(request.url).scheme
+            location = request_scheme + '://' + re.sub('^/*', '', location)
 
         redirected_url = urljoin(request.url, location)
 

--- a/scrapy/downloadermiddlewares/redirect.py
+++ b/scrapy/downloadermiddlewares/redirect.py
@@ -73,7 +73,7 @@ class RedirectMiddleware(BaseRedirectMiddleware):
             return response
 
         location = safe_url_string(response.headers['location'])
-        if response.headers['location'].decode().startswith('/', 1):
+        if response.headers['location'].decode("latin1").startswith('/', 1):
             request_scheme = urlparse(request.url).scheme
             location = request_scheme + '://' + re.sub('^/*', '', location)
 

--- a/scrapy/downloadermiddlewares/redirect.py
+++ b/scrapy/downloadermiddlewares/redirect.py
@@ -1,7 +1,5 @@
 import logging
-import re
-from six.moves.urllib.parse import urljoin
-from six.moves.urllib.parse import urlparse
+from six.moves.urllib.parse import urljoin, urlparse
 
 from w3lib.url import safe_url_string
 
@@ -73,9 +71,9 @@ class RedirectMiddleware(BaseRedirectMiddleware):
             return response
 
         location = safe_url_string(response.headers['location'])
-        if response.headers['location'].decode("latin1").startswith('/', 1):
+        if response.headers['location'].startswith(b'//'):
             request_scheme = urlparse(request.url).scheme
-            location = request_scheme + '://' + re.sub('^/*', '', location)
+            location = request_scheme + '://' + location.lstrip('/')
 
         redirected_url = urljoin(request.url, location)
 

--- a/tests/test_downloadermiddleware_redirect.py
+++ b/tests/test_downloadermiddleware_redirect.py
@@ -106,6 +106,22 @@ class RedirectMiddlewareTest(unittest.TestCase):
         del rsp.headers['Location']
         assert self.mw.process_response(req, rsp, self.spider) is rsp
 
+    def test_redirect_302_relative(self):
+        url = 'http://www.example.com/302'
+        url2 = '///i8n.example2.com/302'
+        url3 = 'http://i8n.example2.com/302'
+        req = Request(url, method='HEAD')
+        rsp = Response(url, headers={'Location': url2}, status=302)
+
+        req2 = self.mw.process_response(req, rsp, self.spider)
+        assert isinstance(req2, Request)
+        self.assertEqual(req2.url, url3)
+        self.assertEqual(req2.method, 'HEAD')
+
+        # response without Location header but with status code is 3XX should be ignored
+        del rsp.headers['Location']
+        assert self.mw.process_response(req, rsp, self.spider) is rsp
+
 
     def test_max_redirect_times(self):
         self.mw.max_redirect_times = 1


### PR DESCRIPTION
The issue was when the location header returned a URL starting with multiple forward slashes `///`.

The browser converted such URLs to its absolute form e.g. : `///fr.hujiang.com/new/p1285798/` was changed to `https://fr.hujiang.com/new/p1285798/`. But in Scrapy the URL was converted to the absolute form w.r.t to the original base URL: `///fr.hujiang.com/new/p1285798/` was changed to `https://www.hjenglish.com/fr.hujiang.com/new/p1285798`.

The fix checks whether the location header value has an URL value starting with more than one `/` if it is the logic will change it to the absolute form `https://fr.hujiang.com/new/p1285798/` by appending the `<scheme>://` before it.

(Edit) Fixes #4032 