### PR TITLE
[WIP] Avoid .callback() in TestProcessProtocol.processEnded()

### DIFF
--- a/scrapy/utils/testproc.py
+++ b/scrapy/utils/testproc.py
@@ -47,4 +47,5 @@ class TestProcessProtocol(protocol.ProcessProtocol):
 
     def processEnded(self, status):
         self.exitcode = status.value.exitCode
+        from twisted.internet import reactor
         reactor.callLater(0, self.deferred.callback, self)

--- a/scrapy/utils/testproc.py
+++ b/scrapy/utils/testproc.py
@@ -47,4 +47,4 @@ class TestProcessProtocol(protocol.ProcessProtocol):
 
     def processEnded(self, status):
         self.exitcode = status.value.exitCode
-        self.deferred.callback(self)
+        reactor.callLater(0, self.deferred.callback, self)

--- a/tests/requirements-py3.txt
+++ b/tests/requirements-py3.txt
@@ -2,7 +2,7 @@
 jmespath
 mitmproxy; python_version >= '3.6'
 mitmproxy<4.0.0; python_version < '3.6'
-pytest < 5.4
+pytest
 pytest-cov
 pytest-twisted >= 1.11
 pytest-xdist


### PR DESCRIPTION
pytest-dev/pytest-twisted#93