### PR TITLE
Use pprint.pformat on versions log message

### DIFF
--- a/scrapy/utils/log.py
+++ b/scrapy/utils/log.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-
+import pprint
 import sys
 import logging
 import warnings

--- a/scrapy/utils/log.py
+++ b/scrapy/utils/log.py
@@ -144,10 +144,10 @@ def _get_handler(settings):
 def log_scrapy_info(settings):
     logger.info("Scrapy %(version)s started (bot: %(bot)s)",
                 {'version': scrapy.__version__, 'bot': settings['BOT_NAME']})
-    logger.info("Versions: %(versions)s",
-                {'versions': ", ".join("%s %s" % (name, version)
+    logger.info("Versions:\n%(versions)s",
+                {'versions': pprint.pformat({name: version
                     for name, version in scrapy_components_versions()
-                    if name != "Scrapy")})
+                    if name != "Scrapy"})})
 
 
 class StreamLogger(object):


### PR DESCRIPTION
This commit use pprint.pformat on overridden settings to keep consistent
with scrapy.middleware, for example:
Original:
```
2019-12-01 11:35:40 [scrapy.utils.log] INFO: Versions: lxml 4.3.4.0, libxml2 2.9.9, cssselect 1.0.3, parsel 1.5.1, w3lib 1.20.0, Twisted 19.2.1, Python 3.7.5 (default, Oct 17 2019, 12:16:48) - [GCC 9.2.1 20190827 (Red Hat 9.2.1-1)], pyOpenSSL 19.0.0 (OpenSSL 1.1.1c  28 May 2019), cryptography 2.7, Platform Linux-5.3.7-301.fc31.x86_64-x86_64-with-fedora-31-Thirty_One
```
Now:
```
2019-12-01 11:04:22 [scrapy.utils.log] INFO: Versions:
{'Platform': 'Linux-5.3.7-301.fc31.x86_64-x86_64-with-fedora-31-Thirty_One',
 'Python': '3.7.5 (default, Oct 17 2019, 12:16:48) - [GCC 9.2.1 20190827 (Red '
           'Hat 9.2.1-1)]',
 'Twisted': '19.2.1',
 'cryptography': '2.7',
 'cssselect': '1.0.3',
 'libxml2': '2.9.9',
 'lxml': '4.3.4.0',
 'parsel': '1.5.1',
 'pyOpenSSL': '19.0.0 (OpenSSL 1.1.1c  28 May 2019)',
 'w3lib': '1.20.0'}
```