### PR TITLE
[WIP] Add S3MultipartFeedStorage and S3Writer

### DIFF
--- a/scrapy/extensions/feedexport.py
+++ b/scrapy/extensions/feedexport.py
@@ -4,6 +4,7 @@ Feed Exports extension
 See documentation in docs/topics/feed-exports.rst
 """
 
+import io
 import os
 import sys
 import logging
@@ -24,7 +25,7 @@ from scrapy.exceptions import NotConfigured
 from scrapy.utils.misc import create_instance, load_object
 from scrapy.utils.log import failure_to_exc_info
 from scrapy.utils.python import without_none_values
-from scrapy.utils.boto import is_botocore
+from scrapy.utils.boto import is_botocore, S3Writer
 
 logger = logging.getLogger(__name__)
 
@@ -153,6 +154,39 @@ class S3FeedStorage(BlockingFeedStorage):
             kwargs = {'policy': self.acl} if self.acl else {}
             key.set_contents_from_file(file, **kwargs)
             key.close()
+
+
+class S3MultipartFeedStorage(S3FeedStorage):
+    """S3 Feed Storage that uses the Multipart Upload feature to export items.
+
+    This Feed Storage writes items to the S3 Bucket during crawler execution.
+    It doesn't wait for the spider to be completed to start exporting items.
+    Therefore, we can save disk space writing data directly to Amazon S3 using
+    a small amount of RAM to buffer some data (50 MiB default).
+    """
+    DEFAULT_BUFFER_SIZE = 52428800  # 50 MiB
+
+    def __init__(self, uri):
+        """Setup S3Writer using default S3FeedStorage credentials."""
+        super(S3MultipartFeedStorage, self).__init__(uri)
+        self.writer = S3Writer(
+            self.access_key,
+            self.secret_key,
+            self.bucketname,
+            self.keyname
+        )
+
+    def open(self, spider):
+        """Create a Buffered Writer using the S3Writer to optimize data upload.
+
+        Default buffer size is 50 MiB.
+        """
+        return io.BufferedWriter(self.writer, self.DEFAULT_BUFFER_SIZE)
+
+    def _store_in_thread(self, buffered_file):
+        """Flush/close buffered data and complete the Multipart Upload."""
+        buffered_file.close()
+        self.writer.close()
 
 
 class FTPFeedStorage(BlockingFeedStorage):

--- a/scrapy/utils/boto.py
+++ b/scrapy/utils/boto.py
@@ -1,6 +1,7 @@
 """Boto/botocore helpers"""
 
 from __future__ import absolute_import
+import io
 import six
 
 from scrapy.exceptions import NotConfigured
@@ -19,3 +20,105 @@ def is_botocore():
                 raise NotConfigured('missing botocore or boto library')
         else:
             raise NotConfigured('missing botocore library')
+
+
+class S3Writer(io.IOBase):
+    """A synchronous writer for Amazon S3 Objects using Multipart Uploads.
+    This class is not Thread Safe!
+    """
+    def __init__(self, access_key, secret_key, bucket_name, key):
+        """Connect to the Amazon S3 resource and start the multipart upload.
+
+        :param access_key: AWS Access Key ID
+        :param secret_key: AWS Secret Access Key
+        :param bucket_name: S3 Bucket Name
+        :param key: S3 Object Key
+        """
+        self.access_key = access_key
+        self.secret_key = secret_key
+        self.bucket_name = bucket_name
+        self.key = key
+
+        self.open = False
+        self.client = self.create_client()
+        self.multipart_upload = self.create_multipart_upload()
+        self.total_parts = 0
+        self.parts = []
+
+    def create_client(self):
+        """Create a boto3 service client by name using the default session.
+
+        Credentials, bucket name and file key are acquired from the project
+        settings.
+
+        :return: Service client instance
+        """
+        try:
+            import boto3
+        except ImportError:
+            raise NotConfigured('missing boto3 library')
+
+        self.open = True
+        return boto3.client(
+            's3',
+            aws_access_key_id=self.access_key,
+            aws_secret_access_key=self.secret_key
+        )
+
+    def create_multipart_upload(self):
+        """Create/begin a multipart upload.
+
+        :return: Multipart Upload dict
+        """
+        return self.client.create_multipart_upload(
+            Bucket=self.bucket_name, Key=self.key
+        )
+
+    def writable(self):
+        return True
+
+    def write(self, raw):
+        """Write bytes by uploading a new part.
+
+        :param raw: raw data to be written (Memory View)
+        :return: number of bytes written
+        """
+        self.total_parts += 1
+        body = raw.tobytes()
+        part = self.client.upload_part(
+            Bucket=self.bucket_name,
+            Key=self.key,
+            UploadId=self.multipart_upload['UploadId'],
+            PartNumber=self.total_parts,
+            Body=body
+        )
+        self.parts.append({
+            'PartNumber': self.total_parts,
+            'ETag': part['ETag'],
+        })
+
+        return len(body)
+
+    def close(self):
+        """Complete the Multipart Upload process.
+
+        If there's not even a single uploaded part, abort the process.
+        """
+        if not self.open:
+            return
+
+        self.open = False
+
+        if self.parts:
+            self.client.complete_multipart_upload(
+                Bucket=self.bucket_name,
+                Key=self.key,
+                UploadId=self.multipart_upload['UploadId'],
+                MultipartUpload={'Parts': self.parts}
+            )
+        else:
+            self.client.abort_multipart_upload(
+                Bucket=self.bucket_name,
+                Key=self.key,
+                UploadId=self.multipart_upload['UploadId']
+            )


### PR DESCRIPTION
This Feed Storage writes items to the S3 Bucket during crawler execution.
It doesn't wait for the spider to be completed to start exporting items.
Therefore, we can save disk space writing data directly to Amazon S3 using
a small amount of RAM to buffer some data (50 MiB default).

I'd like to have some feedback about this feature and maybe additional suggestions.

TODO:

- [ ] add documentation
- [ ] add test cases
