### PR TITLE
Add rule priority support

### DIFF
--- a/scrapy/spiders/crawl.py
+++ b/scrapy/spiders/crawl.py
@@ -34,7 +34,7 @@ _default_link_extractor = LinkExtractor()
 
 class Rule(object):
 
-    def __init__(self, link_extractor=None, callback=None, cb_kwargs=None, follow=None, process_links=None, process_request=None):
+    def __init__(self, link_extractor=None, callback=None, cb_kwargs=None, follow=None, process_links=None, process_request=None, priority=None):
         self.link_extractor = link_extractor or _default_link_extractor
         self.callback = callback
         self.cb_kwargs = cb_kwargs or {}
@@ -42,6 +42,7 @@ class Rule(object):
         self.process_request = process_request or _identity
         self.process_request_argcount = None
         self.follow = follow if follow is not None else not callback
+        self.request_priority = priority or 0
 
     def _compile(self, spider):
         self.callback = _get_method(self.callback, spider)
@@ -57,6 +58,7 @@ class Rule(object):
         Wrapper around the request processing function to maintain backward
         compatibility with functions that do not take a Response object
         """
+        request.priority = self.request_priority
         args = [request] if self.process_request_argcount == 1 else [request, response]
         return self.process_request(*args)
 


### PR DESCRIPTION
Add priority support for rules.
Some times, we need define the priority for the rules of CrawlSpider.
For requirements as below:
1. https://github.com/scrapy/scrapy/issues/3613
2. https://stackoverflow.com/questions/33679366/scrapy-crawlspider-rules-prioritize-next-pages
And we can use priority feature as below
```
class SomeCrawlSpider(PriorityCrawlSpider):
### codes
    rules = (
        # Category link: https://abc.com/cat1/page=2
        PriorityRule(LinkExtractor(allow=r'cat1/page=([0-9])+'), priority=20, follow=True),
        PriorityRule(LinkExtractor(allow=r'cat2/page=([0-9])+'), priority=19, follow=True),
        PriorityRule(LinkExtractor(allow=r'cat3/page=([0-9])+'), priority=18, follow=True),
        # Item link: https://abc.com/items/54460547/<title>
        PriorityRule(LinkExtractor(allow=r'items\/([0-9])+\/.*'), priority=10, callback='parse_item', follow=True),
    )
### codes
```