### PR TITLE
[WIP] Eliminate an internal use of os.environ 

### DIFF
--- a/scrapy/utils/conf.py
+++ b/scrapy/utils/conf.py
@@ -79,14 +79,16 @@ def init_env(project='default', set_syspath=True):
     dir. This sets the Scrapy settings module and modifies the Python path to
     be able to locate the project module.
     """
+    settings_module = None
     cfg = get_config()
     if cfg.has_option('settings', project):
-        os.environ['SCRAPY_SETTINGS_MODULE'] = cfg.get('settings', project)
+        settings_module = cfg.get('settings', project)
     closest = closest_scrapy_cfg()
     if closest:
         projdir = os.path.dirname(closest)
         if set_syspath and projdir not in sys.path:
             sys.path.append(projdir)
+    return settings_module
 
 
 def get_config(use_closest=True):

--- a/scrapy/utils/conf.py
+++ b/scrapy/utils/conf.py
@@ -79,16 +79,16 @@ def init_env(project='default', set_syspath=True):
     dir. This sets the Scrapy settings module and modifies the Python path to
     be able to locate the project module.
     """
-    settings_module = None
+    settings_module_path = None
     cfg = get_config()
     if cfg.has_option('settings', project):
-        settings_module = cfg.get('settings', project)
+        settings_module_path = cfg.get('settings', project)
     closest = closest_scrapy_cfg()
     if closest:
         projdir = os.path.dirname(closest)
         if set_syspath and projdir not in sys.path:
             sys.path.append(projdir)
-    return settings_module
+    return settings_module_path
 
 
 def get_config(use_closest=True):

--- a/scrapy/utils/project.py
+++ b/scrapy/utils/project.py
@@ -15,7 +15,7 @@ DATADIR_CFG_SECTION = 'datadir'
 
 
 def inside_project():
-    scrapy_module = os.environ.get('SCRAPY_SETTINGS_MODULE')
+    scrapy_module = os.environ.get(ENVVAR)
     if scrapy_module is not None:
         try:
             import_module(scrapy_module)
@@ -61,10 +61,11 @@ def data_path(path, createdir=False):
 def get_project_settings():
     if ENVVAR not in os.environ:
         project = os.environ.get('SCRAPY_PROJECT', 'default')
-        init_env(project)
+        settings_module_path = init_env(project)
+    else:
+        settings_module_path = os.environ.get(ENVVAR)
 
     settings = Settings()
-    settings_module_path = os.environ.get(ENVVAR)
     if settings_module_path:
         settings.setmodule(settings_module_path, priority='project')
 

--- a/scrapy/utils/project.py
+++ b/scrapy/utils/project.py
@@ -10,17 +10,18 @@ from scrapy.settings import Settings
 from scrapy.exceptions import NotConfigured, ScrapyDeprecationWarning
 
 
-ENVVAR = 'SCRAPY_SETTINGS_MODULE'
+SCRAPY_SETTINGS_MODULE = 'SCRAPY_SETTINGS_MODULE'
 DATADIR_CFG_SECTION = 'datadir'
 
 
 def inside_project():
-    scrapy_module = os.environ.get(ENVVAR)
-    if scrapy_module is not None:
+    settings_module_path = os.environ.get(SCRAPY_SETTINGS_MODULE)
+    if settings_module_path is not None:
         try:
-            import_module(scrapy_module)
+            import_module(settings_module_path)
         except ImportError as exc:
-            warnings.warn("Cannot import scrapy settings module %s: %s" % (scrapy_module, exc))
+            warnings.warn("Cannot import scrapy settings module %s: %s" %
+                          (settings_module_path, exc))
         else:
             return True
     return bool(closest_scrapy_cfg())
@@ -59,11 +60,11 @@ def data_path(path, createdir=False):
 
 
 def get_project_settings():
-    if ENVVAR not in os.environ:
+    if SCRAPY_SETTINGS_MODULE in os.environ:
+        settings_module_path = os.environ.get(SCRAPY_SETTINGS_MODULE)
+    else:
         project = os.environ.get('SCRAPY_PROJECT', 'default')
         settings_module_path = init_env(project)
-    else:
-        settings_module_path = os.environ.get(ENVVAR)
 
     settings = Settings()
     if settings_module_path:


### PR DESCRIPTION
Currently, scrapy passes the SCRAPY_SETTINGS_MODULE setting between functions by using an environment variable, instead of inside python code. This "side-channel" is unnecessary.