### PR TITLE
Retrying Requests when an IOError/OSError exception is raised when decompressing Response

### DIFF
--- a/docs/topics/downloader-middleware.rst
+++ b/docs/topics/downloader-middleware.rst
@@ -730,6 +730,13 @@ HttpCompressionMiddleware
    This middleware also supports decoding `brotli-compressed`_ responses,
    provided `brotlipy`_ is installed.
 
+   If an exception is raised while trying to decompress the response body,
+   we encapsulate the exception in ``response.meta['_http_compression_exc']``
+   and return the original ``scrapy.Response``. The ``RetryMiddleware`` will
+   check for this exception and try to reprocess the ``scrapy.Request`` if
+   the captured exception is specified in the
+   ``RetryMiddleware.EXCEPTIONS_TO_RETRY`` tuple.
+
 .. _brotli-compressed: https://www.ietf.org/rfc/rfc7932.txt
 .. _brotlipy: https://pypi.python.org/pypi/brotlipy
 

--- a/scrapy/downloadermiddlewares/httpcompression.py
+++ b/scrapy/downloadermiddlewares/httpcompression.py
@@ -36,7 +36,11 @@ class HttpCompressionMiddleware(object):
             content_encoding = response.headers.getlist('Content-Encoding')
             if content_encoding:
                 encoding = content_encoding.pop()
-                decoded_body = self._decode(response.body, encoding.lower())
+                try:
+                    decoded_body = self._decode(response.body, encoding.lower())
+                except Exception as exc:
+                    response.meta['_http_compression_exc'] = exc
+                    return response
                 respcls = responsetypes.from_args(headers=response.headers, \
                     url=response.url, body=decoded_body)
                 kwargs = dict(cls=respcls, body=decoded_body)

--- a/scrapy/downloadermiddlewares/retry.py
+++ b/scrapy/downloadermiddlewares/retry.py
@@ -32,7 +32,7 @@ class RetryMiddleware(object):
     EXCEPTIONS_TO_RETRY = (defer.TimeoutError, TimeoutError, DNSLookupError,
                            ConnectionRefusedError, ConnectionDone, ConnectError,
                            ConnectionLost, TCPTimedOutError, ResponseFailed,
-                           IOError, TunnelError)
+                           IOError, OSError, TunnelError)
 
     def __init__(self, settings):
         if not settings.getbool('RETRY_ENABLED'):
@@ -51,6 +51,12 @@ class RetryMiddleware(object):
         if response.status in self.retry_http_codes:
             reason = response_status_message(response.status)
             return self._retry(request, reason, spider) or response
+        if '_http_compression_exc' in response.meta:
+            exc = response.meta.pop('_http_compression_exc')
+            if isinstance(exc, self.EXCEPTIONS_TO_RETRY):
+                exc_name = type(exc).__name__
+                reason = f'HttpCompressionMiddleware/{exc_name}'
+                return self._retry(request, reason, spider) or response
         return response
 
     def process_exception(self, request, exception, spider):

--- a/scrapy/downloadermiddlewares/retry.py
+++ b/scrapy/downloadermiddlewares/retry.py
@@ -54,8 +54,9 @@ class RetryMiddleware(object):
         if '_http_compression_exc' in response.meta:
             exc = response.meta.pop('_http_compression_exc')
             if isinstance(exc, self.EXCEPTIONS_TO_RETRY):
-                exc_name = type(exc).__name__
-                reason = f'HttpCompressionMiddleware/{exc_name}'
+                reason = 'HttpCompressionMiddleware/{exc_name}'.format(
+                    exc_name=type(exc).__name__
+                )
                 return self._retry(request, reason, spider) or response
         return response
 

--- a/tests/sample_data/compressed/html-invalid-gzip.bin
+++ b/tests/sample_data/compressed/html-invalid-gzip.bin
@@ -1,0 +1,1 @@
+invalid gzip file

--- a/tests/test_downloadermiddleware_httpcompression.py
+++ b/tests/test_downloadermiddleware_httpcompression.py
@@ -17,6 +17,7 @@ SAMPLEDIR = join(tests_datadir, 'compressed')
 
 FORMAT = {
         'gzip': ('html-gzip.bin', 'gzip'),
+        'invalid-gzip': ('html-invalid-gzip.bin', 'gzip'),
         'x-gzip': ('html-gzip.bin', 'gzip'),
         'rawdeflate': ('html-rawdeflate.bin', 'deflate'),
         'zlibdeflate': ('html-zlibdeflate.bin', 'deflate'),
@@ -67,6 +68,15 @@ class HttpCompressionTest(TestCase):
         assert newresponse is not response
         assert newresponse.body.startswith(b'<!DOCTYPE')
         assert 'Content-Encoding' not in newresponse.headers
+
+    def test_process_response_invalid_gzip(self):
+        response = self._getresponse('invalid-gzip')
+        request = response.request
+
+        self.assertEqual(response.headers['Content-Encoding'], b'gzip')
+        newresponse = self.mw.process_response(request, response, self.spider)
+        self.assertEqual(newresponse, response)
+        self.assertIsInstance(response.meta['_http_compression_exc'], OSError)
 
     def test_process_response_br(self):
         try:

--- a/tests/test_downloadermiddleware_retry.py
+++ b/tests/test_downloadermiddleware_retry.py
@@ -74,6 +74,32 @@ class RetryTest(unittest.TestCase):
         assert self.crawler.stats.get_value('retry/reason_count/503 Service Unavailable') == 2
         assert self.crawler.stats.get_value('retry/count') == 2
 
+    def test_http_compression_exception(self):
+        req = Request('http://www.scrapytest.org/')
+        rsp = Response('http://www.scrapytest.org/', body=b'', request=req)
+
+        # first retry
+        rsp.meta['_http_compression_exc'] = OSError('Not a gzipped file')
+        req = self.mw.process_response(req, rsp, self.spider)
+        self.assertIsInstance(req, Request)
+        self.assertNotIn('_http_compression_exc', req.meta)
+        self.assertEqual(req.meta['retry_times'], 1)
+
+        # second retry
+        rsp.meta['_http_compression_exc'] = OSError('Not a gzipped file')
+        req = self.mw.process_response(req, rsp, self.spider)
+        self.assertIsInstance(req, Request)
+        self.assertNotIn('_http_compression_exc', req.meta)
+        self.assertEqual(req.meta['retry_times'], 2)
+
+        # discard it
+        rsp.meta['_http_compression_exc'] = OSError('Not a gzipped file')
+        assert self.mw.process_response(req, rsp, self.spider) is rsp
+
+        assert self.crawler.stats.get_value('retry/max_reached') == 1
+        assert self.crawler.stats.get_value('retry/reason_count/HttpCompressionMiddleware/OSError') == 2
+        assert self.crawler.stats.get_value('retry/count') == 2
+
     def test_twistederrors(self):
         exceptions = [defer.TimeoutError, TCPTimedOutError, TimeoutError,
                 DNSLookupError, ConnectionRefusedError, ConnectionDone,


### PR DESCRIPTION
fix #1900 by handling IOError and OSError exceptions raised while trying to decompress responses

- IOError/OSError exceptions would be raised in HttpCompressionMiddleware.process_response
- exceptions raised from process_response are not handled by downloader middlewares

This might not be the best approach for solving this bug, but it was the best I could think that would not involve a huge refactoring, including some kind of a `RetrySpiderMiddleware`.