### PR TITLE
Removed envirovment documentation about python 2

### DIFF
--- a/docs/intro/install.rst
+++ b/docs/intro/install.rst
@@ -74,37 +74,27 @@ please refer to their respective installation instructions:
 Using a virtual environment (recommended)
 -----------------------------------------
 
-TL;DR: We recommend installing Scrapy inside a virtual environment
-on all platforms.
-
 Python packages can be installed either globally (a.k.a system wide),
-or in user-space. We do not recommend installing scrapy system wide.
+or in user-space. We do not recommend installing Scrapy system wide.
 
-Instead, we recommend that you install scrapy within a so-called
+Instead, we recommend that you install Scrapy within a so-called
 "virtual environment" (`virtualenv`_).
 Virtualenvs allow you to not conflict with already-installed Python
 system packages (which could break some of your system tools and scripts),
 and still install packages normally with ``pip`` (without ``sudo`` and the likes).
-
-To get started with virtual environments, see `virtualenv installation instructions`_.
-To install it globally (having it globally installed actually helps here),
-it should be a matter of running::
-
-    $ [sudo] pip install virtualenv
 
 Check this `user guide`_ on how to create your virtualenv.
 
 .. note::
     If you use Linux or OS X, `virtualenvwrapper`_ is a handy tool to create virtualenvs.
 
-Once you have created a virtualenv, you can install scrapy inside it with ``pip``,
+Once you have created a virtualenv, you can install Scrapy inside it with ``pip``,
 just like any other Python package.
 (See :ref:`platform-specific guides <intro-install-platform-notes>`
 below for non-Python dependencies that you may need to install beforehand).
 
-.. _virtualenv: https://virtualenv.pypa.io
+.. _virtualenv: https://docs.python.org/3/library/venv.html
 .. _virtualenv installation instructions: https://virtualenv.pypa.io/en/stable/installation/
-.. _virtualenvwrapper: https://virtualenvwrapper.readthedocs.io/en/latest/install.html
 .. _user guide: https://virtualenv.pypa.io/en/stable/userguide/
 
 
@@ -141,7 +131,7 @@ albeit with potential issues with TLS connections.
 typically too old and slow to catch up with latest Scrapy.
 
 
-To install scrapy on Ubuntu (or Ubuntu-based) systems, you need to install
+To install Scrapy on Ubuntu (or Ubuntu-based) systems, you need to install
 these dependencies::
 
     sudo apt-get install python-dev python-pip libxml2-dev libxslt1-dev zlib1g-dev libffi-dev libssl-dev
@@ -150,7 +140,7 @@ these dependencies::
   are required for ``lxml``
 - ``libssl-dev`` and ``libffi-dev`` are required for ``cryptography``
 
-If you want to install scrapy on Python 3, you’ll also need Python 3 development headers::
+If you want to install Scrapy on Python 3, you’ll also need Python 3 development headers::
 
     sudo apt-get install python3 python3-dev
 
@@ -226,17 +216,17 @@ PyPy
 We recommend using the latest PyPy version. The version tested is 5.9.0.
 For PyPy3, only Linux installation was tested.
 
-Most scrapy dependencides now have binary wheels for CPython, but not for PyPy.
+Most Scrapy dependencides now have binary wheels for CPython, but not for PyPy.
 This means that these dependecies will be built during installation.
 On OS X, you are likely to face an issue with building Cryptography dependency,
 solution to this problem is described
 `here <https://github.com/pyca/cryptography/issues/2692#issuecomment-272773481>`_,
 that is to ``brew install openssl`` and then export the flags that this command
-recommends (only needed when installing scrapy). Installing on Linux has no special
+recommends (only needed when installing Scrapy). Installing on Linux has no special
 issues besides installing build dependencies.
-Installing scrapy with PyPy on Windows is not tested.
+Installing Scrapy with PyPy on Windows is not tested.
 
-You can check that scrapy is installed correctly by running ``scrapy bench``.
+You can check that Scrapy is installed correctly by running ``scrapy bench``.
 If this command gives errors such as
 ``TypeError: ... got 2 unexpected keyword arguments``, this means
 that setuptools was unable to pick up one PyPy-specific dependency.

--- a/docs/intro/install.rst
+++ b/docs/intro/install.rst
@@ -102,11 +102,6 @@ just like any other Python package.
 (See :ref:`platform-specific guides <intro-install-platform-notes>`
 below for non-Python dependencies that you may need to install beforehand).
 
-Python virtualenvs can be created to use Python 2 by default, or Python 3 by default.
-
-* If you want to install scrapy with Python 3, install scrapy within a Python 3 virtualenv.
-* And if you want to install scrapy with Python 2, install scrapy within a Python 2 virtualenv.
-
 .. _virtualenv: https://virtualenv.pypa.io
 .. _virtualenv installation instructions: https://virtualenv.pypa.io/en/stable/installation/
 .. _virtualenvwrapper: https://virtualenvwrapper.readthedocs.io/en/latest/install.html


### PR DESCRIPTION
Removed envirovment documentation about python 2, because it is no longer suported. As requested in issue #4001 . If that is what you meant. If not sorry, first time contributing.  