### PR TITLE
Support defining file path based on item in media pipelines

### DIFF
--- a/docs/topics/media-pipeline.rst
+++ b/docs/topics/media-pipeline.rst
@@ -412,7 +412,7 @@ See here the methods that you can override in your custom Files Pipeline:
 
 .. class:: FilesPipeline
 
-   .. method:: file_path(self, request, response=None, info=None, item=None)
+   .. method:: file_path(self, request, response=None, info=None, *, item=None)
 
       This method is called once per downloaded item. It returns the
       download path of the file originating from the specified
@@ -437,7 +437,7 @@ See here the methods that you can override in your custom Files Pipeline:
 
         class MyFilesPipeline(FilesPipeline):
 
-            def file_path(self, request, response=None, info=None, item=None):
+            def file_path(self, request, response=None, info=None, *, item=None):
                 return 'files/' + os.path.basename(urlparse(request.url).path)
 
       Similarly, you can use the ``item`` to determine the file path based on some item 
@@ -548,7 +548,7 @@ See here the methods that you can override in your custom Images Pipeline:
     The :class:`ImagesPipeline` is an extension of the :class:`FilesPipeline`,
     customizing the field names and adding custom behavior for images.
 
-   .. method:: file_path(self, request, response=None, info=None, item=None)
+   .. method:: file_path(self, request, response=None, info=None, *, item=None)
 
       This method is called once per downloaded item. It returns the
       download path of the file originating from the specified
@@ -573,7 +573,7 @@ See here the methods that you can override in your custom Images Pipeline:
 
         class MyImagesPipeline(ImagesPipeline):
 
-            def file_path(self, request, response=None, info=None, item=None):
+            def file_path(self, request, response=None, info=None, *, item=None):
                 return 'files/' + os.path.basename(urlparse(request.url).path)
 
       Similarly, you can use the ``item`` to determine the file path based on some item 

--- a/docs/topics/media-pipeline.rst
+++ b/docs/topics/media-pipeline.rst
@@ -412,15 +412,16 @@ See here the methods that you can override in your custom Files Pipeline:
 
 .. class:: FilesPipeline
 
-   .. method:: file_path(self, request, response=None, info=None)
+   .. method:: file_path(self, request, response=None, info=None, item=None)
 
       This method is called once per downloaded item. It returns the
       download path of the file originating from the specified
       :class:`response <scrapy.http.Response>`.
 
       In addition to ``response``, this method receives the original
-      :class:`request <scrapy.Request>` and
-      :class:`info <scrapy.pipelines.media.MediaPipeline.SpiderInfo>`.
+      :class:`request <scrapy.Request>`,
+      :class:`info <scrapy.pipelines.media.MediaPipeline.SpiderInfo>` and 
+      :class:`item <scrapy.item.Item>`
 
       You can override this method to customize the download path of each file.
 
@@ -436,9 +437,12 @@ See here the methods that you can override in your custom Files Pipeline:
 
         class MyFilesPipeline(FilesPipeline):
 
-            def file_path(self, request, response=None, info=None):
+            def file_path(self, request, response=None, info=None, item=None):
                 return 'files/' + os.path.basename(urlparse(request.url).path)
 
+      Similarly, you can use the ``item`` to determine the file path based on some item 
+      property.
+      
       By default the :meth:`file_path` method returns
       ``full/<request URL hash>.<extension>``.
 
@@ -544,15 +548,16 @@ See here the methods that you can override in your custom Images Pipeline:
     The :class:`ImagesPipeline` is an extension of the :class:`FilesPipeline`,
     customizing the field names and adding custom behavior for images.
 
-   .. method:: file_path(self, request, response=None, info=None)
+   .. method:: file_path(self, request, response=None, info=None, item=None)
 
       This method is called once per downloaded item. It returns the
       download path of the file originating from the specified
       :class:`response <scrapy.http.Response>`.
 
       In addition to ``response``, this method receives the original
-      :class:`request <scrapy.Request>` and
-      :class:`info <scrapy.pipelines.media.MediaPipeline.SpiderInfo>`.
+      :class:`request <scrapy.Request>`,
+      :class:`info <scrapy.pipelines.media.MediaPipeline.SpiderInfo>` and 
+      :class:`item <scrapy.item.Item>`
 
       You can override this method to customize the download path of each file.
 
@@ -568,9 +573,12 @@ See here the methods that you can override in your custom Images Pipeline:
 
         class MyImagesPipeline(ImagesPipeline):
 
-            def file_path(self, request, response=None, info=None):
+            def file_path(self, request, response=None, info=None, item=None):
                 return 'files/' + os.path.basename(urlparse(request.url).path)
 
+      Similarly, you can use the ``item`` to determine the file path based on some item 
+      property.
+      
       By default the :meth:`file_path` method returns
       ``full/<request URL hash>.<extension>``.
 

--- a/scrapy/pipelines/files.py
+++ b/scrapy/pipelines/files.py
@@ -409,7 +409,7 @@ class FilesPipeline(MediaPipeline):
         store_cls = self.STORE_SCHEMES[scheme]
         return store_cls(uri)
 
-    def media_to_download(self, request, info, item):
+    def media_to_download(self, request, info, item=None):
         def _onsuccess(result):
             if not result:
                 return  # returning None force download
@@ -460,7 +460,7 @@ class FilesPipeline(MediaPipeline):
 
         raise FileException
 
-    def media_downloaded(self, response, request, info, item):
+    def media_downloaded(self, response, request, info, item=None):
         referer = referer_str(request)
 
         if response.status != 200:
@@ -493,7 +493,7 @@ class FilesPipeline(MediaPipeline):
 
         try:
             path = self.file_path(request, response=response, info=info, item=item)
-            checksum = self.file_downloaded(response, request, info, item)
+            checksum = self.file_downloaded(response, request, info, item=item)
         except FileException as exc:
             logger.warning(
                 'File (error): Error processing file from %(request)s '

--- a/scrapy/pipelines/files.py
+++ b/scrapy/pipelines/files.py
@@ -409,7 +409,7 @@ class FilesPipeline(MediaPipeline):
         store_cls = self.STORE_SCHEMES[scheme]
         return store_cls(uri)
 
-    def media_to_download(self, request, info, item=None):
+    def media_to_download(self, request, info, *, item=None):
         def _onsuccess(result):
             if not result:
                 return  # returning None force download
@@ -460,7 +460,7 @@ class FilesPipeline(MediaPipeline):
 
         raise FileException
 
-    def media_downloaded(self, response, request, info, item=None):
+    def media_downloaded(self, response, request, info, *, item=None):
         referer = referer_str(request)
 
         if response.status != 200:
@@ -522,7 +522,7 @@ class FilesPipeline(MediaPipeline):
         urls = ItemAdapter(item).get(self.files_urls_field, [])
         return [Request(u) for u in urls]
 
-    def file_downloaded(self, response, request, info, item=None):
+    def file_downloaded(self, response, request, info, *, item=None):
         path = self.file_path(request, response=response, info=info, item=item)
         buf = BytesIO(response.body)
         checksum = md5sum(buf)
@@ -535,7 +535,7 @@ class FilesPipeline(MediaPipeline):
             ItemAdapter(item)[self.files_result_field] = [x for ok, x in results if ok]
         return item
 
-    def file_path(self, request, response=None, info=None, item=None):
+    def file_path(self, request, response=None, info=None, *, item=None):
         media_guid = hashlib.sha1(to_bytes(request.url)).hexdigest()
         media_ext = os.path.splitext(request.url)[1]
         # Handles empty and wild extensions by trying to guess the

--- a/scrapy/pipelines/files.py
+++ b/scrapy/pipelines/files.py
@@ -409,7 +409,7 @@ class FilesPipeline(MediaPipeline):
         store_cls = self.STORE_SCHEMES[scheme]
         return store_cls(uri)
 
-    def media_to_download(self, request, info):
+    def media_to_download(self, request, info, item):
         def _onsuccess(result):
             if not result:
                 return  # returning None force download
@@ -436,7 +436,7 @@ class FilesPipeline(MediaPipeline):
             checksum = result.get('checksum', None)
             return {'url': request.url, 'path': path, 'checksum': checksum, 'status': 'uptodate'}
 
-        path = self.file_path(request, info=info)
+        path = self.file_path(request, info=info, item=item)
         dfd = defer.maybeDeferred(self.store.stat_file, path, info)
         dfd.addCallbacks(_onsuccess, lambda _: None)
         dfd.addErrback(
@@ -460,7 +460,7 @@ class FilesPipeline(MediaPipeline):
 
         raise FileException
 
-    def media_downloaded(self, response, request, info):
+    def media_downloaded(self, response, request, info, item):
         referer = referer_str(request)
 
         if response.status != 200:
@@ -492,8 +492,8 @@ class FilesPipeline(MediaPipeline):
         self.inc_stats(info.spider, status)
 
         try:
-            path = self.file_path(request, response=response, info=info)
-            checksum = self.file_downloaded(response, request, info)
+            path = self.file_path(request, response=response, info=info, item=item)
+            checksum = self.file_downloaded(response, request, info, item)
         except FileException as exc:
             logger.warning(
                 'File (error): Error processing file from %(request)s '
@@ -522,8 +522,8 @@ class FilesPipeline(MediaPipeline):
         urls = ItemAdapter(item).get(self.files_urls_field, [])
         return [Request(u) for u in urls]
 
-    def file_downloaded(self, response, request, info):
-        path = self.file_path(request, response=response, info=info)
+    def file_downloaded(self, response, request, info, item):
+        path = self.file_path(request, response=response, info=info, item=item)
         buf = BytesIO(response.body)
         checksum = md5sum(buf)
         buf.seek(0)
@@ -535,7 +535,7 @@ class FilesPipeline(MediaPipeline):
             ItemAdapter(item)[self.files_result_field] = [x for ok, x in results if ok]
         return item
 
-    def file_path(self, request, response=None, info=None):
+    def file_path(self, request, response=None, info=None, item=None):
         media_guid = hashlib.sha1(to_bytes(request.url)).hexdigest()
         media_ext = os.path.splitext(request.url)[1]
         # Handles empty and wild extensions by trying to guess the

--- a/scrapy/pipelines/files.py
+++ b/scrapy/pipelines/files.py
@@ -436,7 +436,7 @@ class FilesPipeline(MediaPipeline):
             checksum = result.get('checksum', None)
             return {'url': request.url, 'path': path, 'checksum': checksum, 'status': 'uptodate'}
 
-        path = self._file_path(request, info=info, item=item)
+        path = self.file_path(request, info=info, item=item)
         dfd = defer.maybeDeferred(self.store.stat_file, path, info)
         dfd.addCallbacks(_onsuccess, lambda _: None)
         dfd.addErrback(
@@ -492,7 +492,7 @@ class FilesPipeline(MediaPipeline):
         self.inc_stats(info.spider, status)
 
         try:
-            path = self._file_path(request, response=response, info=info, item=item)
+            path = self.file_path(request, response=response, info=info, item=item)
             checksum = self.file_downloaded(response, request, info, item)
         except FileException as exc:
             logger.warning(
@@ -522,8 +522,8 @@ class FilesPipeline(MediaPipeline):
         urls = ItemAdapter(item).get(self.files_urls_field, [])
         return [Request(u) for u in urls]
 
-    def file_downloaded(self, response, request, info, item):
-        path = self._file_path(request, response=response, info=info, item=item)
+    def file_downloaded(self, response, request, info, item=None):
+        path = self.file_path(request, response=response, info=info, item=item)
         buf = BytesIO(response.body)
         checksum = md5sum(buf)
         buf.seek(0)

--- a/scrapy/pipelines/files.py
+++ b/scrapy/pipelines/files.py
@@ -13,10 +13,8 @@ from collections import defaultdict
 from contextlib import suppress
 from email.utils import mktime_tz, parsedate_tz
 from ftplib import FTP
-from inspect import signature
 from io import BytesIO
 from urllib.parse import urlparse
-from warnings import warn
 
 from itemadapter import ItemAdapter
 from twisted.internet import defer, threads
@@ -27,7 +25,6 @@ from scrapy.pipelines.media import MediaPipeline
 from scrapy.settings import Settings
 from scrapy.utils.boto import is_botocore
 from scrapy.utils.datatypes import CaselessDict
-from scrapy.utils.deprecate import ScrapyDeprecationWarning
 from scrapy.utils.ftp import ftp_store_file
 from scrapy.utils.log import failure_to_exc_info
 from scrapy.utils.misc import md5sum
@@ -359,15 +356,6 @@ class FilesPipeline(MediaPipeline):
 
         if isinstance(settings, dict) or settings is None:
             settings = Settings(settings)
-
-        # Check if file_path used by user is deprecated
-        file_path_sig = signature(self.file_path)
-        try:
-            file_path_sig.parameters['item']
-        except KeyError:
-            warn('file_path(self, request, response=None, info=None) is deprecated, '
-                 'please use file_path(self, request, response=None, info=None, item=None)',
-                 ScrapyDeprecationWarning, stacklevel=2)
 
         cls_name = "FilesPipeline"
         self.store = self._get_store(store_uri)

--- a/scrapy/pipelines/images.py
+++ b/scrapy/pipelines/images.py
@@ -6,9 +6,7 @@ See documentation in topics/media-pipeline.rst
 import functools
 import hashlib
 from contextlib import suppress
-from inspect import signature
 from io import BytesIO
-from warnings import warn
 
 from itemadapter import ItemAdapter
 from PIL import Image
@@ -18,7 +16,6 @@ from scrapy.http import Request
 from scrapy.pipelines.files import FileException, FilesPipeline
 # TODO: from scrapy.pipelines.media import MediaPipeline
 from scrapy.settings import Settings
-from scrapy.utils.deprecate import ScrapyDeprecationWarning
 from scrapy.utils.misc import md5sum
 from scrapy.utils.python import to_bytes
 
@@ -53,15 +50,6 @@ class ImagesPipeline(FilesPipeline):
 
         if isinstance(settings, dict) or settings is None:
             settings = Settings(settings)
-
-        # Check if file_path used by user is deprecated
-        file_path_sig = signature(self.file_path)
-        try:
-            file_path_sig.parameters['item']
-        except KeyError:
-            warn('file_path(self, request, response=None, info=None) is deprecated, '
-                 'please use file_path(self, request, response=None, info=None, item=None)',
-                 ScrapyDeprecationWarning, stacklevel=2)
 
         resolve = functools.partial(self._key_for_pipe,
                                     base_class_name="ImagesPipeline",

--- a/scrapy/pipelines/images.py
+++ b/scrapy/pipelines/images.py
@@ -104,10 +104,10 @@ class ImagesPipeline(FilesPipeline):
         store_uri = settings['IMAGES_STORE']
         return cls(store_uri, settings=settings)
 
-    def file_downloaded(self, response, request, info, item):
+    def file_downloaded(self, response, request, info, item=None):
         return self.image_downloaded(response, request, info, item)
 
-    def image_downloaded(self, response, request, info, item):
+    def image_downloaded(self, response, request, info, item=None):
         checksum = None
         for path, image, buf in self.get_images(response, request, info, item):
             if checksum is None:
@@ -120,8 +120,8 @@ class ImagesPipeline(FilesPipeline):
                 headers={'Content-Type': 'image/jpeg'})
         return checksum
 
-    def get_images(self, response, request, info, item):
-        path = self._file_path(request, response=response, info=info, item=item)
+    def get_images(self, response, request, info, item=None):
+        path = self.file_path(request, response=response, info=info, item=item)
         orig_image = Image.open(BytesIO(response.body))
 
         width, height = orig_image.size

--- a/scrapy/pipelines/images.py
+++ b/scrapy/pipelines/images.py
@@ -105,11 +105,11 @@ class ImagesPipeline(FilesPipeline):
         return cls(store_uri, settings=settings)
 
     def file_downloaded(self, response, request, info, item=None):
-        return self.image_downloaded(response, request, info, item)
+        return self.image_downloaded(response, request, info, item=item)
 
     def image_downloaded(self, response, request, info, item=None):
         checksum = None
-        for path, image, buf in self.get_images(response, request, info, item):
+        for path, image, buf in self.get_images(response, request, info, item=item):
             if checksum is None:
                 buf.seek(0)
                 checksum = md5sum(buf)

--- a/scrapy/pipelines/images.py
+++ b/scrapy/pipelines/images.py
@@ -104,12 +104,12 @@ class ImagesPipeline(FilesPipeline):
         store_uri = settings['IMAGES_STORE']
         return cls(store_uri, settings=settings)
 
-    def file_downloaded(self, response, request, info):
-        return self.image_downloaded(response, request, info)
+    def file_downloaded(self, response, request, info, item):
+        return self.image_downloaded(response, request, info, item)
 
-    def image_downloaded(self, response, request, info):
+    def image_downloaded(self, response, request, info, item):
         checksum = None
-        for path, image, buf in self.get_images(response, request, info):
+        for path, image, buf in self.get_images(response, request, info, item):
             if checksum is None:
                 buf.seek(0)
                 checksum = md5sum(buf)
@@ -120,8 +120,8 @@ class ImagesPipeline(FilesPipeline):
                 headers={'Content-Type': 'image/jpeg'})
         return checksum
 
-    def get_images(self, response, request, info):
-        path = self.file_path(request, response=response, info=info)
+    def get_images(self, response, request, info, item):
+        path = self.file_path(request, response=response, info=info, item=item)
         orig_image = Image.open(BytesIO(response.body))
 
         width, height = orig_image.size
@@ -167,7 +167,7 @@ class ImagesPipeline(FilesPipeline):
             ItemAdapter(item)[self.images_result_field] = [x for ok, x in results if ok]
         return item
 
-    def file_path(self, request, response=None, info=None):
+    def file_path(self, request, response=None, info=None, item=None):
         image_guid = hashlib.sha1(to_bytes(request.url)).hexdigest()
         return 'full/%s.jpg' % (image_guid)
 

--- a/scrapy/pipelines/images.py
+++ b/scrapy/pipelines/images.py
@@ -104,10 +104,10 @@ class ImagesPipeline(FilesPipeline):
         store_uri = settings['IMAGES_STORE']
         return cls(store_uri, settings=settings)
 
-    def file_downloaded(self, response, request, info, item=None):
+    def file_downloaded(self, response, request, info, *, item=None):
         return self.image_downloaded(response, request, info, item=item)
 
-    def image_downloaded(self, response, request, info, item=None):
+    def image_downloaded(self, response, request, info, *, item=None):
         checksum = None
         for path, image, buf in self.get_images(response, request, info, item=item):
             if checksum is None:
@@ -120,7 +120,7 @@ class ImagesPipeline(FilesPipeline):
                 headers={'Content-Type': 'image/jpeg'})
         return checksum
 
-    def get_images(self, response, request, info, item=None):
+    def get_images(self, response, request, info, *, item=None):
         path = self.file_path(request, response=response, info=info, item=item)
         orig_image = Image.open(BytesIO(response.body))
 
@@ -167,7 +167,7 @@ class ImagesPipeline(FilesPipeline):
             ItemAdapter(item)[self.images_result_field] = [x for ok, x in results if ok]
         return item
 
-    def file_path(self, request, response=None, info=None, item=None):
+    def file_path(self, request, response=None, info=None, *, item=None):
         image_guid = hashlib.sha1(to_bytes(request.url)).hexdigest()
         return 'full/%s.jpg' % (image_guid)
 

--- a/scrapy/pipelines/media.py
+++ b/scrapy/pipelines/media.py
@@ -30,6 +30,7 @@ class MediaPipeline:
 
     def __init__(self, download_func=None, settings=None):
         self.download_func = download_func
+        self._expects_item = {}
 
         if isinstance(settings, dict) or settings is None:
             settings = Settings(settings)
@@ -41,14 +42,8 @@ class MediaPipeline:
         )
         self._handle_statuses(self.allow_redirects)
 
-        # Check if file_path implemented by user in child class is deprecated
-        file_path_sig = signature(self.file_path)
-        self._file_path_expects_item = True
-        if 'item' not in file_path_sig.parameters:
-            warn('file_path(self, request, response=None, info=None) is deprecated, '
-                 'please use file_path(self, request, response=None, info=None, item=None)',
-                 ScrapyDeprecationWarning, stacklevel=2)
-            self._file_path_expects_item = False
+        # Check if deprecated methods are being used and make them compatible
+        self._make_compatible()
 
     def _handle_statuses(self, allow_redirects):
         self.handle_httpstatus_list = None
@@ -122,13 +117,48 @@ class MediaPipeline:
         )
         return dfd.addBoth(lambda _: wad)  # it must return wad at last
 
-    def _file_path(self, *args, **kwargs):
-        """Wrapper for file_path method to allow backwards compatibility"""
-        if self._file_path_expects_item:
-            return self.file_path(*args, **kwargs)
-        else:
-            kwargs.pop('item', None)
-            return self.file_path(*args, **kwargs)
+    def _make_compatible(self):
+        """Make overridable methods of MediaPipeline and subclasses backwards compatible"""
+        # methods = [self.file_path, self.media_to_download, self.media_downloaded]
+        # self.file_downloaded, self.image_downloaded, self.get_images
+
+        methods = [
+            "file_path", "media_to_download", "media_downloaded",
+            "file_downloaded", "image_downloaded", "get_images"
+        ]
+
+        for method_name in methods:
+            method = getattr(self, method_name, None)
+            if callable(method):
+                method = self._compatible(method)
+
+    def _compatible(self, func):
+        """Wrapper for overridable methods to allow backwards compatibility"""
+        if func.__name__ not in self._expects_item:
+            self._check_signature(func)
+
+        @functools.wraps(func)
+        def wrapper(*args, **kwargs):
+            if self._expects_item[func.__name__]:
+                return func(*args, **kwargs)
+            else:
+                kwargs.pop('item', None)
+                return func(*args, **kwargs)
+
+        return wrapper
+
+    def _check_signature(self, func):
+        sig = signature(func)
+        self._expects_item[func.__name__] = True
+
+        if 'item' not in sig.parameters:
+            old_params = str(sig)[1:-1]
+            new_params = old_params + ", item=None"
+            warn('%s(self, %s) is deprecated, '
+                 'please use %s(self, %s)'
+                 % (func.__name__, old_params, func.__name__, new_params),
+                 ScrapyDeprecationWarning, stacklevel=2)
+            self._expects_item[func.__name__] = False
 
     def _modify_media_request(self, request):
         if self.handle_httpstatus_list:

--- a/scrapy/pipelines/media.py
+++ b/scrapy/pipelines/media.py
@@ -1,7 +1,7 @@
 import functools
-from inspect import signature
 import logging
 from collections import defaultdict
+from inspect import signature
 from warnings import warn
 
 from twisted.internet.defer import Deferred, DeferredList

--- a/scrapy/pipelines/media.py
+++ b/scrapy/pipelines/media.py
@@ -110,6 +110,14 @@ class MediaPipeline:
         )
         return dfd.addBoth(lambda _: wad)  # it must return wad at last
 
+    def _file_path(self, *args, **kwargs):
+        """Wrapper for file_path method to allow backwards compatibility"""
+        try:
+            return self.file_path(*args, **kwargs)
+        except TypeError:
+            kwargs.pop('item', None)
+            return self.file_path(*args, **kwargs)
+
     def _modify_media_request(self, request):
         if self.handle_httpstatus_list:
             request.meta['handle_httpstatus_list'] = self.handle_httpstatus_list

--- a/scrapy/pipelines/media.py
+++ b/scrapy/pipelines/media.py
@@ -131,8 +131,7 @@ class MediaPipeline:
 
     def _compatible(self, func):
         """Wrapper for overridable methods to allow backwards compatibility"""
-        if func.__name__ not in self._expects_item:
-            self._check_signature(func)
+        self._check_signature(func)
 
         @functools.wraps(func)
         def wrapper(*args, **kwargs):

--- a/scrapy/pipelines/media.py
+++ b/scrapy/pipelines/media.py
@@ -2,9 +2,10 @@ import functools
 from inspect import signature
 import logging
 from collections import defaultdict
+from warnings import warn
+
 from twisted.internet.defer import Deferred, DeferredList
 from twisted.python.failure import Failure
-from warnings import warn
 
 from scrapy.settings import Settings
 from scrapy.utils.datatypes import SequenceExclude

--- a/tests/test_pipeline_files.py
+++ b/tests/test_pipeline_files.py
@@ -161,6 +161,19 @@ class FilesPipelineTestCase(unittest.TestCase):
         for p in patchers:
             p.stop()
 
+    def test_file_path_from_item(self):
+        """
+        Custom file path based on item data, overriding default implementation
+        """
+        class CustomFilesPipeline(FilesPipeline):
+            def file_path(self, request, response=None, info=None, item=None):
+                return 'full/%s' % item.get('path')
+
+        file_path = CustomFilesPipeline.from_settings(Settings({'FILES_STORE': self.tempdir})).file_path
+        item = dict(path='path-to-store-file')
+        request = Request("http://example.com")
+        self.assertEqual(file_path(request, item=item), 'full/path-to-store-file')
+
 
 class FilesPipelineTestCaseFieldsMixin:
 

--- a/tests/test_pipeline_files.py
+++ b/tests/test_pipeline_files.py
@@ -23,6 +23,7 @@ from scrapy.pipelines.files import (
 )
 from scrapy.settings import Settings
 from scrapy.utils.boto import is_botocore
+from scrapy.utils.deprecate import ScrapyDeprecationWarning
 from scrapy.utils.test import (
     assert_aws_environ,
     assert_gcs_environ,
@@ -185,6 +186,13 @@ class FilesPipelineTestCase(unittest.TestCase):
         file_path = CustomFilesPipeline.from_settings(Settings({'FILES_STORE': self.tempdir})).file_path
         request = Request("http://example.com")
         self.assertEqual(file_path(request), 'full/path')
+        warning = self.flushWarnings([FilesPipeline.__init__])
+        message = (
+            'file_path(self, request, response=None, info=None) is deprecated, '
+            'please use file_path(self, request, response=None, info=None, item=None)'
+        )
+        self.assertEqual(ScrapyDeprecationWarning, warning[0]['category'])
+        self.assertEqual(message, warning[0]['message'])
 
 
 class FilesPipelineTestCaseFieldsMixin:

--- a/tests/test_pipeline_files.py
+++ b/tests/test_pipeline_files.py
@@ -174,6 +174,18 @@ class FilesPipelineTestCase(unittest.TestCase):
         request = Request("http://example.com")
         self.assertEqual(file_path(request, item=item), 'full/path-to-store-file')
 
+    def test_file_path_backwards_compatibility(self):
+        """
+        Test file_path method without `item` parameter in its signature
+        """
+        class CustomFilesPipeline(FilesPipeline):
+            def file_path(self, request, response=None, info=None):
+                return 'full/%s' % 'path'
+
+        file_path = CustomFilesPipeline.from_settings(Settings({'FILES_STORE': self.tempdir})).file_path
+        request = Request("http://example.com")
+        self.assertEqual(file_path(request), 'full/path')
+
 
 class FilesPipelineTestCaseFieldsMixin:
 

--- a/tests/test_pipeline_files.py
+++ b/tests/test_pipeline_files.py
@@ -21,10 +21,8 @@ from scrapy.pipelines.files import (
     GCSFilesStore,
     S3FilesStore,
 )
-from scrapy.pipelines.media import MediaPipeline
 from scrapy.settings import Settings
 from scrapy.utils.boto import is_botocore
-from scrapy.utils.deprecate import ScrapyDeprecationWarning
 from scrapy.utils.test import (
     assert_aws_environ,
     assert_gcs_environ,
@@ -175,44 +173,6 @@ class FilesPipelineTestCase(unittest.TestCase):
         item = dict(path='path-to-store-file')
         request = Request("http://example.com")
         self.assertEqual(file_path(request, item=item), 'full/path-to-store-file')
-
-    def test_file_path_backwards_compatibility(self):
-        """
-        Test file_path method without `item` parameter in its signature
-        """
-        class CustomFilesPipeline(FilesPipeline):
-            def file_path(self, request, response=None, info=None):
-                return 'full/%s' % 'path'
-
-        file_path = CustomFilesPipeline.from_settings(Settings({'FILES_STORE': self.tempdir})).file_path
-        request = Request("http://example.com")
-        self.assertEqual(file_path(request), 'full/path')
-        warning = self.flushWarnings([MediaPipeline._compatible])
-        message = (
-            'file_path(self, request, response=None, info=None) is deprecated, '
-            'please use file_path(self, request, response=None, info=None, item=None)'
-        )
-        self.assertEqual(ScrapyDeprecationWarning, warning[0]['category'])
-        self.assertEqual(message, warning[0]['message'])
-
-    def test_file_downloaded_backwards_compatibility(self):
-        """
-        Test file_downloaded method without `item` parameter in its signature
-        """
-        class CustomFilesPipeline(FilesPipeline):
-            def file_downloaded(self, response, request, info):
-                return 'checksum of file'
-
-        file_downloaded = CustomFilesPipeline.from_settings(Settings({'FILES_STORE': self.tempdir})).file_downloaded
-        response, request, info = dict(), Request("http://example.com"), dict()
-        self.assertEqual(file_downloaded(response, request, info), 'checksum of file')
-        warning = self.flushWarnings([MediaPipeline._compatible])
-        message = (
-            'file_downloaded(self, response, request, info) is deprecated, '
-            'please use file_downloaded(self, response, request, info, item=None)'
-        )
-        self.assertEqual(ScrapyDeprecationWarning, warning[0]['category'])
-        self.assertEqual(message, warning[0]['message'])
 
 
 class FilesPipelineTestCaseFieldsMixin:

--- a/tests/test_pipeline_images.py
+++ b/tests/test_pipeline_images.py
@@ -12,9 +12,7 @@ from twisted.trial import unittest
 from scrapy.http import Request, Response
 from scrapy.item import Field, Item
 from scrapy.pipelines.images import ImagesPipeline
-from scrapy.pipelines.media import MediaPipeline
 from scrapy.settings import Settings
-from scrapy.utils.deprecate import ScrapyDeprecationWarning
 from scrapy.utils.python import to_bytes
 
 
@@ -122,38 +120,6 @@ class ImagesPipelineTestCase(unittest.TestCase):
         converted, _ = self.pipeline.convert_image(im)
         self.assertEqual(converted.mode, 'RGB')
         self.assertEqual(converted.getcolors(), [(10000, (205, 230, 255))])
-
-    def test_image_downloaded_backwards_compatibility(self):
-        class CustomImagesPipeline(ImagesPipeline):
-            def image_downloaded(self, response, request, info):
-                return 'checksum of file'
-
-        image_downloaded = CustomImagesPipeline(self.tempdir, download_func=_mocked_download_func).image_downloaded
-        response, request, info = dict(), Request("http://example.com"), dict()
-        self.assertEqual(image_downloaded(response, request, info), 'checksum of file')
-        warning = self.flushWarnings([MediaPipeline._compatible])
-        message = (
-            'image_downloaded(self, response, request, info) is deprecated, '
-            'please use image_downloaded(self, response, request, info, item=None)'
-        )
-        self.assertEqual(ScrapyDeprecationWarning, warning[0]['category'])
-        self.assertEqual(message, warning[0]['message'])
-
-    def test_get_images_backwards_compatibility(self):
-        class CustomImagesPipeline(ImagesPipeline):
-            def get_images(self, response, request, info):
-                return 'checksum of file'
-
-        get_images = CustomImagesPipeline(self.tempdir, download_func=_mocked_download_func).get_images
-        response, request, info = dict(), Request("http://example.com"), dict()
-        self.assertEqual(get_images(response, request, info), 'checksum of file')
-        warning = self.flushWarnings([MediaPipeline._compatible])
-        message = (
-            'get_images(self, response, request, info) is deprecated, '
-            'please use get_images(self, response, request, info, item=None)'
-        )
-        self.assertEqual(ScrapyDeprecationWarning, warning[0]['category'])
-        self.assertEqual(message, warning[0]['message'])
 
 
 class DeprecatedImagesPipeline(ImagesPipeline):

--- a/tests/test_pipeline_images.py
+++ b/tests/test_pipeline_images.py
@@ -12,7 +12,9 @@ from twisted.trial import unittest
 from scrapy.http import Request, Response
 from scrapy.item import Field, Item
 from scrapy.pipelines.images import ImagesPipeline
+from scrapy.pipelines.media import MediaPipeline
 from scrapy.settings import Settings
+from scrapy.utils.deprecate import ScrapyDeprecationWarning
 from scrapy.utils.python import to_bytes
 
 
@@ -120,6 +122,38 @@ class ImagesPipelineTestCase(unittest.TestCase):
         converted, _ = self.pipeline.convert_image(im)
         self.assertEqual(converted.mode, 'RGB')
         self.assertEqual(converted.getcolors(), [(10000, (205, 230, 255))])
+
+    def test_image_downloaded_backwards_compatibility(self):
+        class CustomImagesPipeline(ImagesPipeline):
+            def image_downloaded(self, response, request, info):
+                return 'checksum of file'
+
+        image_downloaded = CustomImagesPipeline(self.tempdir, download_func=_mocked_download_func).image_downloaded
+        response, request, info = dict(), Request("http://example.com"), dict()
+        self.assertEqual(image_downloaded(response, request, info), 'checksum of file')
+        warning = self.flushWarnings([MediaPipeline._compatible])
+        message = (
+            'image_downloaded(self, response, request, info) is deprecated, '
+            'please use image_downloaded(self, response, request, info, item=None)'
+        )
+        self.assertEqual(ScrapyDeprecationWarning, warning[0]['category'])
+        self.assertEqual(message, warning[0]['message'])
+
+    def test_get_images_backwards_compatibility(self):
+        class CustomImagesPipeline(ImagesPipeline):
+            def get_images(self, response, request, info):
+                return 'checksum of file'
+
+        get_images = CustomImagesPipeline(self.tempdir, download_func=_mocked_download_func).get_images
+        response, request, info = dict(), Request("http://example.com"), dict()
+        self.assertEqual(get_images(response, request, info), 'checksum of file')
+        warning = self.flushWarnings([MediaPipeline._compatible])
+        message = (
+            'get_images(self, response, request, info) is deprecated, '
+            'please use get_images(self, response, request, info, item=None)'
+        )
+        self.assertEqual(ScrapyDeprecationWarning, warning[0]['category'])
+        self.assertEqual(message, warning[0]['message'])
 
 
 class DeprecatedImagesPipeline(ImagesPipeline):

--- a/tests/test_pipeline_media.py
+++ b/tests/test_pipeline_media.py
@@ -9,6 +9,7 @@ from scrapy.settings import Settings
 from scrapy.spiders import Spider
 from scrapy.utils.deprecate import ScrapyDeprecationWarning
 from scrapy.utils.request import request_fingerprint
+from scrapy.pipelines.images import ImagesPipeline
 from scrapy.pipelines.media import MediaPipeline
 from scrapy.pipelines.files import FileException
 from scrapy.utils.log import failure_to_exc_info
@@ -335,43 +336,122 @@ class MediaPipelineTestCase(BaseMediaPipelineTestCase):
             self.pipe._mockcalled,
             ['get_media_requests', 'media_to_download', 'item_completed'])
 
-    def test_media_to_download_backwards_compatibility(self):
-        class CustomMediaPipeline(MediaPipeline):
-            def media_to_download(self, request, info):
-                return 'media_to_download called'
 
-        media_to_download = CustomMediaPipeline(
-            download_func=_mocked_download_func,
-            settings=Settings(self.settings)
-        ).media_to_download
-        request, info = Request("http://example.com"), dict()
-        self.assertEqual(media_to_download(request, info), 'media_to_download called')
-        warning = self.flushWarnings([MediaPipeline._compatible])
+class MockedMediaPipelineDeprecatedMethods(ImagesPipeline):
+
+    def __init__(self, *args, **kwargs):
+        super(MockedMediaPipelineDeprecatedMethods, self).__init__(*args, **kwargs)
+        self._mockcalled = []
+
+    def get_media_requests(self, item, info):
+        item_url = item['image_urls'][0]
+        return Request(
+            item_url,
+            meta={'response': Response(item_url, status=200, body=b'data')}
+        )
+
+    def inc_stats(self, *args, **kwargs):
+        return True
+
+    def media_to_download(self, request, info):
+        self._mockcalled.append('media_to_download')
+        return super(MockedMediaPipelineDeprecatedMethods, self).media_to_download(request, info)
+
+    def media_downloaded(self, response, request, info):
+        self._mockcalled.append('media_downloaded')
+        return super(MockedMediaPipelineDeprecatedMethods, self).media_downloaded(response, request, info)
+
+    def file_downloaded(self, response, request, info):
+        self._mockcalled.append('file_downloaded')
+        return super(MockedMediaPipelineDeprecatedMethods, self).file_downloaded(response, request, info)
+
+    def file_path(self, request, response=None, info=None):
+        self._mockcalled.append('file_path')
+        return super(MockedMediaPipelineDeprecatedMethods, self).file_path(request, response, info)
+
+    def get_images(self, response, request, info):
+        self._mockcalled.append('get_images')
+        return []
+
+    def image_downloaded(self, response, request, info):
+        self._mockcalled.append('image_downloaded')
+        return super(MockedMediaPipelineDeprecatedMethods, self).image_downloaded(response, request, info)
+
+
+class MediaPipelineDeprecatedMethodsTestCase(unittest.TestCase):
+
+    def setUp(self):
+        self.pipe = MockedMediaPipelineDeprecatedMethods(store_uri='store-uri', download_func=_mocked_download_func)
+        self.pipe.open_spider(None)
+        self.item = dict(image_urls=['http://picsum.photos/id/1014/200/300'], images=[])
+
+    def _assert_method_called_with_warnings(self, method, message, warnings):
+        self.assertIn(method, self.pipe._mockcalled)
+        warningShown = False
+        for warning in warnings:
+            if warning['message'] == message and warning['category'] == ScrapyDeprecationWarning:
+                warningShown = True
+        self.assertTrue(warningShown)
+
+    @inlineCallbacks
+    def test_media_to_download_called(self):
+        yield self.pipe.process_item(self.item, None)
+        warnings = self.flushWarnings([MediaPipeline._compatible])
         message = (
             'media_to_download(self, request, info) is deprecated, '
             'please use media_to_download(self, request, info, item=None)'
         )
-        self.assertEqual(ScrapyDeprecationWarning, warning[0]['category'])
-        self.assertEqual(message, warning[0]['message'])
+        self._assert_method_called_with_warnings('media_to_download', message, warnings)
 
-    def test_media_downloaded_backwards_compatibility(self):
-        class CustomMediaPipeline(MediaPipeline):
-            def media_downloaded(self, response, request, info):
-                return 'media_downloaded called'
-
-        media_downloaded = CustomMediaPipeline(
-            download_func=_mocked_download_func,
-            settings=Settings(self.settings)
-        ).media_downloaded
-        response, request, info = dict(), Request("http://example.com"), dict()
-        self.assertEqual(media_downloaded(response, request, info), 'media_downloaded called')
-        warning = self.flushWarnings([MediaPipeline._compatible])
+    @inlineCallbacks
+    def test_media_downloaded_called(self):
+        yield self.pipe.process_item(self.item, None)
+        warnings = self.flushWarnings([MediaPipeline._compatible])
         message = (
             'media_downloaded(self, response, request, info) is deprecated, '
             'please use media_downloaded(self, response, request, info, item=None)'
         )
-        self.assertEqual(ScrapyDeprecationWarning, warning[0]['category'])
-        self.assertEqual(message, warning[0]['message'])
+        self._assert_method_called_with_warnings('media_downloaded', message, warnings)
+
+    @inlineCallbacks
+    def test_file_downloaded_called(self):
+        yield self.pipe.process_item(self.item, None)
+        warnings = self.flushWarnings([MediaPipeline._compatible])
+        message = (
+            'file_downloaded(self, response, request, info) is deprecated, '
+            'please use file_downloaded(self, response, request, info, item=None)'
+        )
+        self._assert_method_called_with_warnings('file_downloaded', message, warnings)
+
+    @inlineCallbacks
+    def test_file_path_called(self):
+        yield self.pipe.process_item(self.item, None)
+        warnings = self.flushWarnings([MediaPipeline._compatible])
+        message = (
+            'file_path(self, request, response=None, info=None) is deprecated, '
+            'please use file_path(self, request, response=None, info=None, item=None)'
+        )
+        self._assert_method_called_with_warnings('file_path', message, warnings)
+
+    @inlineCallbacks
+    def test_get_images_called(self):
+        yield self.pipe.process_item(self.item, None)
+        warnings = self.flushWarnings([MediaPipeline._compatible])
+        message = (
+            'get_images(self, response, request, info) is deprecated, '
+            'please use get_images(self, response, request, info, item=None)'
+        )
+        self._assert_method_called_with_warnings('get_images', message, warnings)
+
+    @inlineCallbacks
+    def test_image_downloaded_called(self):
+        yield self.pipe.process_item(self.item, None)
+        warnings = self.flushWarnings([MediaPipeline._compatible])
+        message = (
+            'image_downloaded(self, response, request, info) is deprecated, '
+            'please use image_downloaded(self, response, request, info, item=None)'
+        )
+        self._assert_method_called_with_warnings('image_downloaded', message, warnings)
 
 
 class MediaPipelineAllowRedirectSettingsTestCase(unittest.TestCase):

--- a/tests/test_pipeline_media.py
+++ b/tests/test_pipeline_media.py
@@ -39,8 +39,7 @@ class BaseMediaPipelineTestCase(unittest.TestCase):
 
     def test_default_media_to_download(self):
         request = Request('http://url')
-        item = dict(name='name')
-        assert self.pipe.media_to_download(request, self.info, item) is None
+        assert self.pipe.media_to_download(request, self.info) is None
 
     def test_default_get_media_requests(self):
         item = dict(name='name')
@@ -49,8 +48,7 @@ class BaseMediaPipelineTestCase(unittest.TestCase):
     def test_default_media_downloaded(self):
         request = Request('http://url')
         response = Response('http://url', body=b'')
-        item = dict(name='name')
-        assert self.pipe.media_downloaded(response, request, self.info, item) is response
+        assert self.pipe.media_downloaded(response, request, self.info) is response
 
     def test_default_media_failed(self):
         request = Request('http://url')
@@ -171,17 +169,17 @@ class MockedMediaPipeline(MediaPipeline):
         self._mockcalled.append('download')
         return super(MockedMediaPipeline, self).download(request, info)
 
-    def media_to_download(self, request, info, item):
+    def media_to_download(self, request, info, item=None):
         self._mockcalled.append('media_to_download')
         if 'result' in request.meta:
             return request.meta.get('result')
-        return super(MockedMediaPipeline, self).media_to_download(request, info, item)
+        return super(MockedMediaPipeline, self).media_to_download(request, info)
 
     def get_media_requests(self, item, info):
         self._mockcalled.append('get_media_requests')
         return item.get('requests')
 
-    def media_downloaded(self, response, request, info, item):
+    def media_downloaded(self, response, request, info, item=None):
         self._mockcalled.append('media_downloaded')
         return super(MockedMediaPipeline, self).media_downloaded(response, request, info)
 

--- a/tests/test_pipeline_media.py
+++ b/tests/test_pipeline_media.py
@@ -39,7 +39,8 @@ class BaseMediaPipelineTestCase(unittest.TestCase):
 
     def test_default_media_to_download(self):
         request = Request('http://url')
-        assert self.pipe.media_to_download(request, self.info) is None
+        item = dict(name='name')
+        assert self.pipe.media_to_download(request, self.info, item) is None
 
     def test_default_get_media_requests(self):
         item = dict(name='name')
@@ -48,7 +49,8 @@ class BaseMediaPipelineTestCase(unittest.TestCase):
     def test_default_media_downloaded(self):
         request = Request('http://url')
         response = Response('http://url', body=b'')
-        assert self.pipe.media_downloaded(response, request, self.info) is response
+        item = dict(name='name')
+        assert self.pipe.media_downloaded(response, request, self.info, item) is response
 
     def test_default_media_failed(self):
         request = Request('http://url')
@@ -169,17 +171,17 @@ class MockedMediaPipeline(MediaPipeline):
         self._mockcalled.append('download')
         return super(MockedMediaPipeline, self).download(request, info)
 
-    def media_to_download(self, request, info):
+    def media_to_download(self, request, info, item):
         self._mockcalled.append('media_to_download')
         if 'result' in request.meta:
             return request.meta.get('result')
-        return super(MockedMediaPipeline, self).media_to_download(request, info)
+        return super(MockedMediaPipeline, self).media_to_download(request, info, item)
 
     def get_media_requests(self, item, info):
         self._mockcalled.append('get_media_requests')
         return item.get('requests')
 
-    def media_downloaded(self, response, request, info):
+    def media_downloaded(self, response, request, info, item):
         self._mockcalled.append('media_downloaded')
         return super(MockedMediaPipeline, self).media_downloaded(response, request, info)
 

--- a/tests/test_pipeline_media.py
+++ b/tests/test_pipeline_media.py
@@ -171,7 +171,7 @@ class MockedMediaPipeline(MediaPipeline):
         self._mockcalled.append('download')
         return super(MockedMediaPipeline, self).download(request, info)
 
-    def media_to_download(self, request, info, item=None):
+    def media_to_download(self, request, info, *, item=None):
         self._mockcalled.append('media_to_download')
         if 'result' in request.meta:
             return request.meta.get('result')
@@ -181,7 +181,7 @@ class MockedMediaPipeline(MediaPipeline):
         self._mockcalled.append('get_media_requests')
         return item.get('requests')
 
-    def media_downloaded(self, response, request, info, item=None):
+    def media_downloaded(self, response, request, info, *, item=None):
         self._mockcalled.append('media_downloaded')
         return super(MockedMediaPipeline, self).media_downloaded(response, request, info)
 
@@ -399,7 +399,7 @@ class MediaPipelineDeprecatedMethodsTestCase(unittest.TestCase):
         warnings = self.flushWarnings([MediaPipeline._compatible])
         message = (
             'media_to_download(self, request, info) is deprecated, '
-            'please use media_to_download(self, request, info, item=None)'
+            'please use media_to_download(self, request, info, *, item=None)'
         )
         self._assert_method_called_with_warnings('media_to_download', message, warnings)
 
@@ -409,7 +409,7 @@ class MediaPipelineDeprecatedMethodsTestCase(unittest.TestCase):
         warnings = self.flushWarnings([MediaPipeline._compatible])
         message = (
             'media_downloaded(self, response, request, info) is deprecated, '
-            'please use media_downloaded(self, response, request, info, item=None)'
+            'please use media_downloaded(self, response, request, info, *, item=None)'
         )
         self._assert_method_called_with_warnings('media_downloaded', message, warnings)
 
@@ -419,7 +419,7 @@ class MediaPipelineDeprecatedMethodsTestCase(unittest.TestCase):
         warnings = self.flushWarnings([MediaPipeline._compatible])
         message = (
             'file_downloaded(self, response, request, info) is deprecated, '
-            'please use file_downloaded(self, response, request, info, item=None)'
+            'please use file_downloaded(self, response, request, info, *, item=None)'
         )
         self._assert_method_called_with_warnings('file_downloaded', message, warnings)
 
@@ -429,7 +429,7 @@ class MediaPipelineDeprecatedMethodsTestCase(unittest.TestCase):
         warnings = self.flushWarnings([MediaPipeline._compatible])
         message = (
             'file_path(self, request, response=None, info=None) is deprecated, '
-            'please use file_path(self, request, response=None, info=None, item=None)'
+            'please use file_path(self, request, response=None, info=None, *, item=None)'
         )
         self._assert_method_called_with_warnings('file_path', message, warnings)
 
@@ -439,7 +439,7 @@ class MediaPipelineDeprecatedMethodsTestCase(unittest.TestCase):
         warnings = self.flushWarnings([MediaPipeline._compatible])
         message = (
             'get_images(self, response, request, info) is deprecated, '
-            'please use get_images(self, response, request, info, item=None)'
+            'please use get_images(self, response, request, info, *, item=None)'
         )
         self._assert_method_called_with_warnings('get_images', message, warnings)
 
@@ -449,7 +449,7 @@ class MediaPipelineDeprecatedMethodsTestCase(unittest.TestCase):
         warnings = self.flushWarnings([MediaPipeline._compatible])
         message = (
             'image_downloaded(self, response, request, info) is deprecated, '
-            'please use image_downloaded(self, response, request, info, item=None)'
+            'please use image_downloaded(self, response, request, info, *, item=None)'
         )
         self._assert_method_called_with_warnings('image_downloaded', message, warnings)
 


### PR DESCRIPTION
Closes #4628, closes #4677 

The existing media pipelines (`FilesPipeline` and `ImagesPipeline`) do not allow the user to dynamically define downloaded file location based on the item returned by the spider, thus, forcing the users to use other workarounds like using the `Request.meta` to pass item data or creating their own `Request` subclass with the item passed to it.

I've updated the media pipelines to pass `item` as a parameter to the `file_path` function and have updated the same in the tests as well. This will now allow the user to define file paths based on the item.
