### PR TITLE
Fix startproject failing for existing folders

### DIFF
--- a/scrapy/commands/startproject.py
+++ b/scrapy/commands/startproject.py
@@ -1,7 +1,7 @@
 import re
 import os
 import string
-from importlib import import_module
+from importlib.util import find_spec
 from os.path import join, exists, abspath
 from shutil import ignore_patterns, move, copy2, copystat
 from stat import S_IWUSR as OWNER_WRITE_PERMISSION
@@ -43,10 +43,10 @@ class Command(ScrapyCommand):
     def _is_valid_name(self, project_name):
         def _module_exists(module_name):
             try:
-                import_module(module_name)
-                return True
-            except ImportError:
+                spec = find_spec(module_name)
+            except ModuleNotFoundError:
                 return False
+            return spec is not None and spec.loader is not None
 
         if not re.search(r'^[_a-zA-Z]\w*$', project_name):
             print('Error: Project names must begin with a letter and contain'

--- a/scrapy/commands/startproject.py
+++ b/scrapy/commands/startproject.py
@@ -42,10 +42,7 @@ class Command(ScrapyCommand):
 
     def _is_valid_name(self, project_name):
         def _module_exists(module_name):
-            try:
-                spec = find_spec(module_name)
-            except ModuleNotFoundError:
-                return False
+            spec = find_spec(module_name)
             return spec is not None and spec.loader is not None
 
         if not re.search(r'^[_a-zA-Z]\w*$', project_name):

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -92,7 +92,10 @@ class ProjectTest(unittest.TestCase):
 class StartprojectTest(ProjectTest):
 
     def test_startproject(self):
-        self.assertEqual(0, self.call('startproject', self.project_name))
+        p, out, err = self.proc('startproject', self.project_name)
+        print(out)
+        print(err, file=sys.stderr)
+        self.assertEqual(p.returncode, 0)
 
         assert exists(join(self.proj_path, 'scrapy.cfg'))
         assert exists(join(self.proj_path, 'testproject'))
@@ -129,29 +132,22 @@ class StartprojectTest(ProjectTest):
 
     def test_existing_project_dir(self):
         project_dir = mkdtemp()
-        os.mkdir(os.path.join(project_dir, self.project_name))
+        project_name = self.project_name + '_existing'
+        project_path = os.path.join(project_dir, project_name)
+        os.mkdir(project_path)
 
-        p, out, err = self.proc('startproject', self.project_name, cwd=project_dir)
+        p, out, err = self.proc('startproject', project_name, cwd=project_dir)
         print(out)
         print(err, file=sys.stderr)
         self.assertEqual(p.returncode, 0)
 
-        assert exists(join(abspath(project_dir), 'scrapy.cfg'))
-        assert exists(join(abspath(project_dir), 'testproject'))
-        assert exists(join(join(abspath(project_dir), self.project_name), '__init__.py'))
-        assert exists(join(join(abspath(project_dir), self.project_name), 'items.py'))
-        assert exists(join(join(abspath(project_dir), self.project_name), 'pipelines.py'))
-        assert exists(join(join(abspath(project_dir), self.project_name), 'settings.py'))
-        assert exists(join(join(abspath(project_dir), self.project_name), 'spiders', '__init__.py'))
-
-        self.assertEqual(0, self.call('startproject', self.project_name, project_dir + '2'))
-
-        self.assertEqual(1, self.call('startproject', self.project_name, project_dir))
-        self.assertEqual(1, self.call('startproject', self.project_name + '2', project_dir))
-        self.assertEqual(1, self.call('startproject', 'wrong---project---name'))
-        self.assertEqual(1, self.call('startproject', 'sys'))
-        self.assertEqual(2, self.call('startproject'))
-        self.assertEqual(2, self.call('startproject', self.project_name, project_dir, 'another_params'))
+        assert exists(join(abspath(project_path), 'scrapy.cfg'))
+        assert exists(join(abspath(project_path), project_name))
+        assert exists(join(join(abspath(project_path), project_name), '__init__.py'))
+        assert exists(join(join(abspath(project_path), project_name), 'items.py'))
+        assert exists(join(join(abspath(project_path), project_name), 'pipelines.py'))
+        assert exists(join(join(abspath(project_path), project_name), 'settings.py'))
+        assert exists(join(join(abspath(project_path), project_name), 'spiders', '__init__.py'))
 
 
 def get_permissions_dict(path, renamings=None, ignore=None):


### PR DESCRIPTION
Fixes #4665

The issue was that empty directories in an import path can be imported as namespace packages since Python 3.3: https://stackoverflow.com/a/49082183/939364

I’ve switched `import_module` to `find_spec`, which does something similar without actually importing, and now we are also checking whether `spec.loader` is `None` (indicating it’s a namespace package).

I suspect this has been happening forever when using Python 3.