### PR TITLE
Fix KeyError in LocalWeakReferencedCache

### DIFF
--- a/scrapy/utils/datatypes.py
+++ b/scrapy/utils/datatypes.py
@@ -105,8 +105,8 @@ class LocalWeakReferencedCache(weakref.WeakKeyDictionary):
     def __getitem__(self, key):
         try:
             return super(LocalWeakReferencedCache, self).__getitem__(key)
-        except TypeError:
-            return None  # key is not weak-referenceable, it's not cached
+        except (TypeError, KeyError):
+            return None  # key is either not weak-referenceable or not cached
 
 
 class SequenceExclude:

--- a/tests/test_utils_datatypes.py
+++ b/tests/test_utils_datatypes.py
@@ -271,6 +271,7 @@ class LocalWeakReferencedCacheTest(unittest.TestCase):
         self.assertNotIn(r1, cache)
         self.assertIn(r2, cache)
         self.assertIn(r3, cache)
+        self.assertEqual(cache[r1], None)
         self.assertEqual(cache[r2], 2)
         self.assertEqual(cache[r3], 3)
         del r2


### PR DESCRIPTION
Fixes #4597

`LocalWeakReferencedCache` uses a `LocalCache` object, which is size-limited, to store references. However, in this case the limit is set to `None`, so I'm not sure that's the issue. Another theory is that somehow all strong references to the key object, which is a spider callback, got deleted and so Python itself deleted the key (from the [upstream implementation](https://github.com/python/cpython/blob/v3.8.3/Lib/weakref.py#L332-L341), "_Entries in the dictionary will be discarded when there is no longer a strong reference to the key_"), but that wouldn't make much sense because the key does exist when trying to access it.

In any case, the key is not available so we are better off catching the `KeyError`.

`LocalWeakReferencedCache` is only used to warn in case of generators with non-None return values (#3869), which is definitely not critical so it shouldn't be causing exceptions like this.

Without catching the `KeyError`, the added test line fails like in the original issue:
```
================================================================================================================== FAILURES ==================================================================================================================
_____________________________________________________________________________________________ LocalWeakReferencedCacheTest.test_cache_with_limit _____________________________________________________________________________________________

self = <tests.test_utils_datatypes.LocalWeakReferencedCacheTest testMethod=test_cache_with_limit>

    def test_cache_with_limit(self):
        cache = LocalWeakReferencedCache(limit=2)
        r1 = Request('https://example.org')
        r2 = Request('https://example.com')
        r3 = Request('https://example.net')
        cache[r1] = 1
        cache[r2] = 2
        cache[r3] = 3
        self.assertEqual(len(cache), 2)
        self.assertNotIn(r1, cache)
        self.assertIn(r2, cache)
        self.assertIn(r3, cache)
>       self.assertEqual(cache[r1], None)

/.../scrapy/tests/test_utils_datatypes.py:274: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
/.../scrapy/scrapy/utils/datatypes.py:107: in __getitem__
    return super(LocalWeakReferencedCache, self).__getitem__(key)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <LocalWeakReferencedCache at 0x7f6710a13b90>, key = <GET https://example.org>

    def __getitem__(self, key):
>       return self.data[ref(key)]
E       KeyError: <weakref at 0x7f67109ab4d0; to 'Request' at 0x7f6710a13b10>

/usr/local/lib/python3.7/weakref.py:396: KeyError
```