### PR TITLE
fix zsh completion file extension

### DIFF
--- a/extras/scrapy_zsh_completion
+++ b/extras/scrapy_zsh_completion
@@ -61,7 +61,7 @@ _scrapy() {
 			'-c[evaluate the code in the shell, print the result and exit]:code:(CODE)'
 			'--no-redirect[do not handle HTTP 3xx status codes and print response as-is]'
 			'--spider[use this spider]:spider:_scrapy_spiders'
-			'::file:_files -g \*.http'
+			'::file:_files -g \*.html'
 			'::URL:_httpie_urls'
 		    )
 		    _scrapy_glb_opts $options


### PR DESCRIPTION
Look for `.html` files instead of `.http` when completing `scrapy shell` command.