### PR TITLE
CsvItemExporter: Warning message on dropped fields

### DIFF
--- a/scrapy/exporters.py
+++ b/scrapy/exporters.py
@@ -249,8 +249,10 @@ class CsvItemExporter(BaseItemExporter):
         if not self._data_loss_already_warned:
             if self.fields_to_export is None:
                 logger.warning("Data loss detected when exporting items -- This message won't be shown for further items")
+                self._data_loss_already_warned = True
             elif set(fields) != set(self.fields_to_export):
                 logger.info("Data loss detected when exporting items -- This message won't be shown for further items")
+                self._data_loss_already_warned = True
         values = list(self._build_row(x for _, x in serialized_fields))
         self.csv_writer.writerow(values)
 

--- a/scrapy/exporters.py
+++ b/scrapy/exporters.py
@@ -268,7 +268,7 @@ class CsvItemExporter(BaseItemExporter):
                 self._is_data_loss_warning_displayed = True
                 self.fields_to_export = fields
             elif not self._fail_on_dataloss_warned:
-                if len(fields) > len(self.fields_to_export):
+                if fields != self.fields_to_export:
                     self._is_data_loss_warning_displayed = True
             if self._is_data_loss_warning_displayed and not self._fail_on_dataloss_warned:
                 logger.warning("Possible chance of data loss detected -- This message won't be shown in further requests")

--- a/scrapy/exporters.py
+++ b/scrapy/exporters.py
@@ -258,21 +258,18 @@ class CsvItemExporter(BaseItemExporter):
 
     def _write_headers_and_set_fields_to_export(self, item):
         if self.include_headers_line:
+            if isinstance(item, dict):
+                # for dicts try using fields of the first item
+                fields = list(item.keys())
+            else:
+                # use fields declared in Item
+                fields = list(item.fields.keys())
             if not self.fields_to_export:
                 self._is_data_loss_warning_displayed = True
-                if isinstance(item, dict):
-                    # for dicts try using fields of the first item
-                    self.fields_to_export = list(item.keys())
-                else:
-                    # use fields declared in Item
-                    self.fields_to_export = list(item.fields.keys())
+                self.fields_to_export = fields
             elif not self._fail_on_dataloss_warned:
-                if isinstance(item, dict):
-                    if len(item.keys()) > self.fields_to_export:
-                        self._is_data_loss_warning_displayed = True
-                else:
-                    if len(item.fields.keys()) > self.fields_to_export:
-                        self._is_data_loss_warning_displayed = True
+                if len(fields) > len(self.fields_to_export):
+                    self._is_data_loss_warning_displayed = True
             if self._is_data_loss_warning_displayed and not self._fail_on_dataloss_warned:
                 logger.warning("Possible chance of data loss detected -- This message won't be shown in further requests")
                 self._fail_on_dataloss_warned = True

--- a/scrapy/exporters.py
+++ b/scrapy/exporters.py
@@ -244,11 +244,13 @@ class CsvItemExporter(BaseItemExporter):
             self._headers_not_written = False
             self._write_headers_and_set_fields_to_export(item)
 
-        serialized_fields = self._get_serialized_fields(item, default_value='',
-                                             include_empty=True)
+        serialized_fields = self._get_serialized_fields(item, default_value='', include_empty=True)
         fields = self._get_fields_from_item(item)
-        if (self.fields_to_export == None or set(fields) != set(self.fields_to_export)) and not self._data_loss_already_warned:
-            logger.warning("Data loss detected when exporting items -- This message won't be shown in further items")
+        if not self._data_loss_already_warned:
+            if self.fields_to_export is None:
+                logger.warning("Data loss detected when exporting items -- This message won't be shown for further items")
+            elif set(fields) != set(self.fields_to_export):
+                logger.info("Data loss detected when exporting items -- This message won't be shown for further items")
         values = list(self._build_row(x for _, x in serialized_fields))
         self.csv_writer.writerow(values)
 
@@ -269,7 +271,7 @@ class CsvItemExporter(BaseItemExporter):
                 if set(fields) != set(self.fields_to_export):
                     self._show_data_loss_warning = True
             if self._show_data_loss_warning and not self._data_loss_already_warned:
-                logger.warning("Data loss detected when exporting items -- This message won't be shown in further items")
+                logger.warning("Data loss detected when exporting items -- This message won't be shown for further items")
                 self._data_loss_already_warned = True
             row = list(self._build_row(self.fields_to_export))
             self.csv_writer.writerow(row)

--- a/scrapy/exporters.py
+++ b/scrapy/exporters.py
@@ -268,7 +268,7 @@ class CsvItemExporter(BaseItemExporter):
                 self._is_data_loss_warning_displayed = True
                 self.fields_to_export = fields
             elif not self._fail_on_dataloss_warned:
-                if fields != self.fields_to_export:
+                if set(fields) != set(self.fields_to_export):
                     self._is_data_loss_warning_displayed = True
             if self._is_data_loss_warning_displayed and not self._fail_on_dataloss_warned:
                 logger.warning("Possible chance of data loss detected -- This message won't be shown in further requests")

--- a/scrapy/exporters.py
+++ b/scrapy/exporters.py
@@ -247,7 +247,7 @@ class CsvItemExporter(BaseItemExporter):
         serialized_fields = self._get_serialized_fields(item, default_value='',
                                              include_empty=True)
         fields = self._get_fields_from_item(item)
-        if set(fields) != set(self.fields_to_export) and not self._data_loss_already_warned:
+        if (self.fields_to_export == None or set(fields) != set(self.fields_to_export)) and not self._data_loss_already_warned:
             logger.warning("Data loss detected when exporting items -- This message won't be shown in further items")
         values = list(self._build_row(x for _, x in serialized_fields))
         self.csv_writer.writerow(values)

--- a/scrapy/exporters.py
+++ b/scrapy/exporters.py
@@ -224,8 +224,8 @@ class CsvItemExporter(BaseItemExporter):
         self.csv_writer = csv.writer(self.stream, **kwargs)
         self._headers_not_written = True
         self._join_multivalued = join_multivalued
-        self._is_data_loss_warning_displayed = False
-        self._fail_on_dataloss_warned = False
+        self._show_data_loss_warning = False
+        self._data_loss_already_warned = False
 
     def serialize_field(self, field, name, value):
         serializer = field.get('serializer', self._join_if_needed)
@@ -265,14 +265,14 @@ class CsvItemExporter(BaseItemExporter):
                 # use fields declared in Item
                 fields = list(item.fields.keys())
             if not self.fields_to_export:
-                self._is_data_loss_warning_displayed = True
+                self._show_data_loss_warning = True
                 self.fields_to_export = fields
-            elif not self._fail_on_dataloss_warned:
+            elif not self._data_loss_already_warned:
                 if set(fields) != set(self.fields_to_export):
-                    self._is_data_loss_warning_displayed = True
-            if self._is_data_loss_warning_displayed and not self._fail_on_dataloss_warned:
-                logger.warning("Possible chance of data loss detected -- This message won't be shown in further requests")
-                self._fail_on_dataloss_warned = True
+                    self._show_data_loss_warning = True
+            if self._show_data_loss_warning and not self._data_loss_already_warned:
+                logger.warning("Data loss detected when exporting items -- This message won't be shown in further items")
+                self._data_loss_already_warned = True
             row = list(self._build_row(self.fields_to_export))
             self.csv_writer.writerow(row)
 

--- a/tests/test_feedexport.py
+++ b/tests/test_feedexport.py
@@ -633,7 +633,7 @@ class FeedExportTest(unittest.TestCase):
         with mock.patch('logging.Logger.warning') as logs:
             settings = {'FEED_FORMAT': 'csv'}
             yield self.exported_data(items, settings)
-        logs.assert_called_with("Data loss detected when exporting items -- This message won't be shown in further items")
+        logs.assert_called_with("Data loss detected when exporting items -- This message won't be shown for further items")
 
     @defer.inlineCallbacks
     def test_export_dicts_no_warning(self):
@@ -659,7 +659,7 @@ class FeedExportTest(unittest.TestCase):
         with mock.patch('logging.Logger.warning') as logs:
             settings = {'FEED_EXPORT_FIELDS': ['foo', 'egg']}
             yield self.exported_data(items, settings)
-        logs.assert_called_with("Data loss detected when exporting items -- This message won't be shown in further items")
+        logs.assert_called_with("Data loss detected when exporting items -- This message won't be shown for further items")
     
     @defer.inlineCallbacks
     def test_export_item_warning(self):
@@ -670,7 +670,7 @@ class FeedExportTest(unittest.TestCase):
             with mock.patch('logging.Logger.warning') as logs:
                 settings = {'FEED_FORMAT': 'csv'}
                 yield self.exported_data(items, settings)
-            logs.assert_called_with("Data loss detected when exporting items -- This message won't be shown in further items")
+            logs.assert_called_with("Data loss detected when exporting items -- This message won't be shown for further items")
 
     @defer.inlineCallbacks
     def test_export_feed_export_fields(self):

--- a/tests/test_feedexport.py
+++ b/tests/test_feedexport.py
@@ -623,6 +623,34 @@ class FeedExportTest(unittest.TestCase):
         yield self.assertExportedJsonLines(items, rows_jl)
 
     @defer.inlineCallbacks
+    def test_export_dicts_warning(self):
+        # When dicts are used, only keys from the first row are used as
+        # a header for CSV, and all fields are used for JSON Lines.
+        items = [
+            {'foo': 'bar', 'egg': 'spam'},
+            {'foo': 'bar', 'egg': 'spam', 'baz': 'quux'},
+        ]
+        with self.assertLogs('scrapy.exporters', level='WARNING') as logs:
+            settings = {}
+            settings.update({'FEED_FORMAT': 'csv'})
+            yield self.exported_data(items, settings)
+        self.assertEqual(logs.output, ['WARNING:scrapy.exporters:Possible chance of data loss detected -- This message won\'t be shown in further requests'])
+    
+    @defer.inlineCallbacks
+    def test_export_dicts_with_settings_warning(self):
+        # When dicts are used, only keys from the first row are used as
+        # a header for CSV, and all fields are used for JSON Lines.
+        items = [
+            {'foo': 'bar', 'egg': 'spam'},
+            {'foo': 'bar', 'egg': 'spam', 'baz': 'quux'},
+        ]
+        with self.assertLogs('scrapy.exporters', level='WARNING') as logs:
+            settings = {}
+            settings.update({'FEED_FORMAT': 'csv', 'FIELD_EXPORT_FIELDS': ['foo', 'egg']})
+            yield self.exported_data(items, settings)
+        self.assertEqual(logs.output, ['WARNING:scrapy.exporters:Possible chance of data loss detected -- This message won\'t be shown in further requests'])
+    
+    @defer.inlineCallbacks
     def test_export_feed_export_fields(self):
         # FEED_EXPORT_FIELDS option allows to order export fields
         # and to select a subset of fields to export, both for Items and dicts.

--- a/tests/test_feedexport.py
+++ b/tests/test_feedexport.py
@@ -633,7 +633,7 @@ class FeedExportTest(unittest.TestCase):
         with mock.patch('logging.Logger.warning') as logs:
             settings = {'FEED_FORMAT': 'csv'}
             yield self.exported_data(items, settings)
-        logs.assert_called_with("Possible chance of data loss detected -- This message won't be shown in further requests")
+        logs.assert_called_with("Data loss detected when exporting items -- This message won't be shown in further items")
 
     @defer.inlineCallbacks
     def test_export_dicts_no_warning(self):
@@ -659,8 +659,19 @@ class FeedExportTest(unittest.TestCase):
         with mock.patch('logging.Logger.warning') as logs:
             settings = {'FEED_EXPORT_FIELDS': ['foo', 'egg']}
             yield self.exported_data(items, settings)
-        logs.assert_called_with("Possible chance of data loss detected -- This message won't be shown in further requests")
+        logs.assert_called_with("Data loss detected when exporting items -- This message won't be shown in further items")
     
+    @defer.inlineCallbacks
+    def test_export_item_warning(self):
+        for item_cls in [self.MyItem, dict]:
+            items = [
+                item_cls({'foo': 'bar1', 'egg': 'spam1'})
+            ]
+            with mock.patch('logging.Logger.warning') as logs:
+                settings = {'FEED_FORMAT': 'csv'}
+                yield self.exported_data(items, settings)
+            logs.assert_called_with("Data loss detected when exporting items -- This message won't be shown in further items")
+
     @defer.inlineCallbacks
     def test_export_feed_export_fields(self):
         # FEED_EXPORT_FIELDS option allows to order export fields

--- a/tests/test_feedexport.py
+++ b/tests/test_feedexport.py
@@ -653,8 +653,8 @@ class FeedExportTest(unittest.TestCase):
         # When dicts are used, only keys from the first row are used as
         # a header for CSV, and all fields are used for JSON Lines.
         items = [
-            {'foo': 'bar', 'egg': 'spam'},
             {'foo': 'bar', 'egg': 'spam', 'baz': 'quux'},
+            {'foo': 'bar', 'egg': 'spam'},
         ]
         with mock.patch('logging.Logger.warning') as logs:
             settings = {'FEED_EXPORT_FIELDS': ['foo', 'egg']}


### PR DESCRIPTION
Fix for [Warning messages to add in the CSV exporter when there's any field dropped #4002](https://github.com/scrapy/scrapy/issues/4002).

We check if the FEED_EXPORT_FIELDS is set or not, if not a warning `Possible chance of data loss detected -- This message won't be shown in further requests` is logged. This warning is also logged when the first row length and subsequent row length differs signalling that there is a possibility of data loss.

Fixes #4002