### PR TITLE
Set the bases for testing code examples from the documentation

### DIFF
--- a/docs/conftest.py
+++ b/docs/conftest.py
@@ -1,0 +1,16 @@
+from doctest import ELLIPSIS
+
+from sybil import Sybil
+from sybil.parsers.codeblock import CodeBlockParser
+from sybil.parsers.doctest import DocTestParser
+from sybil.parsers.skip import skip
+
+
+pytest_collect_file = Sybil(
+    parsers=[
+        DocTestParser(optionflags=ELLIPSIS),
+        CodeBlockParser(future_imports=['print_function']),
+        skip,
+    ],
+    pattern='*.rst',
+).pytest()

--- a/pytest.ini
+++ b/pytest.ini
@@ -2,7 +2,25 @@
 usefixtures = chdir
 python_files=test_*.py __init__.py
 python_classes=
-addopts = --doctest-modules --assert=plain
+addopts =
+    --assert=plain
+    --doctest-modules
+    --ignore=docs/_ext
+    --ignore=docs/conf.py
+    --ignore=docs/intro/tutorial.rst
+    --ignore=docs/news.rst
+    --ignore=docs/topics/commands.rst
+    --ignore=docs/topics/debug.rst
+    --ignore=docs/topics/developer-tools.rst
+    --ignore=docs/topics/dynamic-content.rst
+    --ignore=docs/topics/items.rst
+    --ignore=docs/topics/leaks.rst
+    --ignore=docs/topics/loaders.rst
+    --ignore=docs/topics/selectors.rst
+    --ignore=docs/topics/shell.rst
+    --ignore=docs/topics/stats.rst
+    --ignore=docs/topics/telnetconsole.rst
+    --ignore=docs/utils
 twisted = 1
 flake8-ignore =
     # extras

--- a/tests/requirements-py3.txt
+++ b/tests/requirements-py3.txt
@@ -4,6 +4,7 @@ pytest
 pytest-cov
 pytest-twisted
 pytest-xdist
+sybil
 testfixtures
 
 # optional for shell wrapper tests

--- a/tox.ini
+++ b/tox.ini
@@ -21,7 +21,7 @@ passenv =
     GCS_TEST_FILE_URI
     GCS_PROJECT_ID
 commands =
-    py.test --cov=scrapy --cov-report= {posargs:scrapy tests}
+    py.test --cov=scrapy --cov-report= {posargs:docs scrapy tests}
 
 [testenv:py35]
 basepython = python3.5
@@ -60,7 +60,7 @@ basepython = python3.8
 [testenv:pypy3]
 basepython = pypy3
 commands =
-    py.test {posargs:scrapy tests}
+    py.test {posargs:docs scrapy tests}
 
 [testenv:flake8]
 basepython = python3.8
@@ -68,7 +68,7 @@ deps =
     {[testenv]deps}
     pytest-flake8
 commands =
-    py.test --flake8 {posargs:scrapy tests}
+    py.test --flake8 {posargs:docs scrapy tests}
 
 [docs]
 changedir = docs


### PR DESCRIPTION
The documentation is now searched for code examples to test.

I’ve marked all currently-failing pages as ignored, to be fixed in later changes. Probably after I find a solution for https://github.com/cjw296/sybil/issues/16.