### PR TITLE
Authorize each and every request for basic http authentication in HttpAuthMiddleware

### DIFF
--- a/scrapy/downloadermiddlewares/httpauth.py
+++ b/scrapy/downloadermiddlewares/httpauth.py
@@ -6,6 +6,7 @@ See documentation in docs/topics/downloader-middleware.rst
 
 from w3lib.http import basic_auth_header
 
+from scrapy.http.response import Response
 from scrapy import signals
 
 
@@ -15,17 +16,28 @@ class HttpAuthMiddleware:
 
     @classmethod
     def from_crawler(cls, crawler):
-        o = cls()
+        o = cls()   
         crawler.signals.connect(o.spider_opened, signal=signals.spider_opened)
         return o
 
     def spider_opened(self, spider):
-        usr = getattr(spider, 'http_user', '')
-        pwd = getattr(spider, 'http_pass', '')
-        if usr or pwd:
-            self.auth = basic_auth_header(usr, pwd)
+        pass
+
+    def _authenticated(self, response):
+        if response.status == "401":
+            return False
+
+        return True
 
     def process_request(self, request, spider):
-        auth = getattr(self, 'auth', None)
-        if auth and b'Authorization' not in request.headers:
+        if _authenticated(self, Response(request.url)):
+            if request.url in spider.url_user_pwd.keys():
+                usr = spider.url_user_pwd[request.url][0] #url_user_pwd is a dictionary of urls with their corresponding username, password
+                pwd = spider.url_user_pwd[request.url][1]
+                if usr or pwd:
+                    self.auth = basic_auth_header(usr, pwd)
+
+            auth = getattr(self, 'auth', None)
             request.headers[b'Authorization'] = auth
+
+        # here redirect or retry middleware can be used if request needs authentication


### PR DESCRIPTION
Hi @whalebot-helmsman 
I have made some changes for the problem that we discussed. These are not perfect changes but to explain my idea. Please suggest if approach is right or wrong.
I have used a dictionary that will be declared in spider by user for accessing every username and password for corresponding urls.
I have a doubts if i should use Redirect middleware(and it's disciples) if response is not authenticated or Retry Middleware(and it's disciples) or you suggest any other way.
Thanks!
Akshay