### PR TITLE
Basic support for async def start_requests.

### DIFF
--- a/scrapy/crawler.py
+++ b/scrapy/crawler.py
@@ -1,3 +1,4 @@
+import inspect
 import logging
 import pprint
 import signal
@@ -13,6 +14,7 @@ from scrapy.extension import ExtensionManager
 from scrapy.interfaces import ISpiderLoader
 from scrapy.settings import overridden_settings, Settings
 from scrapy.signalmanager import SignalManager
+from scrapy.utils.defer import deferred_from_coro
 from scrapy.utils.log import (
     configure_logging,
     get_scrapy_root_handler,
@@ -87,7 +89,10 @@ class Crawler:
         try:
             self.spider = self._create_spider(*args, **kwargs)
             self.engine = self._create_engine()
-            start_requests = iter(self.spider.start_requests())
+            if inspect.iscoroutinefunction(self.spider.start_requests):
+                start_requests = yield deferred_from_coro(self.spider.start_requests())
+            else:
+                start_requests = iter(self.spider.start_requests())
             yield self.engine.open_spider(self.spider, start_requests)
             yield defer.maybeDeferred(self.engine.start)
         except Exception:

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -15,7 +15,6 @@ import re
 import sys
 from urllib.parse import urlparse
 
-from pytest import mark
 from twisted.internet import reactor, defer
 from twisted.web import server, static, util
 from twisted.trial import unittest

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -207,7 +207,6 @@ class EngineTest(unittest.TestCase):
         yield self.run.run()
         self._assert_items_error()
 
-    @mark.only_asyncio()
     @defer.inlineCallbacks
     def test_crawler_startrequests_asyncdef(self):
         self.run = CrawlerRun(StartRequestsAsyncDefSpider)


### PR DESCRIPTION
Again, no yield, only returning a list or iterator is supported. 