### PR TITLE
Make BaseItemExporter’s dont_fail parameter keyword-only

### DIFF
--- a/scrapy/exporters.py
+++ b/scrapy/exporters.py
@@ -23,7 +23,7 @@ __all__ = ['BaseItemExporter', 'PprintItemExporter', 'PickleItemExporter',
 
 class BaseItemExporter(object):
 
-    def __init__(self, dont_fail=False, **kwargs):
+    def __init__(self, *, dont_fail=False, **kwargs):
         self._kwargs = kwargs
         self._configure(kwargs, dont_fail=dont_fail)
 


### PR DESCRIPTION
Make the new `dont_fail` parameter of `BaseItemExporter` keyword only.

Otherwise, we are adding an non-intuitive positional parameter to a class that used to require keyword parameters only.

`dont_fail` was introduced after 1.8, so it would be great to have this change in for 2.0, otherwise we will need to introduce this change with a deprecation message for positional argument usages.

Split out from #4329