### PR TITLE
Updated RFPDupeFilter line separator for correct universal newlines mode usage.

### DIFF
--- a/scrapy/dupefilters.py
+++ b/scrapy/dupefilters.py
@@ -49,7 +49,7 @@ class RFPDupeFilter(BaseDupeFilter):
             return True
         self.fingerprints.add(fp)
         if self.file:
-            self.file.write(fp + os.linesep)
+            self.file.write(fp + '\n')
 
     def request_fingerprint(self, request):
         return request_fingerprint(request)

--- a/tests/test_dupefilters.py
+++ b/tests/test_dupefilters.py
@@ -2,6 +2,7 @@ import hashlib
 import tempfile
 import unittest
 import shutil
+import os
 from testfixtures import LogCapture
 
 from scrapy.dupefilters import RFPDupeFilter
@@ -128,6 +129,26 @@ class RFPDupeFilterTest(unittest.TestCase):
         assert case_insensitive_dupefilter.request_seen(r2)
 
         case_insensitive_dupefilter.close('finished')
+
+    def test_seenreq_newlines(self):
+        """ Checks against adding duplicate \r to
+        line endings on Windows platforms. """
+
+        r1 = Request('http://scrapytest.org/1')
+
+        path = tempfile.mkdtemp()
+        try:
+            df = RFPDupeFilter(path)
+            df.open()
+            df.request_seen(r1)
+            df.close('finished')
+
+            with open(os.path.join(path, 'requests.seen'), 'rb') as seen_file:
+                line = next(seen_file).decode()
+                assert not line.endswith('\r\r\n')
+
+        finally:
+            shutil.rmtree(path)
 
     def test_log(self):
         with LogCapture() as l:

--- a/tests/test_dupefilters.py
+++ b/tests/test_dupefilters.py
@@ -85,17 +85,21 @@ class RFPDupeFilterTest(unittest.TestCase):
         path = tempfile.mkdtemp()
         try:
             df = RFPDupeFilter(path)
-            df.open()
-            assert not df.request_seen(r1)
-            assert df.request_seen(r1)
-            df.close('finished')
+            try:
+                df.open()
+                assert not df.request_seen(r1)
+                assert df.request_seen(r1)
+            finally:
+                df.close('finished')
 
             df2 = RFPDupeFilter(path)
-            df2.open()
-            assert df2.request_seen(r1)
-            assert not df2.request_seen(r2)
-            assert df2.request_seen(r2)
-            df2.close('finished')
+            try:
+                df2.open()
+                assert df2.request_seen(r1)
+                assert not df2.request_seen(r2)
+                assert df2.request_seen(r2)
+            finally:
+                df2.close('finished')
         finally:
             shutil.rmtree(path)
 

--- a/tests/test_dupefilters.py
+++ b/tests/test_dupefilters.py
@@ -3,6 +3,7 @@ import tempfile
 import unittest
 import shutil
 import os
+import sys
 from testfixtures import LogCapture
 
 from scrapy.dupefilters import RFPDupeFilter
@@ -150,6 +151,10 @@ class RFPDupeFilterTest(unittest.TestCase):
             with open(os.path.join(path, 'requests.seen'), 'rb') as seen_file:
                 line = next(seen_file).decode()
                 assert not line.endswith('\r\r\n')
+                if sys.platform == 'win32':
+                    assert line.endswith('\r\n')
+                else:
+                    assert line.endswith('\n')
 
         finally:
             shutil.rmtree(path)


### PR DESCRIPTION
Hey guys, found another small non-breaking glitch that I'm not sure if anybody else noticed that existed since RFPDupfilter was implement back on commit 549725215e79fbd3c7b3590c2a47fc9c0ad30a1b that's specific to Windows and the RFPDupeFilter used in Scrapy. It looks like when RFPDupeFilter writes its request hashes to the `requests.seen` file for a job, it seems to be using [Python's universal newlines](https://docs.python.org/3.8/library/functions.html#open-newline-parameter) feature incorrectly and ends up writing '\r\r\n' as each line ending instead of '\r\n', though it works fine in Linux and writes '\n' as expected.

Here's an example file demonstrating what's happening, opened in Notepad++ and a Hex editor with one of the line endings highlighted:
![Newlines](https://user-images.githubusercontent.com/15223575/72988393-2d36d100-3dba-11ea-94bf-cb12dc3be8ec.png)

I've tested this PR (using a subclass in my actual project overriding the base behavior) and it works fine on both Linux and Windows writing '\n' and '\r\n' accordingly. This bug's not that serious but would be a nice data storage optimization for those running Scrapy on Windows using job storage, instead of writing thousands of extra carriage returns (\r) to the file.