### PR TITLE
Remove deprecated Crawler.spiders property

### DIFF
--- a/scrapy/crawler.py
+++ b/scrapy/crawler.py
@@ -68,17 +68,6 @@ class Crawler:
         self.spider = None
         self.engine = None
 
-    @property
-    def spiders(self):
-        if not hasattr(self, '_spiders'):
-            warnings.warn("Crawler.spiders is deprecated, use "
-                          "CrawlerRunner.spider_loader or instantiate "
-                          "scrapy.spiderloader.SpiderLoader with your "
-                          "settings.",
-                          category=ScrapyDeprecationWarning, stacklevel=2)
-            self._spiders = _get_spider_loader(self.settings.frozencopy())
-        return self._spiders
-
     @defer.inlineCallbacks
     def crawl(self, *args, **kwargs):
         assert not self.crawling, "Crawling already taking place"
@@ -130,11 +119,27 @@ class CrawlerRunner:
             ":meth:`crawl` and managed by this class."
     )
 
+    @staticmethod
+    def _get_spider_loader(settings):
+        """ Get SpiderLoader instance from settings """
+        cls_path = settings.get('SPIDER_LOADER_CLASS')
+        loader_cls = load_object(cls_path)
+        try:
+            verifyClass(ISpiderLoader, loader_cls)
+        except DoesNotImplement:
+            warnings.warn(
+                'SPIDER_LOADER_CLASS (previously named SPIDER_MANAGER_CLASS) does '
+                'not fully implement scrapy.interfaces.ISpiderLoader interface. '
+                'Please add all missing methods to avoid unexpected runtime errors.',
+                category=ScrapyDeprecationWarning, stacklevel=2
+            )
+        return loader_cls.from_settings(settings.frozencopy())
+
     def __init__(self, settings=None):
         if isinstance(settings, dict) or settings is None:
             settings = Settings(settings)
         self.settings = settings
-        self.spider_loader = _get_spider_loader(settings)
+        self.spider_loader = self._get_spider_loader(settings)
         self._crawlers = set()
         self._active = set()
         self.bootstrap_failed = False
@@ -327,19 +332,3 @@ class CrawlerProcess(CrawlerRunner):
         if self.settings.get("TWISTED_REACTOR"):
             install_reactor(self.settings["TWISTED_REACTOR"])
         super()._handle_twisted_reactor()
-
-
-def _get_spider_loader(settings):
-    """ Get SpiderLoader instance from settings """
-    cls_path = settings.get('SPIDER_LOADER_CLASS')
-    loader_cls = load_object(cls_path)
-    try:
-        verifyClass(ISpiderLoader, loader_cls)
-    except DoesNotImplement:
-        warnings.warn(
-            'SPIDER_LOADER_CLASS (previously named SPIDER_MANAGER_CLASS) does '
-            'not fully implement scrapy.interfaces.ISpiderLoader interface. '
-            'Please add all missing methods to avoid unexpected runtime errors.',
-            category=ScrapyDeprecationWarning, stacklevel=2
-        )
-    return loader_cls.from_settings(settings.frozencopy())

--- a/tests/test_crawler.py
+++ b/tests/test_crawler.py
@@ -33,21 +33,6 @@ class CrawlerTestCase(BaseCrawlerTest):
     def setUp(self):
         self.crawler = Crawler(DefaultSpider, Settings())
 
-    def test_deprecated_attribute_spiders(self):
-        with warnings.catch_warnings(record=True) as w:
-            spiders = self.crawler.spiders
-            self.assertEqual(len(w), 1)
-            self.assertIn("Crawler.spiders", str(w[0].message))
-            sl_cls = load_object(self.crawler.settings['SPIDER_LOADER_CLASS'])
-            self.assertIsInstance(spiders, sl_cls)
-
-            self.crawler.spiders
-            is_one_warning = len(w) == 1
-            if not is_one_warning:
-                for warning in w:
-                    print(warning)
-            self.assertTrue(is_one_warning, "Warn deprecated access only once")
-
     def test_populate_spidercls_settings(self):
         spider_settings = {'TEST1': 'spider', 'TEST2': 'spider'}
         project_settings = {'TEST1': 'project', 'TEST3': 'project'}


### PR DESCRIPTION
Two commits,
the 1st removing `Crawler.spiders`; deprecated since 4190266 (2014, Scrapy 0.25)
~the 2nd removing `CrawlerRunner.spiders`; deprecated since ad587ea (2015, Scrapy 0.25.1)~

~Adding `SPIDER_MANAGER_CLASS` to `scrapy/settings/deprecated.py` is somewhat too late, just for completeness' sake; so it's been there and can be removed again next commit?~