### PR TITLE
test(spiderloader): no duplicate spider names

### DIFF
--- a/tests/test_spiderloader/__init__.py
+++ b/tests/test_spiderloader/__init__.py
@@ -137,6 +137,11 @@ class DuplicateSpiderNameLoaderTest(unittest.TestCase):
             msg = str(w[0].message)
             self.assertIn("several spiders with the same name", msg)
             self.assertIn("'spider3'", msg)
+            self.assertTrue(msg.count("'spider3'") == 2)
+
+            self.assertNotIn("'spider1'", msg)
+            self.assertNotIn("'spider2'", msg)
+            self.assertNotIn("'spider4'", msg)
 
             spiders = set(spider_loader.list())
             self.assertEqual(spiders, set(['spider1', 'spider2', 'spider3', 'spider4']))
@@ -156,7 +161,13 @@ class DuplicateSpiderNameLoaderTest(unittest.TestCase):
             msg = str(w[0].message)
             self.assertIn("several spiders with the same name", msg)
             self.assertIn("'spider1'", msg)
+            self.assertTrue(msg.count("'spider1'") == 2)
+
             self.assertIn("'spider2'", msg)
+            self.assertTrue(msg.count("'spider2'") == 2)
+
+            self.assertNotIn("'spider3'", msg)
+            self.assertNotIn("'spider4'", msg)
 
             spiders = set(spider_loader.list())
             self.assertEqual(spiders, set(['spider1', 'spider2', 'spider3', 'spider4']))


### PR DESCRIPTION
Removal of [Line-31](https://github.com/scrapy/scrapy/commit/4c12a234ae65d49678a9840708ff5e7b9d6dcecc#diff-04eeb72b0ac2a03d00f2b1dcc3268ebcL31) in 4c12a234ae65d49678a9840708ff5e7b9d6dcecc do not fail the tests. If we update the tests to check that
1. The number of occurence in the warning should be 2
2. Spider classes not having duplicate names do not show in warning

The tests will fail for 4c12a234ae65d49678a9840708ff5e7b9d6dcecc

Fixes #4549 