### PR TITLE
Add a warning/error in case of incorrect gcs permissions

### DIFF
--- a/scrapy/pipelines/files.py
+++ b/scrapy/pipelines/files.py
@@ -229,6 +229,19 @@ class GCSFilesStore:
         bucket, prefix = uri[5:].split('/', 1)
         self.bucket = client.bucket(bucket)
         self.prefix = prefix
+        permissions = self.bucket.test_iam_permissions(
+            ['storage.objects.get', 'storage.objects.create']
+        )
+        if 'storage.objects.get' not in permissions:
+            logger.warning(
+                "No 'storage.objects.get' permission for GSC bucket %(bucket)s",
+                {'bucket': bucket}
+            )
+        if 'storage.objects.create' not in permissions:
+            logger.error(
+                "No 'storage.objects.create' permission for GSC bucket %(bucket)s. Saving files will be impossible!",
+                {'bucket': bucket}
+            )
 
     def stat_file(self, path, info):
         def _onsuccess(blob):

--- a/scrapy/pipelines/files.py
+++ b/scrapy/pipelines/files.py
@@ -234,8 +234,8 @@ class GCSFilesStore:
         )
         if 'storage.objects.get' not in permissions:
             logger.warning(
-                "No 'storage.objects.get' permission for GSC bucket %(bucket)s. \
-                Checking if files are up to date will be impossible. Files will be downloaded every time.",
+                "No 'storage.objects.get' permission for GSC bucket %(bucket)s. "
+                "Checking if files are up to date will be impossible. Files will be downloaded every time.",
                 {'bucket': bucket}
             )
         if 'storage.objects.create' not in permissions:

--- a/scrapy/pipelines/files.py
+++ b/scrapy/pipelines/files.py
@@ -234,7 +234,8 @@ class GCSFilesStore:
         )
         if 'storage.objects.get' not in permissions:
             logger.warning(
-                "No 'storage.objects.get' permission for GSC bucket %(bucket)s",
+                "No 'storage.objects.get' permission for GSC bucket %(bucket)s. \
+                Checking if files are up to date will be impossible. Files will be downloaded every time.",
                 {'bucket': bucket}
             )
         if 'storage.objects.create' not in permissions:


### PR DESCRIPTION
Added a warning in case of lack of read access to GCS bucket used with `FilePipeline` and error in case of lack of write access (as it makes it impossible to upload files). Incorrect GCS permissions could be the cause of a problem described in #4346 .