### PR TITLE
give write access to template files after copying with startproject

### DIFF
--- a/scrapy/commands/startproject.py
+++ b/scrapy/commands/startproject.py
@@ -79,6 +79,7 @@ class Command(ScrapyCommand):
             else:
                 copy2(srcname, dstname)
         copystat(src, dst)
+        self._set_rw_permissions(dst)
 
     def _set_rw_permissions(self, path):
         """
@@ -122,8 +123,6 @@ class Command(ScrapyCommand):
             return
 
         self._copytree(self.templates_dir, abspath(project_dir))
-
-        self._set_rw_permissions(abspath(project_dir))
 
         move(join(project_dir, 'module'), join(project_dir, project_name))
         for paths in TEMPLATES_TO_RENDER:

--- a/scrapy/commands/startproject.py
+++ b/scrapy/commands/startproject.py
@@ -1,10 +1,10 @@
 import re
 import os
+import stat
 import string
 from importlib import import_module
 from os.path import join, exists, abspath
 from shutil import ignore_patterns, move, copy2, copystat
-import stat
 
 import scrapy
 from scrapy.commands import ScrapyCommand
@@ -123,7 +123,6 @@ class Command(ScrapyCommand):
             return
 
         self._copytree(self.templates_dir, abspath(project_dir))
-
         move(join(project_dir, 'module'), join(project_dir, project_name))
         for paths in TEMPLATES_TO_RENDER:
             path = join(*paths)


### PR DESCRIPTION
`scrapy startproject myproject` fails with permission denied if the original template permissions are read-only. This is the case on nix-based systems that ensure that installed libraries are immutable. I am not sure what the best place is to put these permissions but here is a quick fix.