### PR TITLE
Update exceptions.rst

### DIFF
--- a/docs/topics/exceptions.rst
+++ b/docs/topics/exceptions.rst
@@ -36,7 +36,7 @@ CloseSpider
 For example::
 
     def parse_page(self, response):
-        if 'Bandwidth exceeded' in response.body:
+        if b'Bandwidth exceeded' in response.body:
             raise CloseSpider('bandwidth_exceeded')
 
 DontCloseSpider

--- a/docs/topics/exceptions.rst
+++ b/docs/topics/exceptions.rst
@@ -36,7 +36,7 @@ CloseSpider
 For example::
 
     def parse_page(self, response):
-        if b'Bandwidth exceeded' in response.body:
+        if 'Bandwidth exceeded' in re  sponse.text:
             raise CloseSpider('bandwidth_exceeded')
 
 DontCloseSpider

--- a/docs/topics/exceptions.rst
+++ b/docs/topics/exceptions.rst
@@ -36,7 +36,7 @@ CloseSpider
 For example::
 
     def parse_page(self, response):
-        if 'Bandwidth exceeded' in re  sponse.text:
+        if 'Bandwidth exceeded' in response.text:
             raise CloseSpider('bandwidth_exceeded')
 
 DontCloseSpider


### PR DESCRIPTION
response.body is a bytes value, but "Bandwidth exceeded" is str. 
You can't mix the types because "TypeError: a bytes-like object is required, not 'str'" will be raised.

Use bytes literal:
if b'Bandwidth exceeded' in response.body: