### PR TITLE
Return single element from coroutine callback

### DIFF
--- a/scrapy/utils/spider.py
+++ b/scrapy/utils/spider.py
@@ -1,5 +1,5 @@
-import logging
 import inspect
+import logging
 
 from scrapy.spiders import Spider
 from scrapy.utils.defer import deferred_from_coro
@@ -18,7 +18,11 @@ def iterate_spider_output(result):
         d = deferred_from_coro(collect_asyncgen(result))
         d.addCallback(iterate_spider_output)
         return d
-    return arg_to_iter(deferred_from_coro(result))
+    elif inspect.iscoroutine(result):
+        d = deferred_from_coro(result)
+        d.addCallback(iterate_spider_output)
+        return d
+    return arg_to_iter(result)
 
 
 def iter_spider_classes(module):

--- a/tests/spiders.py
+++ b/tests/spiders.py
@@ -119,6 +119,17 @@ class AsyncDefAsyncioReturnSpider(SimpleSpider):
         return [{'id': 1}, {'id': 2}]
 
 
+class AsyncDefAsyncioReturnSingleElementSpider(SimpleSpider):
+
+    name = "asyncdef_asyncio_return_single_element"
+
+    async def parse(self, response):
+        await asyncio.sleep(0.1)
+        status = await get_from_asyncio_queue(response.status)
+        self.logger.info("Got response %d" % status)
+        return {"foo": 42}
+
+
 class AsyncDefAsyncioReqsReturnSpider(SimpleSpider):
 
     name = 'asyncdef_asyncio_reqs_return'


### PR DESCRIPTION
Currently, single elements cannot be returned from coroutine callbacks.

Consider the following sample spider:

```python
from scrapy import Spider, Request

class AsyncDefSpider(Spider):
    name = "async_def"
    start_urls = ["https://example.org"]

    async def parse(self, response):
        return Request("https://example.com")
```
which produces:
```
2020-06-01 17:10:24 [scrapy.core.engine] INFO: Spider opened
2020-06-01 17:10:24 [scrapy.extensions.logstats] INFO: Crawled 0 pages (at 0 pages/min), scraped 0 items (at 0 items/min)
2020-06-01 17:10:24 [scrapy.extensions.telnet] INFO: Telnet console listening on 127.0.0.1:6023
2020-06-01 17:10:25 [scrapy.core.engine] DEBUG: Crawled (200) <GET https://example.org> (referer: None)
2020-06-01 17:10:25 [scrapy.core.scraper] ERROR: Spider error processing <GET https://example.org> (referer: None)
Traceback (most recent call last):
  File "/.../scrapy/scrapy/utils/defer.py", line 120, in iter_errback
    yield next(it)
  File "/.../scrapy/scrapy/utils/python.py", line 346, in __next__
    return next(self.data)
  File "/.../scrapy/scrapy/utils/python.py", line 346, in __next__
    return next(self.data)
  File "/.../scrapy/scrapy/core/spidermw.py", line 64, in _evaluate_iterable
    for r in iterable:
  File "/.../scrapy/scrapy/spidermiddlewares/offsite.py", line 29, in process_spider_output
    for x in result:
  File "/.../scrapy/scrapy/core/spidermw.py", line 64, in _evaluate_iterable
    for r in iterable:
  File "/.../scrapy/scrapy/spidermiddlewares/referer.py", line 340, in <genexpr>
    return (_set_referer(r) for r in result or ())
  File "/.../scrapy/scrapy/core/spidermw.py", line 64, in _evaluate_iterable
    for r in iterable:
  File "/.../scrapy/scrapy/spidermiddlewares/urllength.py", line 37, in <genexpr>
    return (r for r in result or () if _filter(r))
  File "/.../scrapy/scrapy/core/spidermw.py", line 64, in _evaluate_iterable
    for r in iterable:
  File "/.../scrapy/scrapy/spidermiddlewares/depth.py", line 58, in <genexpr>
    return (r for r in result or () if _filter(r))
  File "/.../scrapy/scrapy/core/spidermw.py", line 64, in _evaluate_iterable
    for r in iterable:
TypeError: 'Request' object is not iterable
2020-06-01 17:10:25 [scrapy.core.engine] INFO: Closing spider (finished)
```

If the returned item is a `dict`, it's iterated and so the following error appears instead:
```
2020-06-01 17:03:36 [scrapy.core.scraper] ERROR: Spider must return Request, BaseItem, dict or None, got 'str' in <GET https://example.org>
```