### PR TITLE
Pickle: use protocol 4, update tests

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -166,6 +166,7 @@ flake8-ignore =
     scrapy/signalmanager.py E501
     scrapy/spiderloader.py F841 E501 E126
     scrapy/squeues.py E128
+    scrapy/squeues.py E501
     scrapy/statscollectors.py E501
     # tests
     tests/__init__.py E402 E501

--- a/scrapy/exporters.py
+++ b/scrapy/exporters.py
@@ -250,7 +250,7 @@ class CsvItemExporter(BaseItemExporter):
 
 class PickleItemExporter(BaseItemExporter):
 
-    def __init__(self, file, protocol=2, **kwargs):
+    def __init__(self, file, protocol=4, **kwargs):
         super().__init__(**kwargs)
         self.file = file
         self.protocol = protocol

--- a/scrapy/extensions/httpcache.py
+++ b/scrapy/extensions/httpcache.py
@@ -250,7 +250,7 @@ class DbmCacheStorage:
             'headers': dict(response.headers),
             'body': response.body,
         }
-        self.db['%s_data' % key] = pickle.dumps(data, protocol=2)
+        self.db['%s_data' % key] = pickle.dumps(data, protocol=4)
         self.db['%s_time' % key] = str(time())
 
     def _read_data(self, spider, request):
@@ -317,7 +317,7 @@ class FilesystemCacheStorage:
         with self._open(os.path.join(rpath, 'meta'), 'wb') as f:
             f.write(to_bytes(repr(metadata)))
         with self._open(os.path.join(rpath, 'pickled_meta'), 'wb') as f:
-            pickle.dump(metadata, f, protocol=2)
+            pickle.dump(metadata, f, protocol=4)
         with self._open(os.path.join(rpath, 'response_headers'), 'wb') as f:
             f.write(headers_dict_to_raw(response.headers))
         with self._open(os.path.join(rpath, 'response_body'), 'wb') as f:

--- a/scrapy/extensions/spiderstate.py
+++ b/scrapy/extensions/spiderstate.py
@@ -26,7 +26,7 @@ class SpiderState:
     def spider_closed(self, spider):
         if self.jobdir:
             with open(self.statefn, 'wb') as f:
-                pickle.dump(spider.state, f, protocol=2)
+                pickle.dump(spider.state, f, protocol=4)
 
     def spider_opened(self, spider):
         if self.jobdir and os.path.exists(self.statefn):

--- a/scrapy/squeues.py
+++ b/scrapy/squeues.py
@@ -81,7 +81,7 @@ def _scrapy_non_serialization_queue(queue_class):
 
 def _pickle_serialize(obj):
     try:
-        return pickle.dumps(obj, protocol=2)
+        return pickle.dumps(obj, protocol=4)
     # Python <= 3.4 raises pickle.PicklingError here while
     # 3.5 <= Python < 3.6 raises AttributeError and
     # Python >= 3.6 raises TypeError

--- a/scrapy/squeues.py
+++ b/scrapy/squeues.py
@@ -82,11 +82,10 @@ def _scrapy_non_serialization_queue(queue_class):
 def _pickle_serialize(obj):
     try:
         return pickle.dumps(obj, protocol=4)
-    # Python <= 3.4 raises pickle.PicklingError here while
-    # 3.5 <= Python < 3.6 raises AttributeError and
-    # Python >= 3.6 raises TypeError
+    # Both pickle.PicklingError and AttributeError can be raised by pickle.dump(s)
+    # TypeError is raised from parsel.Selector
     except (pickle.PicklingError, AttributeError, TypeError) as e:
-        raise ValueError(str(e))
+        raise ValueError(str(e)) from e
 
 
 PickleFifoDiskQueueNonRequest = _serializable_queue(

--- a/tests/test_squeues.py
+++ b/tests/test_squeues.py
@@ -47,12 +47,7 @@ def nonserializable_object_test(self):
     self.assertRaises(ValueError, q.push, sel)
 
 
-class MarshalFifoDiskQueueTest(t.FifoDiskQueueTest):
-
-    chunksize = 100000
-
-    def queue(self):
-        return MarshalFifoDiskQueue(self.qpath, chunksize=self.chunksize)
+class FifoDiskQueueTestMixin:
 
     def test_serialize(self):
         q = self.queue()
@@ -64,6 +59,13 @@ class MarshalFifoDiskQueueTest(t.FifoDiskQueueTest):
         self.assertEqual(q.pop(), {'a': 'dict'})
 
     test_nonserializable_object = nonserializable_object_test
+
+
+class MarshalFifoDiskQueueTest(t.FifoDiskQueueTest, FifoDiskQueueTestMixin):
+    chunksize = 100000
+
+    def queue(self):
+        return MarshalFifoDiskQueue(self.qpath, chunksize=self.chunksize)
 
 
 class ChunkSize1MarshalFifoDiskQueueTest(MarshalFifoDiskQueueTest):
@@ -82,7 +84,7 @@ class ChunkSize4MarshalFifoDiskQueueTest(MarshalFifoDiskQueueTest):
     chunksize = 4
 
 
-class PickleFifoDiskQueueTest(MarshalFifoDiskQueueTest):
+class PickleFifoDiskQueueTest(t.FifoDiskQueueTest, FifoDiskQueueTestMixin):
 
     chunksize = 100000
 
@@ -133,10 +135,7 @@ class ChunkSize4PickleFifoDiskQueueTest(PickleFifoDiskQueueTest):
     chunksize = 4
 
 
-class MarshalLifoDiskQueueTest(t.LifoDiskQueueTest):
-
-    def queue(self):
-        return MarshalLifoDiskQueue(self.qpath)
+class LifoDiskQueueTestMixin:
 
     def test_serialize(self):
         q = self.queue()
@@ -150,7 +149,13 @@ class MarshalLifoDiskQueueTest(t.LifoDiskQueueTest):
     test_nonserializable_object = nonserializable_object_test
 
 
-class PickleLifoDiskQueueTest(MarshalLifoDiskQueueTest):
+class MarshalLifoDiskQueueTest(t.LifoDiskQueueTest, LifoDiskQueueTestMixin):
+
+    def queue(self):
+        return MarshalLifoDiskQueue(self.qpath)
+
+
+class PickleLifoDiskQueueTest(t.LifoDiskQueueTest, LifoDiskQueueTestMixin):
 
     def queue(self):
         return PickleLifoDiskQueue(self.qpath)

--- a/tests/test_squeues.py
+++ b/tests/test_squeues.py
@@ -1,5 +1,3 @@
-import pickle
-
 from queuelib.tests import test_queue as t
 from scrapy.squeues import (
     MarshalFifoDiskQueueNonRequest as MarshalFifoDiskQueue,

--- a/tests/test_squeues.py
+++ b/tests/test_squeues.py
@@ -1,3 +1,6 @@
+import pickle
+import sys
+
 from queuelib.tests import test_queue as t
 from scrapy.squeues import (
     MarshalFifoDiskQueueNonRequest as MarshalFifoDiskQueue,
@@ -108,8 +111,10 @@ class PickleFifoDiskQueueTest(t.FifoDiskQueueTest, FifoDiskQueueTestMixin):
         try:
             q.push(lambda x: x)
         except ValueError as exc:
-            self.assertIsInstance(exc.__context__, AttributeError)
-
+            if hasattr(sys, "pypy_version_info"):
+                self.assertIsInstance(exc.__context__, pickle.PicklingError)
+            else:
+                self.assertIsInstance(exc.__context__, AttributeError)
         sel = Selector(text='<html><body><p>some text</p></body></html>')
         try:
             q.push(sel)


### PR DESCRIPTION
Fixes #4135

I started by adding a `PICKLE_PROTOCOL` setting, but that didn't work well with `scrapy.squeues._pickle_serialize` because it's defined as a top level function. There is probably a way around that, I just didn't think it was worth the trouble.

I simplified the testing of unserializable objects, since https://twistedmatrix.com/trac/ticket/7989 only affects py2 AFAICT.

A simple and non-rigorous benchmark shows a performance improvement of about 10%:

```python
from tempfile import mkdtemp
from scrapy import Request
from scrapy.utils.test import get_crawler
from scrapy.squeues import PickleFifoDiskQueue

def test(request_count):
    jobdir = mkdtemp()
    crawler = get_crawler(settings_dict={"JOBDIR": jobdir})
    queue = PickleFifoDiskQueue(crawler, jobdir)
    for i in range(request_count):
        queue.push(Request("https://example.org/{}".format(i)))
```

Protocol 2 (3878b67a3771102d4b6668ac749afbec7dc85a8f):
```python
In [2]: %timeit -n 10 test(10**5)                                                                                                                                                                                                             
7.63 s ± 75.1 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)
```

Protocol 4:
```python
In [2]: %timeit -n 10 test(10**5)                                                                                                                                                                                                             
6.87 s ± 11.5 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)
```

Additionally, I reworded the comment about `pickle.PicklingError` being raised in Python <= 3.4. We no longer support 3.4, but I think we should keep catching `pickle.PicklingError` since it's raised when trying to pickle a `lambda` function in 3.5 <= Python <= 3.8. For the record, the test actually raises `AttributeError("Can't pickle local object 'PickleFifoDiskQueueTest.test_non_pickable_object.<locals>.<lambda>'")` in CPython, but `pickle.PicklingError` is raised in `pypy`.
