### PR TITLE
Improve support for external request queues

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -229,6 +229,7 @@ Extending Scrapy
    topics/api
    topics/signals
    topics/exporters
+   topics/queues
 
 
 :doc:`topics/architecture`
@@ -251,6 +252,9 @@ Extending Scrapy
 
 :doc:`topics/exporters`
     Quickly export your scraped items to a file (XML, CSV, etc).
+
+:doc:`topics/queues`
+    Store requests in an external queue.
 
 
 All the rest

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -229,7 +229,7 @@ Extending Scrapy
    topics/api
    topics/signals
    topics/exporters
-   topics/queues
+   topics/request-queues
 
 
 :doc:`topics/architecture`
@@ -253,8 +253,8 @@ Extending Scrapy
 :doc:`topics/exporters`
     Quickly export your scraped items to a file (XML, CSV, etc).
 
-:doc:`topics/queues`
-    Store requests in an external queue.
+:doc:`topics/request-queues`
+    Customizing the queuing of requests.
 
 
 All the rest

--- a/docs/topics/jobs.rst
+++ b/docs/topics/jobs.rst
@@ -17,6 +17,8 @@ facilities:
 * an extension that keeps some spider state (key/value pairs) persistent
   between batches
 
+.. _jobs-job-directory:
+
 Job directory
 =============
 

--- a/docs/topics/queues.rst
+++ b/docs/topics/queues.rst
@@ -1,0 +1,83 @@
+.. _topics-queues:
+
+======
+Queues
+======
+
+Scrapy uses queues to schedule requests. By default, a memory-based queue is
+used but if :ref:`crawls should be paused and resumed <topics-jobs>` or more
+requests than fit in memory are scheduled, using an external queue (disk
+queue) is necessary. The setting :setting:`SCHEDULER_DISK_QUEUE` determines
+the type of disk queue that will be used by the scheduler.
+
+If you want to use your own disk queue implementation, it has to conform to
+the following interface:
+
+.. class:: MyExternalQueue
+
+   .. classmethod:: from_crawler(cls, crawler, key)
+
+      Creates a new queue object based on ``crawler`` and ``key``.
+
+      This factory method receives the ``crawler`` argument to access the
+      crawler's settings and the ``key`` argument which identifies the queue.
+      The class method creates and returns a queue object based on the
+      arguments.
+
+      The method is expected to verify the arguments and the relevant settings
+      and raise an exception in case of an error. This may involve opening
+      a connection to a remote service.
+
+      .. note::
+         In case an exception is raised, the crawling process is halted.
+
+      :raises Exception: If ``key`` or a queue-specific setting is invalid.
+
+   .. method:: push(self, request)
+
+      Pushes a request to the queue.
+
+      The helper function :meth:`~scrapy.utils.reqser.request_to_dict` can be
+      used to convert the request to a dict which can then be easily
+      serialized with, for example, :meth:`pickle.dumps`.
+
+      The scheduler will fall back to the memory queue (for this particular
+      request) in case of a :exc:`TransientError` or a :exc:`ValueError`. In
+      case of any other exception the crawling process is halted.
+
+      :raises TransientError: If pushing to the queue failed due to a
+          temporary error (e.g. the connection was dropped).
+      :raises ValueError: If pushing to the queue failed because the request
+          could not be serialized.
+
+   .. method:: pop(self)
+
+      Pops a request from the queue. In case of a temporary problem, ``None``
+      is returned.
+
+      The helper function :meth:`~scrapy.utils.reqser.request_from_dict` can
+      be used to convert the deserialized dict back to a request.
+
+      It is up to the queue implementation to decide if the most recently
+      pushed value (LIFO) or the least recently pushed value (FIFO) is
+      returned.
+
+      .. note::
+         In case of a temporary error, the method must not raise an exception
+         but return ``None`` instead.
+
+   .. method:: close(self)
+
+      Releases internal resources (e.g. closes a file or socket).
+
+   .. method:: __len__(self)
+
+      Returns the number of elements in the queue.
+
+      If the number of elements cannot be determined (e.g. because of a
+      connection problem), the method must not return 0 because this would
+      cause the queue to be closed.
+
+      .. note::
+         In case of a temporary error, the method must not raise an exception
+         but return the number of elements instead.

--- a/docs/topics/queues.rst
+++ b/docs/topics/queues.rst
@@ -42,13 +42,14 @@ the following interface:
       serialized with, for example, :meth:`pickle.dumps`.
 
       The scheduler will fall back to the memory queue (for this particular
-      request) in case of a :exc:`TransientError` or a :exc:`ValueError`. In
-      case of any other exception the crawling process is halted.
+      request) in case of a :exc:`TransientError` or a
+      :exc:`SerializationError`. In case of any other exception the crawling
+      process is halted.
 
       :raises TransientError: If pushing to the queue failed due to a
           temporary error (e.g. the connection was dropped).
-      :raises ValueError: If pushing to the queue failed because the request
-          could not be serialized.
+      :raises SerializationError: If pushing to the queue failed because the
+          request could not be serialized.
 
    .. method:: pop(self)
 

--- a/docs/topics/request-queues.rst
+++ b/docs/topics/request-queues.rst
@@ -1,8 +1,8 @@
-.. _topics-queues:
+.. _topics-request-queues:
 
-======
-Queues
-======
+==============
+Request Queues
+==============
 
 Scrapy uses queues to schedule requests. By default, a memory-based queue is
 used but if :ref:`crawls should be paused and resumed <topics-jobs>` or more

--- a/docs/topics/request-queues.rst
+++ b/docs/topics/request-queues.rst
@@ -47,8 +47,8 @@ is ``'scrapy.squeues.LifoMemoryQueue'``.
 Disk queue
 ----------
 
-Disk queues allow :ref:`crawls to be paused and resumed <topics-jobs>` and more
-requests than fit in memory can be scheduled. The default for
+With disk queues it is possible to :ref:`pause and resume crawls <topics-jobs>`
+and schedule more requests than fit in memory. The default for
 :setting:`SCHEDULER_DISK_QUEUE` is ``'scrapy.squeues.PickleLifoDiskQueue'``.
 
 Disk queues serialize requests, e.g. using :meth:`pickle.serialize`. If

--- a/docs/topics/request-queues.rst
+++ b/docs/topics/request-queues.rst
@@ -4,11 +4,51 @@
 Request Queues
 ==============
 
-Scrapy uses queues to schedule requests. By default, a memory-based queue is
-used but if :ref:`crawls should be paused and resumed <topics-jobs>` or more
-requests than fit in memory are scheduled, using an external queue (disk
-queue) is necessary. The setting :setting:`SCHEDULER_DISK_QUEUE` determines
-the type of disk queue that will be used by the scheduler.
+Scrapy uses queues to store requests and to decide what request to schedule
+next. The scheduler does not use a specific queue implementation (called
+*downstream queue*) directly but instead the downstream queue is wrapped by a
+priority queue.
+
+Priority Queues
+===============
+
+Priority queues make sure that requests with the highest priority are scheduled
+first. For this purpose, a priority queue uses multiple downstream queues---one
+for each priority. The setting :setting:`SCHEDULER_PRIORITY_QUEUE` determines
+the type of priority queue that will be used by the scheduler.
+
+Scrapy comes with two priority queue implementations:
+
+  * ``'scrapy.pqueues.ScrapyPriorityQueue'``
+  * ``'scrapy.pqueues.DownloaderAwarePriorityQueue'``
+
+The default priority queue is ``'scrapy.pqueues.ScrapyPriorityQueue'`` and works
+best during single-domain crawls (see also
+:ref:`broad-crawls-scheduler-priority-queue`). For crawling multiple different
+domains in parallel the recommended priority queue is
+``'scrapy.pqueues.DownloaderAwarePriorityQueue'``. This priority queue takes
+downloader activity into account: Domains with the least amount of active
+downloads are dequeued first.
+
+Downstream Queues
+=================
+
+By default, the scheduler uses a memory-based queue as a downstream queue but if
+:ref:`crawls should be paused and resumed <topics-jobs>` or more requests than
+fit in memory are scheduled, using an external queue (disk queue) is necessary.
+The setting :setting:`SCHEDULER_DISK_QUEUE` determines the type of disk queue
+that will be used by the scheduler. It is
+``'scrapy.squeues.PickleLifoDiskQueue'`` by default. To enable the use of disk
+queues, the :setting:`JOBDIR` setting has to be defined (see also
+:ref:`jobs-job-directory`).
+
+.. note::
+
+    If :setting:`JOBDIR` is undefined, the scheduler uses a memory-based queue
+    regardless of how :setting:`SCHEDULER_DISK_QUEUE` is configured.
+
+Interface
+---------
 
 If you want to use your own disk queue implementation, it has to conform to
 the following interface:

--- a/docs/topics/request-queues.rst
+++ b/docs/topics/request-queues.rst
@@ -33,9 +33,10 @@ downloads are dequeued first.
 Downstream Queues
 =================
 
-Scrapy differentiates between two types of downstream queues: memory queues and
-disk queues. If the :setting:`JOBDIR` setting is defined, a disk queue is used.
-If it is not defined, a memory queue is used (this is the default).
+Scrapy differentiates between two types of downstream queues (the data
+structures that hold the actual data): memory queues and disk queues. If the
+:setting:`JOBDIR` setting is defined, a disk queue is used.  If it is not
+defined, a memory queue is used (this is the default).
 
 Memory queue
 ------------
@@ -105,8 +106,10 @@ the following interface:
 
    .. method:: pop(self)
 
-      Pops a request from the queue. In case of a temporary problem, ``None``
-      is returned.
+      Pops a request from the queue.
+
+      In case of a temporary problem, ``None`` is returned. In all other cases,
+      an exception is raised.
 
       The helper function :meth:`~scrapy.utils.reqser.request_from_dict` can
       be used to convert the deserialized dict back to a request.
@@ -117,7 +120,8 @@ the following interface:
 
       .. note::
          In case of a temporary error, the method must not raise an exception
-         but return ``None`` instead.
+         but return ``None`` instead. If an exception is raised, the crawling
+         process is halted.
 
    .. method:: close(self)
 

--- a/docs/topics/request-queues.rst
+++ b/docs/topics/request-queues.rst
@@ -33,19 +33,31 @@ downloads are dequeued first.
 Downstream Queues
 =================
 
-By default, the scheduler uses a memory-based queue as a downstream queue but if
-:ref:`crawls should be paused and resumed <topics-jobs>` or more requests than
-fit in memory are scheduled, using an external queue (disk queue) is necessary.
-The setting :setting:`SCHEDULER_DISK_QUEUE` determines the type of disk queue
-that will be used by the scheduler. It is
-``'scrapy.squeues.PickleLifoDiskQueue'`` by default. To enable the use of disk
-queues, the :setting:`JOBDIR` setting has to be defined (see also
-:ref:`jobs-job-directory`).
+Scrapy differentiates between two types of downstream queues: memory queues and
+disk queues. If the :setting:`JOBDIR` setting is defined, a disk queue is used.
+If it is not defined, a memory queue is used (this is the default).
+
+Memory queue
+------------
+
+Memory queues do not require additional configuration or additional storage and
+are therefore used by default. The default for :setting:`SCHEDULER_MEMORY_QUEUE`
+is ``'scrapy.squeues.LifoMemoryQueue'``.
+
+Disk queue
+----------
+
+Disk queues allow :ref:`crawls to be paused and resumed <topics-jobs>` and more
+requests than fit in memory can be scheduled. The default for
+:setting:`SCHEDULER_DISK_QUEUE` is ``'scrapy.squeues.PickleLifoDiskQueue'``.
+
+Disk queues serialize requests, e.g. using :meth:`pickle.serialize`. If
+serialization fails, the scheduler falls back to a memory queue.
 
 .. note::
 
-    If :setting:`JOBDIR` is undefined, the scheduler uses a memory-based queue
-    regardless of how :setting:`SCHEDULER_DISK_QUEUE` is configured.
+    :setting:`JOBDIR` has to be set so that the scheduler uses the disk queue
+    configured by :setting:`SCHEDULER_DISK_QUEUE`.
 
 Interface
 ---------

--- a/scrapy/core/scheduler.py
+++ b/scrapy/core/scheduler.py
@@ -6,6 +6,7 @@ from os.path import join, exists
 
 from queuelib import PriorityQueue
 
+from scrapy.exceptions import TransientError
 from scrapy.utils.misc import load_object, create_instance
 from scrapy.utils.job import job_dir
 from scrapy.utils.deprecate import ScrapyDeprecationWarning
@@ -129,6 +130,10 @@ class Scheduler:
                 self.logunser = False
             self.stats.inc_value('scheduler/unserializable',
                                  spider=self.spider)
+            return
+        except TransientError as e:
+            msg = "Unable to push request to queue: %s"
+            logger.warning(msg, e, exc_info=True, extra={'spider': self.spider})
             return
         else:
             return True

--- a/scrapy/core/scheduler.py
+++ b/scrapy/core/scheduler.py
@@ -6,7 +6,7 @@ from os.path import join, exists
 
 from queuelib import PriorityQueue
 
-from scrapy.exceptions import TransientError
+from scrapy.exceptions import SerializationError, TransientError
 from scrapy.utils.misc import load_object, create_instance
 from scrapy.utils.job import job_dir
 from scrapy.utils.deprecate import ScrapyDeprecationWarning
@@ -120,7 +120,7 @@ class Scheduler:
             return
         try:
             self.dqs.push(request)
-        except ValueError as e:  # non serializable request
+        except SerializationError as e:  # non serializable request
             if self.logunser:
                 msg = ("Unable to serialize request: %(request)s - reason:"
                        " %(reason)s - no more unserializable requests will be"

--- a/scrapy/exceptions.py
+++ b/scrapy/exceptions.py
@@ -27,6 +27,11 @@ class TransientError(Exception):
     pass
 
 
+class SerializationError(ValueError):
+    """Indicates an error with the serialization, usually of a request."""
+    pass
+
+
 # HTTP and crawling
 
 

--- a/scrapy/exceptions.py
+++ b/scrapy/exceptions.py
@@ -21,6 +21,12 @@ class _InvalidOutput(TypeError):
     pass
 
 
+class TransientError(Exception):
+    """Indicates a temporary problem (e.g. connection error) that is likely to
+    not be permanent."""
+    pass
+
+
 # HTTP and crawling
 
 

--- a/scrapy/pqueues.py
+++ b/scrapy/pqueues.py
@@ -58,7 +58,11 @@ class ScrapyPriorityQueue:
         self.key = key
         self.queues = {}
         self.curprio = None
+        self.selfcheck()
         self.init_prios(startprios)
+
+    def selfcheck(self):
+        self.qfactory('selfcheck').close()
 
     def init_prios(self, startprios):
         if not startprios:
@@ -157,10 +161,13 @@ class DownloaderAwarePriorityQueue:
         self.downstream_queue_cls = downstream_queue_cls
         self.key = key
         self.crawler = crawler
-
+        self.selfcheck()
         self.pqueues = {}  # slot -> priority queue
         for slot, startprios in (slot_startprios or {}).items():
             self.pqueues[slot] = self.pqfactory(slot, startprios)
+
+    def selfcheck(self):
+        self.pqfactory('hostname.invalid').close()
 
     def pqfactory(self, slot, startprios=()):
         return ScrapyPriorityQueue(self.crawler,

--- a/scrapy/squeues.py
+++ b/scrapy/squeues.py
@@ -29,6 +29,10 @@ def _serializable_queue(queue_class, serialize, deserialize):
 
     class SerializableQueue(queue_class):
 
+        def __init__(self, path, settings=None, *args, **kwargs):
+            self.settings = settings
+            super(SerializableQueue, self).__init__(path, *args, **kwargs)
+
         def push(self, obj):
             s = serialize(obj)
             super(SerializableQueue, self).push(s)
@@ -47,7 +51,7 @@ def _scrapy_serialization_queue(queue_class):
 
         def __init__(self, crawler, key):
             self.spider = crawler.spider
-            super(ScrapyRequestQueue, self).__init__(key)
+            super(ScrapyRequestQueue, self).__init__(key, crawler.settings)
 
         @classmethod
         def from_crawler(cls, crawler, key, *args, **kwargs):

--- a/scrapy/squeues.py
+++ b/scrapy/squeues.py
@@ -8,6 +8,7 @@ import pickle
 
 from queuelib import queue
 
+from scrapy.exceptions import SerializationError
 from scrapy.utils.reqser import request_to_dict, request_from_dict
 
 
@@ -89,7 +90,7 @@ def _pickle_serialize(obj):
     # Both pickle.PicklingError and AttributeError can be raised by pickle.dump(s)
     # TypeError is raised from parsel.Selector
     except (pickle.PicklingError, AttributeError, TypeError) as e:
-        raise ValueError(str(e)) from e
+        raise SerializationError(str(e)) from e
 
 
 PickleFifoDiskQueueNonRequest = _serializable_queue(

--- a/setup.cfg
+++ b/setup.cfg
@@ -52,6 +52,9 @@ ignore_errors = True
 [mypy-scrapy.spidermiddlewares.referer]
 ignore_errors = True
 
+[mypy-scrapy.squeues]
+ignore_errors = True
+
 [mypy-scrapy.utils.httpobj]
 ignore_errors = True
 


### PR DESCRIPTION
This PR contains a specification for how request queues are expected to behave and some adjustments to make the code conform to that specification.

The main change is the introduction of the `TransientError` exception which indicates a temporary problem (e.g. connection error) that is likely to not be permanent. A fallback to the memory queue happens in such a case. Another change is that once a priority queue object is created, a downstream queue is also created as a self-check. This allows to fail early and consistently if there is a problem with the downstream queue.

This PR is related to #4326.