### PR TITLE
XmlItemExporter can export using diferent tags and derive tags from container.

### DIFF
--- a/scrapy/exporters.py
+++ b/scrapy/exporters.py
@@ -136,7 +136,10 @@ class XmlItemExporter(BaseItemExporter):
     def __init__(self, file, **kwargs):
         self.item_element = kwargs.pop('item_element', 'item')
         self.root_element = kwargs.pop('root_element', 'items')
-        self._configure(kwargs)
+        self.serialized_keys = kwargs.pop('serialized_keys',dict())
+        self.default_key = kwargs.pop('default_key','value')
+        self.enable_derive = kwargs.pop('enable_derive',False)
+        self._configure(kwargs, dont_fail=True)
         if not self.encoding:
             self.encoding = 'utf-8'
         self.xg = XMLGenerator(file, encoding=self.encoding)
@@ -168,10 +171,10 @@ class XmlItemExporter(BaseItemExporter):
         self.xg.endElement(self.root_element)
         self.xg.endDocument()
 
-    def _export_xml_field(self, name, serialized_value, depth):
+    def _export_xml_field(self, name, serialized_value, depth=None):
         self._beautify_indent(depth=depth)
         self.xg.startElement(name, {})
-        if hasattr(serialized_value, 'items'):
+        if hasattr(serialized_value, self.root_element):
             self._beautify_newline()
             for subname, value in serialized_value.items():
                 self._export_xml_field(subname, value, depth=depth+1)
@@ -179,7 +182,15 @@ class XmlItemExporter(BaseItemExporter):
         elif is_listlike(serialized_value):
             self._beautify_newline()
             for value in serialized_value:
-                self._export_xml_field('value', value, depth=depth+1)
+                # looks for the name of the iterable in the dict
+                if name in self.serialized_keys:
+                    self._export_xml_field(self.serialized_keys[name], value,
+                                           depth=depth+1)
+                # derives a name
+                elif self.enable_derive and  name[-1].lower() == 's':
+                    self._export_xml_field(name[:-1], value, depth=depth+1)
+                else:
+                    self._export_xml_field(self.default_key, value, depth=depth+1)
             self._beautify_indent(depth=depth)
         elif isinstance(serialized_value, six.text_type):
             self._xg_characters(serialized_value)


### PR DESCRIPTION
At the moment scrapy expors element in a list using the <value> tag and it is impractical to change this behaviour.
My patch aims to make exporting an xml according to a specified formal easier.

- the function is 100% retro compatible
- you can define the default tag to be anything else using the "default_key" argument
- you can specify custom names for elements in a given iterable field using the "serialized_keys" dictionary 
e.g. serialized_keys={'array1':'CustomNameForArray1Elements'}
- you can choose to enable derived names so that fields with a plural name have elements with the same name but singular.
e.g. fruits[]'s elements will have the fuit tag