### PR TITLE
Update tutorial.rst

### DIFF
--- a/docs/intro/tutorial.rst
+++ b/docs/intro/tutorial.rst
@@ -93,14 +93,18 @@ This is the code for our first Spider. Save it in a file named
 
         def start_requests(self):
             urls = [
-                'http://quotes.toscrape.com/page/1/',
+                'http://quotes.toscrape.com/',
                 'http://quotes.toscrape.com/page/2/',
             ]
             for url in urls:
                 yield scrapy.Request(url=url, callback=self.parse)
 
         def parse(self, response):
-            page = response.url.split("/")[-2]
+            page = 0
+            if (response.url.split("/")[-2].isnumeric()):
+                page  = response.url.split("/")[-2]
+            else:
+                page = 1
             filename = 'quotes-%s.html' % page
             with open(filename, 'wb') as f:
                 f.write(response.body)


### PR DESCRIPTION
Description

https://docs.scrapy.org/en/latest/intro/tutorial.html
The document for scrapy tutorial contains invalid links to the 'http://quotes.toscrape.com' page
The code given under the title 'Our first Spider' contains the link 'http://quotes.toscrape.com/page/1/', since the page 'http://quotes.toscrape.com/page/1/', one gets back a response code 404.

Suggestion:
To fix we can simply edit out 'http://quotes.toscrape.com/page/1/' or we can add links to page2 and page3 of 'http://quotes.toscrape.com' website