### PR TITLE
[Docs] Fix variable name `author_page_links`

### DIFF
--- a/docs/intro/tutorial.rst
+++ b/docs/intro/tutorial.rst
@@ -652,7 +652,7 @@ this time for scraping author information::
 
         def parse(self, response):
             author_page_links = response.css('.author + a')
-            yield from response.follow_all(author_links, self.parse_author)
+            yield from response.follow_all(author_page_links, self.parse_author)
 
             pagination_links = response.css('li.next a')
             yield from response.follow_all(pagination_links, self.parse)


### PR DESCRIPTION
I did not test this code, but the change from `href` to this
`author_page_links` seems to have a typo ?