### PR TITLE
Use Python 3.7 to build the documentation

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -2,6 +2,8 @@ version: 2
 sphinx:
   configuration: docs/conf.py
 python:
-  version: 3.8
+  # For available versions, see:
+  # https://docs.readthedocs.io/en/stable/config-file/v2.html#build-image
+  version: 3.7  # Keep in sync with .travis.yml
   install:
     - requirements: docs/requirements.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ matrix:
     - env: TOXENV=extra-deps
       python: 3.8
     - env: TOXENV=docs
-      python: 3.8
+      python: 3.7  # Keep in sync with .readthedocs.yml
 install:
   - |
       if [ "$TOXENV" = "pypy3" ]; then


### PR DESCRIPTION
I broke the build changing it to 3.8 in #4140, it turns out Read The Docs does not support 3.8 yet.