### PR TITLE
added custom scheduler breakage in news.rst

### DIFF
--- a/docs/news.rst
+++ b/docs/news.rst
@@ -291,7 +291,7 @@ Backward-incompatible changes
 *   An additional `crawler` paramter has been added to the `__init__` method of
     the `scrapy.core.scheduler.Scheduler` class. Custom scheduler subclassses 
     don't accept arbitrary parameters in their `__init__` method. This version of
-    scrapy breaks custom schedulers.
+    Scrapy might break custom schedulers.
 
     For more information:
     Refer to: https://docs.scrapy.org/en/latest/topics/settings.html#scheduler

--- a/docs/news.rst
+++ b/docs/news.rst
@@ -288,7 +288,13 @@ Backward-incompatible changes
     :class:`~scrapy.http.Request` objects instead of arbitrary Python data
     structures.
 
-*   This version of scrapy breaks custom schedulers 
+*   An additional `crawler` paramter has been added to the `__init__` method of
+    the `scrapy.core.scheduler.Scheduler` class. Custom scheduler subclassses 
+    don't accept binary parameters in their `__init__` method. This version of
+    scrapy breaks custom schedulers.
+
+    For more information:
+    Refer to: https://docs.scrapy.org/en/latest/topics/settings.html#scheduler
 
 See also :ref:`1.7-deprecation-removals` below.
 

--- a/docs/news.rst
+++ b/docs/news.rst
@@ -288,6 +288,8 @@ Backward-incompatible changes
     :class:`~scrapy.http.Request` objects instead of arbitrary Python data
     structures.
 
+*   This version of scrapy breaks custom schedulers 
+
 See also :ref:`1.7-deprecation-removals` below.
 
 

--- a/docs/news.rst
+++ b/docs/news.rst
@@ -289,11 +289,11 @@ Backward-incompatible changes
     structures.
 
 *   An additional ``crawler`` parameter has been added to the ``__init__`` method
-    of the `scrapy.core.scheduler.Scheduler` class. 
+    of the :class:`scrapy.core.scheduler.Scheduler` class. 
     Custom scheduler subclasses which don't accept arbitrary parameters in 
     their ``__init__`` method might break because of this change.
 
-    For more information, refer to :class:`scrapy.core.scheduler.Scheduler`
+    For more information, refer to the documentation for the :setting:`SCHEDULER` setting.
 
 See also :ref:`1.7-deprecation-removals` below.
 

--- a/docs/news.rst
+++ b/docs/news.rst
@@ -288,13 +288,10 @@ Backward-incompatible changes
     :class:`~scrapy.http.Request` objects instead of arbitrary Python data
     structures.
 
-*   An additional `crawler` paramter has been added to the `__init__` method of
-    the `scrapy.core.scheduler.Scheduler` class. Custom scheduler subclassses 
-    don't accept arbitrary parameters in their `__init__` method. This version of
-    Scrapy might break custom schedulers.
+*   Custom scheduler subclasses which don't accept arbitrary parameters in 
+    their __init__ method might break because of this change.
 
-    For more information:
-    Refer to: https://docs.scrapy.org/en/latest/topics/settings.html#scheduler
+    For more information, refer to the :setting:`SCHEDULER` setting
 
 See also :ref:`1.7-deprecation-removals` below.
 

--- a/docs/news.rst
+++ b/docs/news.rst
@@ -288,10 +288,12 @@ Backward-incompatible changes
     :class:`~scrapy.http.Request` objects instead of arbitrary Python data
     structures.
 
-*   Custom scheduler subclasses which don't accept arbitrary parameters in 
-    their __init__ method might break because of this change.
+*   An additional ``crawler`` parameter has been added to the ``__init__`` method
+    of the `scrapy.core.scheduler.Scheduler` class. 
+    Custom scheduler subclasses which don't accept arbitrary parameters in 
+    their ``__init__`` method might break because of this change.
 
-    For more information, refer to the :setting:`SCHEDULER` setting
+    For more information, refer to :class:`scrapy.core.scheduler.Scheduler`
 
 See also :ref:`1.7-deprecation-removals` below.
 

--- a/docs/news.rst
+++ b/docs/news.rst
@@ -290,7 +290,7 @@ Backward-incompatible changes
 
 *   An additional `crawler` paramter has been added to the `__init__` method of
     the `scrapy.core.scheduler.Scheduler` class. Custom scheduler subclassses 
-    don't accept binary parameters in their `__init__` method. This version of
+    don't accept arbitrary parameters in their `__init__` method. This version of
     scrapy breaks custom schedulers.
 
     For more information:


### PR DESCRIPTION
@Gallaecio created an issue #4264, in which I had to add in the backward-incompatible changes that scrapy 1.7.0 version breaks custom schedulers. 
I have added it to **news.rst**, please check it out and let me know if it needs to be more thorough.

I have ran all the tests using **tox**

(edit) Fixes #4264