### PR TITLE
Obsolete S3FeedStorage instancing without AWS credentials

### DIFF
--- a/scrapy/extensions/feedexport.py
+++ b/scrapy/extensions/feedexport.py
@@ -94,23 +94,10 @@ class FileFeedStorage:
 class S3FeedStorage(BlockingFeedStorage):
 
     def __init__(self, uri, access_key=None, secret_key=None, acl=None):
-        # BEGIN Backward compatibility for initialising without keys (and
-        # without using from_crawler)
-        no_defaults = access_key is None and secret_key is None
-        if no_defaults:
-            from scrapy.utils.project import get_project_settings
-            settings = get_project_settings()
-            if 'AWS_ACCESS_KEY_ID' in settings or 'AWS_SECRET_ACCESS_KEY' in settings:
-                warnings.warn(
-                    "Initialising `scrapy.extensions.feedexport.S3FeedStorage` "
-                    "without AWS keys is deprecated. Please supply credentials or "
-                    "use the `from_crawler()` constructor.",
-                    category=ScrapyDeprecationWarning,
-                    stacklevel=2
-                )
-                access_key = settings['AWS_ACCESS_KEY_ID']
-                secret_key = settings['AWS_SECRET_ACCESS_KEY']
-        # END Backward compatibility
+        no_keys = access_key is None and secret_key is None
+        if no_keys:
+            raise NotConfigured('%s is missing AWS credentials' %
+                                self.__class__.__name__)
         u = urlparse(uri)
         self.bucketname = u.hostname
         self.access_key = u.username or access_key

--- a/scrapy/extensions/feedexport.py
+++ b/scrapy/extensions/feedexport.py
@@ -94,10 +94,6 @@ class FileFeedStorage:
 class S3FeedStorage(BlockingFeedStorage):
 
     def __init__(self, uri, access_key=None, secret_key=None, acl=None):
-        no_keys = access_key is None and secret_key is None
-        if no_keys:
-            raise NotConfigured('%s is missing AWS credentials' %
-                                self.__class__.__name__)
         u = urlparse(uri)
         self.bucketname = u.hostname
         self.access_key = u.username or access_key

--- a/tests/test_feedexport.py
+++ b/tests/test_feedexport.py
@@ -21,7 +21,6 @@ from zope.interface.verify import verifyObject
 
 import scrapy
 from scrapy.crawler import CrawlerRunner
-from scrapy.exceptions import NotConfigured
 from scrapy.exporters import CsvItemExporter
 from scrapy.extensions.feedexport import (BlockingFeedStorage, FileFeedStorage, FTPFeedStorage,
                                           IFeedStorage, S3FeedStorage, StdoutFeedStorage)
@@ -187,9 +186,6 @@ class S3FeedStorageTest(unittest.TestCase):
                                 aws_credentials['AWS_SECRET_ACCESS_KEY'])
         self.assertEqual(storage.access_key, 'uri_key')
         self.assertEqual(storage.secret_key, 'uri_secret')
-        # Instantiate without credentials
-        with self.assertRaises(NotConfigured):
-            S3FeedStorage('s3://mybucket/export.csv')
 
     @defer.inlineCallbacks
     def test_store(self):

--- a/tests/test_feedexport.py
+++ b/tests/test_feedexport.py
@@ -167,9 +167,9 @@ class S3FeedStorageTest(unittest.TestCase):
                 create=True)
     def test_parse_credentials(self):
         try:
-            import boto  # noqa: F401
+            import botocore  # noqa: F401
         except ImportError:
-            raise unittest.SkipTest("S3FeedStorage requires boto")
+            raise unittest.SkipTest("S3FeedStorage requires botocore")
         aws_credentials = {'AWS_ACCESS_KEY_ID': 'settings_key',
                            'AWS_SECRET_ACCESS_KEY': 'settings_secret'}
         crawler = get_crawler(settings_dict=aws_credentials)

--- a/tests/test_feedexport.py
+++ b/tests/test_feedexport.py
@@ -21,6 +21,7 @@ from zope.interface.verify import verifyObject
 
 import scrapy
 from scrapy.crawler import CrawlerRunner
+from scrapy.exceptions import NotConfigured
 from scrapy.exporters import CsvItemExporter
 from scrapy.extensions.feedexport import (BlockingFeedStorage, FileFeedStorage, FTPFeedStorage,
                                           IFeedStorage, S3FeedStorage, StdoutFeedStorage)
@@ -161,10 +162,6 @@ class BlockingFeedStorageTest(unittest.TestCase):
 
 class S3FeedStorageTest(unittest.TestCase):
 
-    @mock.patch('scrapy.utils.project.get_project_settings',
-                new=mock.MagicMock(return_value={'AWS_ACCESS_KEY_ID': 'conf_key',
-                                                 'AWS_SECRET_ACCESS_KEY': 'conf_secret'}),
-                create=True)
     def test_parse_credentials(self):
         try:
             import botocore  # noqa: F401
@@ -190,12 +187,9 @@ class S3FeedStorageTest(unittest.TestCase):
                                 aws_credentials['AWS_SECRET_ACCESS_KEY'])
         self.assertEqual(storage.access_key, 'uri_key')
         self.assertEqual(storage.secret_key, 'uri_secret')
-        # Backward compatibility for initialising without settings
-        with warnings.catch_warnings(record=True) as w:
-            storage = S3FeedStorage('s3://mybucket/export.csv')
-            self.assertEqual(storage.access_key, 'conf_key')
-            self.assertEqual(storage.secret_key, 'conf_secret')
-            self.assertTrue('without AWS keys' in str(w[-1].message))
+        # Instantiate without credentials
+        with self.assertRaises(NotConfigured):
+            S3FeedStorage('s3://mybucket/export.csv')
 
     @defer.inlineCallbacks
     def test_store(self):


### PR DESCRIPTION
Question: does `access_key is None and secret_key is None` make sense here?
It's been the current behaviour, but is there a use-case for having no `access_key` but a `secret_key`? Otherwise this should possibly be `or`, instead of `and`?