### PR TITLE
Handle XMLSyntaxError on blank sitemap pages for SitemapSpider

### DIFF
--- a/scrapy/spiders/sitemap.py
+++ b/scrapy/spiders/sitemap.py
@@ -1,11 +1,7 @@
 import re
 import logging
-<<<<<<< HEAD
 
-import six
 from lxml.etree import XMLSyntaxError
-=======
->>>>>>> master
 
 from scrapy.spiders import Spider
 from scrapy.http import Request, XmlResponse

--- a/scrapy/spiders/sitemap.py
+++ b/scrapy/spiders/sitemap.py
@@ -1,13 +1,14 @@
 import re
 import logging
+
 import six
+from lxml.etree import XMLSyntaxError
 
 from scrapy.spiders import Spider
 from scrapy.http import Request, XmlResponse
 from scrapy.utils.sitemap import Sitemap, sitemap_urls_from_robots
 from scrapy.utils.gz import gunzip, gzip_magic_number
 
-from lxml.etree import XMLSyntaxError
 
 logger = logging.getLogger(__name__)
 

--- a/scrapy/spiders/sitemap.py
+++ b/scrapy/spiders/sitemap.py
@@ -7,6 +7,7 @@ from scrapy.http import Request, XmlResponse
 from scrapy.utils.sitemap import Sitemap, sitemap_urls_from_robots
 from scrapy.utils.gz import gunzip, gzip_magic_number
 
+from lxml.etree import XMLSyntaxError
 
 logger = logging.getLogger(__name__)
 
@@ -50,7 +51,13 @@ class SitemapSpider(Spider):
                                {'response': response}, extra={'spider': self})
                 return
 
-            s = Sitemap(body)
+            try:
+                s = Sitemap(body)
+            except XMLSyntaxError:
+                logger.warning("Ignoring invalid sitemap: %(response)s",
+                               {'response': response}, extra={'spider': self})
+                return
+
             it = self.sitemap_filter(s)
 
             if s.type == 'sitemapindex':

--- a/tests/test_spider.py
+++ b/tests/test_spider.py
@@ -418,6 +418,9 @@ class SitemapSpiderTest(SpiderTest):
         r = Response(url="http://www.example.com/favicon.ico", body=self.BODY)
         self.assertSitemapBody(r, None)
 
+        r = Response(url="http://www.example.com", body=b"")
+        self.assertSitemapBody(r, None)
+
     def test_get_sitemap_body_gzip_headers(self):
         r = Response(url="http://www.example.com/sitemap", body=self.GZBODY,
                      headers={"content-type": "application/gzip"})


### PR DESCRIPTION
This PR implements a fix for the issue mentioned on #4211. Namely, it gracefully handles the `XMLSyntaxError` that gets thrown anytime the `SitemapSpider` encounters a blank sitemap page.

Fixes #4211