### PR TITLE
Extend hoverxref_roles to custom crossrefs (#4495)

### DIFF
--- a/docs/README.rst
+++ b/docs/README.rst
@@ -57,3 +57,12 @@ There is a way to recreate the doc automatically when you make changes, you
 need to install watchdog (``pip install watchdog``) and then use::
 
     make watch
+
+Alternative method using tox
+----------------------------
+
+To compile the documentation to HTML run the following command::
+
+    tox -e docs
+
+Documentation will be generated (in HTML format) inside the ``.tox/docs/tmp/html`` dir.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -300,3 +300,4 @@ hoverxref_role_types = {
     "mod": "tooltip",
     "ref": "tooltip",
 }
+hoverxref_roles = ['command', 'reqmeta', 'setting', 'signal']


### PR DESCRIPTION
Additionally, I think the documentation in docs/README.rst is out
of date: none of the commands built the docs properly for me (I had to
revert the changes in 901892da to docs/conf.py to get them to build
properly, and even then no tooltips displayed).

Building them with tox worked for me, but other developers say they
can still use the original method, so the docs now contain both.

Fixes #4495.