### PR TITLE
Allow not to dedupe urls with different fragments

### DIFF
--- a/scrapy/utils/request.py
+++ b/scrapy/utils/request.py
@@ -42,6 +42,11 @@ def request_fingerprint(request, include_headers=None, keep_fragments=False):
     the fingeprint. If you want to include specific headers use the
     include_headers argument, which is a list of Request headers to include.
 
+    Also, servers usually ignore fragments in urls when handling requests,
+    so they are also ignored by default when calculating the fingerprint.
+    If you want to include them, set the keep_fragments argument to True
+    (for instance when handling requests with a headless browser).
+
     """
     if include_headers:
         include_headers = tuple(to_bytes(h.lower())

--- a/tests/test_utils_request.py
+++ b/tests/test_utils_request.py
@@ -17,7 +17,7 @@ class UtilsRequestTest(unittest.TestCase):
         self.assertNotEqual(request_fingerprint(r1), request_fingerprint(r2))
 
         # make sure caching is working
-        self.assertEqual(request_fingerprint(r1), _fingerprint_cache[r1][None])
+        self.assertEqual(request_fingerprint(r1), _fingerprint_cache[r1][(None, False)])
 
         r1 = Request("http://www.example.com/members/offers.html")
         r2 = Request("http://www.example.com/members/offers.html")
@@ -41,6 +41,13 @@ class UtilsRequestTest(unittest.TestCase):
 
         self.assertEqual(request_fingerprint(r3, include_headers=['accept-language', 'sessionid']),
                          request_fingerprint(r3, include_headers=['SESSIONID', 'Accept-Language']))
+
+        r1 = Request("http://www.example.com/test.html")
+        r2 = Request("http://www.example.com/test.html#fragment")
+        self.assertEqual(request_fingerprint(r1), request_fingerprint(r2))
+        self.assertEqual(request_fingerprint(r1), request_fingerprint(r1, keep_fragments=True))
+        self.assertNotEqual(request_fingerprint(r2), request_fingerprint(r2, keep_fragments=True))
+        self.assertNotEqual(request_fingerprint(r1), request_fingerprint(r2, keep_fragments=True))
 
         r1 = Request("http://www.example.com")
         r2 = Request("http://www.example.com", method='POST')


### PR DESCRIPTION
w3lib's canonicalize_url has an option to keep fragments but it is not accessible from scrapy's request_fingerprint method, so it's impossible without changing scrapy's code to make a custom dedupe filter which would keep urls identical except for fragments.

We need this in our webcrawler Hyphe for our future headless crawling feature using chromedriver (currently developed in https://github.com/medialab/hyphe/pull/288 ) to crawl modern websites with routing included in the fragment.

For what I understand the solution discussed in #4067 using `dont_filter=False` on each query would completely disable deduping for the spider which is not an option for a crawler that adds new links from each crawled page as it would then run indefinitely in loop

cc @arnaudmolo