### PR TITLE
Test Python 3.5.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,13 +45,15 @@ install:
         virtualenv --python="$PYPY_VERSION/bin/pypy3" "$HOME/virtualenvs/$PYPY_VERSION"
         source "$HOME/virtualenvs/$PYPY_VERSION/bin/activate"
       elif [ "$INSTALL_PYTHON_VERSION" ]; then
-        wget "https://www.python.org/ftp/python/$INSTALL_PYTHON_VERSION/Python-$INSTALL_PYTHON_VERSION.tar.xz"
-        tar -axf Python-$INSTALL_PYTHON_VERSION.tar.xz
-        cd Python-$INSTALL_PYTHON_VERSION
-        ./configure --prefix=$(pwd)
-        make
-        make install
-        cd ..
+        if [ ! -d "Python-$INSTALL_PYTHON_VERSION" ]; then
+          wget "https://www.python.org/ftp/python/$INSTALL_PYTHON_VERSION/Python-$INSTALL_PYTHON_VERSION.tar.xz"
+          tar -axf Python-$INSTALL_PYTHON_VERSION.tar.xz
+          cd Python-$INSTALL_PYTHON_VERSION
+          ./configure --prefix=$(pwd)
+          make
+          make install
+          cd ..
+        fi
         virtualenv --python="Python-$INSTALL_PYTHON_VERSION/bin/python3" "$HOME/virtualenvs/$INSTALL_PYTHON_VERSION"
         source "$HOME/virtualenvs/$INSTALL_PYTHON_VERSION/bin/activate"
       fi
@@ -69,6 +71,7 @@ notifications:
 cache:
   directories:
     - $HOME/.cache/pip
+    - Python-3.5.0
 deploy:
   provider: pypi
   distributions: "sdist bdist_wheel"

--- a/.travis.yml
+++ b/.travis.yml
@@ -71,7 +71,6 @@ notifications:
 cache:
   directories:
     - $HOME/.cache/pip
-    - Python-3.5.0
 deploy:
   provider: pypi
   distributions: "sdist bdist_wheel"

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,13 +14,14 @@ matrix:
     - env: TOXENV=docs
       python: 3.7  # Keep in sync with .readthedocs.yml
 
-    - env: TOXENV=py
-      python: 3.5
-    - env: TOXENV=pinned INSTALL_PYTHON_VERSION=3.5.0
+    - env: TOXENV=pinned
+      python: 3.5.0
+    - env: TOXENV=asyncio
+      python: 3.5.0  # We use additional code to support 3.5.3 and earlier
     - env: TOXENV=asyncio
       python: 3.5
-    # We use additional code to support 3.5.3 and earlier
-    - env: TOXENV=asyncio INSTALL_PYTHON_VERSION=3.5.0
+    - env: TOXENV=py
+      python: 3.5
 
     - env: TOXENV=py
       python: 3.6
@@ -44,18 +45,6 @@ install:
         tar -jxf ${PYPY_VERSION}.tar.bz2
         virtualenv --python="$PYPY_VERSION/bin/pypy3" "$HOME/virtualenvs/$PYPY_VERSION"
         source "$HOME/virtualenvs/$PYPY_VERSION/bin/activate"
-      elif [ "$INSTALL_PYTHON_VERSION" ]; then
-        if [ ! -d "Python-$INSTALL_PYTHON_VERSION" ]; then
-          wget "https://www.python.org/ftp/python/$INSTALL_PYTHON_VERSION/Python-$INSTALL_PYTHON_VERSION.tar.xz"
-          tar -axf Python-$INSTALL_PYTHON_VERSION.tar.xz
-          cd Python-$INSTALL_PYTHON_VERSION
-          ./configure --prefix=$(pwd)
-          make
-          make install
-          cd ..
-        fi
-        virtualenv --python="Python-$INSTALL_PYTHON_VERSION/bin/python3" "$HOME/virtualenvs/$INSTALL_PYTHON_VERSION"
-        source "$HOME/virtualenvs/$INSTALL_PYTHON_VERSION/bin/activate"
       fi
   - pip install -U tox twine wheel codecov
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,12 +16,11 @@ matrix:
 
     - env: TOXENV=py
       python: 3.5
-    - env: TOXENV=pinned
-      python: 3.5.0
+    - env: TOXENV=pinned INSTALL_PYTHON_VERSION=3.5.0
     - env: TOXENV=asyncio
       python: 3.5
-    - env: TOXENV=asyncio
-      python: 3.5.0  # We use additional code to support 3.5.3 and earlier
+    # We use additional code to support 3.5.3 and earlier
+    - env: TOXENV=asyncio INSTALL_PYTHON_VERSION=3.5.0
 
     - env: TOXENV=py
       python: 3.6
@@ -45,6 +44,16 @@ install:
         tar -jxf ${PYPY_VERSION}.tar.bz2
         virtualenv --python="$PYPY_VERSION/bin/pypy3" "$HOME/virtualenvs/$PYPY_VERSION"
         source "$HOME/virtualenvs/$PYPY_VERSION/bin/activate"
+      elif [ "$INSTALL_PYTHON_VERSION" ]; then
+        wget "https://www.python.org/ftp/python/$INSTALL_PYTHON_VERSION/Python-$INSTALL_PYTHON_VERSION.tar.xz"
+        tar -axf Python-$INSTALL_PYTHON_VERSION.tar.xz
+        cd Python-$INSTALL_PYTHON_VERSION
+        ./configure --prefix=$(pwd)
+        make
+        make install
+        cd ..
+        virtualenv --python="Python-$INSTALL_PYTHON_VERSION/bin/python3" "$HOME/virtualenvs/$INSTALL_PYTHON_VERSION"
+        source "$HOME/virtualenvs/$INSTALL_PYTHON_VERSION/bin/activate"
       fi
   - pip install -U tox twine wheel codecov
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,25 +11,32 @@ matrix:
       python: 3.8
     - env: TOXENV=flake8
       python: 3.8
-    - env: TOXENV=pypy3
-    - env: TOXENV=py35
+    - env: TOXENV=docs
+      python: 3.7  # Keep in sync with .readthedocs.yml
+
+    - env: TOXENV=py
       python: 3.5
     - env: TOXENV=pinned
+      python: 3.5.0
+    - env: TOXENV=asyncio
       python: 3.5
-    - env: TOXENV=py35-asyncio
-      python: 3.5
-    - env: TOXENV=py36
+    - env: TOXENV=asyncio
+      python: 3.5.0  # We use additional code to support 3.5.3 and earlier
+
+    - env: TOXENV=py
       python: 3.6
-    - env: TOXENV=py37
+    - env: TOXENV=py
       python: 3.7
-    - env: TOXENV=py38
+
+    - env: TOXENV=py PYPI_RELEASE_JOB=true
       python: 3.8
     - env: TOXENV=extra-deps
       python: 3.8
-    - env: TOXENV=py38-asyncio
+    - env: TOXENV=asyncio
       python: 3.8
-    - env: TOXENV=docs
-      python: 3.7  # Keep in sync with .readthedocs.yml
+
+    - env: TOXENV=pypy3
+
 install:
   - |
       if [ "$TOXENV" = "pypy3" ]; then
@@ -62,4 +69,4 @@ deploy:
   on:
     tags: true
     repo: scrapy/scrapy
-    condition: "$TOXENV == py37 && $TRAVIS_TAG =~ ^[0-9]+[.][0-9]+[.][0-9]+(rc[0-9]+|[.]dev[0-9]+)?$"
+    condition: "$PYPI_RELEASE_JOB == true && $TRAVIS_TAG =~ ^[0-9]+[.][0-9]+[.][0-9]+(rc[0-9]+|[.]dev[0-9]+)?$"

--- a/tests/requirements-py3.txt
+++ b/tests/requirements-py3.txt
@@ -1,7 +1,7 @@
 # Tests requirements
 jmespath
 mitmproxy; python_version >= '3.6'
-mitmproxy<4.0.0; python_version < '3.6'
+mitmproxy<4.0.0; python_version >= '3.5.4' and python_version < '3.6'
 pytest
 pytest-cov
 pytest-twisted >= 1.11

--- a/tests/requirements-py3.txt
+++ b/tests/requirements-py3.txt
@@ -1,7 +1,7 @@
 # Tests requirements
 jmespath
 mitmproxy; python_version >= '3.6'
-mitmproxy<4.0.0; python_version >= '3.5.4' and python_version < '3.6'
+mitmproxy<4.0.0; python_version < '3.6'
 pytest
 pytest-cov
 pytest-twisted >= 1.11

--- a/tests/test_proxy_connect.py
+++ b/tests/test_proxy_connect.py
@@ -4,6 +4,7 @@ import re
 import sys
 from subprocess import Popen, PIPE
 from urllib.parse import urlsplit, urlunsplit
+from unittest import skipIf
 
 import pytest
 from testfixtures import LogCapture
@@ -56,6 +57,8 @@ def _wrong_credentials(proxy_url):
     return urlunsplit(bad_auth_proxy)
 
 
+@skipIf(sys.version_info < (3, 5, 4),
+        "requires mitmproxy < 3.0.0, which these tests do not support")
 class ProxyConnectTestCase(TestCase):
 
     def setUp(self):
@@ -80,7 +83,7 @@ class ProxyConnectTestCase(TestCase):
             yield crawler.crawl(self.mockserver.url("/status?n=200", is_secure=True))
         self._assert_got_response_code(200, l)
 
-    @pytest.mark.xfail(reason='Python 3.6+ fails this earlier', condition=sys.version_info.minor >= 6)
+    @pytest.mark.xfail(reason='Python 3.6+ fails this earlier', condition=sys.version_info >= (3, 6))
     @defer.inlineCallbacks
     def test_https_connect_tunnel_error(self):
         crawler = get_crawler(SimpleSpider)

--- a/tox.ini
+++ b/tox.ini
@@ -71,6 +71,10 @@ deps =
     reppy
     robotexclusionrulesparser
 
+[testenv:asyncio]
+commands =
+    {[testenv]commands} --reactor=asyncio
+
 [docs]
 changedir = docs
 deps =
@@ -96,17 +100,3 @@ changedir = {[docs]changedir}
 deps = {[docs]deps}
 commands =
     sphinx-build -W -b linkcheck . {envtmpdir}/linkcheck
-
-[asyncio]
-commands =
-    {[testenv]commands} --reactor=asyncio
-
-[testenv:py35-asyncio]
-basepython = python3.5
-deps = {[testenv]deps}
-commands = {[asyncio]commands}
-
-[testenv:py38-asyncio]
-basepython = python3.8
-deps = {[testenv]deps}
-commands = {[asyncio]commands}


### PR DESCRIPTION
Changes:

- Group quick tests together (move `docs` up)
- Separate with a line break Travis job definition groups: static, minimum Python, middle Python, maximum Python, PyPy
- Use Python 3.5.0 for the pinned-dependencies job
- Test asyncio both with 3.5.0 and the latest 3.5
- Simplify the asyncio Tox configuration, allowing to run the asyncio tests on any Python version
- Use the `py` automatic Tox environment when a more specific environment name is not necessary
- Use a `PYPI_RELEASE_JOB` environment variable to mark which job is used to deploy to PyPI

Note: `tests/test_proxy_connect.py` is skipped in Python 3.5.0. I tried to get the tests to work, but the introduction of some `typing` in mitproxy 3.0.0 required using an even earlier mitproxy for these tests. mitmproxy 2 had completely different command-line options, and while I did try the following, it caused timeouts and I preferred not to spend more time on this:

```
# …
                           '-c', script,
                           '--bind-address', '127.0.0.1',
                           '--port', '0',
                           '--htpasswd', '/scrapy/htpasswd',
                           '--cert', cert_path,
                           '--insecure',
# …
```