### PR TITLE
Feature/autothrottle 429

### DIFF
--- a/scrapy/core/downloader/__init__.py
+++ b/scrapy/core/downloader/__init__.py
@@ -20,6 +20,7 @@ class Slot:
         self.concurrency = concurrency
         self.delay = delay
         self.randomize_delay = randomize_delay
+        self.rate_limit_special_delay = 0
 
         self.active = set()
         self.queue = deque()
@@ -31,9 +32,11 @@ class Slot:
         return self.concurrency - len(self.transferring)
 
     def download_delay(self):
+        sp = self.rate_limit_special_delay
+        self.rate_limit_special_delay = 0
         if self.randomize_delay:
-            return random.uniform(0.5 * self.delay, 1.5 * self.delay)
-        return self.delay
+            return random.uniform(0.5 * self.delay, 1.5 * self.delay) + sp
+        return self.delay + sp
 
     def close(self):
         if self.latercall and self.latercall.active():

--- a/scrapy/core/downloader/webclient.py
+++ b/scrapy/core/downloader/webclient.py
@@ -141,6 +141,7 @@ class ScrapyHTTPClientFactory(HTTPClientFactory):
 
     def _build_response(self, body, request):
         request.meta['download_latency'] = self.headers_time - self.start_time
+        request.meta['sent_at'] = self.start_time
         status = int(self.status)
         headers = Headers(self.response_headers)
         respcls = responsetypes.from_args(headers=headers, url=self._url)

--- a/scrapy/extensions/throttle.py
+++ b/scrapy/extensions/throttle.py
@@ -261,8 +261,8 @@ class AutoThrottle429Handler:
         wanted_rate = (window.previous_count
                        * ((self._tim.get_parts(time_slot)
                            - self._tim.get_time_part(sent_at, time_slot))
-                        / self._tim.get_parts(time_slot))) \
-                      + window.current_count - 1
+                          / self._tim.get_parts(time_slot))) \
+            + window.current_count - 1
 
         # 2. calculate delay required to achieve that rate.
         return self._tim.get_seconds(time_slot) / wanted_rate

--- a/scrapy/extensions/throttle.py
+++ b/scrapy/extensions/throttle.py
@@ -2,6 +2,9 @@ import logging
 
 from scrapy.exceptions import NotConfigured
 from scrapy import signals
+from enum import Enum
+from datetime import datetime, timedelta
+from typing import Tuple
 
 logger = logging.getLogger(__name__)
 
@@ -15,6 +18,12 @@ class AutoThrottle:
 
         self.debug = crawler.settings.getbool("AUTOTHROTTLE_DEBUG")
         self.target_concurrency = crawler.settings.getfloat("AUTOTHROTTLE_TARGET_CONCURRENCY")
+        self.enable_429 = crawler.settings.getbool("AUTOTHROTTLE_HANDLE_API_RATE_LIMIT")
+        self.rate_limit_handler = None
+        self.rate_limit_status = crawler.settings.getint("AUTOTHROTTLE_RATE_LIMIT_STATUS")
+        if self.enable_429:
+            self.rate_limit_handler = AutoThrottle429Handler(
+                self.target_concurrency)
         crawler.signals.connect(self._spider_opened, signal=signals.spider_opened)
         crawler.signals.connect(self._response_downloaded, signal=signals.response_downloaded)
 
@@ -40,11 +49,14 @@ class AutoThrottle:
     def _response_downloaded(self, response, request, spider):
         key, slot = self._get_slot(request, spider)
         latency = request.meta.get('download_latency')
+        sent_at = request.meta.get('sent_at')
+        if self.enable_429:
+            self.rate_limit_handler.add_to_history(response, sent_at)
         if latency is None or slot is None:
             return
 
         olddelay = slot.delay
-        self._adjust_delay(slot, latency, response)
+        self._adjust_delay(slot, sent_at, latency, response)
         if self.debug:
             diff = slot.delay - olddelay
             size = len(response.body)
@@ -65,7 +77,7 @@ class AutoThrottle:
         key = request.meta.get('download_slot')
         return key, self.crawler.engine.downloader.slots.get(key)
 
-    def _adjust_delay(self, slot, latency, response):
+    def _adjust_delay(self, slot, sent_at, latency, response):
         """Define delay adjustment policy"""
 
         # If a server needs `latency` seconds to respond then
@@ -80,8 +92,17 @@ class AutoThrottle:
         # It works better with problematic sites.
         new_delay = max(target_delay, new_delay)
 
+        if response.status == self.rate_limit_status:
+            self.rate_limit_handler.increase_min_delay(response, sent_at)
+        new_delay = max(new_delay, self.rate_limit_handler.get_min_delay(response))
+
         # Make sure self.mindelay <= new_delay <= self.max_delay
         new_delay = min(max(self.mindelay, new_delay), self.maxdelay)
+
+        if response.status == self.rate_limit_status:
+            # set a special delay on the slot to make it wait until the end of the current time interval
+            # before continuing requests.
+            slot.rate_limit_special_delay = self.rate_limit_handler.pop_special_delay(response)
 
         # Dont adjust delay if response status != 200 and new delay is smaller
         # than old one, as error pages (and redirections) are usually small and
@@ -91,3 +112,186 @@ class AutoThrottle:
             return
 
         slot.delay = new_delay
+
+
+class TimeInterval(Enum):
+    SECOND = "%Y/%m/%d %H:%M:%S", 1, 1000000
+    MINUTE = "%Y/%m/%d %H:%M", 60, 60
+    HOUR = "%Y/%m/%d %H", 3600, 60
+    DAY = "%Y/%m/%d", 86400, 24
+
+
+class TimeIntervalManager:
+
+    def __init__(self):
+        self.time_interval_next_map = {TimeInterval.SECOND: TimeInterval.MINUTE, TimeInterval.MINUTE: TimeInterval.HOUR,
+                                       TimeInterval.HOUR: TimeInterval.DAY}
+        self.time_interval_attr = {TimeInterval.SECOND: 'microsecond', TimeInterval.MINUTE: 'second',
+                                   TimeInterval.HOUR: 'minute', TimeInterval.DAY: 'hour'}
+
+    def get_next_interval(self, degree: TimeInterval):
+        return self.time_interval_next_map.get(degree, TimeInterval.DAY)
+
+    def get_time_part(self, time_stamp: datetime, degree: TimeInterval):
+        return time_stamp.__getattribute__(self.time_interval_attr[degree])
+
+    def get_seconds_until_end_of_interval(self, time_stamp: datetime, interval: TimeInterval) -> int:
+        # if interval is seconds, return 1.
+        # if interval is minutes, return:  get_seconds(1 minute) - current second
+        # if interval is hour, return:  get_seconds(1 hour) - (get_seconds(1 minute) * (60 minutes - current_minutes)
+        #                           + (60 seconds - current second))
+        # if interval is day, return:  get_seconds(1 day) - (get_seconds(1 hour) * (24 hours - current hour) +
+        #                          (get_seconds(1 min) * (60 minutes - current_minutes) + (60 seconds - current second))
+        spent_time = 0
+        if interval == TimeInterval.SECOND:
+            return self.get_seconds(interval) - spent_time
+        spent_time += time_stamp.second
+        if interval == TimeInterval.MINUTE:
+            return self.get_seconds(interval) - spent_time
+        spent_time += time_stamp.minute * self.get_seconds(TimeInterval.MINUTE)
+        if interval == TimeInterval.HOUR:
+            return self.get_seconds(interval) - spent_time
+        spent_time += time_stamp.hour * self.get_seconds(TimeInterval.HOUR)
+        return self.get_seconds(interval) - spent_time
+
+    @staticmethod
+    def get_timestamp_key(t: datetime, degree: TimeInterval):
+        return t.strftime(degree.value[0])
+
+    @staticmethod
+    def get_delta(degree: TimeInterval):
+        return timedelta(seconds=TimeIntervalManager.get_seconds(degree))
+
+    @staticmethod
+    def get_parts(degree: TimeInterval):
+        return degree.value[2]
+
+    @staticmethod
+    def get_seconds(degree: TimeInterval):
+        return degree.value[1]
+
+
+class SlidingWindow:
+
+    """
+    This structure implements keeps track of the number of requests over the previous and current time intervals.
+    """
+
+    def __init__(self, interval: TimeInterval, current: datetime, current_count=1, previous_count=0):
+        self.interval = interval
+        self.current = current
+        self.current_count = current_count
+        self.previous_count = previous_count
+        self._tim = TimeIntervalManager()
+
+    def add_request(self, sent_at: datetime):
+        label = self._tim.get_timestamp_key(sent_at, self.interval)
+        if label != self._tim.get_timestamp_key(self.current, self.interval):
+            # slide window
+            # case 1. next window. case 2, previous window was blank. (no requests in the last interval).
+            if self.is_next_window(label):
+                self.reset_window(sent_at, self.current_count)
+            else:
+                self.reset_window(sent_at, 0)
+        else:
+            self.current_count += 1
+
+    def reset_window(self, new_current, new_previous_count):
+        self.current = new_current
+        self.current_count = 1
+        self.previous_count = new_previous_count
+
+    def is_next_window(self, label: str):
+        return self._tim.get_timestamp_key(self.current + self._tim.get_delta(self.interval)
+                                           , self.interval) == label
+
+    def __repr__(self):
+        return "SlidingWindow: {}\n Current Window: {}\n Current Count{}\n Previous Count{}" \
+            .format(self.interval, self._tim.get_timestamp_key(self.current, self.interval),
+                    self.current_count,
+                    self.previous_count)
+
+
+class AutoThrottle429Handler:
+
+    def __init__(self, target_concurrency):
+        self.__initial_failover_lives__ = max(3, target_concurrency + 2)  # Allows for simultaneous requests to fail
+        self._tim = TimeIntervalManager()
+        self.delay_intervals = {}
+        self.delay = {}
+        self.failover_lives = {}  # for each domain, keep track of the number of times the current time slot has failed.
+        self.rate_limit_reset_delay = {}
+        self.request_history = {}
+
+    def increase_min_delay(self, response, sent_at):
+        domain = self._get_domain(response)
+        time_slot = self.get_delay_interval(domain)
+
+        if self.failover_lives.get(domain, self.__initial_failover_lives__) <= 0:
+            # when failover lives reaches 0, increase the time interval from eg: n req per second -> x req per minute.
+            time_slot = self._increase_time_slot(domain, time_slot)
+        self.delay[domain] = self._compute_delay(sent_at, time_slot, self.request_history[domain])
+
+        # Then, because any more requests this time slot are likely to still be blocked...
+        self._set_special_delay(domain, sent_at, time_slot)
+        # reduce failover lives
+        self.failover_lives[domain] = self.failover_lives.get(domain, self.__initial_failover_lives__) - 1
+        logger.log(logging.INFO, "Decreasing request rate due to rate limit.\n" +
+                   "New rate: {}, {}".format(self.delay.get(domain)), time_slot.name)
+
+    def get_min_delay(self, response):
+        return self.delay.get(self._get_domain(response), 0)
+
+    def _compute_delay(self, sent_at, time_slot, history) -> float:
+
+        # 1. estimate the request rate -1.
+        # the sliding window formula makes an estimation assuming constant rate of requests in previous time slot
+        # for example 20 requests were made in the previous minute, 7 requests made in the current minute
+        # and we are 20 seconds into the current minute.
+        # so the estimation will be 20 * ((60 - 20) / 60)  = 20  * 2/3 = 13.2
+        # to this we add the number of requests made in the current minute.
+        # 13.2 + 7 => 20.2 requests per minute.
+        # We subtract 1 because the last request threw a rate limit error and we want to be below that rate.
+
+        wanted_rate = (history[0].previous_count *
+                       ((self._tim.get_parts(time_slot) - self._tim.get_time_part(sent_at, time_slot))
+                        / self._tim.get_parts(time_slot))) + history[0].current_count - 1
+
+        # 2. calculate delay required to achieve that rate.
+        return self._tim.get_seconds(time_slot) / wanted_rate
+
+    def _increase_time_slot(self, domain, current_time_slot) -> TimeInterval:
+        new_time_slot = self._tim.get_next_interval(current_time_slot)  # get the next logical time slot
+        self.delay_intervals[domain] = new_time_slot
+        # reset failover lives.
+        self.failover_lives[domain] = self.__initial_failover_lives__
+        return new_time_slot
+
+    def add_to_history(self, response, sent_at):
+        domain = self._get_domain(response)
+
+        if response.status == 200:  # only keep track of good requests because this works better.
+            if domain not in self.request_history.keys():
+                self.request_history[domain] = (SlidingWindow(TimeInterval.SECOND, sent_at),
+                                                SlidingWindow(TimeInterval.MINUTE, sent_at),
+                                                SlidingWindow(TimeInterval.HOUR, sent_at),
+                                                SlidingWindow(TimeInterval.DAY, sent_at))
+            else:
+                for struct in self.request_history[domain]:
+                    struct.add_request(sent_at)
+
+        return self.request_history[domain]
+
+    def _set_special_delay(self, domain, sent_at: datetime, time_slot: TimeInterval):
+        self.rate_limit_reset_delay[domain] = self._tim.get_seconds_until_end_of_interval(sent_at, time_slot)
+
+    def pop_special_delay(self, response):
+        return self.rate_limit_reset_delay.pop(self._get_domain(response), 0)
+
+    def get_delay_interval(self, domain):
+        return self.delay_intervals.get(domain, TimeInterval.SECOND)
+
+    @staticmethod
+    def _get_domain(response):
+        # is 1 api = 1 domain a fair assumption? Seems iffy. TODO:
+        return '/'.join(response.meta['url'].split('/')[:3])

--- a/tests/test_throttle.py
+++ b/tests/test_throttle.py
@@ -1,5 +1,6 @@
 import unittest
-from scrapy.extensions.throttle import TimeIntervalManager, TimeInterval, SlidingWindow, AutoThrottle429Handler
+from scrapy.extensions.throttle import TimeIntervalManager,\
+    TimeInterval, SlidingWindow, AutoThrottle429Handler
 from datetime import datetime, timedelta
 from typing import List
 from scrapy.http import Response
@@ -12,28 +13,39 @@ class TestAutothrottle429(unittest.TestCase):
 
     def test_min_delay_calculation(self):
         domain = 'https://test.some-domain.com'
-        req_sent_times = TestSlidingWindow.create_reqs(51)
-        for sent_at in req_sent_times[:len(req_sent_times)-1]:
+        req_sent_times = TestSlidingWindow._create_reqs(51)
+        for sent_at in req_sent_times[:len(req_sent_times) - 1]:
             self.handler.add_to_history(Response(domain),
                                         sent_at)
         bad_res = Response(domain, status=429)
         self.handler.add_to_history(bad_res, req_sent_times[-1])
         self.handler.increase_min_delay(bad_res, req_sent_times[-1])
         assert self.handler.get_min_delay(bad_res) == 1,\
-            "{} Estimated min delay is incorrect. Correct is: {}".format(self.handler.get_min_delay(bad_res), 1)
-        self.handler.add_to_history(bad_res, req_sent_times[-1] + timedelta(seconds=1))
-        self.handler.increase_min_delay(bad_res, req_sent_times[-1] + timedelta(seconds=1))
-        self.handler.add_to_history(bad_res, req_sent_times[-1] + timedelta(seconds=2))
-        self.handler.increase_min_delay(bad_res, req_sent_times[-1] + timedelta(seconds=2))
-        self.handler.add_to_history(bad_res, req_sent_times[-1] + timedelta(seconds=3))
-        self.handler.increase_min_delay(bad_res, req_sent_times[-1] + timedelta(seconds=3))
+            "{} Estimated min delay is incorrect. Correct is: {}"\
+                .format(self.handler.get_min_delay(bad_res), 1)
+        self.handler.add_to_history(bad_res, req_sent_times[-1]
+                                    + timedelta(seconds=1))
+        self.handler.increase_min_delay(bad_res, req_sent_times[-1]
+                                        + timedelta(seconds=1))
+        self.handler.add_to_history(bad_res, req_sent_times[-1]
+                                    + timedelta(seconds=2))
+        self.handler.increase_min_delay(bad_res, req_sent_times[-1]
+                                        + timedelta(seconds=2))
+        self.handler.add_to_history(bad_res, req_sent_times[-1]
+                                    + timedelta(seconds=3))
+        self.handler.increase_min_delay(bad_res, req_sent_times[-1]
+                                        + timedelta(seconds=3))
         assert self.handler.get_delay_interval(domain) == TimeInterval.MINUTE
         min_allowed_delay = 60 / (len(req_sent_times) - 1)
         assert self.handler.get_min_delay(bad_res) >= min_allowed_delay, \
-            "{} Estimated min delay is incorrect. Correct is: {}".format(self.handler.get_min_delay(bad_res), )
-        assert self.handler.get_min_delay(bad_res) <= min_allowed_delay * 1.1, \
-            "{} Forced delay is too long. Should be less than: {}".format(self.handler.get_min_delay(bad_res),
-                                                                          min_allowed_delay * 1.1)
+            "{} Estimated min delay is incorrect. Correct is: {}"\
+                .format(self.handler.get_min_delay(bad_res),
+                        min_allowed_delay)
+        assert self.handler.get_min_delay(bad_res) <= min_allowed_delay\
+            * 1.1,\
+            "{} Forced delay is too long. Should be less than: {}"\
+            .format(self.handler.get_min_delay(bad_res),
+                    min_allowed_delay * 1.1)
 
 
 class TestSlidingWindow(unittest.TestCase):
@@ -69,7 +81,8 @@ class TestSlidingWindow(unittest.TestCase):
 
     def _assert_all_current(self, interval, reqs):
         window = self._create_history(interval, reqs)
-        assert window.current_count == len(reqs), "{} not equal to {}".format(window.current_count, len(reqs))
+        assert window.current_count == len(reqs), "{} not equal to {}"\
+            .format(window.current_count, len(reqs))
 
     def _create_history(self, interval: TimeInterval, history: List[datetime]):
         window = SlidingWindow(interval, history[0])
@@ -78,23 +91,29 @@ class TestSlidingWindow(unittest.TestCase):
         return window
 
     @staticmethod
-    def create_reqs(length, day=1, hour=10, minute=13, second=5, increment=True) -> List[datetime]:
+    def _create_reqs(length, day=1, hour=10, minute=13, second=5, increment=True)\
+            -> List[datetime]:
         return [datetime(year=2020, month=3,
                          day=day, hour=hour, minute=minute,
-                         second=second) + timedelta(seconds=(i if increment else 0)) for i in range(length)]
+                         second=second)
+                + timedelta(seconds=(i if increment else 0))
+                for i in range(length)]
 
 
-class TimeIntervalManager(unittest.TestCase):
+class TestTimeIntervalManager(unittest.TestCase):
 
     def setUp(self) -> None:
         self._tim = TimeIntervalManager()
 
     def test_seconds_remaining(self):
-        d = datetime(year=2020, month=3, day=5, hour=10, minute=6, second=12)
-        assert 1 == self._tim.get_seconds_until_end_of_interval(d, TimeInterval.SECOND)
-        assert 48 == self._tim.get_seconds_until_end_of_interval(d, TimeInterval.MINUTE)
-        assert (53 * 60) + 48 == self._tim.get_seconds_until_end_of_interval(d, TimeInterval.HOUR)
-        assert (13 * 3600) + (53 * 60) + 48 == self._tim.get_seconds_until_end_of_interval(d, TimeInterval.DAY)
+        d = datetime(year=2020, month=3, day=5,
+                     hour=10, minute=6, second=12)
+        assert 1 == self._tim.get_seconds_until_end(d, TimeInterval.SECOND)
+        assert 48 == self._tim.get_seconds_until_end(d, TimeInterval.MINUTE)
+        assert (53 * 60) + 48 \
+            == self._tim.get_seconds_until_end(d, TimeInterval.HOUR)
+        assert (13 * 3600) + (53 * 60) + 48 \
+            == self._tim.get_seconds_until_end(d, TimeInterval.DAY)
 
 
 

--- a/tests/test_throttle.py
+++ b/tests/test_throttle.py
@@ -1,0 +1,100 @@
+import unittest
+from scrapy.extensions.throttle import TimeIntervalManager, TimeInterval, SlidingWindow, AutoThrottle429Handler
+from datetime import datetime, timedelta
+from typing import List
+from scrapy.http import Response
+
+
+class TestAutothrottle429(unittest.TestCase):
+
+    def setUp(self) -> None:
+        self.handler = AutoThrottle429Handler(1)
+
+    def test_min_delay_calculation(self):
+        domain = 'https://test.some-domain.com'
+        req_sent_times = TestSlidingWindow.create_reqs(51)
+        for sent_at in req_sent_times[:len(req_sent_times)-1]:
+            self.handler.add_to_history(Response(domain),
+                                        sent_at)
+        bad_res = Response(domain, status=429)
+        self.handler.add_to_history(bad_res, req_sent_times[-1])
+        self.handler.increase_min_delay(bad_res, req_sent_times[-1])
+        assert self.handler.get_min_delay(bad_res) == 1,\
+            "{} Estimated min delay is incorrect. Correct is: {}".format(self.handler.get_min_delay(bad_res), 1)
+        self.handler.add_to_history(bad_res, req_sent_times[-1] + timedelta(seconds=1))
+        self.handler.increase_min_delay(bad_res, req_sent_times[-1] + timedelta(seconds=1))
+        self.handler.add_to_history(bad_res, req_sent_times[-1] + timedelta(seconds=2))
+        self.handler.increase_min_delay(bad_res, req_sent_times[-1] + timedelta(seconds=2))
+        self.handler.add_to_history(bad_res, req_sent_times[-1] + timedelta(seconds=3))
+        self.handler.increase_min_delay(bad_res, req_sent_times[-1] + timedelta(seconds=3))
+        assert self.handler.get_delay_interval(domain) == TimeInterval.MINUTE
+        min_allowed_delay = 60 / (len(req_sent_times) - 1)
+        assert self.handler.get_min_delay(bad_res) >= min_allowed_delay, \
+            "{} Estimated min delay is incorrect. Correct is: {}".format(self.handler.get_min_delay(bad_res), )
+        assert self.handler.get_min_delay(bad_res) <= min_allowed_delay * 1.1, \
+            "{} Forced delay is too long. Should be less than: {}".format(self.handler.get_min_delay(bad_res),
+                                                                          min_allowed_delay * 1.1)
+
+
+class TestSlidingWindow(unittest.TestCase):
+
+    def test_same_interval_count_second(self):
+        reqs = self._create_reqs(5, increment=False)
+        window = self._create_history(TimeInterval.SECOND, reqs)
+        assert window.current_count == len(reqs)
+
+    def test_same_interval_count_minute_hour_day(self):
+        reqs = self._create_reqs(5, second=1)
+        self._assert_all_current(TimeInterval.MINUTE, reqs)
+        self._assert_all_current(TimeInterval.HOUR, reqs)
+        self._assert_all_current(TimeInterval.DAY, reqs)
+
+    def test_next_interval_count_second(self):
+        reqs = self._create_reqs(5, second=58)
+        window = self._create_history(TimeInterval.SECOND, reqs)
+        assert window.current_count == 1
+        assert window.previous_count == 1
+        window.add_request(reqs[-1] + timedelta(seconds=2))
+        assert window.current_count == 1
+        assert window.previous_count == 0
+
+    def test_next_interval_count_minute(self):
+        reqs = self._create_reqs(5, second=58)
+        window = self._create_history(TimeInterval.MINUTE, reqs)
+        assert window.current_count == 3
+        assert window.previous_count == 2
+        window.add_request(reqs[-1] + timedelta(minutes=2))
+        assert window.current_count == 1
+        assert window.previous_count == 0
+
+    def _assert_all_current(self, interval, reqs):
+        window = self._create_history(interval, reqs)
+        assert window.current_count == len(reqs), "{} not equal to {}".format(window.current_count, len(reqs))
+
+    def _create_history(self, interval: TimeInterval, history: List[datetime]):
+        window = SlidingWindow(interval, history[0])
+        for req in history[1:]:
+            window.add_request(req)
+        return window
+
+    @staticmethod
+    def create_reqs(length, day=1, hour=10, minute=13, second=5, increment=True) -> List[datetime]:
+        return [datetime(year=2020, month=3,
+                         day=day, hour=hour, minute=minute,
+                         second=second) + timedelta(seconds=(i if increment else 0)) for i in range(length)]
+
+
+class TimeIntervalManager(unittest.TestCase):
+
+    def setUp(self) -> None:
+        self._tim = TimeIntervalManager()
+
+    def test_seconds_remaining(self):
+        d = datetime(year=2020, month=3, day=5, hour=10, minute=6, second=12)
+        assert 1 == self._tim.get_seconds_until_end_of_interval(d, TimeInterval.SECOND)
+        assert 48 == self._tim.get_seconds_until_end_of_interval(d, TimeInterval.MINUTE)
+        assert (53 * 60) + 48 == self._tim.get_seconds_until_end_of_interval(d, TimeInterval.HOUR)
+        assert (13 * 3600) + (53 * 60) + 48 == self._tim.get_seconds_until_end_of_interval(d, TimeInterval.DAY)
+
+
+

--- a/tests/test_throttle.py
+++ b/tests/test_throttle.py
@@ -22,7 +22,7 @@ class TestAutothrottle429(unittest.TestCase):
         self.handler.increase_min_delay(bad_res, req_sent_times[-1])
         assert self.handler.get_min_delay(bad_res) == 1,\
             "{} Estimated min delay is incorrect. Correct is: {}"\
-                .format(self.handler.get_min_delay(bad_res), 1)
+            .format(self.handler.get_min_delay(bad_res), 1)
         self.handler.add_to_history(bad_res, req_sent_times[-1]
                                     + timedelta(seconds=1))
         self.handler.increase_min_delay(bad_res, req_sent_times[-1]
@@ -39,8 +39,8 @@ class TestAutothrottle429(unittest.TestCase):
         min_allowed_delay = 60 / (len(req_sent_times) - 1)
         assert self.handler.get_min_delay(bad_res) >= min_allowed_delay, \
             "{} Estimated min delay is incorrect. Correct is: {}"\
-                .format(self.handler.get_min_delay(bad_res),
-                        min_allowed_delay)
+            .format(self.handler.get_min_delay(bad_res),
+                    min_allowed_delay)
         assert self.handler.get_min_delay(bad_res) <= min_allowed_delay\
             * 1.1,\
             "{} Forced delay is too long. Should be less than: {}"\
@@ -91,8 +91,8 @@ class TestSlidingWindow(unittest.TestCase):
         return window
 
     @staticmethod
-    def _create_reqs(length, day=1, hour=10, minute=13, second=5, increment=True)\
-            -> List[datetime]:
+    def _create_reqs(length, day=1, hour=10, minute=13,
+                     second=5, increment=True) -> List[datetime]:
         return [datetime(year=2020, month=3,
                          day=day, hour=hour, minute=minute,
                          second=second)
@@ -114,6 +114,3 @@ class TestTimeIntervalManager(unittest.TestCase):
             == self._tim.get_seconds_until_end(d, TimeInterval.HOUR)
         assert (13 * 3600) + (53 * 60) + 48 \
             == self._tim.get_seconds_until_end(d, TimeInterval.DAY)
-
-
-


### PR DESCRIPTION
I've got a draft PR for #4424 .

The main idea is to try to estimate both the interval the API blocks requests at and the number of requests that trigger the limit.

There are 4 common intervals used for api rate limits that are considered here. Per second, Per Minute, Per Hour, Per Day (per month limits are unlikely to be fixed at the throttler level).

In implementing these there are 2 possible strategies that can be used to measure the time.

Fixed interval measurement. -> N requests per minute is measured for each minute, so theoretically you could have up to 2N requests within a 60 second interval without bad responses, if you started requests at 30s past the minute mark.
Measurement from first request time. -> I don't think this is very common, but the idea is that the clock starts on the first request, and from that time a time interval T is measured within which a maximum of N requests can be made.

This is still a work in progress, but do give me any feedback.

I'm also making the uncomfortable assumption that a rate limiting entity is bound to a domain
which is not actually true, (example.com/names and example.com/places may have different rate limits), 
Also as mentioned by @Gallaecio this is not going to work optimally when multiple slots are used on the same api / domain because i'm setting the delay at the slot level.

Fixes #4424.