### PR TITLE
better deprecation warning for Response.body_as_unicode()

### DIFF
--- a/scrapy/http/response/text.py
+++ b/scrapy/http/response/text.py
@@ -65,7 +65,7 @@ class TextResponse(Response):
         """Return body as unicode"""
         warnings.warn('Response.body_as_unicode() is deprecated, '
                       'please use Response.text instead.',
-                      ScrapyDeprecationWarning)
+                      ScrapyDeprecationWarning, stacklevel=2)
         return self.text
 
     @property


### PR DESCRIPTION
A follow-up to #4555.
In Scrapy master the following warning is logged:

```
[py.warnings] WARNING: /Users/kmike/envs/foo/lib/python3.8/site-packages/scrapy/http/response/text.py:66: ScrapyDeprecationWarning: Response.body_as_unicode() is deprecated, please use Response.text instead.
  warnings.warn('Response.body_as_unicode() is deprecated, '
```

It is not easily actionable because it doesn't point to the user code; it is unclear where the problem is actually happening. Adding stacklevel=2 fixes it:

```
[py.warnings] WARNING: /Users/kmike/svn/myspider/foo/bar/spiders/newsmonitor.py:53: ScrapyDeprecationWarning: Response.body_as_unicode() is deprecated, please use Response.text instead.
  print(response.body_as_unicode())
```