### PR TITLE
change link for brotli package to a supported one

### DIFF
--- a/docs/topics/downloader-middleware.rst
+++ b/docs/topics/downloader-middleware.rst
@@ -704,13 +704,14 @@ HttpCompressionMiddleware
    sent/received from web sites.
 
    This middleware also supports decoding `brotli-compressed`_ as well as
-   `zstd-compressed`_ responses, provided that `brotlipy`_ or `zstandard`_ is
+   `zstd-compressed`_ responses, provided that `brotli`_ or `zstandard`_ is
    installed, respectively.
 
 .. _brotli-compressed: https://www.ietf.org/rfc/rfc7932.txt
-.. _brotlipy: https://pypi.org/project/brotlipy/
+.. _brotli: https://pypi.org/project/Brotli/
 .. _zstd-compressed: https://www.ietf.org/rfc/rfc8478.txt
 .. _zstandard: https://pypi.org/project/zstandard/
+
 
 HttpCompressionMiddleware Settings
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -12,7 +12,7 @@ uvloop; platform_system != "Windows" and python_version > '3.6'
 
 # optional for shell wrapper tests
 bpython
-brotlipy  # optional for HTTP compress downloader middleware tests
+brotli  # optional for HTTP compress downloader middleware tests
 zstandard; implementation_name != 'pypy'  # optional for HTTP compress downloader middleware tests
 ipython
 pywin32; sys_platform == "win32"


### PR DESCRIPTION
I have noticed that the offcial documentation suggests using [brotlipy](https://pypi.org/project/brotlipy/). While this works, the project seems to be stale or abandoned. Most recent release was in 2017 and most recent commit - in 2018.

I suggest replacing that with a more recent and seemingly more actively supported [Brotli](https://pypi.org/project/Brotli) by google. It's most recent release was in 2018 and most recent commit - this month. This library has same API and judging by my experience, has proved to work seamlessly.
