### PR TITLE
DOC: Update docs on accessing callback arguments in errback

### DIFF
--- a/docs/topics/request-response.rst
+++ b/docs/topics/request-response.rst
@@ -333,7 +333,7 @@ achieve this by using ``Failure.request.cb_kwargs``::
                                  cb_kwargs=dict(main_url=response.url))
         yield request
 
-    def parse_page2(self, response, main_url, foo):
+    def parse_page2(self, response, main_url):
         pass
 
     def errback_page2(self, failure):

--- a/docs/topics/request-response.rst
+++ b/docs/topics/request-response.rst
@@ -190,7 +190,8 @@ Request objects
         accessed, in your spider, from the ``response.cb_kwargs`` attribute.
 
         In case of a failure to process the request, this dict can be accessed as
-        ``failure.request.cb_kwargs``. For more information, see :ref:`topics-request-response-ref-accessing-callback-arguments-in-errback`.
+        ``failure.request.cb_kwargs`` in the request's errback. For more information,
+        see :ref:`topics-request-response-ref-accessing-callback-arguments-in-errback`.
 
     .. method:: Request.copy()
 

--- a/docs/topics/request-response.rst
+++ b/docs/topics/request-response.rst
@@ -323,30 +323,21 @@ Accessing additional data in errback functions
 In case of a failure to process the request, you may be interested in
 accessing arguments to the callback functions so you can process further
 based on the arguments in the errback. The following example shows how to
-achieve this by using ``Failure.request.cb_kwargs``
-
-::
+achieve this by using ``Failure.request.cb_kwargs``::
 
     def parse(self, response):
         request = scrapy.Request('http://www.example.com/index.html',
                                  callback=self.parse_page2,
                                  errback=self.errback_page2,
                                  cb_kwargs=dict(main_url=response.url))
-        request.cb_kwargs['foo'] = 'bar'  # add more arguments for the callback
         yield request
 
     def parse_page2(self, response, main_url, foo):
-        yield dict(
-            main_url=main_url,
-            other_url=response.url,
-            foo=foo,
-        )
+        pass
 
     def errback_page2(self, failure):
         yield dict(
             main_url=failure.request.cb_kwargs['main_url'],
-            other_url=failure.value.response.url,
-            foo=failure.request.cb_kwargs['foo'],
         )
 
 .. _topics-request-meta:

--- a/docs/topics/request-response.rst
+++ b/docs/topics/request-response.rst
@@ -189,6 +189,9 @@ Request objects
         cloned using the ``copy()`` or ``replace()`` methods, and can also be
         accessed, in your spider, from the ``response.cb_kwargs`` attribute.
 
+        In case of a failure to process the request, this dict can be accessed as
+        ``failure.request.cb_kwargs``. For more information, see :ref:`topics-request-response-ref-accessing-callback-arguments-in-errback`.
+
     .. method:: Request.copy()
 
        Return a new Request which is a copy of this Request. See also:
@@ -311,6 +314,40 @@ errors if needed::
             elif failure.check(TimeoutError, TCPTimedOutError):
                 request = failure.request
                 self.logger.error('TimeoutError on %s', request.url)
+
+.. _topics-request-response-ref-accessing-callback-arguments-in-errback:
+
+Accessing additional data in errback functions
+----------------------------------------------
+
+In case of a failure to process the request, you may be interested in
+accessing arguments to the callback functions so you can process further
+based on the arguments in the errback. The following example shows how to
+achieve this by using ``Failure.request.cb_kwargs``
+
+::
+
+    def parse(self, response):
+        request = scrapy.Request('http://www.example.com/index.html',
+                                 callback=self.parse_page2,
+                                 errback=self.errback_page2,
+                                 cb_kwargs=dict(main_url=response.url))
+        request.cb_kwargs['foo'] = 'bar'  # add more arguments for the callback
+        yield request
+
+    def parse_page2(self, response, main_url, foo):
+        yield dict(
+            main_url=main_url,
+            other_url=response.url,
+            foo=foo,
+        )
+
+    def errback_page2(self, failure):
+        yield dict(
+            main_url=failure.request.cb_kwargs['main_url'],
+            other_url=failure.value.response.url,
+            foo=failure.request.cb_kwargs['foo'],
+        )
 
 .. _topics-request-meta:
 


### PR DESCRIPTION
Update docs with the info on accessing callback arguments
(cb_kwargs) in errback. Also, included an example for the same.

Fixes #4598 