### PR TITLE
Restrict pytest to versions prior to 5.4

### DIFF
--- a/tests/requirements-py3.txt
+++ b/tests/requirements-py3.txt
@@ -2,7 +2,7 @@
 jmespath
 mitmproxy; python_version >= '3.6'
 mitmproxy<4.0.0; python_version < '3.6'
-pytest
+pytest < 5.4
 pytest-cov
 pytest-twisted >= 1.11
 pytest-xdist


### PR DESCRIPTION
Let us see if that’s what is breaking the tests.