### PR TITLE
Deprecate Spider.make_requests_from_url, part 2

### DIFF
--- a/scrapy/spiders/__init__.py
+++ b/scrapy/spiders/__init__.py
@@ -78,6 +78,12 @@ class Spider(object_ref):
 
     def make_requests_from_url(self, url):
         """ This method is deprecated. """
+        warnings.warn(
+            "Spider.make_requests_from_url method is deprecated: "
+            "it will be removed and not be called by the default "
+            "Spider.start_requests method in future Scrapy releases. "
+            "Please override Spider.start_requests method instead."
+        )
         return Request(url, dont_filter=True)
 
     def parse(self, response):

--- a/tests/test_spider.py
+++ b/tests/test_spider.py
@@ -602,13 +602,19 @@ class DeprecationTest(unittest.TestCase):
             self.assertEqual(len(list(spider1.start_requests())), 1)
             self.assertEqual(len(w), 0)
 
+            # spider without overridden make_requests_from_url method
+            # should issue a warning when called directly
+            request = spider1.make_requests_from_url("http://www.example.com")
+            self.assertTrue(isinstance(request, Request))
+            self.assertEqual(len(w), 1)
+
             # spider with overridden make_requests_from_url issues a warning,
             # but the method still works
             spider2 = MySpider5()
             requests = list(spider2.start_requests())
             self.assertEqual(len(requests), 1)
             self.assertEqual(requests[0].url, 'http://example.com/foo')
-            self.assertEqual(len(w), 1)
+            self.assertEqual(len(w), 2)
 
 
 class NoParseMethodSpiderTest(unittest.TestCase):


### PR DESCRIPTION
Follow-up for #1728, 
Blocking #4178