### PR TITLE
Added parallel execution of pytest

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -21,7 +21,7 @@ passenv =
     GCS_TEST_FILE_URI
     GCS_PROJECT_ID
 commands =
-    py.test --cov=scrapy --cov-report= {posargs:--durations=10 docs scrapy tests}
+    py.test -n={env:PYTEST_XDIST_PROC_NR:auto} --dist=loadfile --cov=scrapy --cov-report= {posargs:--durations=10 docs scrapy tests}
 
 [testenv:security]
 basepython = python3


### PR DESCRIPTION
Using same principle as in tox project we can cut the test execution time during development:
```py.test -n={env:PYTEST_XDIST_PROC_NR:auto} --dist=loadfile```

Grouping per file is needed to avoid race condition in some tests.

Afterwards we can get parallel pytest by default using all cores, or select them via PYTEST_XDIST_PROC_NR=<number> tox

On my linux machine with 8T/4C AMD Ryzen 5 2400G it cuts execution from approx 260 to:
- ~140 seconds on 2
- ~90 seconds on 4 workers,
- <75 seconds on auto -- 8 workers.


There are few tests taking >10s, therefore they block execution of others.