### PR TITLE
Updating link for miniconda

### DIFF
--- a/docs/intro/install.rst
+++ b/docs/intro/install.rst
@@ -290,5 +290,5 @@ For details, see `Issue #2473 <https://github.com/scrapy/scrapy/issues/2473>`_.
 .. _zsh: https://www.zsh.org/
 .. _Scrapinghub: https://scrapinghub.com
 .. _Anaconda: https://docs.anaconda.com/anaconda/
-.. _Miniconda: https://conda.io/docs/user-guide/install/index.html
+.. _Miniconda: https://docs.conda.io/en/latest/miniconda.html
 .. _conda-forge: https://conda-forge.org/


### PR DESCRIPTION
The previous link was a 404 (https://conda.io/docs/user-guide/install/index.html)

I updated to https://docs.conda.io/en/latest/miniconda.html