### PR TITLE
Re-arrange the imports in the httpproxy module

### DIFF
--- a/scrapy/downloadermiddlewares/httpproxy.py
+++ b/scrapy/downloadermiddlewares/httpproxy.py
@@ -1,7 +1,8 @@
 import base64
+from urllib.request import _parse_proxy
+
 from six.moves.urllib.parse import unquote, urlunparse
 from six.moves.urllib.request import getproxies, proxy_bypass
-from urllib.request import _parse_proxy
 
 from scrapy.exceptions import NotConfigured
 from scrapy.utils.httpobj import urlparse_cached


### PR DESCRIPTION
This commit re-arranges the imports in the httpproxy module to follow
pep8