### PR TITLE
Upgrade minimum dependencies for Python 3.6 support

### DIFF
--- a/tests/requirements-py3.txt
+++ b/tests/requirements-py3.txt
@@ -1,8 +1,7 @@
 # Tests requirements
 attrs
 dataclasses; python_version == '3.6'
-mitmproxy; python_version >= '3.6'
-mitmproxy<4.0.0; python_version < '3.6'
+mitmproxy >=4, <5  # The latest version does not support some pinned dependencies
 # https://github.com/pytest-dev/pytest-twisted/issues/93
 pytest != 5.4, != 5.4.1
 pytest-azurepipelines

--- a/tests/requirements-py3.txt
+++ b/tests/requirements-py3.txt
@@ -1,7 +1,8 @@
 # Tests requirements
 attrs
 dataclasses; python_version == '3.6'
-mitmproxy >=4, <5  # The latest version does not support some pinned dependencies
+mitmproxy >=4, <5; python_version < '3.6'  # The latest version does not support some pinned dependencies
+mitmproxy <4; python_version < '3.6'
 # https://github.com/pytest-dev/pytest-twisted/issues/93
 pytest != 5.4, != 5.4.1
 pytest-azurepipelines

--- a/tests/requirements-py3.txt
+++ b/tests/requirements-py3.txt
@@ -1,8 +1,9 @@
 # Tests requirements
 attrs
-dataclasses; python_version == '3.6'
-mitmproxy >=4, <5; python_version < '3.6'  # The latest version does not support some pinned dependencies
-mitmproxy <4; python_version < '3.6'
+dataclasses; python_version ==3.6
+mitmproxy; python_version >=3.7
+mitmproxy >=4, <5; python_version >=3.6, <3.7
+mitmproxy <4; python_version <3.6
 # https://github.com/pytest-dev/pytest-twisted/issues/93
 pytest != 5.4, != 5.4.1
 pytest-azurepipelines

--- a/tests/requirements-py3.txt
+++ b/tests/requirements-py3.txt
@@ -1,9 +1,9 @@
 # Tests requirements
 attrs
-dataclasses; python_version ==3.6
-mitmproxy; python_version >=3.7
-mitmproxy >=4, <5; python_version >=3.6, <3.7
-mitmproxy <4; python_version <3.6
+dataclasses; python_version == '3.6'
+mitmproxy; python_version >= '3.7'
+mitmproxy >= 4, < 5; python_version >= '3.6' and python_version < '3.7'
+mitmproxy < 4; python_version < '3.6'
 # https://github.com/pytest-dev/pytest-twisted/issues/93
 pytest != 5.4, != 5.4.1
 pytest-azurepipelines

--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,7 @@ deps =
     -rtests/requirements-py3.txt
     # Extras
     boto3>=1.13.0
-    botocore>=1.3.23
+    botocore>=1.4.87
     Pillow>=3.4.2
 passenv =
     S3_TEST_FILE_URI
@@ -76,7 +76,7 @@ deps =
     zope.interface==4.1.3
     -rtests/requirements-py3.txt
     # Extras
-    botocore==1.3.23
+    botocore==1.4.87
     google-cloud-storage==1.29.0
     Pillow==3.4.2
 


### PR DESCRIPTION
While working on HTTP/2 support, @adityaa30 [discovered](https://github.com/scrapy/scrapy/pull/4669) that simply upgrading the pinned Travis CI job to 3.6 would cause tests to fail.

[It turns out](https://github.com/scrapy/scrapy/pull/4681) we need to first upgrade some pinned dependencies for that to work.

This does so, in preparation for the upcoming removal of Python 3.5 support, but without actually dropping such support yet just in case.