### PR TITLE
Use protego version with fix

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -74,7 +74,7 @@ setup(
         'service_identity>=16.0.0',
         'w3lib>=1.17.0',
         'zope.interface>=4.1.3',
-        'protego>=0.1.15',
+        'protego>=0.1.16',
     ],
     extras_require=extras_require,
 )

--- a/tox.ini
+++ b/tox.ini
@@ -51,7 +51,7 @@ deps =
     cssselect==0.9.1
     lxml==3.5.0
     parsel==1.5.0
-    Protego==0.1.15
+    Protego==0.1.16
     PyDispatcher==2.0.5
     pyOpenSSL==16.2.0
     queuelib==1.4.2


### PR DESCRIPTION
Use version of protego with fixed issue (https://github.com/scrapy/scrapy/issues/4145) by default