### PR TITLE
Fix[#3553] Add http by checking scheme in domain in genspider

### DIFF
--- a/docs/topics/commands.rst
+++ b/docs/topics/commands.rst
@@ -226,10 +226,14 @@ Usage example::
 genspider
 ---------
 
-* Syntax: ``scrapy genspider [-t template] <name> <domain>``
+* Syntax: ``scrapy genspider [-t template] <name> <domain|url>``
 * Requires project: *no*
 
-Create a new spider in the current folder or in the current project's ``spiders`` folder, if called from inside a project. The ``<name>`` parameter is set as the spider's ``name``, while ``<domain>`` is used to generate the ``allowed_domains`` and ``start_urls`` spider's attributes.
+Create a new spider in the current folder or in the current project's ``spiders``
+folder, if called from inside a project. The ``<name>`` parameter is set as the
+spider's ``name``, while ``<domain|url>`` is used to generate the ``allowed_domains``
+and ``start_urls`` spider's attributes, which if HTTP is not specified it would
+be automatically prepended in the ``start_urls`` spider's attribute.
 
 Usage example::
 
@@ -458,7 +462,7 @@ Supported options:
 * ``--callback`` or ``-c``: spider method to use as callback for parsing the
   response
 
-* ``--meta`` or ``-m``: additional request meta that will be passed to the callback 
+* ``--meta`` or ``-m``: additional request meta that will be passed to the callback
   request. This must be a valid json string. Example: --meta='{"foo" : "bar"}'
 
 * ``--cbkwargs``: additional keyword arguments that will be passed to the callback.

--- a/scrapy/commands/genspider.py
+++ b/scrapy/commands/genspider.py
@@ -28,7 +28,7 @@ def sanitize_module_name(module_name):
 class Command(ScrapyCommand):
 
     requires_project = False
-    default_settings = {'LOG_ENABLED': True}
+    default_settings = {'LOG_ENABLED': False}
 
     def syntax(self):
         return "[options] <name> <domain|url>"

--- a/scrapy/commands/genspider.py
+++ b/scrapy/commands/genspider.py
@@ -5,7 +5,7 @@ import string
 
 from importlib import import_module
 from os.path import join, dirname, abspath, exists, splitext
-from urllib.parse import urlparse
+from six.moves.urllib.parse import urlparse
 
 import scrapy
 from scrapy.commands import ScrapyCommand
@@ -65,9 +65,8 @@ class Command(ScrapyCommand):
 
         parsed_url = urlparse(domain)
 
-        # Automatically it is prepended 'http' if the scheme is missing
         if not parsed_url.scheme:
-            parsed_url = urlparse('http://' + domain)
+            parsed_url._replace(scheme='http')
 
         module = sanitize_module_name(name)
 

--- a/scrapy/commands/genspider.py
+++ b/scrapy/commands/genspider.py
@@ -6,6 +6,7 @@ import string
 from importlib import import_module
 from os.path import join, dirname, abspath, exists, splitext
 from six.moves.urllib.parse import urlparse
+from w3lib.url import is_url
 
 import scrapy
 from scrapy.commands import ScrapyCommand
@@ -27,10 +28,10 @@ def sanitize_module_name(module_name):
 class Command(ScrapyCommand):
 
     requires_project = False
-    default_settings = {'LOG_ENABLED': False}
+    default_settings = {'LOG_ENABLED': True}
 
     def syntax(self):
-        return "[options] <name> <domain>"
+        return "[options] <name> <domain|url>"
 
     def short_desc(self):
         return "Generate new spider using pre-defined templates"
@@ -63,10 +64,10 @@ class Command(ScrapyCommand):
 
         name, domain = args[0:2]
 
-        parsed_url = urlparse(domain)
+        if not is_url(domain) and not domain.startswith('//'):
+            domain = '//' + domain
 
-        if not parsed_url.scheme:
-            parsed_url._replace(scheme='http')
+        parsed_url = urlparse(domain.rstrip('/'), scheme='http')
 
         module = sanitize_module_name(name)
 

--- a/scrapy/templates/spiders/basic.tmpl
+++ b/scrapy/templates/spiders/basic.tmpl
@@ -5,7 +5,7 @@ import scrapy
 class $classname(scrapy.Spider):
     name = '$name'
     allowed_domains = ['$domain']
-    start_urls = ['http://$domain/']
+    start_urls = ['$url']
 
     def parse(self, response):
         pass

--- a/scrapy/templates/spiders/crawl.tmpl
+++ b/scrapy/templates/spiders/crawl.tmpl
@@ -7,7 +7,7 @@ from scrapy.spiders import CrawlSpider, Rule
 class $classname(CrawlSpider):
     name = '$name'
     allowed_domains = ['$domain']
-    start_urls = ['http://$domain/']
+    start_urls = ['$url']
 
     rules = (
         Rule(LinkExtractor(allow=r'Items/'), callback='parse_item', follow=True),

--- a/scrapy/templates/spiders/csvfeed.tmpl
+++ b/scrapy/templates/spiders/csvfeed.tmpl
@@ -5,7 +5,7 @@ from scrapy.spiders import CSVFeedSpider
 class $classname(CSVFeedSpider):
     name = '$name'
     allowed_domains = ['$domain']
-    start_urls = ['http://$domain/feed.csv']
+    start_urls = ['$url/feed.csv']
     # headers = ['id', 'name', 'description', 'image_link']
     # delimiter = '\t'
 

--- a/scrapy/templates/spiders/xmlfeed.tmpl
+++ b/scrapy/templates/spiders/xmlfeed.tmpl
@@ -5,7 +5,7 @@ from scrapy.spiders import XMLFeedSpider
 class $classname(XMLFeedSpider):
     name = '$name'
     allowed_domains = ['$domain']
-    start_urls = ['http://$domain/feed.xml']
+    start_urls = ['$url/feed.xml']
     iterator = 'iternodes' # you can change this; see the docs
     itertag = 'item' # change it accordingly
 

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -9,8 +9,6 @@ from tempfile import mkdtemp
 from contextlib import contextmanager
 from threading import Timer
 
-import importlib
-
 from twisted.trial import unittest
 from twisted.internet import defer
 


### PR DESCRIPTION
In **genspider**, `urllib.parse.urlparse` is being used on the domain parameter and prepend 'http' scheme in the case is not there. But, this is a very tricky situation because of the command syntax, which asks for a domain and not an URL, so we're just putting a very big bet that it should be HTTP but what about if we ask for a URL instead of a domain, then the contradiction is solved right away since we can extract the domain without making any assumption. Don't you think fellas?
Lastly, **each template file**, in order to receive domain and URL values.
I checked the test just for tests/test_commands.py, I didn't add test because I don't know how to make a test for this particular scenario where two attributes are set based on user input on a class created through a template. If someone has an idea how it could be made please I'm all ears