### PR TITLE
IOError and other cleanup

### DIFF
--- a/docs/utils/linkfix.py
+++ b/docs/utils/linkfix.py
@@ -29,7 +29,7 @@ def main():
     try:
         with open("build/linkcheck/output.txt") as out:
             output_lines = out.readlines()
-    except IOError:
+    except OSError:
         print("linkcheck output not found; please run linkcheck first.")
         exit(1)
 

--- a/scrapy/downloadermiddlewares/decompression.py
+++ b/scrapy/downloadermiddlewares/decompression.py
@@ -55,7 +55,7 @@ class DecompressionMiddleware:
         archive = BytesIO(response.body)
         try:
             body = gzip.GzipFile(fileobj=archive).read()
-        except IOError:
+        except OSError:
             return
 
         respcls = responsetypes.from_args(body=body)
@@ -64,7 +64,7 @@ class DecompressionMiddleware:
     def _is_bzip2(self, response):
         try:
             body = bz2.decompress(response.body)
-        except IOError:
+        except OSError:
             return
 
         respcls = responsetypes.from_args(body=body)

--- a/scrapy/downloadermiddlewares/httpcache.py
+++ b/scrapy/downloadermiddlewares/httpcache.py
@@ -22,7 +22,7 @@ class HttpCacheMiddleware:
     DOWNLOAD_EXCEPTIONS = (defer.TimeoutError, TimeoutError, DNSLookupError,
                            ConnectionRefusedError, ConnectionDone, ConnectError,
                            ConnectionLost, TCPTimedOutError, ResponseFailed,
-                           IOError)
+                           OSError)
 
     def __init__(self, settings, stats):
         if not settings.getbool('HTTPCACHE_ENABLED'):

--- a/scrapy/downloadermiddlewares/retry.py
+++ b/scrapy/downloadermiddlewares/retry.py
@@ -33,12 +33,12 @@ logger = logging.getLogger(__name__)
 
 class RetryMiddleware:
 
-    # IOError is raised by the HttpCompression middleware when trying to
+    # OSError is raised by the HttpCompression middleware when trying to
     # decompress an empty response
     EXCEPTIONS_TO_RETRY = (defer.TimeoutError, TimeoutError, DNSLookupError,
                            ConnectionRefusedError, ConnectionDone, ConnectError,
                            ConnectionLost, TCPTimedOutError, ResponseFailed,
-                           IOError, TunnelError)
+                           OSError, TunnelError)
 
     def __init__(self, settings):
         if not settings.getbool('RETRY_ENABLED'):

--- a/scrapy/pipelines/__init__.py
+++ b/scrapy/pipelines/__init__.py
@@ -18,7 +18,7 @@ class ItemPipelineManager(MiddlewareManager):
         return build_component_list(settings.getwithbase('ITEM_PIPELINES'))
 
     def _add_middleware(self, pipe):
-        super(ItemPipelineManager, self)._add_middleware(pipe)
+        super()._add_middleware(pipe)
         if hasattr(pipe, 'process_item'):
             self.methods['process_item'].append(deferred_f_from_coro_f(pipe.process_item))
 

--- a/scrapy/utils/gz.py
+++ b/scrapy/utils/gz.py
@@ -28,7 +28,7 @@ def gunzip(data):
         try:
             chunk = f.read1(8196)
             output_list.append(chunk)
-        except (IOError, EOFError, struct.error):
+        except (OSError, EOFError, struct.error):
             # complete only if there is some data, otherwise re-raise
             # see issue 87 about catching struct.error
             # some pages are quite small so output_list is empty and f.extrabuf

--- a/scrapy/utils/python.py
+++ b/scrapy/utils/python.py
@@ -296,7 +296,7 @@ def retry_on_eintr(function, *args, **kw):
     while True:
         try:
             return function(*args, **kw)
-        except IOError as e:
+        except OSError as e:
             if e.errno != errno.EINTR:
                 raise
 
@@ -310,7 +310,7 @@ def without_none_values(iterable):
     try:
         return {k: v for k, v in iterable.items() if v is not None}
     except AttributeError:
-        return type(iterable)((v for v in iterable if v is not None))
+        return type(iterable)(v for v in iterable if v is not None)
 
 
 def global_object_name(obj):

--- a/tests/test_downloader_handlers.py
+++ b/tests/test_downloader_handlers.py
@@ -123,7 +123,7 @@ class FileTestCase(unittest.TestCase):
     def test_non_existent(self):
         request = Request('file://%s' % self.mktemp())
         d = self.download_request(request, Spider('foo'))
-        return self.assertFailure(d, IOError)
+        return self.assertFailure(d, OSError)
 
 
 class ContentLengthHeaderResource(resource.Resource):

--- a/tests/test_downloadermiddleware.py
+++ b/tests/test_downloadermiddleware.py
@@ -71,7 +71,7 @@ class DefaultsTest(ManagerTestCase):
         In particular when some website returns a 30x response with header
         'Content-Encoding: gzip' giving as result the error below:
 
-            exceptions.IOError: Not a gzipped file
+            BadGzipFile: Not a gzipped file (...)
 
         """
         req = Request('http://example.com')
@@ -97,7 +97,7 @@ class DefaultsTest(ManagerTestCase):
             'Content-Encoding': 'gzip',
             'Location': 'http://example.com/login',
         })
-        self.assertRaises(IOError, self._download, request=req, response=resp)
+        self.assertRaises(OSError, self._download, request=req, response=resp)
 
 
 class ResponseFromProcessRequestTest(ManagerTestCase):

--- a/tests/test_mail.py
+++ b/tests/test_mail.py
@@ -1,5 +1,3 @@
-# coding=utf-8
-
 import unittest
 from io import BytesIO
 from email.charset import Charset

--- a/tests/test_robotstxt_interface.py
+++ b/tests/test_robotstxt_interface.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 from twisted.trial import unittest
 
 

--- a/tests/test_utils_gz.py
+++ b/tests/test_utils_gz.py
@@ -24,7 +24,7 @@ class GunzipTest(unittest.TestCase):
 
     def test_gunzip_no_gzip_file_raises(self):
         with open(join(SAMPLEDIR, 'feed-sample1.xml'), 'rb') as f:
-            self.assertRaises(IOError, gunzip, f.read())
+            self.assertRaises(OSError, gunzip, f.read())
 
     def test_gunzip_truncated_short(self):
         with open(join(SAMPLEDIR, 'truncated-crc-error-short.gz'), 'rb') as f:

--- a/tests/test_utils_iterators.py
+++ b/tests/test_utils_iterators.py
@@ -272,8 +272,8 @@ class UtilsCsvTestCase(unittest.TestCase):
 
         # explicit type check cuz' we no like stinkin' autocasting! yarrr
         for result_row in result:
-            self.assertTrue(all((isinstance(k, str) for k in result_row.keys())))
-            self.assertTrue(all((isinstance(v, str) for v in result_row.values())))
+            self.assertTrue(all(isinstance(k, str) for k in result_row.keys()))
+            self.assertTrue(all(isinstance(v, str) for v in result_row.values()))
 
     def test_csviter_delimiter(self):
         body = get_testdata('feeds', 'feed-sample3.csv').replace(b',', b'\t')


### PR DESCRIPTION
From Python 3.3 the `IOError` is just an alias for OSError and is kept for compatibility reasons.

reference: https://docs.python.org/3/whatsnew/3.3.html#pep-3151-reworking-the-os-and-io-exception-hierarchy