### PR TITLE
Use pprint.pformat on overridden settings

### DIFF
--- a/scrapy/crawler.py
+++ b/scrapy/crawler.py
@@ -46,7 +46,7 @@ class Crawler(object):
         logging.root.addHandler(handler)
 
         d = dict(overridden_settings(self.settings))
-        logger.info("Overridden settings: %(settings)s",
+        logger.info("Overridden settings:\n%(settings)s",
                     {'settings': pprint.pformat(d)})
 
         if get_scrapy_root_handler() is not None:

--- a/scrapy/crawler.py
+++ b/scrapy/crawler.py
@@ -1,3 +1,4 @@
+import pprint
 import six
 import signal
 import logging
@@ -45,7 +46,8 @@ class Crawler(object):
         logging.root.addHandler(handler)
 
         d = dict(overridden_settings(self.settings))
-        logger.info("Overridden settings: %(settings)r", {'settings': d})
+        logger.info("Overridden settings: %(settings)r",
+                    {'settings': pprint.pformat(d)})
 
         if get_scrapy_root_handler() is not None:
             # scrapy root handler already installed: update it with new settings

--- a/scrapy/crawler.py
+++ b/scrapy/crawler.py
@@ -46,7 +46,7 @@ class Crawler(object):
         logging.root.addHandler(handler)
 
         d = dict(overridden_settings(self.settings))
-        logger.info("Overridden settings: %(settings)r",
+        logger.info("Overridden settings: %(settings)s",
                     {'settings': pprint.pformat(d)})
 
         if get_scrapy_root_handler() is not None:


### PR DESCRIPTION
This commit use pprint.pformat on overridden settings to keep consistent
with scrapy.middleware, for example:

Original:
```
2019-11-28 22:23:57 [scrapy.crawler] INFO: Overridden settings: {'BOT_NAME': 'spider_demo', 'NEWSPIDER_MODULE': 'spider_demo.spiders', 'SPIDER_MODULES': ['spider_demo.spiders'], 'USER_AGENT': 'Mozilla/5.0 (X11; Fedora; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.157 Safari/537.36'}
2019-11-28 22:23:57 [scrapy.middleware] INFO: Enabled extensions:
['scrapy.extensions.corestats.CoreStats',
 'scrapy.extensions.telnet.TelnetConsole',
 'scrapy.extensions.memusage.MemoryUsage',
 'scrapy.extensions.logstats.LogStats']
```
```
2019-11-28 22:23:57 [scrapy.crawler] INFO: Overridden settings:
{'BOT_NAME': 'spider_demo',
 'NEWSPIDER_MODULE': 'spider_demo.spiders',
 'SPIDER_MODULES': ['spider_demo.spiders'],
 'USER_AGENT': 'Mozilla/5.0 (X11; Fedora; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.157 Safari/537.36'}
2019-11-28 22:23:57 [scrapy.middleware] INFO: Enabled extensions:
['scrapy.extensions.corestats.CoreStats',
 'scrapy.extensions.telnet.TelnetConsole',
 'scrapy.extensions.memusage.MemoryUsage',
 'scrapy.extensions.logstats.LogStats']
```