### PR TITLE
Travis CI: do not run security and Flake8 on multiple jobs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,14 +15,17 @@ matrix:
       python: 3.7  # Keep in sync with .readthedocs.yml
 
     - env: TOXENV=pypy3
-    - python: 3.5
+    - env: TOXENV=py
+      python: 3.5
     - env: TOXENV=pinned
       python: 3.5
     - env: TOXENV=asyncio
       python: 3.5.2
-    - python: 3.6
-    - python: 3.7
-    - env: PYPI_RELEASE_JOB=true
+    - env: TOXENV=py
+      python: 3.6
+    - env: TOXENV=py
+      python: 3.7
+    - env: TOXENV=py PYPI_RELEASE_JOB=true
       python: 3.8
     - env: TOXENV=extra-deps
       python: 3.8

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = security,flake8,py3
+envlist = security,flake8,py
 minversion = 1.7.0
 
 [testenv]


### PR DESCRIPTION
I did not realize that, due to https://github.com/scrapy/scrapy/commit/fc3af54dbd5b7fdcbc44c82ba4ced528a104cd88#diff-b91f3d5bd63fcd17221b267e851608e8R7, removing TOXENV from Travis CI entries would cause security and Flake8 checks to be run in those jobs as well.