### PR TITLE
Add settings hook to allow overriding of Scraper class

### DIFF
--- a/docs/topics/settings.rst
+++ b/docs/topics/settings.rst
@@ -1241,6 +1241,14 @@ Type of priority queue used by the scheduler. Another available type is
 domains in parallel. But currently ``scrapy.pqueues.DownloaderAwarePriorityQueue``
 does not work together with :setting:`CONCURRENT_REQUESTS_PER_IP`.
 
+.. setting:: SCRAPER
+
+SCRAPER
+-------
+Default: ``'scrapy.core.scraper.Scraper'``
+
+The scraper to use for crawling.
+
 .. setting:: SPIDER_CONTRACTS
 
 SPIDER_CONTRACTS

--- a/scrapy/core/engine.py
+++ b/scrapy/core/engine.py
@@ -11,7 +11,6 @@ from twisted.internet import defer, task
 from twisted.python.failure import Failure
 
 from scrapy import signals
-from scrapy.core.scraper import Scraper
 from scrapy.exceptions import DontCloseSpider
 from scrapy.http import Response, Request
 from scrapy.utils.misc import load_object
@@ -67,7 +66,7 @@ class ExecutionEngine(object):
         self.scheduler_cls = load_object(self.settings['SCHEDULER'])
         downloader_cls = load_object(self.settings['DOWNLOADER'])
         self.downloader = downloader_cls(crawler)
-        self.scraper = Scraper(crawler)
+        self.scraper = load_object(self.settings['SCRAPER'])(crawler)
         self._spider_closed_callback = spider_closed_callback
 
     @defer.inlineCallbacks

--- a/scrapy/settings/default_settings.py
+++ b/scrapy/settings/default_settings.py
@@ -254,6 +254,8 @@ SCHEDULER_DISK_QUEUE = 'scrapy.squeues.PickleLifoDiskQueue'
 SCHEDULER_MEMORY_QUEUE = 'scrapy.squeues.LifoMemoryQueue'
 SCHEDULER_PRIORITY_QUEUE = 'scrapy.pqueues.ScrapyPriorityQueue'
 
+SCRAPER = 'scrapy.core.scraper.Scraper'
+
 SPIDER_LOADER_CLASS = 'scrapy.spiderloader.SpiderLoader'
 SPIDER_LOADER_WARN_ONLY = False
 


### PR DESCRIPTION
Put a hook in the settings to allow developers to implement their own scrapers (via subclassing the Scraper class). 

This allows overriding of the error handling when spiders fail; fixes #4156.