### PR TITLE
deprecate retry_on_eintr

### DIFF
--- a/scrapy/utils/python.py
+++ b/scrapy/utils/python.py
@@ -285,6 +285,7 @@ class WeakKeyCache:
         return self._weakdict[key]
 
 
+@deprecated
 def retry_on_eintr(function, *args, **kw):
     """Run a function and retry it while getting EINTR errors"""
     while True:


### PR DESCRIPTION
This function is not used, is not tested and is not documented, so we should probably remove it.

It was introduced to be used in `test_commands.py` but is not used anymore (ref: https://github.com/scrapy/scrapy/commit/6217f108cce8a7db0c0ee3682848159b06c9e9d3)

