### PR TITLE
Make doc downloadable on ReadTheDocs.org

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,4 +1,5 @@
 version: 2
+formats: all
 sphinx:
   configuration: docs/conf.py
   fail_on_warning: true

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -100,6 +100,9 @@ exclude_trees = ['.build']
 # The name of the Pygments (syntax highlighting) style to use.
 pygments_style = 'sphinx'
 
+# List of Sphinx warnings that will not be raised
+suppress_warnings = ['epub.unknown_project_files']
+
 
 # Options for HTML output
 # -----------------------


### PR DESCRIPTION
FIxes #4578 

From 2.0.0 on, a .readthedocs.yml config file was added but there was no line specifying that a downloadable version should be built.  It is now set to build "all" formats, which means pdf, epub and zipped html.

When I first tested it on readthedocs.org the following warning was raised during the epub creation :
`WARNING: unknown mimetype for _static/selectors-sample1.html, ignoring`
This is expected since sphinx does not parse HTML natively, and actually it never parses it, only quotes it literally in the doc, so it _should_ be ignored.  However .readthedocs.yml is set to fail on sphinx warnings. Sphinx issue [3214](https://github.com/sphinx-doc/sphinx/issues/3214) suggests a way to mute only this type of warning, which I find preferable as opposed to let readthedocs.org build projects with potentially more serious warnings.

I wouldn't know how to integrate those two lines in automated testing but [here](https://readthedocs.org/projects/scrapy-doctest/downloads/)'s a downloadable version of the doc created with those settings, with the [associated build](https://readthedocs.org/projects/scrapy-doctest/builds/11069214/).