### PR TITLE
[Docs] Fix Twisted links

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -279,7 +279,7 @@ intersphinx_mapping = {
     'python': ('https://docs.python.org/3', None),
     'sphinx': ('https://www.sphinx-doc.org/en/master', None),
     'tox': ('https://tox.readthedocs.io/en/latest', None),
-    'twisted': ('https://twistedmatrix.com/documents/current', None),
+    'twisted': ('https://twistedmatrix.com/documents/current/api', None),
 }
 
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -279,7 +279,8 @@ intersphinx_mapping = {
     'python': ('https://docs.python.org/3', None),
     'sphinx': ('https://www.sphinx-doc.org/en/master', None),
     'tox': ('https://tox.readthedocs.io/en/latest', None),
-    'twisted': ('https://twistedmatrix.com/documents/current/api', None),
+    'twisted': ('https://twistedmatrix.com/documents/current', None),
+    'twistedapi': ('https://twistedmatrix.com/documents/current/api', None),
 }
 
 


### PR DESCRIPTION
The current link for the Twisted API is not working for me when I generate the docs. There are no public links to show, since this change has not been deployed to the main docs yet.