### PR TITLE
'Unskipped' a  passing test at test_utils_url.py  

### DIFF
--- a/tests/test_utils_url.py
+++ b/tests/test_utils_url.py
@@ -195,13 +195,6 @@ def create_guess_scheme_t(args):
                 args[0], url, args[1])
     return do_expected
 
-def create_skipped_scheme_t(args):
-    def do_expected(self):
-        raise unittest.SkipTest(args[2])
-        url = guess_scheme(args[0])
-        assert url.startswith(args[1])
-    return do_expected
-
 for k, args in enumerate ([
             ('/index',                              'file://'),
             ('/index.html',                         'file://'),
@@ -232,13 +225,11 @@ for k, args in enumerate ([
     t_method.__name__ = 'test_uri_%03d' % k
     setattr (GuessSchemeTest, t_method.__name__, t_method)
 
-# TODO: the following tests do not pass with current implementation
-for k, args in enumerate([
+for j, args in enumerate([
             (r'C:\absolute\path\to\a\file.html', 'file://',
              'Windows filepath are not supported for scrapy shell'),
-        ], start=1):
-    t_method = create_skipped_scheme_t(args)
-    t_method.__name__ = 'test_uri_skipped_%03d' % k
+        ], start=k+1):
+    t_method.__name__ = 'test_uri_%03d' % j
     setattr (GuessSchemeTest, t_method.__name__, t_method)
 
 


### PR DESCRIPTION
I might be missing something obvious but I found that  the 'TODO' was contradicting the  current situation. The current version of scrapy is actually passing the test.
```
shivam@shivam-Latitude-D630:~/scrapy/scrapy$ tox -- tests/test_utils_url.py::GuessSchemeTest -v
GLOB sdist-make: /home/shivam/scrapy/scrapy/setup.py
py27 inst-nodeps: /home/shivam/scrapy/scrapy/.tox/.tmp/package/2/Scrapy-1.7.0.zip
py27 installed: DEPRECATION: Python 2.7 will reach the end of its life on January 1st, 2020. Please upgrade your Python as Python 2.7 won't be maintained after that date. A future version of pip will drop support for Python 2.7. More details about Python 2 support in pip, can be found at https://pip.pypa.io/en/latest/development/release-process/#python-2-support,apipkg==1.5,atomicwrites==1.3.0,attrs==19.3.0,Automat==0.8.0,backports.shutil-get-terminal-size==1.0.0,blessings==1.7,botocore==1.13.2,bpython==0.18,brotlipy==0.7.0,cachetools==3.1.1,certifi==2019.9.11,cffi==1.13.1,chardet==3.0.4,Click==7.0,configparser==4.0.2,constantly==15.1.0,contextlib2==0.6.0.post1,coverage==4.5.4,cryptography==2.8,cssselect==1.1.0,curtsies==0.3.0,decorator==4.4.0,docutils==0.15.2,enum34==1.1.6,execnet==1.7.1,Flask==1.1.1,funcsigs==1.0.2,functools32==3.2.3.post2,futures==3.3.0,google-api-core==1.14.3,google-auth==1.6.3,google-cloud-core==1.0.3,google-cloud-storage==1.20.0,google-resumable-media==0.4.1,googleapis-common-protos==1.6.0,greenlet==0.4.15,hyperlink==19.0.0,idna==2.8,importlib-metadata==0.23,incremental==17.5.0,ipaddress==1.0.23,ipython==5.8.0,ipython-genutils==0.2.0,itsdangerous==1.1.0,Jinja2==2.10.3,jmespath==0.9.4,leveldb==0.194,lxml==4.4.1,MarkupSafe==1.1.1,mitmproxy==0.10.1,mock==3.0.5,more-itertools==5.0.0,netlib==0.10.1,packaging==19.2,parsel==1.5.2,pathlib2==2.3.5,pexpect==4.7.0,pickleshare==0.7.5,Pillow==6.2.1,pkg-resources==0.0.0,pluggy==0.13.0,prompt-toolkit==1.0.18,Protego==0.1.15,protobuf==3.10.0,ptyprocess==0.6.0,py==1.8.0,pyasn1==0.4.7,pyasn1-modules==0.2.7,pycparser==2.19,PyDispatcher==2.0.5,Pygments==2.4.2,PyHamcrest==1.9.0,pyOpenSSL==19.0.0,pyparsing==2.4.2,pytest==4.6.6,pytest-cov==2.8.1,pytest-forked==1.1.3,pytest-twisted==1.12,pytest-xdist==1.30.0,python-dateutil==2.8.0,pytz==2019.3,queuelib==1.5.0,requests==2.22.0,rsa==4.0,scandir==1.10.0,Scrapy==1.7.0,service-identity==18.1.0,simplegeneric==0.8.1,six==1.12.0,testfixtures==6.10.0,traitlets==4.3.3,Twisted==19.7.0,typing==3.7.4.1,urllib3==1.25.6,urwid==2.0.1,w3lib==1.21.0,wcwidth==0.1.7,Werkzeug==0.16.0,zipp==0.6.0,zope.interface==4.6.0
py27 run-test-pre: PYTHONHASHSEED='3862348216'
py27 run-test: commands[0] | py.test --cov=scrapy --cov-report= tests/test_utils_url.py::GuessSchemeTest -v
==================================================================== test session starts ====================================================================
platform linux2 -- Python 2.7.16, pytest-4.6.6, py-1.8.0, pluggy-0.13.0 -- /home/shivam/scrapy/scrapy/.tox/py27/bin/python
cachedir: .tox/py27/.pytest_cache
rootdir: /home/shivam/scrapy/scrapy, inifile: pytest.ini
plugins: xdist-1.30.0, twisted-1.12, cov-2.8.1, forked-1.1.3
collected 21 items                                                                                                                                          

tests/test_utils_url.py::GuessSchemeTest::test_uri_001 PASSED                                                                                         [  4%]
tests/test_utils_url.py::GuessSchemeTest::test_uri_002 PASSED                                                                                         [  9%]
tests/test_utils_url.py::GuessSchemeTest::test_uri_003 PASSED                                                                                         [ 14%]
tests/test_utils_url.py::GuessSchemeTest::test_uri_004 PASSED                                                                                         [ 19%]
tests/test_utils_url.py::GuessSchemeTest::test_uri_005 PASSED                                                                                         [ 23%]
tests/test_utils_url.py::GuessSchemeTest::test_uri_006 PASSED                                                                                         [ 28%]
tests/test_utils_url.py::GuessSchemeTest::test_uri_007 PASSED                                                                                         [ 33%]
tests/test_utils_url.py::GuessSchemeTest::test_uri_008 PASSED                                                                                         [ 38%]
tests/test_utils_url.py::GuessSchemeTest::test_uri_009 PASSED                                                                                         [ 42%]
tests/test_utils_url.py::GuessSchemeTest::test_uri_010 PASSED                                                                                         [ 47%]
tests/test_utils_url.py::GuessSchemeTest::test_uri_011 PASSED                                                                                         [ 52%]
tests/test_utils_url.py::GuessSchemeTest::test_uri_012 PASSED                                                                                         [ 57%]
tests/test_utils_url.py::GuessSchemeTest::test_uri_013 PASSED                                                                                         [ 61%]
tests/test_utils_url.py::GuessSchemeTest::test_uri_014 PASSED                                                                                         [ 66%]
tests/test_utils_url.py::GuessSchemeTest::test_uri_015 PASSED                                                                                         [ 71%]
tests/test_utils_url.py::GuessSchemeTest::test_uri_016 PASSED                                                                                         [ 76%]
tests/test_utils_url.py::GuessSchemeTest::test_uri_017 PASSED                                                                                         [ 80%]
tests/test_utils_url.py::GuessSchemeTest::test_uri_018 PASSED                                                                                         [ 85%]
tests/test_utils_url.py::GuessSchemeTest::test_uri_019 PASSED                                                                                         [ 90%]
tests/test_utils_url.py::GuessSchemeTest::test_uri_020 PASSED                                                                                         [ 95%]
tests/test_utils_url.py::GuessSchemeTest::test_uri_021 PASSED                                                                                         [100%]



================================================================= 21 passed in 3.01 seconds =================================================================
__________________________________________________________________________ summary __________________________________________________________________________
  py27: commands succeeded
  congratulations :)
```
The  test 'test_uri_021' (previously called 'test_uri_skipped_001' ) was the one being skipped.

The  `create_skipped_scheme_t(args)` method was unused after  the 'unskipping'. Hence I figured out to remove it(I doubt it's the best thing to do.)
