### PR TITLE
Include /requirements-py3.txt from /docs/requirements.txt

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,4 @@
+-r ../requirements-py3.txt
 Sphinx>=2.1
 sphinx-notfound-page
 sphinx_rtd_theme


### PR DESCRIPTION
With #4152 I broke the documentation build, because in Read the Docs we are installing the requirements from `/requirements-py3.txt`, and #4152 introduced into `/docs/requirements.txt` a new requirement that is not installed in Read the Docs by default.

After this change, I count on fixing the Read the Docs build by changing the requirements file in Read the Docs to `/docs/requirements.txt`.