### PR TITLE
Remove obsolete S3FeedStorage instancing without AWS credentials

### DIFF
--- a/scrapy/extensions/feedexport.py
+++ b/scrapy/extensions/feedexport.py
@@ -94,23 +94,10 @@ class FileFeedStorage:
 class S3FeedStorage(BlockingFeedStorage):
 
     def __init__(self, uri, access_key=None, secret_key=None, acl=None):
-        # BEGIN Backward compatibility for initialising without keys (and
-        # without using from_crawler)
-        no_defaults = access_key is None and secret_key is None
-        if no_defaults:
-            from scrapy.utils.project import get_project_settings
-            settings = get_project_settings()
-            if 'AWS_ACCESS_KEY_ID' in settings or 'AWS_SECRET_ACCESS_KEY' in settings:
-                warnings.warn(
-                    "Initialising `scrapy.extensions.feedexport.S3FeedStorage` "
-                    "without AWS keys is deprecated. Please supply credentials or "
-                    "use the `from_crawler()` constructor.",
-                    category=ScrapyDeprecationWarning,
-                    stacklevel=2
-                )
-                access_key = settings['AWS_ACCESS_KEY_ID']
-                secret_key = settings['AWS_SECRET_ACCESS_KEY']
-        # END Backward compatibility
+        no_keys = access_key is None and secret_key is None
+        if no_keys:
+            raise NotConfigured('%s is missing AWS credentials' %
+                                self.__class__.__name__)
         u = urlparse(uri)
         self.bucketname = u.hostname
         self.access_key = u.username or access_key

--- a/scrapy/extensions/feedexport.py
+++ b/scrapy/extensions/feedexport.py
@@ -94,10 +94,6 @@ class FileFeedStorage:
 class S3FeedStorage(BlockingFeedStorage):
 
     def __init__(self, uri, access_key=None, secret_key=None, acl=None):
-        no_keys = access_key is None and secret_key is None
-        if no_keys:
-            raise NotConfigured('%s is missing AWS credentials' %
-                                self.__class__.__name__)
         u = urlparse(uri)
         self.bucketname = u.hostname
         self.access_key = u.username or access_key

--- a/tests/test_feedexport.py
+++ b/tests/test_feedexport.py
@@ -24,7 +24,6 @@ from zope.interface.verify import verifyObject
 
 import scrapy
 from scrapy.crawler import CrawlerRunner
-from scrapy.exceptions import NotConfigured
 from scrapy.exporters import CsvItemExporter
 from scrapy.extensions.feedexport import (
     BlockingFeedStorage,
@@ -202,9 +201,6 @@ class S3FeedStorageTest(unittest.TestCase):
                                 aws_credentials['AWS_SECRET_ACCESS_KEY'])
         self.assertEqual(storage.access_key, 'uri_key')
         self.assertEqual(storage.secret_key, 'uri_secret')
-        # Instantiate without credentials
-        with self.assertRaises(NotConfigured):
-            S3FeedStorage('s3://mybucket/export.csv')
 
     @defer.inlineCallbacks
     def test_store(self):

--- a/tests/test_feedexport.py
+++ b/tests/test_feedexport.py
@@ -5,7 +5,6 @@ import random
 import shutil
 import string
 import tempfile
-import warnings
 from io import BytesIO
 from logging import getLogger
 from pathlib import Path

--- a/tests/test_feedexport.py
+++ b/tests/test_feedexport.py
@@ -182,9 +182,9 @@ class S3FeedStorageTest(unittest.TestCase):
                 create=True)
     def test_parse_credentials(self):
         try:
-            import boto  # noqa: F401
+            import botocore  # noqa: F401
         except ImportError:
-            raise unittest.SkipTest("S3FeedStorage requires boto")
+            raise unittest.SkipTest("S3FeedStorage requires botocore")
         aws_credentials = {'AWS_ACCESS_KEY_ID': 'settings_key',
                            'AWS_SECRET_ACCESS_KEY': 'settings_secret'}
         crawler = get_crawler(settings_dict=aws_credentials)


### PR DESCRIPTION
I have taken this PR https://github.com/scrapy/scrapy/pull/4411 and added fix for a failure in tests (not used import).

I hope @nyov is fine with that.

https://github.com/scrapy/scrapy/issues/4356