### PR TITLE
add zsh -h autocomplete option

### DIFF
--- a/extras/scrapy_zsh_completion
+++ b/extras/scrapy_zsh_completion
@@ -1,11 +1,12 @@
 #compdef scrapy
 _scrapy() {
     local context state state_descr line
+    local ret=1
     typeset -A opt_args
     _arguments \
-	"(- 1 *)--help[Help]" \
+	"(- 1 *)"{-h,--help}"[Help]" \
 	"1: :->command" \
-	"*:: :->args"
+	"*:: :->args" && ret=0
 
     case $state in
 	command)
@@ -134,6 +135,8 @@ _scrapy() {
 	    esac
 	    ;;
     esac
+
+    return ret
 }
 
 _scrapy_cmds() {


### PR DESCRIPTION
This PR adds autocompletion for `-h` option for zsh. 
This option was not added to #4069 due to the problem described in [this so question](https://stackoverflow.com/q/58312199/5745120).
