### PR TITLE
Remove deprecated `sel` shortcut in scrapy shell

### DIFF
--- a/scrapy/shell.py
+++ b/scrapy/shell.py
@@ -5,14 +5,13 @@ See documentation in docs/topics/shell.rst
 """
 import os
 import signal
-import warnings
 
 from twisted.internet import threads, defer
 from twisted.python import threadable
 from w3lib.url import any_to_uri
 
 from scrapy.crawler import Crawler
-from scrapy.exceptions import IgnoreRequest, ScrapyDeprecationWarning
+from scrapy.exceptions import IgnoreRequest
 from scrapy.http import Request, Response
 from scrapy.item import BaseItem
 from scrapy.settings import Settings

--- a/scrapy/shell.py
+++ b/scrapy/shell.py
@@ -126,7 +126,6 @@ class Shell(object):
         self.vars['spider'] = spider
         self.vars['request'] = request
         self.vars['response'] = response
-        self.vars['sel'] = _SelectorProxy(response)
         if self.inthread:
             self.vars['fetch'] = self.fetch
         self.vars['view'] = open_in_browser
@@ -192,15 +191,3 @@ def _request_deferred(request):
 
     request.callback, request.errback = d.callback, d.errback
     return d
-
-
-class _SelectorProxy(object):
-
-    def __init__(self, response):
-        self._proxiedresponse = response
-
-    def __getattr__(self, name):
-        warnings.warn('"sel" shortcut is deprecated. Use "response.xpath()", '
-                      '"response.css()" or "response.selector" instead',
-                      category=ScrapyDeprecationWarning, stacklevel=2)
-        return getattr(self._proxiedresponse.selector, name)


### PR DESCRIPTION
It was 6 years ago when this deprecation warning was added, before Scrapy 1.0 was released.

Could we remove it when releasing the new Scrapy 2.0 version?

