### PR TITLE
Remove monkeypatches module from mypy section in setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -13,9 +13,6 @@ follow_imports = skip
 [mypy-scrapy]
 ignore_errors = True
 
-[mypy-scrapy._monkeypatches]
-ignore_errors = True
-
 [mypy-scrapy.commands]
 ignore_errors = True
 


### PR DESCRIPTION
No need to ignore the `_monkeypatches` module during the typing check, it does not exist any more since #4568