### PR TITLE
Use communicate() instead of wait() after killing the mock server

### DIFF
--- a/tests/mockserver.py
+++ b/tests/mockserver.py
@@ -205,9 +205,8 @@ class MockServer():
         return self
 
     def __exit__(self, exc_type, exc_value, traceback):
-        self.proc.communicate()  # Close the stdout PIPE
         self.proc.kill()
-        self.proc.wait()
+        self.proc.communicate()
         time.sleep(0.2)
 
     def url(self, path, is_secure=False):

--- a/tests/mockserver.py
+++ b/tests/mockserver.py
@@ -205,6 +205,7 @@ class MockServer():
         return self
 
     def __exit__(self, exc_type, exc_value, traceback):
+        self.proc.communicate()  # Close the stdout PIPE
         self.proc.kill()
         self.proc.wait()
         time.sleep(0.2)

--- a/tests/mockserver.py
+++ b/tests/mockserver.py
@@ -207,7 +207,6 @@ class MockServer():
     def __exit__(self, exc_type, exc_value, traceback):
         self.proc.kill()
         self.proc.communicate()
-        time.sleep(0.2)
 
     def url(self, path, is_secure=False):
         host = self.http_address.replace('0.0.0.0', '127.0.0.1')

--- a/tests/test_crawler.py
+++ b/tests/test_crawler.py
@@ -1,6 +1,7 @@
 import logging
 import warnings
 
+from six import text_type
 from twisted.internet import defer
 from twisted.trial import unittest
 from pytest import raises
@@ -14,6 +15,9 @@ from scrapy.utils.spider import DefaultSpider
 from scrapy.utils.misc import load_object
 from scrapy.extensions.throttle import AutoThrottle
 from scrapy.extensions import telnet
+
+
+logger = logging.getLogger(__name__)
 
 
 class BaseCrawlerTest(unittest.TestCase):
@@ -31,6 +35,15 @@ class CrawlerTestCase(BaseCrawlerTest):
     def test_deprecated_attribute_spiders(self):
         with warnings.catch_warnings(record=True) as w:
             spiders = self.crawler.spiders
+
+            # Log unexpected extra warnings that are randomly captured.
+            # e.g. https://travis-ci.org/scrapy/scrapy/jobs/585543449
+            if len(w) > 1:
+                logger.error(
+                    'Too many warnings captured (known error that happens '
+                    'randomly, #4014):\n%s',
+                    '\n'.join(text_type(warning) for warning in w))
+
             self.assertEqual(len(w), 1)
             self.assertIn("Crawler.spiders", str(w[0].message))
             sl_cls = load_object(self.crawler.settings['SPIDER_LOADER_CLASS'])
@@ -170,6 +183,15 @@ class CrawlerRunnerTestCase(BaseCrawlerTest):
         with warnings.catch_warnings(record=True) as w:
             runner = CrawlerRunner(Settings())
             spiders = runner.spiders
+
+            # Log unexpected extra warnings that are randomly captured.
+            # e.g. https://travis-ci.org/scrapy/scrapy/jobs/601196450
+            if len(w) > 1:
+                logger.error(
+                    'Too many warnings captured (known error that happens '
+                    'randomly, #4014):\n%s',
+                    '\n'.join(text_type(warning) for warning in w))
+
             self.assertEqual(len(w), 1)
             self.assertIn("CrawlerRunner.spiders", str(w[0].message))
             self.assertIn("CrawlerRunner.spider_loader", str(w[0].message))

--- a/tests/test_crawler.py
+++ b/tests/test_crawler.py
@@ -1,7 +1,6 @@
 import logging
 import warnings
 
-from six import text_type
 from twisted.internet import defer
 from twisted.trial import unittest
 from pytest import raises
@@ -15,9 +14,6 @@ from scrapy.utils.spider import DefaultSpider
 from scrapy.utils.misc import load_object
 from scrapy.extensions.throttle import AutoThrottle
 from scrapy.extensions import telnet
-
-
-logger = logging.getLogger(__name__)
 
 
 class BaseCrawlerTest(unittest.TestCase):
@@ -35,15 +31,6 @@ class CrawlerTestCase(BaseCrawlerTest):
     def test_deprecated_attribute_spiders(self):
         with warnings.catch_warnings(record=True) as w:
             spiders = self.crawler.spiders
-
-            # Log unexpected extra warnings that are randomly captured.
-            # e.g. https://travis-ci.org/scrapy/scrapy/jobs/585543449
-            if len(w) > 1:
-                logger.error(
-                    'Too many warnings captured (known error that happens '
-                    'randomly, #4014):\n%s',
-                    '\n'.join(text_type(warning) for warning in w))
-
             self.assertEqual(len(w), 1)
             self.assertIn("Crawler.spiders", str(w[0].message))
             sl_cls = load_object(self.crawler.settings['SPIDER_LOADER_CLASS'])
@@ -183,15 +170,6 @@ class CrawlerRunnerTestCase(BaseCrawlerTest):
         with warnings.catch_warnings(record=True) as w:
             runner = CrawlerRunner(Settings())
             spiders = runner.spiders
-
-            # Log unexpected extra warnings that are randomly captured.
-            # e.g. https://travis-ci.org/scrapy/scrapy/jobs/601196450
-            if len(w) > 1:
-                logger.error(
-                    'Too many warnings captured (known error that happens '
-                    'randomly, #4014):\n%s',
-                    '\n'.join(text_type(warning) for warning in w))
-
             self.assertEqual(len(w), 1)
             self.assertIn("CrawlerRunner.spiders", str(w[0].message))
             self.assertIn("CrawlerRunner.spider_loader", str(w[0].message))


### PR DESCRIPTION
Fixes #4014

When using pipes, and we are using a pipe for `stdout` in `MockServer`, you are meant to call `process.communicate()` instead of `process.wait()`.

This was causing unexpected warnings in `test_crawler.py` tests, when the garbage collection happened to warn about unclosed resources while one of the affected tests was capturing warnings.

I’ve run the tests a few rounds with this fix, and it seems to have worked.