### PR TITLE
change string formatting to fstring

### DIFF
--- a/scrapy/cmdline.py
+++ b/scrapy/cmdline.py
@@ -44,7 +44,7 @@ def _get_commands_from_entry_points(inproject, group='scrapy.commands'):
         if inspect.isclass(obj):
             cmds[entry_point.name] = obj()
         else:
-            raise Exception("Invalid entry point %s" % entry_point.name)
+            raise Exception(f"Invalid entry point {entry_point.name}") 
     return cmds
 
 
@@ -68,10 +68,9 @@ def _pop_command_name(argv):
 
 def _print_header(settings, inproject):
     if inproject:
-        print("Scrapy %s - project: %s\n" % (scrapy.__version__,
-                                             settings['BOT_NAME']))
+        print(f"Scrapy {scrapy.__version__} - project: {settings['BOT_NAME']}\n")
     else:
-        print("Scrapy %s - no active project\n" % scrapy.__version__)
+        print(f"Scrapy {scrapy.__version__} - no active project\n")
 
 
 def _print_commands(settings, inproject):
@@ -81,7 +80,7 @@ def _print_commands(settings, inproject):
     print("Available commands:")
     cmds = _get_commands_dict(settings, inproject)
     for cmdname, cmdclass in sorted(cmds.items()):
-        print("  %-13s %s" % (cmdname, cmdclass.short_desc()))
+        print(f"  {cmdname:<13} {cmdclass.short_desc()}")  
     if not inproject:
         print()
         print("  [ more ]      More commands available when run from project directory")
@@ -91,7 +90,7 @@ def _print_commands(settings, inproject):
 
 def _print_unknown_command(settings, cmdname, inproject):
     _print_header(settings, inproject)
-    print("Unknown command: %s\n" % cmdname)
+    print(f"Unknown command: {cmdname}\n")
     print('Use "scrapy" to see available commands')
 
 
@@ -133,7 +132,7 @@ def execute(argv=None, settings=None):
         sys.exit(2)
 
     cmd = cmds[cmdname]
-    parser.usage = "scrapy %s %s" % (cmdname, cmd.syntax())
+    parser.usage = f"scrapy {cmdname} {cmd.syntax()}")
     parser.description = cmd.long_desc()
     settings.setdict(cmd.default_settings, priority='command')
     cmd.settings = settings
@@ -155,7 +154,7 @@ def _run_command(cmd, args, opts):
 
 def _run_command_profiled(cmd, args, opts):
     if opts.profile:
-        sys.stderr.write("scrapy: writing cProfile stats to %r\n" % opts.profile)
+        sys.stderr.write(f"scrapy: writing cProfile stats to {opts.profile!r}\n")
     loc = locals()
     p = cProfile.Profile()
     p.runctx('cmd.run(args, opts)', globals(), loc)


### PR DESCRIPTION
Old-style string formatting with '%' were replaced by new-style f-strings in the scrapy/cmdline.py file.