### PR TITLE
Added error message in stats if exception is thrown in start_requests of spider

### DIFF
--- a/scrapy/core/engine.py
+++ b/scrapy/core/engine.py
@@ -132,7 +132,7 @@ class ExecutionEngine(object):
                 slot.start_requests = None
                 logger.error('Error while obtaining start requests',
                              exc_info=True, extra={'spider': spider})
-                reason = str(exception)
+                reason = repr(exception)
             else:
                 self.crawl(request, spider)
 

--- a/scrapy/core/engine.py
+++ b/scrapy/core/engine.py
@@ -112,6 +112,7 @@ class ExecutionEngine(object):
 
     def _next_request(self, spider):
         slot = self.slot
+        reason = "finished"
         if not slot:
             return
 
@@ -127,11 +128,11 @@ class ExecutionEngine(object):
                 request = next(slot.start_requests)
             except StopIteration:
                 slot.start_requests = None
-            except Exception as e:
+            except Exception as exception:
                 slot.start_requests = None
                 logger.error('Error while obtaining start requests',
                              exc_info=True, extra={'spider': spider})
-                reason = str(e)
+                reason = str(exception)
             else:
                 self.crawl(request, spider)
 

--- a/scrapy/exceptions.py
+++ b/scrapy/exceptions.py
@@ -31,7 +31,7 @@ class CloseSpider(Exception):
     """Raise this from callbacks to request the spider to be closed"""
 
     def __init__(self, reason='cancelled'):
-        super(CloseSpider, self).__init__()
+        super(CloseSpider, self).__init__(reason)
         self.reason = reason
 
 # Items

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -309,7 +309,10 @@ class EngineTest(unittest.TestCase):
          self.run = CrawlerRun(ErrorInStartRequestsSpider)
          yield self.run.run()
          print(type(self.run.crawler.stats.get_stats()['finish_reason']))
-         self.assertEqual(self.run.crawler.stats.get_stats()['finish_reason'], "Exception('Error raised from start_requests method')")
+         # Check both as the latter one is produced for Python < 3.7
+         # https://bugs.python.org/issue30399 
+         self.assertIn(self.run.crawler.stats.get_stats()['finish_reason'], 
+         ["Exception('Error raised from start_requests method')", "Exception('Error raised from start_requests method',)"])
 
 if __name__ == "__main__":
     if len(sys.argv) > 1 and sys.argv[1] == 'runserver':

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -28,7 +28,7 @@ from scrapy.item import Item, Field
 from scrapy.linkextractors import LinkExtractor
 from scrapy.http import Request
 from scrapy.utils.signal import disconnect_all
-from scrapy.exceptions import CloseSpider
+
 
 
 class TestItem(Item):
@@ -87,7 +87,7 @@ class ErrorInStartRequestsSpider(TestSpider):
         yield self._raise_error()
     
     def _raise_error(self):
-        raise CloseSpider("Error raised from start_requests method")
+        raise Exception("Error raised from start_requests method")
 
 def start_test_site(debug=False):
     root_dir = os.path.join(tests_datadir, "test_site")
@@ -308,7 +308,8 @@ class EngineTest(unittest.TestCase):
     def test_crawler_with_error_in_start_requests(self):
          self.run = CrawlerRun(ErrorInStartRequestsSpider)
          yield self.run.run()
-         self.assertEqual(self.run.crawler.stats.get_stats()['finish_reason'], "CloseSpider('Error raised from start_requests method')")
+         print(type(self.run.crawler.stats.get_stats()['finish_reason']))
+         self.assertEqual(self.run.crawler.stats.get_stats()['finish_reason'], "Exception('Error raised from start_requests method')")
 
 if __name__ == "__main__":
     if len(sys.argv) > 1 and sys.argv[1] == 'runserver':


### PR DESCRIPTION
Fixes #3463

This enhancement aims to capture the error message from the `engine._next_request` method and add it in the stats property `finish_reason`. The previous behavior was to always populate `finished` in the `finish_reason` property when the Exception was raised in the `start_requests ` method of the spider.