### PR TITLE
reorder default console shell

### DIFF
--- a/scrapy/utils/console.py
+++ b/scrapy/utils/console.py
@@ -56,8 +56,8 @@ def _embed_standard_shell(namespace={}, banner=''):
     return wrapper
 
 DEFAULT_PYTHON_SHELLS = OrderedDict([
-    ('ptpython', _embed_ptpython_shell),
     ('ipython', _embed_ipython_shell),
+    ('ptpython', _embed_ptpython_shell),
     ('bpython', _embed_bpython_shell),
     ('python', _embed_standard_shell),
 ])


### PR DESCRIPTION
according to https://docs.scrapy.org/en/latest/topics/shell.html#configuring-the-shell, make `highly recommend` ipython as the first choice!