### PR TITLE
Add 'pyasn1' explicit build dependency in 'install_requires'

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -72,6 +72,7 @@ setup(
         'pyOpenSSL>=16.2.0',
         'queuelib>=1.4.2',
         'service_identity>=16.0.0',
+        'pyasn1>=0.4.8',
         'w3lib>=1.17.0',
         'zope.interface>=4.1.3',
         'protego>=0.1.15',


### PR DESCRIPTION
On current HEAD of master of 25 Jan 2020 `8b8df31` in a fresh venv

```
mv venv venv-old
python -m venv venv
. venv/bin/activate
# (venv) is shown in prompt
python --version
# => Python 3.7.5
python setup.py install
```
eventually fails with:
```
running install
...
<many successful outputs>
...
Searching for six>=1.4.1
Reading https://pypi.org/simple/six/
Downloading https://files.pythonhosted.org/packages/65/eb/1f97cb97bfc2390a276969c6fae16075da282f5058082d4cb10c6c5c1dba/six-1.14.0-py2.py3-none-any.whl#sha256=8f3cd2e254d8f793e7f3d6d9df77b92252b52637291d0f0da013c76ea2724b6c
Best match: six 1.14.0
Processing six-1.14.0-py2.py3-none-any.whl
Installing six-1.14.0-py2.py3-none-any.whl to /home/peter_v/data/github/scrapy/scrapy/venv/lib/python3.7/site-packages
Adding six 1.14.0 to easy-install.pth file

Installed /home/peter_v/data/github/scrapy/scrapy/venv/lib/python3.7/site-packages/six-1.14.0-py3.7.egg
Searching for pyasn1-modules
Reading https://pypi.org/simple/pyasn1-modules/
Downloading https://files.pythonhosted.org/packages/95/de/214830a981892a3e286c3794f41ae67a4495df1108c3da8a9f62159b9a9d/pyasn1_modules-0.2.8-py2.py3-none-any.whl#sha256=a50b808ffeb97cb3601dd25981f6b016cbb3d31fbf57a8b8a87428e6158d0c74
Best match: pyasn1-modules 0.2.8
Processing pyasn1_modules-0.2.8-py2.py3-none-any.whl
Installing pyasn1_modules-0.2.8-py2.py3-none-any.whl to /home/peter_v/data/github/scrapy/scrapy/venv/lib/python3.7/site-packages
writing requirements to /home/peter_v/data/github/scrapy/scrapy/venv/lib/python3.7/site-packages/pyasn1_modules-0.2.8-py3.7.egg/EGG-INFO/requires.txt
Adding pyasn1-modules 0.2.8 to easy-install.pth file

Installed /home/peter_v/data/github/scrapy/scrapy/venv/lib/python3.7/site-packages/pyasn1_modules-0.2.8-py3.7.egg
Searching for pyasn1
Downloading https://files.pythonhosted.org/packages/88/87/72eb9ccf8a58021c542de2588a867dbefc7556e14b2866d1e40e9e2b587e/pyasn1-modules-0.2.8.tar.gz#sha256=905f84c712230b2c592c19470d3ca8d552de726050d1d1716282a1f6146be65e
Best match: pyasn1 modules-0.2.8
Processing pyasn1-modules-0.2.8.tar.gz
Writing /tmp/easy_install-b0mkr5fp/pyasn1-modules-0.2.8/setup.cfg
Running pyasn1-modules-0.2.8/setup.py -q bdist_egg --dist-dir /tmp/easy_install-b0mkr5fp/pyasn1-modules-0.2.8/egg-dist-tmp-7iodndnm
no previously-included directories found matching 'doc/build'
removing '/home/peter_v/data/github/scrapy/scrapy/venv/lib/python3.7/site-packages/pyasn1_modules-0.2.8-py3.7.egg' (and everything under it)
Moving pyasn1_modules-0.2.8-py3.7.egg to /home/peter_v/data/github/scrapy/scrapy/venv/lib/python3.7/site-packages
pyasn1-modules 0.2.8 is already the active version in easy-install.pth

Installed /home/peter_v/data/github/scrapy/scrapy/venv/lib/python3.7/site-packages/pyasn1_modules-0.2.8-py3.7.egg
error: The 'pyasn1' distribution was not found and is required by service-identity
```

I googled around and the suggested fix/work-around was to explicitly add the
`pyasn1` dependency to `install_requires`. I added the dependency _without_ a specific version
for `pyasn1` (different from the "change" in this PR).

I did that and now the `python setup install` succeeded.

I presume the relevant part of the output for the second run is:
```
# byte-compiling a lot
...
Processing Scrapy-1.8.0-py3.7.egg
removing '/home/peter_v/data/github/scrapy/scrapy/venv/lib/python3.7/site-packages/Scrapy-1.8.0-py3.7.egg' (and everything under it)
creating /home/peter_v/data/github/scrapy/scrapy/venv/lib/python3.7/site-packages/Scrapy-1.8.0-py3.7.egg
Extracting Scrapy-1.8.0-py3.7.egg to /home/peter_v/data/github/scrapy/scrapy/venv/lib/python3.7/site-packages
Scrapy 1.8.0 is already the active version in easy-install.pth
Installing scrapy script to /home/peter_v/data/github/scrapy/scrapy/venv/bin

Installed /home/peter_v/data/github/scrapy/scrapy/venv/lib/python3.7/site-packages/Scrapy-1.8.0-py3.7.egg
Processing dependencies for Scrapy==1.8.0
Searching for pyasn1
Reading https://pypi.org/simple/pyasn1/
Downloading https://files.pythonhosted.org/packages/62/1e/a94a8d635fa3ce4cfc7f506003548d0a2447ae76fd5ca53932970fe3053f/pyasn1-0.4.8-py2.py3-none-any.whl#sha256=39c7e2ec30515947ff4e87fb6f456dfc6e84857d34be479c9d4a4ba4bf46aa5d
Best match: pyasn1 0.4.8
Processing pyasn1-0.4.8-py2.py3-none-any.whl
Installing pyasn1-0.4.8-py2.py3-none-any.whl to /home/peter_v/data/github/scrapy/scrapy/venv/lib/python3.7/site-packages
Adding pyasn1 0.4.8 to easy-install.pth file

Installed /home/peter_v/data/github/scrapy/scrapy/venv/lib/python3.7/site-packages/pyasn1-0.4.8-py3.7.egg
...
# continues with the remaining packages and then succeeds
```

The current packages in this venv are:
```
(venv) peter_v@dell-ubuntu:~/data/github/scrapy/scrapy$ pip list
Package          Version
---------------- -------
attrs            19.3.0 
Automat          0.8.0  
cffi             1.13.2 
constantly       15.1.0 
cryptography     2.8    
cssselect        1.1.0  
hyperlink        19.0.0 
idna             2.8    
incremental      17.5.0 
lxml             4.4.2  
parsel           1.5.2  
pip              18.1   
pkg-resources    0.0.0  
Protego          0.1.16 
pyasn1           0.4.8  
pyasn1-modules   0.2.8  
pycparser        2.19   
PyDispatcher     2.0.5  
PyHamcrest       2.0.0  
pyOpenSSL        19.1.0 
queuelib         1.5.0  
Scrapy           1.8.0  
service-identity 18.1.0 
setuptools       40.8.0 
six              1.14.0 
Twisted          19.10.0
w3lib            1.21.0 
zope.interface   4.7.1  
```

Since I now see that `pyasn1` version is `0.4.8`, I have pinned it in the `install_requires` to be at least `0.4.8` (similar to all the other dependencies that are pinned). Maybe an older version of `pyasn1` would also work, but I would have a hard time validating that.