### PR TITLE
Feature: XmlItemExporter can use custom tags for iterables.

### DIFF
--- a/scrapy/exporters.py
+++ b/scrapy/exporters.py
@@ -136,7 +136,10 @@ class XmlItemExporter(BaseItemExporter):
     def __init__(self, file, **kwargs):
         self.item_element = kwargs.pop('item_element', 'item')
         self.root_element = kwargs.pop('root_element', 'items')
-        self._configure(kwargs)
+        self.serialized_keys = kwargs.pop('serialized_keys',dict())
+        self.default_key = kwargs.pop('default_key','value')
+        self.enable_derive = kwargs.pop('enable_derive',False)
+        self._configure(kwargs, dont_fail=True)
         if not self.encoding:
             self.encoding = 'utf-8'
         self.xg = XMLGenerator(file, encoding=self.encoding)
@@ -168,10 +171,10 @@ class XmlItemExporter(BaseItemExporter):
         self.xg.endElement(self.root_element)
         self.xg.endDocument()
 
-    def _export_xml_field(self, name, serialized_value, depth):
+    def _export_xml_field(self, name, serialized_value, depth=None):
         self._beautify_indent(depth=depth)
         self.xg.startElement(name, {})
-        if hasattr(serialized_value, 'items'):
+        if hasattr(serialized_value, self.root_element):
             self._beautify_newline()
             for subname, value in serialized_value.items():
                 self._export_xml_field(subname, value, depth=depth+1)
@@ -179,7 +182,15 @@ class XmlItemExporter(BaseItemExporter):
         elif is_listlike(serialized_value):
             self._beautify_newline()
             for value in serialized_value:
-                self._export_xml_field('value', value, depth=depth+1)
+                # looks for the name of the iterable in the dict
+                if name in self.serialized_keys:
+                    self._export_xml_field(self.serialized_keys[name], value,
+                                           depth=depth+1)
+                # derives a name
+                elif self.enable_derive and  name[-1].lower() == 's':
+                    self._export_xml_field(name[:-1], value, depth=depth+1)
+                else:
+                    self._export_xml_field(self.default_key, value, depth=depth+1)
             self._beautify_indent(depth=depth)
         elif isinstance(serialized_value, six.text_type):
             self._xg_characters(serialized_value)

--- a/scrapy/exporters.py
+++ b/scrapy/exporters.py
@@ -136,9 +136,9 @@ class XmlItemExporter(BaseItemExporter):
     def __init__(self, file, **kwargs):
         self.item_element = kwargs.pop('item_element', 'item')
         self.root_element = kwargs.pop('root_element', 'items')
-        self.serialized_keys = kwargs.pop('serialized_keys',dict())
-        self.default_key = kwargs.pop('default_key','value')
-        self.enable_derive = kwargs.pop('enable_derive',False)
+        self.serialized_keys = kwargs.pop('serialized_keys', dict())
+        self.default_key = kwargs.pop('default_key', 'value')
+        self.enable_derive = kwargs.pop('enable_derive', False)
         self._configure(kwargs, dont_fail=True)
         if not self.encoding:
             self.encoding = 'utf-8'
@@ -187,7 +187,7 @@ class XmlItemExporter(BaseItemExporter):
                     self._export_xml_field(self.serialized_keys[name], value,
                                            depth=depth+1)
                 # derives a name
-                elif self.enable_derive and  name[-1].lower() == 's':
+                elif self.enable_derive and name[-1].lower() == 's':
                     self._export_xml_field(name[:-1], value, depth=depth+1)
                 else:
                     self._export_xml_field(self.default_key, value, depth=depth+1)
@@ -226,7 +226,7 @@ class CsvItemExporter(BaseItemExporter):
             line_buffering=False,
             write_through=True,
             encoding=self.encoding,
-            newline='' # Windows needs this https://github.com/scrapy/scrapy/issues/3034
+            newline=''  # Windows needs this https://github.com/scrapy/scrapy/issues/3034
         ) if six.PY3 else file
         self.csv_writer = csv.writer(self.stream, **kwargs)
         self._headers_not_written = True

--- a/tests/test_exporters.py
+++ b/tests/test_exporters.py
@@ -366,18 +366,7 @@ class XmlItemExporterTest(BaseItemExporterTest):
 
     def test_nonstring_types_item(self):
         item = self._get_nonstring_types_item()
-        self.assertExportResult(
-            item,
-            b'<?xml version="1.0" encoding="utf-8"?>\n'
-            b'<items>'
-               b'<item>'
-                   b'<float>3.14</float>'
-                   b'<boolean>False</boolean>'
-                   b'<number>22</number>'
-                   b'<time>2015-01-01 01:01:01</time>'
-               b'</item>'
-            b'</items>'
-        )
+        self.assertExportResult(item,b'<?xml version="1.0" encoding="utf-8"?>\n<items><item><float>3.14</float><boolean>False</boolean><number>22</number><time>2015-01-01 01:01:01</time></item></items>')
 
 
 class JsonLinesItemExporterTest(BaseItemExporterTest):

--- a/tests/test_exporters.py
+++ b/tests/test_exporters.py
@@ -350,9 +350,9 @@ class XmlItemExporterTest(BaseItemExporterTest):
         i3 = TestItem(name=u'buz', age=i2)
 
         self.assertExportResult(
-                i3,
-                b'<?xml version="1.0" encoding="utf-8"?>\n<items><item><age><age><age>22</age><name>foo\xc2\xa3hoo</name></age><name>bar</name></age><name>buz</name></item></items>'
-            )
+            i3,
+            b'<?xml version="1.0" encoding="utf-8"?>\n<items><item><age><age><age>22</age><name>foo\xc2\xa3hoo</name></age><name>bar</name></age><name>buz</name></item></items>'
+        )
 
     def test_nested_list_item(self):
         i1 = TestItem(name=u'foo')
@@ -361,16 +361,7 @@ class XmlItemExporterTest(BaseItemExporterTest):
 
         self.assertExportResult(
             i3,
-            b'<?xml version="1.0" encoding="utf-8"?>\n'
-            b'<items>'
-                b'<item>'
-                    b'<age>'
-                        b'<value><name>foo</name></value>'
-                        b'<value><name>bar</name><v2><egg><value>spam</value></egg></v2></value>'
-                    b'</age>'
-                    b'<name>buz</name>'
-                b'</item>'
-            b'</items>'
+            b'<?xml version="1.0" encoding="utf-8"?>\n<items><item><age><value><name>foo</name></value><value><name>bar</name><v2><egg><value>spam</value></egg></v2></value></age><name>buz</name></item></items>'
         )
 
     def test_nonstring_types_item(self):

--- a/tests/test_exporters.py
+++ b/tests/test_exporters.py
@@ -311,6 +311,7 @@ class XmlItemExporterTest(BaseItemExporterTest):
         return XmlItemExporter(self.output, **kwargs)
 
     def assertXmlEquivalent(self, first, second, msg=None):
+
         def xmltuple(elem):
             children = list(elem.iterchildren())
             if children:
@@ -318,6 +319,7 @@ class XmlItemExporterTest(BaseItemExporterTest):
                         for child in children]
             else:
                 return [(elem.tag, [(elem.text, ())])]
+
         def xmlsplit(xmlcontent):
             doc = lxml.etree.fromstring(xmlcontent)
             return xmltuple(doc)
@@ -334,22 +336,22 @@ class XmlItemExporterTest(BaseItemExporterTest):
     def _check_output(self):
         expected_value = b'<?xml version="1.0" encoding="utf-8"?>\n<items><item><age>22</age><name>John\xc2\xa3</name></item></items>'
         self.assertXmlEquivalent(self.output.getvalue(), expected_value)
-    
+
     def test_multivalued_fields(self):
-       
+
         outputs = [
                 b'<?xml version="1.0" encoding="utf-8"?>\n<items><item><name><value>John\xc2\xa3</value><value>Doe</value></name></item></items>',
                 b'<?xml version="1.0" encoding="utf-8"?>\n<root><item><name><value>John\xc2\xa3</value><value>Doe</value></name></item></root>',
                 b'<?xml version="1.0" encoding="utf-8"?>\n<items><person><name><value>John\xc2\xa3</value><value>Doe</value></name></person></items>'
             ]
 
-        arguments = [{},{'root_element':'root'},{'item_element':'person'}]
+        arguments = [{}, {'root_element': 'root'}, {'item_element': 'person'}]
 
         for output, argument in zip(outputs, arguments):
             with self.subTest(output=output, argument=argument):
                 self.assertExportResult(TestItem(name=[u'John\xa3', u'Doe']),
-                                        output,**argument)
-    
+                                        output, **argument)
+
     def test_multivalued_field_custom_name(self):
         outputs = [
                 b'<?xml version="1.0" encoding="utf-8"?>\n<items><item><name><value>John\xc2\xa3</value><value>Doe</value></name></item></items>',
@@ -357,17 +359,18 @@ class XmlItemExporterTest(BaseItemExporterTest):
                 b'<?xml version="1.0" encoding="utf-8"?>\n<root><item><name><field>John\xc2\xa3</field><field>Doe</field></name></item></root>',
             ]
 
-        arguments = [{},{'default_key':'data'},{'serialized_keys':{'name':'field'}}]
+        arguments = [{}, {'default_key': 'data'}, {'serialized_keys': {'name': 'field'}}]
 
         for output, argument in zip(outputs, arguments):
             with self.subTest(output=output, argument=argument):
                 self.assertExportResult(TestItem(name=[u'John\xa3', u'Doe']),
-                                        output,**argument)
+                                        output, **argument)
+
     def test_derive_name(self):
         self.assertExportResult(
                 TestDeriveItem(names=[u'John\xa3', u'Doe']),
                 b'<?xml version="1.0" encoding="utf-8"?>\n<items><item><names><name>John\xc2\xa3</name><name>Doe</name></names></item></items>',
-                **{'enable_derive':True}
+                **{'enable_derive': True}
             )
 
     def test_nested_item(self):
@@ -375,21 +378,22 @@ class XmlItemExporterTest(BaseItemExporterTest):
         i2 = dict(name=u'bar', age=i1)
         i3 = TestItem(name=u'buz', age=i2)
 
-        self.assertExportResult(i3,
-            b'<?xml version="1.0" encoding="utf-8"?>\n'
-            b'<items>'
-                b'<item>'
-                    b'<age>'
+        self.assertExportResult(
+                i3,
+                b'<?xml version="1.0" encoding="utf-8"?>\n'
+                b'<items>'
+                    b'<item>'
                         b'<age>'
-                            b'<age>22</age>'
-                            b'<name>foo\xc2\xa3hoo</name>'
+                            b'<age>'
+                                b'<age>22</age>'
+                                b'<name>foo\xc2\xa3hoo</name>'
+                            b'</age>'
+                            b'<name>bar</name>'
                         b'</age>'
-                        b'<name>bar</name>'
-                    b'</age>'
-                    b'<name>buz</name>'
-                b'</item>'
-            b'</items>'
-        )
+                        b'<name>buz</name>'
+                    b'</item>'
+                b'</items>'
+            )
 
     def test_nested_list_item(self):
         i1 = TestItem(name=u'foo')

--- a/tests/test_exporters.py
+++ b/tests/test_exporters.py
@@ -340,10 +340,10 @@ class XmlItemExporterTest(BaseItemExporterTest):
     def test_multivalued_fields(self):
 
         outputs = [
-                b'<?xml version="1.0" encoding="utf-8"?>\n<items><item><name><value>John\xc2\xa3</value><value>Doe</value></name></item></items>',
-                b'<?xml version="1.0" encoding="utf-8"?>\n<root><item><name><value>John\xc2\xa3</value><value>Doe</value></name></item></root>',
-                b'<?xml version="1.0" encoding="utf-8"?>\n<items><person><name><value>John\xc2\xa3</value><value>Doe</value></name></person></items>'
-            ]
+            b'<?xml version="1.0" encoding="utf-8"?>\n<items><item><name><value>John\xc2\xa3</value><value>Doe</value></name></item></items>',
+            b'<?xml version="1.0" encoding="utf-8"?>\n<root><item><name><value>John\xc2\xa3</value><value>Doe</value></name></item></root>',
+            b'<?xml version="1.0" encoding="utf-8"?>\n<items><person><name><value>John\xc2\xa3</value><value>Doe</value></name></person></items>'
+        ]
 
         arguments = [{}, {'root_element': 'root'}, {'item_element': 'person'}]
 
@@ -354,10 +354,10 @@ class XmlItemExporterTest(BaseItemExporterTest):
 
     def test_multivalued_field_custom_name(self):
         outputs = [
-                b'<?xml version="1.0" encoding="utf-8"?>\n<items><item><name><value>John\xc2\xa3</value><value>Doe</value></name></item></items>',
-                b'<?xml version="1.0" encoding="utf-8"?>\n<items><item><name><data>John\xc2\xa3</data><data>Doe</data></name></item></items>',
-                b'<?xml version="1.0" encoding="utf-8"?>\n<root><item><name><field>John\xc2\xa3</field><field>Doe</field></name></item></root>',
-            ]
+            b'<?xml version="1.0" encoding="utf-8"?>\n<items><item><name><value>John\xc2\xa3</value><value>Doe</value></name></item></items>',
+            b'<?xml version="1.0" encoding="utf-8"?>\n<items><item><name><data>John\xc2\xa3</data><data>Doe</data></name></item></items>',
+            b'<?xml version="1.0" encoding="utf-8"?>\n<root><item><name><field>John\xc2\xa3</field><field>Doe</field></name></item></root>',
+        ]
 
         arguments = [{}, {'default_key': 'data'}, {'serialized_keys': {'name': 'field'}}]
 
@@ -368,31 +368,18 @@ class XmlItemExporterTest(BaseItemExporterTest):
 
     def test_derive_name(self):
         self.assertExportResult(
-                TestDeriveItem(names=[u'John\xa3', u'Doe']),
-                b'<?xml version="1.0" encoding="utf-8"?>\n<items><item><names><name>John\xc2\xa3</name><name>Doe</name></names></item></items>',
-                **{'enable_derive': True}
-            )
+            TestDeriveItem(names=[u'John\xa3', u'Doe']),
+            b'<?xml version="1.0" encoding="utf-8"?>\n<items><item><names><name>John\xc2\xa3</name><name>Doe</name></names></item></items>',
+            **{'enable_derive': True}
+        )
 
     def test_nested_item(self):
         i1 = TestItem(name=u'foo\xa3hoo', age='22')
         i2 = dict(name=u'bar', age=i1)
         i3 = TestItem(name=u'buz', age=i2)
 
-        self.assertExportResult(
-                i3,
-                b'<?xml version="1.0" encoding="utf-8"?>\n'
-                b'<items>'
-                    b'<item>'
-                        b'<age>'
-                            b'<age>'
-                                b'<age>22</age>'
-                                b'<name>foo\xc2\xa3hoo</name>'
-                            b'</age>'
-                            b'<name>bar</name>'
-                        b'</age>'
-                        b'<name>buz</name>'
-                    b'</item>'
-                b'</items>'
+        self.assertExportResult(i3,
+                b'<?xml version="1.0" encoding="utf-8"?>\n<items><item><age><age><age>22</age><name>foo\xc2\xa3hoo</name></age><name>bar</name></age><name>buz</name></item></items>'
             )
 
     def test_nested_list_item(self):

--- a/tests/test_exporters.py
+++ b/tests/test_exporters.py
@@ -366,7 +366,7 @@ class XmlItemExporterTest(BaseItemExporterTest):
 
     def test_nonstring_types_item(self):
         item = self._get_nonstring_types_item()
-        self.assertExportResult(item,b'<?xml version="1.0" encoding="utf-8"?>\n<items><item><float>3.14</float><boolean>False</boolean><number>22</number><time>2015-01-01 01:01:01</time></item></items>')
+        self.assertExportResult(item, b'<?xml version="1.0" encoding="utf-8"?>\n<items><item><float>3.14</float><boolean>False</boolean><number>22</number><time>2015-01-01 01:01:01</time></item></items>')
 
 
 class JsonLinesItemExporterTest(BaseItemExporterTest):

--- a/tests/test_exporters.py
+++ b/tests/test_exporters.py
@@ -325,9 +325,9 @@ class XmlItemExporterTest(BaseItemExporterTest):
             return xmltuple(doc)
         return self.assertEqual(xmlsplit(first), xmlsplit(second), msg)
 
-    def assertExportResult(self, item, expected_value, **kwargs):
+    def assertExportResult(self, item, expected_value):
         fp = BytesIO()
-        ie = XmlItemExporter(fp, **kwargs)
+        ie = XmlItemExporter(fp)
         ie.start_exporting()
         ie.export_item(item)
         ie.finish_exporting()
@@ -339,38 +339,9 @@ class XmlItemExporterTest(BaseItemExporterTest):
 
     def test_multivalued_fields(self):
 
-        outputs = [
-            b'<?xml version="1.0" encoding="utf-8"?>\n<items><item><name><value>John\xc2\xa3</value><value>Doe</value></name></item></items>',
-            b'<?xml version="1.0" encoding="utf-8"?>\n<root><item><name><value>John\xc2\xa3</value><value>Doe</value></name></item></root>',
-            b'<?xml version="1.0" encoding="utf-8"?>\n<items><person><name><value>John\xc2\xa3</value><value>Doe</value></name></person></items>'
-        ]
-
-        arguments = [{}, {'root_element': 'root'}, {'item_element': 'person'}]
-
-        for output, argument in zip(outputs, arguments):
-            with self.subTest(output=output, argument=argument):
-                self.assertExportResult(TestItem(name=[u'John\xa3', u'Doe']),
-                                        output, **argument)
-
-    def test_multivalued_field_custom_name(self):
-        outputs = [
-            b'<?xml version="1.0" encoding="utf-8"?>\n<items><item><name><value>John\xc2\xa3</value><value>Doe</value></name></item></items>',
-            b'<?xml version="1.0" encoding="utf-8"?>\n<items><item><name><data>John\xc2\xa3</data><data>Doe</data></name></item></items>',
-            b'<?xml version="1.0" encoding="utf-8"?>\n<root><item><name><field>John\xc2\xa3</field><field>Doe</field></name></item></root>',
-        ]
-
-        arguments = [{}, {'default_key': 'data'}, {'serialized_keys': {'name': 'field'}}]
-
-        for output, argument in zip(outputs, arguments):
-            with self.subTest(output=output, argument=argument):
-                self.assertExportResult(TestItem(name=[u'John\xa3', u'Doe']),
-                                        output, **argument)
-
-    def test_derive_name(self):
         self.assertExportResult(
-            TestDeriveItem(names=[u'John\xa3', u'Doe']),
-            b'<?xml version="1.0" encoding="utf-8"?>\n<items><item><names><name>John\xc2\xa3</name><name>Doe</name></names></item></items>',
-            **{'enable_derive': True}
+            TestItem(name=[u'John\xa3', u'Doe']),
+            b'<?xml version="1.0" encoding="utf-8"?>\n<items><item><name><value>John\xc2\xa3</value><value>Doe</value></name></item></items>',
         )
 
     def test_nested_item(self):
@@ -378,7 +349,8 @@ class XmlItemExporterTest(BaseItemExporterTest):
         i2 = dict(name=u'bar', age=i1)
         i3 = TestItem(name=u'buz', age=i2)
 
-        self.assertExportResult(i3,
+        self.assertExportResult(
+                i3,
                 b'<?xml version="1.0" encoding="utf-8"?>\n<items><item><age><age><age>22</age><name>foo\xc2\xa3hoo</name></age><name>bar</name></age><name>buz</name></item></items>'
             )
 
@@ -387,7 +359,8 @@ class XmlItemExporterTest(BaseItemExporterTest):
         i2 = dict(name=u'bar', v2={"egg": ["spam"]})
         i3 = TestItem(name=u'buz', age=[i1, i2])
 
-        self.assertExportResult(i3,
+        self.assertExportResult(
+            i3,
             b'<?xml version="1.0" encoding="utf-8"?>\n'
             b'<items>'
                 b'<item>'
@@ -402,7 +375,8 @@ class XmlItemExporterTest(BaseItemExporterTest):
 
     def test_nonstring_types_item(self):
         item = self._get_nonstring_types_item()
-        self.assertExportResult(item,
+        self.assertExportResult(
+            item,
             b'<?xml version="1.0" encoding="utf-8"?>\n'
             b'<items>'
                b'<item>'

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py35
+envlist = py37
 
 [testenv]
 deps =


### PR DESCRIPTION
At the moment scrapy exports element in a list using the <value> tag and it is impractical to change this behavior.
My patch aims to make exporting an xml according to a specified formal easier.

- the function is 100% retro compatible
- you can define the default tag to be anything else using the "default_key" argument
- you can specify custom names for elements in a given iterable field using the "serialized_keys" dictionary 
e.g. serialized_keys={'array1':'CustomNameForArray1Elements'}
- you can choose to enable derived names so that fields with a plural name have elements with the same name but singular.
e.g. fruits[]'s elements will have the fruit tag