### PR TITLE
Improve URL schema validation on scrapy.Request initialization

### DIFF
--- a/scrapy/http/request/__init__.py
+++ b/scrapy/http/request/__init__.py
@@ -66,7 +66,7 @@ class Request(object_ref):
         s = safe_url_string(url, self.encoding)
         self._url = escape_ajax(s)
 
-        if ':' not in self._url:
+        if ('://' not in self._url) and (not self._url.startswith('data:')):
             raise ValueError('Missing scheme in request url: %s' % self._url)
 
     url = property(_get_url, obsolete_setter(_set_url, 'url'))

--- a/tests/test_http_request.py
+++ b/tests/test_http_request.py
@@ -52,6 +52,8 @@ class RequestTest(unittest.TestCase):
 
     def test_url_no_scheme(self):
         self.assertRaises(ValueError, self.request_class, 'foo')
+        self.assertRaises(ValueError, self.request_class, '/foo/')
+        self.assertRaises(ValueError, self.request_class, '/foo:bar')
 
     def test_headers(self):
         # Different ways of setting headers attribute


### PR DESCRIPTION
This PR should fix issue #2552 by improving the request schema validation on its initialization. 
The implementation is based on feedback posted by @pawelmhm and @hsumerf 