### PR TITLE
fix flake E11X and E12X except E127, E128 and E129

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -50,30 +50,30 @@ flake8-ignore =
     scrapy/core/engine.py E501 E128 E127 E502
     scrapy/core/scheduler.py E501
     scrapy/core/scraper.py E501 E128 W504
-    scrapy/core/spidermw.py E501 E731 E126
+    scrapy/core/spidermw.py E501 E731
     scrapy/core/downloader/__init__.py E501
-    scrapy/core/downloader/contextfactory.py E501 E128 E126
+    scrapy/core/downloader/contextfactory.py E501 E128
     scrapy/core/downloader/middleware.py E501 E502
     scrapy/core/downloader/tls.py E501 E241
-    scrapy/core/downloader/webclient.py E731 E501 E128 E126
+    scrapy/core/downloader/webclient.py E731 E501 E128
     scrapy/core/downloader/handlers/__init__.py E501
     scrapy/core/downloader/handlers/ftp.py E501 E128 E127
     scrapy/core/downloader/handlers/http10.py E501
     scrapy/core/downloader/handlers/http11.py E501
-    scrapy/core/downloader/handlers/s3.py E501 E128 E126
+    scrapy/core/downloader/handlers/s3.py E501 E128
     # scrapy/downloadermiddlewares
     scrapy/downloadermiddlewares/ajaxcrawl.py E501
     scrapy/downloadermiddlewares/decompression.py E501
     scrapy/downloadermiddlewares/defaultheaders.py E501
-    scrapy/downloadermiddlewares/httpcache.py E501 E126
+    scrapy/downloadermiddlewares/httpcache.py E501
     scrapy/downloadermiddlewares/httpcompression.py E501 E128
     scrapy/downloadermiddlewares/httpproxy.py E501
     scrapy/downloadermiddlewares/redirect.py E501 W504
-    scrapy/downloadermiddlewares/retry.py E501 E126
+    scrapy/downloadermiddlewares/retry.py E501
     scrapy/downloadermiddlewares/robotstxt.py E501
     scrapy/downloadermiddlewares/stats.py E501
     # scrapy/extensions
-    scrapy/extensions/closespider.py E501 E128 E123
+    scrapy/extensions/closespider.py E501 E128
     scrapy/extensions/corestats.py E501
     scrapy/extensions/feedexport.py E128 E501
     scrapy/extensions/httpcache.py E128 E501
@@ -85,10 +85,10 @@ flake8-ignore =
     scrapy/http/common.py E501
     scrapy/http/cookies.py E501
     scrapy/http/request/__init__.py E501
-    scrapy/http/request/form.py E501 E123
+    scrapy/http/request/form.py E501
     scrapy/http/request/json_request.py E501
     scrapy/http/response/__init__.py E501 E128
-    scrapy/http/response/text.py E501 E128 E124
+    scrapy/http/response/text.py E501 E128
     # scrapy/linkextractors
     scrapy/linkextractors/__init__.py E731 E501 E402 W504
     scrapy/linkextractors/lxmlhtml.py E501 E731
@@ -97,15 +97,17 @@ flake8-ignore =
     scrapy/loader/processors.py E501
     # scrapy/pipelines
     scrapy/pipelines/__init__.py E501
-    scrapy/pipelines/files.py E116 E501 E266
+    scrapy/pipelines/files.py E501 E266
+
     scrapy/pipelines/images.py E265 E501
-    scrapy/pipelines/media.py E125 E501 E266
+    scrapy/pipelines/media.py E501 E266
+
     # scrapy/selector
     scrapy/selector/__init__.py F403
-    scrapy/selector/unified.py E501 E111
+    scrapy/selector/unified.py E501
     # scrapy/settings
     scrapy/settings/__init__.py E501
-    scrapy/settings/default_settings.py E501 E114 E116
+    scrapy/settings/default_settings.py E501
     scrapy/settings/deprecated.py E501
     # scrapy/spidermiddlewares
     scrapy/spidermiddlewares/httperror.py E501
@@ -164,12 +166,12 @@ flake8-ignore =
     scrapy/robotstxt.py E501
     scrapy/shell.py E501
     scrapy/signalmanager.py E501
-    scrapy/spiderloader.py F841 E501 E126
+    scrapy/spiderloader.py F841 E501
     scrapy/squeues.py E128
     scrapy/statscollectors.py E501
     # tests
     tests/__init__.py E402 E501
-    tests/mockserver.py E401 E501 E126 E123
+    tests/mockserver.py E401 E501
     tests/pipelines.py F841
     tests/spiders.py E501 E127
     tests/test_closespider.py E501 E127
@@ -181,37 +183,38 @@ flake8-ignore =
     tests/test_crawl.py E501 E741 E265
     tests/test_crawler.py F841 E501
     tests/test_dependencies.py F841 E501
-    tests/test_downloader_handlers.py E124 E127 E128 E265 E501 E126 E123
+    tests/test_downloader_handlers.py E127 E128 E265 E501
     tests/test_downloadermiddleware.py E501
     tests/test_downloadermiddleware_ajaxcrawlable.py E501
-    tests/test_downloadermiddleware_cookies.py E731 E741 E501 E128 E265 E126
+    tests/test_downloadermiddleware_cookies.py E731 E741 E501 E128 E265
     tests/test_downloadermiddleware_decompression.py E127
     tests/test_downloadermiddleware_defaultheaders.py E501
     tests/test_downloadermiddleware_downloadtimeout.py E501
     tests/test_downloadermiddleware_httpcache.py E501
-    tests/test_downloadermiddleware_httpcompression.py E501 E126 E123
+    tests/test_downloadermiddleware_httpcompression.py E501
     tests/test_downloadermiddleware_httpproxy.py E501 E128
     tests/test_downloadermiddleware_redirect.py E501 E128 E127
-    tests/test_downloadermiddleware_retry.py E501 E128 E126
+    tests/test_downloadermiddleware_retry.py E501 E128
     tests/test_downloadermiddleware_robotstxt.py E501
     tests/test_downloadermiddleware_stats.py E501
-    tests/test_dupefilters.py E501 E741 E128 E124
+    tests/test_dupefilters.py E501 E741 E128
     tests/test_engine.py E401 E501 E128
-    tests/test_exporters.py E501 E731 E128 E124
+    tests/test_exporters.py E501 E731 E128
     tests/test_extension_telnet.py F841
     tests/test_feedexport.py E501 F841 E241
     tests/test_http_cookies.py E501
     tests/test_http_headers.py E501
-    tests/test_http_request.py E402 E501 E127 E128 E128 E126 E123
+    tests/test_http_request.py E402 E501 E127 E128 E128
     tests/test_http_response.py E501 E128 E265
     tests/test_item.py E128 F841
     tests/test_link.py E501
-    tests/test_linkextractors.py E501 E128 E124
-    tests/test_loader.py E501 E731 E741 E128 E117 E241
-    tests/test_logformatter.py E128 E501 E122
+    tests/test_linkextractors.py E501 E128
+    tests/test_loader.py E501 E731 E741 E128 E241
+
+    tests/test_logformatter.py E128 E501
     tests/test_mail.py E128 E501
     tests/test_middleware.py E501 E128
-    tests/test_pipeline_crawl.py E501 E128 E126
+    tests/test_pipeline_crawl.py E501 E128
     tests/test_pipeline_files.py E501
     tests/test_pipeline_images.py F841 E501
     tests/test_pipeline_media.py E501 E741 E731 E128 E502
@@ -219,14 +222,14 @@ flake8-ignore =
     tests/test_request_cb_kwargs.py E501
     tests/test_responsetypes.py E501
     tests/test_robotstxt_interface.py E501 E501
-    tests/test_scheduler.py E501 E126 E123
+    tests/test_scheduler.py E501
     tests/test_selector.py E501 E127
     tests/test_spider.py E501
     tests/test_spidermiddleware.py E501
-    tests/test_spidermiddleware_httperror.py E128 E501 E127 E121
-    tests/test_spidermiddleware_offsite.py E501 E128 E111
+    tests/test_spidermiddleware_httperror.py E128 E501 E127
+    tests/test_spidermiddleware_offsite.py E501 E128
     tests/test_spidermiddleware_output_chain.py E501
-    tests/test_spidermiddleware_referer.py E501 F841 E125 E201 E124 E501 E241 E121
+    tests/test_spidermiddleware_referer.py E501 F841 E201 E501 E241
     tests/test_squeues.py E501 E741
     tests/test_utils_asyncio.py E501
     tests/test_utils_conf.py E501 E128
@@ -242,9 +245,9 @@ flake8-ignore =
     tests/test_utils_request.py E501 E128
     tests/test_utils_response.py E501
     tests/test_utils_signal.py E741 F841 E731
-    tests/test_utils_sitemap.py E128 E501 E124
-    tests/test_utils_url.py E501 E127 E125 E501 E241 E126 E123
-    tests/test_webclient.py E501 E128 E122 E402 E241 E123 E126
+    tests/test_utils_sitemap.py E128 E501
+    tests/test_utils_url.py E501 E127 E501 E241
+    tests/test_webclient.py E501 E128 E402 E241
     tests/test_cmdline/__init__.py E501
     tests/test_settings/__init__.py E501 E128
     tests/test_spiderloader/__init__.py E128 E501

--- a/scrapy/core/downloader/contextfactory.py
+++ b/scrapy/core/downloader/contextfactory.py
@@ -86,8 +86,10 @@ class BrowserLikeContextFactory(ScrapyClientContextFactory):
         #
         # This means that a website like https://www.cacert.org will be rejected
         # by default, since CAcert.org CA certificate is seldom shipped.
-        return optionsForClientTLS(hostname.decode("ascii"),
-                                   trustRoot=platformTrust(),
-                                   extraCertificateOptions={
-                                        'method': self._ssl_method,
-                                   })
+        return optionsForClientTLS(
+            hostname.decode("ascii"),
+            trustRoot=platformTrust(),
+            extraCertificateOptions={
+                'method': self._ssl_method,
+            }
+        )

--- a/scrapy/core/downloader/handlers/s3.py
+++ b/scrapy/core/downloader/handlers/s3.py
@@ -100,11 +100,11 @@ class S3DownloadHandler:
                 url=url, headers=awsrequest.headers.items())
         else:
             signed_headers = self.conn.make_request(
-                    method=request.method,
-                    bucket=bucket,
-                    key=unquote(p.path),
-                    query_args=unquote(p.query),
-                    headers=request.headers,
-                    data=request.body)
+                method=request.method,
+                bucket=bucket,
+                key=unquote(p.path),
+                query_args=unquote(p.query),
+                headers=request.headers,
+                data=request.body)
             request = request.replace(url=url, headers=signed_headers)
         return self._download_http(request, spider)

--- a/scrapy/core/downloader/webclient.py
+++ b/scrapy/core/downloader/webclient.py
@@ -89,8 +89,8 @@ class ScrapyHTTPPageGetter(HTTPClient):
             self.transport.stopProducing()
 
         self.factory.noPage(
-                defer.TimeoutError("Getting %s took longer than %s seconds." %
-                                   (self.factory.url, self.factory.timeout)))
+            defer.TimeoutError("Getting %s took longer than %s seconds." %
+                               (self.factory.url, self.factory.timeout)))
 
 
 class ScrapyHTTPClientFactory(HTTPClientFactory):

--- a/scrapy/downloadermiddlewares/retry.py
+++ b/scrapy/downloadermiddlewares/retry.py
@@ -13,8 +13,8 @@ import logging
 
 from twisted.internet import defer
 from twisted.internet.error import TimeoutError, DNSLookupError, \
-        ConnectionRefusedError, ConnectionDone, ConnectError, \
-        ConnectionLost, TCPTimedOutError
+    ConnectionRefusedError, ConnectionDone, ConnectError, \
+    ConnectionLost, TCPTimedOutError
 from twisted.web.client import ResponseFailed
 
 from scrapy.exceptions import NotConfigured

--- a/scrapy/extensions/closespider.py
+++ b/scrapy/extensions/closespider.py
@@ -22,7 +22,7 @@ class CloseSpider(object):
             'itemcount': crawler.settings.getint('CLOSESPIDER_ITEMCOUNT'),
             'pagecount': crawler.settings.getint('CLOSESPIDER_PAGECOUNT'),
             'errorcount': crawler.settings.getint('CLOSESPIDER_ERRORCOUNT'),
-            }
+        }
 
         if not any(self.close_on.values()):
             raise NotConfigured

--- a/scrapy/http/request/form.py
+++ b/scrapy/http/request/form.py
@@ -183,7 +183,7 @@ def _get_clickable(clickdata, form):
             'descendant::input[re:test(@type, "^(submit|image)$", "i")]'
             '|descendant::button[not(@type) or re:test(@type, "^submit$", "i")]',
             namespaces={"re": "http://exslt.org/regular-expressions"})
-        ]
+    ]
     if not clickables:
         return
 

--- a/scrapy/pipelines/files.py
+++ b/scrapy/pipelines/files.py
@@ -83,8 +83,9 @@ class S3FilesStore(object):
     AWS_USE_SSL = None
     AWS_VERIFY = None
 
-    POLICY = 'private'  # Overriden from settings.FILES_STORE_S3_ACL in
-                        # FilesPipeline.from_settings.
+    # POLICY overridden from settings.FILES_STORE_S3_ACL in FilesPipeline.from_settings.
+    POLICY = 'private'
+
     HEADERS = {
         'Cache-Control': 'max-age=172800',
     }

--- a/scrapy/pipelines/media.py
+++ b/scrapy/pipelines/media.py
@@ -56,7 +56,7 @@ class MediaPipeline(object):
         class_name = self.__class__.__name__
         formatted_key = "{}_{}".format(class_name.upper(), key)
         if class_name == base_class_name or not base_class_name \
-            or (settings and not settings.get(formatted_key)):
+                or (settings and not settings.get(formatted_key)):
             return key
         return formatted_key
 

--- a/scrapy/selector/unified.py
+++ b/scrapy/selector/unified.py
@@ -66,8 +66,8 @@ class Selector(_ParselSelector, object_ref):
 
     def __init__(self, response=None, text=None, type=None, root=None, **kwargs):
         if not(response is None or text is None):
-           raise ValueError('%s.__init__() received both response and text'
-                            % self.__class__.__name__)
+            raise ValueError('%s.__init__() received both response and text'
+                             % self.__class__.__name__)
 
         st = _st(response, type or self._default_type)
 

--- a/scrapy/spiderloader.py
+++ b/scrapy/spiderloader.py
@@ -24,15 +24,18 @@ class SpiderLoader(object):
         self._load_all_spiders()
 
     def _check_name_duplicates(self):
-        dupes = ["\n".join("  {cls} named {name!r} (in {module})".format(
-                                module=mod, cls=cls, name=name)
-                           for (mod, cls) in locations)
-                 for name, locations in self._found.items()
-                 if len(locations) > 1]
+        dupes = [
+            "\n".join("  {cls} named {name!r} (in {module})".format(
+                module=mod, cls=cls, name=name)
+                for (mod, cls) in locations)
+            for name, locations in self._found.items()
+            if len(locations) > 1
+        ]
         if dupes:
-            msg = ("There are several spiders with the same name:\n\n"
-                   "{}\n\n  This can cause unexpected behavior.".format(
-                        "\n\n".join(dupes)))
+            msg = (
+                "There are several spiders with the same name:\n\n"
+                "{}\n\n  This can cause unexpected behavior.".format(
+                    "\n\n".join(dupes)))
             warnings.warn(msg, UserWarning)
 
     def _load_spiders(self, module):
@@ -47,9 +50,10 @@ class SpiderLoader(object):
                     self._load_spiders(module)
             except ImportError as e:
                 if self.warn_only:
-                    msg = ("\n{tb}Could not load spiders from module '{modname}'. "
-                           "See above traceback for details.".format(
-                                modname=name, tb=traceback.format_exc()))
+                    msg = (
+                        "\n{tb}Could not load spiders from module '{modname}'. "
+                        "See above traceback for details.".format(
+                            modname=name, tb=traceback.format_exc()))
                     warnings.warn(msg, RuntimeWarning)
                 else:
                     raise

--- a/tests/mockserver.py
+++ b/tests/mockserver.py
@@ -226,9 +226,9 @@ class MockServer():
 
 def ssl_context_factory(keyfile='keys/localhost.key', certfile='keys/localhost.crt', cipher_string=None):
     factory = ssl.DefaultOpenSSLContextFactory(
-         os.path.join(os.path.dirname(__file__), keyfile),
-         os.path.join(os.path.dirname(__file__), certfile),
-         )
+        os.path.join(os.path.dirname(__file__), keyfile),
+        os.path.join(os.path.dirname(__file__), certfile),
+    )
     if cipher_string:
         ctx = factory.getContext()
         # disabling TLS1.2+ because it unconditionally enables some strong ciphers

--- a/tests/test_downloader_handlers.py
+++ b/tests/test_downloader_handlers.py
@@ -826,7 +826,7 @@ class S3TestCase(unittest.TestCase):
             'Content-Type': 'image/jpeg',
             'Date': date,
             'Content-Length': '94328',
-            })
+        })
         with self._mocked_date(date):
             httpreq = self.download_request(req, self.spider)
         self.assertEqual(httpreq.headers['Authorization'],
@@ -910,7 +910,7 @@ class S3TestCase(unittest.TestCase):
              "?response-content-disposition=my puppy.jpg"),
             method='GET',
             headers={'Date': date},
-            )
+        )
         with self._mocked_date(date):
             httpreq = self.download_request(req, self.spider)
         self.assertEqual(

--- a/tests/test_downloadermiddleware_cookies.py
+++ b/tests/test_downloadermiddleware_cookies.py
@@ -140,11 +140,12 @@ class CookiesMiddlewareTest(TestCase):
 
     def test_complex_cookies(self):
         # merge some cookies into jar
-        cookies = [{'name': 'C1', 'value': 'value1', 'path': '/foo', 'domain': 'scrapytest.org'},
-                {'name': 'C2', 'value': 'value2', 'path': '/bar', 'domain': 'scrapytest.org'},
-                {'name': 'C3', 'value': 'value3', 'path': '/foo', 'domain': 'scrapytest.org'},
-                {'name': 'C4', 'value': 'value4', 'path': '/foo', 'domain': 'scrapy.org'}]
-
+        cookies = [
+            {'name': 'C1', 'value': 'value1', 'path': '/foo', 'domain': 'scrapytest.org'},
+            {'name': 'C2', 'value': 'value2', 'path': '/bar', 'domain': 'scrapytest.org'},
+            {'name': 'C3', 'value': 'value3', 'path': '/foo', 'domain': 'scrapytest.org'},
+            {'name': 'C4', 'value': 'value4', 'path': '/foo', 'domain': 'scrapy.org'}
+        ]
         req = Request('http://scrapytest.org/', cookies=cookies)
         self.mw.process_request(req, self.spider)
 

--- a/tests/test_downloadermiddleware_httpcompression.py
+++ b/tests/test_downloadermiddleware_httpcompression.py
@@ -16,12 +16,12 @@ from w3lib.encoding import resolve_encoding
 SAMPLEDIR = join(tests_datadir, 'compressed')
 
 FORMAT = {
-        'gzip': ('html-gzip.bin', 'gzip'),
-        'x-gzip': ('html-gzip.bin', 'gzip'),
-        'rawdeflate': ('html-rawdeflate.bin', 'deflate'),
-        'zlibdeflate': ('html-zlibdeflate.bin', 'deflate'),
-        'br': ('html-br.bin', 'br')
-        }
+    'gzip': ('html-gzip.bin', 'gzip'),
+    'x-gzip': ('html-gzip.bin', 'gzip'),
+    'rawdeflate': ('html-rawdeflate.bin', 'deflate'),
+    'zlibdeflate': ('html-zlibdeflate.bin', 'deflate'),
+    'br': ('html-br.bin', 'br')
+}
 
 
 class HttpCompressionTest(TestCase):
@@ -40,12 +40,12 @@ class HttpCompressionTest(TestCase):
             body = sample.read()
 
         headers = {
-                'Server': 'Yaws/1.49 Yet Another Web Server',
-                'Date': 'Sun, 08 Mar 2009 00:41:03 GMT',
-                'Content-Length': len(body),
-                'Content-Type': 'text/html',
-                'Content-Encoding': contentencoding,
-                }
+            'Server': 'Yaws/1.49 Yet Another Web Server',
+            'Date': 'Sun, 08 Mar 2009 00:41:03 GMT',
+            'Content-Length': len(body),
+            'Content-Type': 'text/html',
+            'Content-Encoding': contentencoding,
+        }
 
         response = Response('http://scrapytest.org/', body=body, headers=headers)
         response.request = Request('http://scrapytest.org', headers={'Accept-Encoding': 'gzip, deflate'})

--- a/tests/test_downloadermiddleware_retry.py
+++ b/tests/test_downloadermiddleware_retry.py
@@ -1,8 +1,8 @@
 import unittest
 from twisted.internet import defer
 from twisted.internet.error import TimeoutError, DNSLookupError, \
-        ConnectionRefusedError, ConnectionDone, ConnectError, \
-        ConnectionLost, TCPTimedOutError
+    ConnectionRefusedError, ConnectionDone, ConnectError, \
+    ConnectionLost, TCPTimedOutError
 from twisted.web.client import ResponseFailed
 
 from scrapy.downloadermiddlewares.retry import RetryMiddleware

--- a/tests/test_dupefilters.py
+++ b/tests/test_dupefilters.py
@@ -197,8 +197,7 @@ class RFPDupeFilterTest(unittest.TestCase):
 
             r1 = Request('http://scrapytest.org/index.html')
             r2 = Request('http://scrapytest.org/index.html',
-                headers={'Referer': 'http://scrapytest.org/INDEX.html'}
-            )
+                         headers={'Referer': 'http://scrapytest.org/INDEX.html'})
 
             dupefilter.log(r1, spider)
             dupefilter.log(r2, spider)

--- a/tests/test_exporters.py
+++ b/tests/test_exporters.py
@@ -341,19 +341,20 @@ class XmlItemExporterTest(BaseItemExporterTest):
         i2 = dict(name=u'bar', age=i1)
         i3 = TestItem(name=u'buz', age=i2)
 
-        self.assertExportResult(i3,
+        self.assertExportResult(
+            i3,
             b'<?xml version="1.0" encoding="utf-8"?>\n'
             b'<items>'
-                b'<item>'
-                    b'<age>'
-                        b'<age>'
-                            b'<age>22</age>'
-                            b'<name>foo\xc2\xa3hoo</name>'
-                        b'</age>'
-                        b'<name>bar</name>'
-                    b'</age>'
-                    b'<name>buz</name>'
-                b'</item>'
+            b'<item>'
+            b'<age>'
+            b'<age>'
+            b'<age>22</age>'
+            b'<name>foo\xc2\xa3hoo</name>'
+            b'</age>'
+            b'<name>bar</name>'
+            b'</age>'
+            b'<name>buz</name>'
+            b'</item>'
             b'</items>'
         )
 
@@ -362,30 +363,32 @@ class XmlItemExporterTest(BaseItemExporterTest):
         i2 = dict(name=u'bar', v2={"egg": ["spam"]})
         i3 = TestItem(name=u'buz', age=[i1, i2])
 
-        self.assertExportResult(i3,
+        self.assertExportResult(
+            i3,
             b'<?xml version="1.0" encoding="utf-8"?>\n'
             b'<items>'
-                b'<item>'
-                    b'<age>'
-                        b'<value><name>foo</name></value>'
-                        b'<value><name>bar</name><v2><egg><value>spam</value></egg></v2></value>'
-                    b'</age>'
-                    b'<name>buz</name>'
-                b'</item>'
+            b'<item>'
+            b'<age>'
+            b'<value><name>foo</name></value>'
+            b'<value><name>bar</name><v2><egg><value>spam</value></egg></v2></value>'
+            b'</age>'
+            b'<name>buz</name>'
+            b'</item>'
             b'</items>'
         )
 
     def test_nonstring_types_item(self):
         item = self._get_nonstring_types_item()
-        self.assertExportResult(item,
+        self.assertExportResult(
+            item,
             b'<?xml version="1.0" encoding="utf-8"?>\n'
             b'<items>'
-               b'<item>'
-                   b'<float>3.14</float>'
-                   b'<boolean>False</boolean>'
-                   b'<number>22</number>'
-                   b'<time>2015-01-01 01:01:01</time>'
-               b'</item>'
+            b'<item>'
+            b'<float>3.14</float>'
+            b'<boolean>False</boolean>'
+            b'<number>22</number>'
+            b'<time>2015-01-01 01:01:01</time>'
+            b'</item>'
             b'</items>'
         )
 

--- a/tests/test_http_request.py
+++ b/tests/test_http_request.py
@@ -469,7 +469,7 @@ class FormRequestTest(RequestTest):
             </form>""",
             url="http://www.example.com/this/list.html",
             encoding='latin1',
-            )
+        )
         req = self.request_class.from_response(response,
                 formdata={'one': ['two', 'three'], 'six': 'seven'})
 
@@ -504,11 +504,12 @@ class FormRequestTest(RequestTest):
 
     def test_from_response_duplicate_form_key(self):
         response = _buildresponse(
-                '<form></form>',
-                url='http://www.example.com')
-        req = self.request_class.from_response(response,
-                method='GET',
-                formdata=(('foo', 'bar'), ('foo', 'baz')))
+            '<form></form>',
+            url='http://www.example.com')
+        req = self.request_class.from_response(
+            response,
+            method='GET',
+            formdata=(('foo', 'bar'), ('foo', 'baz')))
         self.assertEqual(urlparse(req.url).hostname, 'www.example.com')
         self.assertEqual(urlparse(req.url).query, 'foo=bar&foo=baz')
 
@@ -532,9 +533,10 @@ class FormRequestTest(RequestTest):
             <input type="hidden" name="test" value="val2">
             <input type="hidden" name="test2" value="xxx">
             </form>""")
-        req = self.request_class.from_response(response,
-                formdata={'one': ['two', 'three'], 'six': 'seven'},
-                headers={"Accept-Encoding": "gzip,deflate"})
+        req = self.request_class.from_response(
+            response,
+            formdata={'one': ['two', 'three'], 'six': 'seven'},
+            headers={"Accept-Encoding": "gzip,deflate"})
         self.assertEqual(req.method, 'POST')
         self.assertEqual(req.headers['Content-type'], b'application/x-www-form-urlencoded')
         self.assertEqual(req.headers['Accept-Encoding'], b'gzip,deflate')
@@ -582,9 +584,9 @@ class FormRequestTest(RequestTest):
 
     def test_from_response_override_method(self):
         response = _buildresponse(
-                '''<html><body>
-                <form action="/app"></form>
-                </body></html>''')
+            '''<html><body>
+            <form action="/app"></form>
+            </body></html>''')
         request = FormRequest.from_response(response)
         self.assertEqual(request.method, 'GET')
         request = FormRequest.from_response(response, method='POST')
@@ -592,9 +594,9 @@ class FormRequestTest(RequestTest):
 
     def test_from_response_override_url(self):
         response = _buildresponse(
-                '''<html><body>
-                <form action="/app"></form>
-                </body></html>''')
+            '''<html><body>
+               <form action="/app"></form>
+               </body></html>''')
         request = FormRequest.from_response(response)
         self.assertEqual(request.url, 'http://example.com/app')
         request = FormRequest.from_response(response, url='http://foo.bar/absolute')

--- a/tests/test_linkextractors.py
+++ b/tests/test_linkextractors.py
@@ -419,7 +419,7 @@ class Base:
                               Link(url='http://example.com/nofollow.html', text=u'Dont follow this one', fragment='', nofollow=True),
                               Link(url='http://example.com/nofollow2.html', text=u'Choose to follow or not', fragment='', nofollow=False),
                               Link(url='http://google.com/something', text=u'External link not to follow', nofollow=True)]
-                            )
+                             )
 
             response = XmlResponse("http://example.com/index.xhtml", body=xhtml)
 
@@ -430,7 +430,7 @@ class Base:
                               Link(url='http://example.com/nofollow.html', text=u'Dont follow this one', fragment='', nofollow=True),
                               Link(url='http://example.com/nofollow2.html', text=u'Choose to follow or not', fragment='', nofollow=False),
                               Link(url='http://google.com/something', text=u'External link not to follow', nofollow=True)]
-                            )
+                             )
 
         def test_link_wrong_href(self):
             html = b"""

--- a/tests/test_pipeline_crawl.py
+++ b/tests/test_pipeline_crawl.py
@@ -45,8 +45,8 @@ class RedirectedMediaDownloadSpider(MediaDownloadSpider):
 
     def _process_url(self, url):
         return add_or_replace_parameter(
-                    self.mockserver.url('/redirect-to'),
-                    'goto', url)
+            self.mockserver.url('/redirect-to'),
+            'goto', url)
 
 
 class FileDownloadCrawlTestCase(TestCase):

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -46,13 +46,13 @@ class MockCrawler(Crawler):
     def __init__(self, priority_queue_cls, jobdir):
 
         settings = dict(
-                LOG_UNSERIALIZABLE_REQUESTS=False,
-                SCHEDULER_DISK_QUEUE='scrapy.squeues.PickleLifoDiskQueue',
-                SCHEDULER_MEMORY_QUEUE='scrapy.squeues.LifoMemoryQueue',
-                SCHEDULER_PRIORITY_QUEUE=priority_queue_cls,
-                JOBDIR=jobdir,
-                DUPEFILTER_CLASS='scrapy.dupefilters.BaseDupeFilter'
-                )
+            LOG_UNSERIALIZABLE_REQUESTS=False,
+            SCHEDULER_DISK_QUEUE='scrapy.squeues.PickleLifoDiskQueue',
+            SCHEDULER_MEMORY_QUEUE='scrapy.squeues.LifoMemoryQueue',
+            SCHEDULER_PRIORITY_QUEUE=priority_queue_cls,
+            JOBDIR=jobdir,
+            DUPEFILTER_CLASS='scrapy.dupefilters.BaseDupeFilter'
+        )
         super(MockCrawler, self).__init__(Spider, settings)
         self.engine = MockEngine(downloader=MockDownloader())
 
@@ -305,10 +305,10 @@ class StartUrlsSpider(Spider):
 class TestIntegrationWithDownloaderAwareInMemory(TestCase):
     def setUp(self):
         self.crawler = get_crawler(
-                    StartUrlsSpider,
-                    {'SCHEDULER_PRIORITY_QUEUE': 'scrapy.pqueues.DownloaderAwarePriorityQueue',
-                     'DUPEFILTER_CLASS': 'scrapy.dupefilters.BaseDupeFilter'}
-                    )
+            StartUrlsSpider,
+            {'SCHEDULER_PRIORITY_QUEUE': 'scrapy.pqueues.DownloaderAwarePriorityQueue',
+             'DUPEFILTER_CLASS': 'scrapy.dupefilters.BaseDupeFilter'}
+        )
 
     @defer.inlineCallbacks
     def tearDown(self):
@@ -329,9 +329,9 @@ class TestIncompatibility(unittest.TestCase):
 
     def _incompatible(self):
         settings = dict(
-                SCHEDULER_PRIORITY_QUEUE='scrapy.pqueues.DownloaderAwarePriorityQueue',
-                CONCURRENT_REQUESTS_PER_IP=1
-                )
+            SCHEDULER_PRIORITY_QUEUE='scrapy.pqueues.DownloaderAwarePriorityQueue',
+            CONCURRENT_REQUESTS_PER_IP=1
+        )
         crawler = Crawler(Spider, settings)
         scheduler = Scheduler.from_crawler(crawler)
         spider = Spider(name='spider')

--- a/tests/test_spidermiddleware_httperror.py
+++ b/tests/test_spidermiddleware_httperror.py
@@ -21,10 +21,10 @@ class _HttpErrorSpider(MockServerSpider):
     def __init__(self, *args, **kwargs):
         super(_HttpErrorSpider, self).__init__(*args, **kwargs)
         self.start_urls = [
-           self.mockserver.url("/status?n=200"),
-           self.mockserver.url("/status?n=404"),
-           self.mockserver.url("/status?n=402"),
-           self.mockserver.url("/status?n=500"),
+            self.mockserver.url("/status?n=200"),
+            self.mockserver.url("/status?n=404"),
+            self.mockserver.url("/status?n=402"),
+            self.mockserver.url("/status?n=500"),
         ]
         self.failed = set()
         self.skipped = set()

--- a/tests/test_spidermiddleware_offsite.py
+++ b/tests/test_spidermiddleware_offsite.py
@@ -62,14 +62,14 @@ class TestOffsiteMiddleware3(TestOffsiteMiddleware2):
 class TestOffsiteMiddleware4(TestOffsiteMiddleware3):
 
     def _get_spider(self):
-      bad_hostname = urlparse('http:////scrapytest.org').hostname
-      return dict(name='foo', allowed_domains=['scrapytest.org', None, bad_hostname])
+        bad_hostname = urlparse('http:////scrapytest.org').hostname
+        return dict(name='foo', allowed_domains=['scrapytest.org', None, bad_hostname])
 
     def test_process_spider_output(self):
-      res = Response('http://scrapytest.org')
-      reqs = [Request('http://scrapytest.org/1')]
-      out = list(self.mw.process_spider_output(res, reqs, self.spider))
-      self.assertEqual(out, reqs)
+        res = Response('http://scrapytest.org')
+        reqs = [Request('http://scrapytest.org/1')]
+        out = list(self.mw.process_spider_output(res, reqs, self.spider))
+        self.assertEqual(out, reqs)
 
 
 class TestOffsiteMiddleware5(TestOffsiteMiddleware4):

--- a/tests/test_spidermiddleware_referer.py
+++ b/tests/test_spidermiddleware_referer.py
@@ -487,7 +487,7 @@ class TestSettingsPolicyByName(TestCase):
                 (POLICY_ORIGIN_WHEN_CROSS_ORIGIN, OriginWhenCrossOriginPolicy),
                 (POLICY_STRICT_ORIGIN_WHEN_CROSS_ORIGIN, StrictOriginWhenCrossOriginPolicy),
                 (POLICY_UNSAFE_URL, UnsafeUrlPolicy),
-            ]:
+        ]:
             settings = Settings({'REFERRER_POLICY': s})
             mw = RefererMiddleware(settings)
             self.assertEqual(mw.default_policy, p)
@@ -503,7 +503,7 @@ class TestSettingsPolicyByName(TestCase):
                 (POLICY_ORIGIN_WHEN_CROSS_ORIGIN, OriginWhenCrossOriginPolicy),
                 (POLICY_STRICT_ORIGIN_WHEN_CROSS_ORIGIN, StrictOriginWhenCrossOriginPolicy),
                 (POLICY_UNSAFE_URL, UnsafeUrlPolicy),
-            ]:
+        ]:
             settings = Settings({'REFERRER_POLICY': s.upper()})
             mw = RefererMiddleware(settings)
             self.assertEqual(mw.default_policy, p)
@@ -541,7 +541,8 @@ class TestReferrerOnRedirect(TestRefererMiddleware):
 
     settings = {'REFERRER_POLICY': 'scrapy.spidermiddlewares.referer.UnsafeUrlPolicy'}
     scenarii = [
-        (   'http://scrapytest.org/1',      # parent
+        (
+            'http://scrapytest.org/1',      # parent
             'http://scrapytest.org/2',      # target
             (
                 # redirections: code, URL
@@ -551,7 +552,8 @@ class TestReferrerOnRedirect(TestRefererMiddleware):
             b'http://scrapytest.org/1',  # expected initial referer
             b'http://scrapytest.org/1',  # expected referer for the redirection request
         ),
-        (   'https://scrapytest.org/1',
+        (
+            'https://scrapytest.org/1',
             'https://scrapytest.org/2',
             (
                 # redirecting to non-secure URL
@@ -560,7 +562,8 @@ class TestReferrerOnRedirect(TestRefererMiddleware):
             b'https://scrapytest.org/1',
             b'https://scrapytest.org/1',
         ),
-        (   'https://scrapytest.org/1',
+        (
+            'https://scrapytest.org/1',
             'https://scrapytest.com/2',
             (
                 # redirecting to non-secure URL: different origin
@@ -602,7 +605,8 @@ class TestReferrerOnRedirectNoReferrer(TestReferrerOnRedirect):
     """
     settings = {'REFERRER_POLICY': 'no-referrer'}
     scenarii = [
-        (   'http://scrapytest.org/1',      # parent
+        (
+            'http://scrapytest.org/1',      # parent
             'http://scrapytest.org/2',      # target
             (
                 # redirections: code, URL
@@ -612,7 +616,8 @@ class TestReferrerOnRedirectNoReferrer(TestReferrerOnRedirect):
             None,  # expected initial "Referer"
             None,  # expected "Referer" for the redirection request
         ),
-        (   'https://scrapytest.org/1',
+        (
+            'https://scrapytest.org/1',
             'https://scrapytest.org/2',
             (
                 (301, 'http://scrapytest.org/3'),
@@ -620,7 +625,8 @@ class TestReferrerOnRedirectNoReferrer(TestReferrerOnRedirect):
             None,
             None,
         ),
-        (   'https://scrapytest.org/1',
+        (
+            'https://scrapytest.org/1',
             'https://example.com/2',    # different origin
             (
                 (301, 'http://scrapytest.com/3'),
@@ -641,7 +647,8 @@ class TestReferrerOnRedirectSameOrigin(TestReferrerOnRedirect):
     """
     settings = {'REFERRER_POLICY': 'same-origin'}
     scenarii = [
-        (   'http://scrapytest.org/101',      # origin
+        (
+            'http://scrapytest.org/101',      # origin
             'http://scrapytest.org/102',      # target
             (
                 # redirections: code, URL
@@ -651,7 +658,8 @@ class TestReferrerOnRedirectSameOrigin(TestReferrerOnRedirect):
             b'http://scrapytest.org/101',  # expected initial "Referer"
             b'http://scrapytest.org/101',  # expected referer for the redirection request
         ),
-        (   'https://scrapytest.org/201',
+        (
+            'https://scrapytest.org/201',
             'https://scrapytest.org/202',
             (
                 # redirecting from secure to non-secure URL == different origin
@@ -660,7 +668,8 @@ class TestReferrerOnRedirectSameOrigin(TestReferrerOnRedirect):
             b'https://scrapytest.org/201',
             None,
         ),
-        (   'https://scrapytest.org/301',
+        (
+            'https://scrapytest.org/301',
             'https://scrapytest.org/302',
             (
                 # different domain == different origin
@@ -683,7 +692,8 @@ class TestReferrerOnRedirectStrictOrigin(TestReferrerOnRedirect):
     """
     settings = {'REFERRER_POLICY': POLICY_STRICT_ORIGIN}
     scenarii = [
-        (   'http://scrapytest.org/101',
+        (
+            'http://scrapytest.org/101',
             'http://scrapytest.org/102',
             (
                 (301, 'http://scrapytest.org/103'),
@@ -692,7 +702,8 @@ class TestReferrerOnRedirectStrictOrigin(TestReferrerOnRedirect):
             b'http://scrapytest.org/',  # send origin
             b'http://scrapytest.org/',  # redirects to same origin: send origin
         ),
-        (   'https://scrapytest.org/201',
+        (
+            'https://scrapytest.org/201',
             'https://scrapytest.org/202',
             (
                 # redirecting to non-secure URL: no referrer
@@ -701,7 +712,8 @@ class TestReferrerOnRedirectStrictOrigin(TestReferrerOnRedirect):
             b'https://scrapytest.org/',
             None,
         ),
-        (   'https://scrapytest.org/301',
+        (
+            'https://scrapytest.org/301',
             'https://scrapytest.org/302',
             (
                 # redirecting to non-secure URL (different domain): no referrer
@@ -710,7 +722,8 @@ class TestReferrerOnRedirectStrictOrigin(TestReferrerOnRedirect):
             b'https://scrapytest.org/',
             None,
         ),
-        (   'http://scrapy.org/401',
+        (
+            'http://scrapy.org/401',
             'http://example.com/402',
             (
                 (301, 'http://scrapytest.org/403'),
@@ -718,7 +731,8 @@ class TestReferrerOnRedirectStrictOrigin(TestReferrerOnRedirect):
             b'http://scrapy.org/',
             b'http://scrapy.org/',
         ),
-        (   'https://scrapy.org/501',
+        (
+            'https://scrapy.org/501',
             'https://example.com/502',
             (
                 # HTTPS all along, so origin referrer is kept as-is
@@ -728,7 +742,8 @@ class TestReferrerOnRedirectStrictOrigin(TestReferrerOnRedirect):
             b'https://scrapy.org/',
             b'https://scrapy.org/',
         ),
-        (   'https://scrapytest.org/601',
+        (
+            'https://scrapytest.org/601',
             'http://scrapytest.org/602',                # TLS to non-TLS: no referrer
             (
                 (301, 'https://scrapytest.org/603'),    # TLS URL again: (still) no referrer
@@ -750,7 +765,8 @@ class TestReferrerOnRedirectOriginWhenCrossOrigin(TestReferrerOnRedirect):
     """
     settings = {'REFERRER_POLICY': POLICY_ORIGIN_WHEN_CROSS_ORIGIN}
     scenarii = [
-        (   'http://scrapytest.org/101',      # origin
+        (
+            'http://scrapytest.org/101',      # origin
             'http://scrapytest.org/102',      # target + redirection
             (
                 # redirections: code, URL
@@ -760,7 +776,8 @@ class TestReferrerOnRedirectOriginWhenCrossOrigin(TestReferrerOnRedirect):
             b'http://scrapytest.org/101',  # expected initial referer
             b'http://scrapytest.org/101',  # expected referer for the redirection request
         ),
-        (   'https://scrapytest.org/201',
+        (
+            'https://scrapytest.org/201',
             'https://scrapytest.org/202',
             (
                 # redirecting to non-secure URL: send origin
@@ -769,7 +786,8 @@ class TestReferrerOnRedirectOriginWhenCrossOrigin(TestReferrerOnRedirect):
             b'https://scrapytest.org/201',
             b'https://scrapytest.org/',
         ),
-        (   'https://scrapytest.org/301',
+        (
+            'https://scrapytest.org/301',
             'https://scrapytest.org/302',
             (
                 # redirecting to non-secure URL (different domain): send origin
@@ -778,7 +796,8 @@ class TestReferrerOnRedirectOriginWhenCrossOrigin(TestReferrerOnRedirect):
             b'https://scrapytest.org/301',
             b'https://scrapytest.org/',
         ),
-        (   'http://scrapy.org/401',
+        (
+            'http://scrapy.org/401',
             'http://example.com/402',
             (
                 (301, 'http://scrapytest.org/403'),
@@ -786,7 +805,8 @@ class TestReferrerOnRedirectOriginWhenCrossOrigin(TestReferrerOnRedirect):
             b'http://scrapy.org/',
             b'http://scrapy.org/',
         ),
-        (   'https://scrapy.org/501',
+        (
+            'https://scrapy.org/501',
             'https://example.com/502',
             (
                 # all different domains: send origin
@@ -796,10 +816,11 @@ class TestReferrerOnRedirectOriginWhenCrossOrigin(TestReferrerOnRedirect):
             b'https://scrapy.org/',
             b'https://scrapy.org/',
         ),
-        (   'https://scrapytest.org/301',
-            'http://scrapytest.org/302',                # TLS to non-TLS: send origin
+        (
+            'https://scrapytest.org/301',
+            'http://scrapytest.org/302',  # TLS to non-TLS: send origin
             (
-                (301, 'https://scrapytest.org/303'),    # TLS URL again: send origin (also)
+                (301, 'https://scrapytest.org/303'),  # TLS URL again: send origin (also)
             ),
             b'https://scrapytest.org/',
             b'https://scrapytest.org/',
@@ -820,7 +841,8 @@ class TestReferrerOnRedirectStrictOriginWhenCrossOrigin(TestReferrerOnRedirect):
     """
     settings = {'REFERRER_POLICY': POLICY_STRICT_ORIGIN_WHEN_CROSS_ORIGIN}
     scenarii = [
-        (   'http://scrapytest.org/101',      # origin
+        (
+            'http://scrapytest.org/101',      # origin
             'http://scrapytest.org/102',      # target + redirection
             (
                 # redirections: code, URL
@@ -830,7 +852,8 @@ class TestReferrerOnRedirectStrictOriginWhenCrossOrigin(TestReferrerOnRedirect):
             b'http://scrapytest.org/101',  # expected initial referer
             b'http://scrapytest.org/101',  # expected referer for the redirection request
         ),
-        (   'https://scrapytest.org/201',
+        (
+            'https://scrapytest.org/201',
             'https://scrapytest.org/202',
             (
                 # redirecting to non-secure URL: do not send the "Referer" header
@@ -839,7 +862,8 @@ class TestReferrerOnRedirectStrictOriginWhenCrossOrigin(TestReferrerOnRedirect):
             b'https://scrapytest.org/201',
             None,
         ),
-        (   'https://scrapytest.org/301',
+        (
+            'https://scrapytest.org/301',
             'https://scrapytest.org/302',
             (
                 # redirecting to non-secure URL (different domain): send origin
@@ -848,7 +872,8 @@ class TestReferrerOnRedirectStrictOriginWhenCrossOrigin(TestReferrerOnRedirect):
             b'https://scrapytest.org/301',
             None,
         ),
-        (   'http://scrapy.org/401',
+        (
+            'http://scrapy.org/401',
             'http://example.com/402',
             (
                 (301, 'http://scrapytest.org/403'),
@@ -856,7 +881,8 @@ class TestReferrerOnRedirectStrictOriginWhenCrossOrigin(TestReferrerOnRedirect):
             b'http://scrapy.org/',
             b'http://scrapy.org/',
         ),
-        (   'https://scrapy.org/501',
+        (
+            'https://scrapy.org/501',
             'https://example.com/502',
             (
                 # all different domains: send origin
@@ -866,10 +892,11 @@ class TestReferrerOnRedirectStrictOriginWhenCrossOrigin(TestReferrerOnRedirect):
             b'https://scrapy.org/',
             b'https://scrapy.org/',
         ),
-        (   'https://scrapytest.org/601',
-            'http://scrapytest.org/602',                # TLS to non-TLS: do not send "Referer"
+        (
+            'https://scrapytest.org/601',
+            'http://scrapytest.org/602',  # TLS to non-TLS: do not send "Referer"
             (
-                (301, 'https://scrapytest.org/603'),    # TLS URL again: (still) send nothing
+                (301, 'https://scrapytest.org/603'),  # TLS URL again: (still) send nothing
             ),
             None,
             None,

--- a/tests/test_utils_sitemap.py
+++ b/tests/test_utils_sitemap.py
@@ -58,10 +58,12 @@ class SitemapTest(unittest.TestCase):
   </url>
 </urlset>
 """)
-        self.assertEqual(list(s),
-            [{'priority': '1', 'loc': 'http://www.example.com/', 'lastmod': '2009-08-16', 'changefreq': 'daily'},
-             {'loc': 'http://www.example.com/2', 'lastmod': ''},
-            ])
+        self.assertEqual(
+            list(s), [
+                {'priority': '1', 'loc': 'http://www.example.com/', 'lastmod': '2009-08-16', 'changefreq': 'daily'},
+                {'loc': 'http://www.example.com/2', 'lastmod': ''},
+            ]
+        )
 
     def test_sitemap_wrong_ns(self):
         """We have seen sitemaps with wrongs ns. Presumably, Google still works
@@ -80,10 +82,12 @@ class SitemapTest(unittest.TestCase):
   </url>
 </urlset>
 """)
-        self.assertEqual(list(s),
-            [{'priority': '1', 'loc': 'http://www.example.com/', 'lastmod': '2009-08-16', 'changefreq': 'daily'},
-             {'loc': 'http://www.example.com/2', 'lastmod': ''},
-            ])
+        self.assertEqual(
+            list(s), [
+                {'priority': '1', 'loc': 'http://www.example.com/', 'lastmod': '2009-08-16', 'changefreq': 'daily'},
+                {'loc': 'http://www.example.com/2', 'lastmod': ''},
+            ]
+        )
 
     def test_sitemap_wrong_ns2(self):
         """We have seen sitemaps with wrongs ns. Presumably, Google still works
@@ -103,10 +107,12 @@ class SitemapTest(unittest.TestCase):
 </urlset>
 """)
         assert s.type == 'urlset'
-        self.assertEqual(list(s),
-            [{'priority': '1', 'loc': 'http://www.example.com/', 'lastmod': '2009-08-16', 'changefreq': 'daily'},
-             {'loc': 'http://www.example.com/2', 'lastmod': ''},
-            ])
+        self.assertEqual(
+            list(s), [
+                {'priority': '1', 'loc': 'http://www.example.com/', 'lastmod': '2009-08-16', 'changefreq': 'daily'},
+                {'loc': 'http://www.example.com/2', 'lastmod': ''},
+            ]
+        )
 
     def test_sitemap_urls_from_robots(self):
         robots = """User-agent: *
@@ -195,11 +201,13 @@ Disallow: /forum/active/
         </url>
     </urlset>""")
 
-        self.assertEqual(list(s), [
-            {'loc': 'http://www.example.com/english/',
-             'alternate': ['http://www.example.com/deutsch/', 'http://www.example.com/schweiz-deutsch/', 'http://www.example.com/english/']
-            }
-        ])
+        self.assertEqual(
+            list(s), [
+                {'loc': 'http://www.example.com/english/',
+                 'alternate': ['http://www.example.com/deutsch/', 'http://www.example.com/schweiz-deutsch/', 'http://www.example.com/english/']
+                 }
+            ]
+        )
 
     def test_xml_entity_expansion(self):
         s = Sitemap(b"""<?xml version="1.0" encoding="utf-8"?>

--- a/tests/test_utils_url.py
+++ b/tests/test_utils_url.py
@@ -203,40 +203,39 @@ def create_skipped_scheme_t(args):
 
 
 for k, args in enumerate([
-            ('/index',                              'file://'),
-            ('/index.html',                         'file://'),
-            ('./index.html',                        'file://'),
-            ('../index.html',                       'file://'),
-            ('../../index.html',                    'file://'),
-            ('./data/index.html',                   'file://'),
-            ('.hidden/data/index.html',             'file://'),
-            ('/home/user/www/index.html',           'file://'),
-            ('//home/user/www/index.html',          'file://'),
-            ('file:///home/user/www/index.html',    'file://'),
+    ('/index',                              'file://'),
+    ('/index.html',                         'file://'),
+    ('./index.html',                        'file://'),
+    ('../index.html',                       'file://'),
+    ('../../index.html',                    'file://'),
+    ('./data/index.html',                   'file://'),
+    ('.hidden/data/index.html',             'file://'),
+    ('/home/user/www/index.html',           'file://'),
+    ('//home/user/www/index.html',          'file://'),
+    ('file:///home/user/www/index.html',    'file://'),
 
-            ('index.html',                          'http://'),
-            ('example.com',                         'http://'),
-            ('www.example.com',                     'http://'),
-            ('www.example.com/index.html',          'http://'),
-            ('http://example.com',                  'http://'),
-            ('http://example.com/index.html',       'http://'),
-            ('localhost',                           'http://'),
-            ('localhost/index.html',                'http://'),
+    ('index.html',                          'http://'),
+    ('example.com',                         'http://'),
+    ('www.example.com',                     'http://'),
+    ('www.example.com/index.html',          'http://'),
+    ('http://example.com',                  'http://'),
+    ('http://example.com/index.html',       'http://'),
+    ('localhost',                           'http://'),
+    ('localhost/index.html',                'http://'),
 
-            # some corner cases (default to http://)
-            ('/',                                   'http://'),
-            ('.../test',                            'http://'),
-
-        ], start=1):
+    # some corner cases (default to http://)
+    ('/',                                   'http://'),
+    ('.../test',                            'http://'),
+], start=1):
     t_method = create_guess_scheme_t(args)
     t_method.__name__ = 'test_uri_%03d' % k
     setattr(GuessSchemeTest, t_method.__name__, t_method)
 
 # TODO: the following tests do not pass with current implementation
 for k, args in enumerate([
-            (r'C:\absolute\path\to\a\file.html', 'file://',
-             'Windows filepath are not supported for scrapy shell'),
-        ], start=1):
+    (r'C:\absolute\path\to\a\file.html', 'file://',
+     'Windows filepath are not supported for scrapy shell'),
+], start=1):
     t_method = create_skipped_scheme_t(args)
     t_method.__name__ = 'test_uri_skipped_%03d' % k
     setattr(GuessSchemeTest, t_method.__name__, t_method)
@@ -272,7 +271,7 @@ class StripUrl(unittest.TestCase):
             ('http://www.example.com',
              True,
              'http://www.example.com/'),
-            ]:
+        ]:
             self.assertEqual(strip_url(input_url, origin_only=origin), output_url)
 
     def test_credentials(self):
@@ -285,7 +284,7 @@ class StripUrl(unittest.TestCase):
 
             ('ftp://username:password@www.example.com/index.html?somekey=somevalue#section',
              'ftp://www.example.com/index.html?somekey=somevalue'),
-            ]:
+        ]:
             self.assertEqual(strip_url(i, strip_credentials=True), o)
 
     def test_credentials_encoded_delims(self):
@@ -304,7 +303,7 @@ class StripUrl(unittest.TestCase):
             # password: "user@domain.com"
             ('ftp://me:user%40domain.com@www.example.com/index.html?somekey=somevalue#section',
              'ftp://www.example.com/index.html?somekey=somevalue'),
-            ]:
+        ]:
             self.assertEqual(strip_url(i, strip_credentials=True), o)
 
     def test_default_ports_creds_off(self):
@@ -332,7 +331,7 @@ class StripUrl(unittest.TestCase):
 
             ('ftp://username:password@www.example.com:221/file.txt',
              'ftp://www.example.com:221/file.txt'),
-            ]:
+        ]:
             self.assertEqual(strip_url(i), o)
 
     def test_default_ports(self):
@@ -360,7 +359,7 @@ class StripUrl(unittest.TestCase):
 
             ('ftp://username:password@www.example.com:221/file.txt',
              'ftp://username:password@www.example.com:221/file.txt'),
-            ]:
+        ]:
             self.assertEqual(strip_url(i, strip_default_port=True, strip_credentials=False), o)
 
     def test_default_ports_keep(self):
@@ -388,7 +387,7 @@ class StripUrl(unittest.TestCase):
 
             ('ftp://username:password@www.example.com:221/file.txt',
              'ftp://username:password@www.example.com:221/file.txt'),
-            ]:
+        ]:
             self.assertEqual(strip_url(i, strip_default_port=False, strip_credentials=False), o)
 
     def test_origin_only(self):
@@ -404,7 +403,7 @@ class StripUrl(unittest.TestCase):
 
             ('https://username:password@www.example.com:443/index.html',
              'https://www.example.com/'),
-            ]:
+        ]:
             self.assertEqual(strip_url(i, origin_only=True), o)
 
 

--- a/tests/test_webclient.py
+++ b/tests/test_webclient.py
@@ -48,29 +48,29 @@ class ParseUrlTestCase(unittest.TestCase):
     def testParse(self):
         lip = '127.0.0.1'
         tests = (
-    ("http://127.0.0.1?c=v&c2=v2#fragment",     ('http', lip, lip, 80, '/?c=v&c2=v2')),
-    ("http://127.0.0.1/?c=v&c2=v2#fragment",    ('http', lip, lip, 80, '/?c=v&c2=v2')),
-    ("http://127.0.0.1/foo?c=v&c2=v2#frag",     ('http', lip, lip, 80, '/foo?c=v&c2=v2')),
-    ("http://127.0.0.1:100?c=v&c2=v2#fragment", ('http', lip + ':100', lip, 100, '/?c=v&c2=v2')),
-    ("http://127.0.0.1:100/?c=v&c2=v2#frag",    ('http', lip + ':100', lip, 100, '/?c=v&c2=v2')),
-    ("http://127.0.0.1:100/foo?c=v&c2=v2#frag", ('http', lip + ':100', lip, 100, '/foo?c=v&c2=v2')),
+            ("http://127.0.0.1?c=v&c2=v2#fragment", ('http', lip, lip, 80, '/?c=v&c2=v2')),
+            ("http://127.0.0.1/?c=v&c2=v2#fragment", ('http', lip, lip, 80, '/?c=v&c2=v2')),
+            ("http://127.0.0.1/foo?c=v&c2=v2#frag", ('http', lip, lip, 80, '/foo?c=v&c2=v2')),
+            ("http://127.0.0.1:100?c=v&c2=v2#fragment", ('http', lip + ':100', lip, 100, '/?c=v&c2=v2')),
+            ("http://127.0.0.1:100/?c=v&c2=v2#frag", ('http', lip + ':100', lip, 100, '/?c=v&c2=v2')),
+            ("http://127.0.0.1:100/foo?c=v&c2=v2#frag", ('http', lip + ':100', lip, 100, '/foo?c=v&c2=v2')),
 
-    ("http://127.0.0.1",              ('http', lip, lip, 80, '/')),
-    ("http://127.0.0.1/",             ('http', lip, lip, 80, '/')),
-    ("http://127.0.0.1/foo",          ('http', lip, lip, 80, '/foo')),
-    ("http://127.0.0.1?param=value",  ('http', lip, lip, 80, '/?param=value')),
-    ("http://127.0.0.1/?param=value", ('http', lip, lip, 80, '/?param=value')),
-    ("http://127.0.0.1:12345/foo",    ('http', lip + ':12345', lip, 12345, '/foo')),
-    ("http://spam:12345/foo",         ('http', 'spam:12345', 'spam', 12345, '/foo')),
-    ("http://spam.test.org/foo",      ('http', 'spam.test.org', 'spam.test.org', 80, '/foo')),
+            ("http://127.0.0.1", ('http', lip, lip, 80, '/')),
+            ("http://127.0.0.1/", ('http', lip, lip, 80, '/')),
+            ("http://127.0.0.1/foo", ('http', lip, lip, 80, '/foo')),
+            ("http://127.0.0.1?param=value", ('http', lip, lip, 80, '/?param=value')),
+            ("http://127.0.0.1/?param=value", ('http', lip, lip, 80, '/?param=value')),
+            ("http://127.0.0.1:12345/foo", ('http', lip + ':12345', lip, 12345, '/foo')),
+            ("http://spam:12345/foo", ('http', 'spam:12345', 'spam', 12345, '/foo')),
+            ("http://spam.test.org/foo", ('http', 'spam.test.org', 'spam.test.org', 80, '/foo')),
 
-    ("https://127.0.0.1/foo",         ('https', lip, lip, 443, '/foo')),
-    ("https://127.0.0.1/?param=value", ('https', lip, lip, 443, '/?param=value')),
-    ("https://127.0.0.1:12345/",      ('https', lip + ':12345', lip, 12345, '/')),
+            ("https://127.0.0.1/foo", ('https', lip, lip, 443, '/foo')),
+            ("https://127.0.0.1/?param=value", ('https', lip, lip, 443, '/?param=value')),
+            ("https://127.0.0.1:12345/", ('https', lip + ':12345', lip, 12345, '/')),
 
-    ("http://scrapytest.org/foo ",    ('http', 'scrapytest.org', 'scrapytest.org', 80, '/foo')),
-    ("http://egg:7890 ",              ('http', 'egg:7890', 'egg', 7890, '/')),
-    )
+            ("http://scrapytest.org/foo ", ('http', 'scrapytest.org', 'scrapytest.org', 80, '/foo')),
+            ("http://egg:7890 ", ('http', 'egg:7890', 'egg', 7890, '/')),
+        )
 
         for url, test in tests:
             test = tuple(
@@ -144,7 +144,7 @@ class ScrapyHTTPPageGetterTests(unittest.TestCase):
             headers={
                 'X-Meta-Single': 'single',
                 'X-Meta-Multivalued': ['value1', 'value2'],
-                }))
+            }))
 
         self._test(factory,
             b"GET /bar HTTP/1.0\r\n"
@@ -160,7 +160,7 @@ class ScrapyHTTPPageGetterTests(unittest.TestCase):
             headers=Headers({
                 'X-Meta-Single': 'single',
                 'X-Meta-Multivalued': ['value1', 'value2'],
-                })))
+            })))
 
         self._test(factory,
             b"GET /bar HTTP/1.0\r\n"
@@ -196,8 +196,8 @@ class ScrapyHTTPPageGetterTests(unittest.TestCase):
 
 
 from twisted.web.test.test_webclient import ForeverTakingResource, \
-        ErrorResource, NoLengthResource, HostHeaderResource, \
-        PayloadResource, BrokenDownloadResource
+    ErrorResource, NoLengthResource, HostHeaderResource, \
+    PayloadResource, BrokenDownloadResource
 
 
 class EncodingResource(resource.Resource):


### PR DESCRIPTION
This fixes:

E11X:

* E111: Indentation is not a multiple of four
* E114: Indentation is not a multiple of four (comment)
* E116: Unexpected indentation (comment)
* E117: Over-indented code blocks

Some E12X

* E121: Continuation line under-indented for hanging indent
* E122: Continuation line missing indentation or outdented
* E123: Closing bracket does not match indentation of opening bracket's line
* E124: Closing bracket does not match visual indentation
* E126: Continuation line over-indented for hanging indent


**Sorry for this big PR**. The E126 has several occurrences and is hard to review (and that's the reason why I decided to exclude E127, E128 and E129 from this PR).

It's a good chance to use the "viewed" checkbox when reviewing... :sweat_smile: 