### PR TITLE
test_utils_iterators.py: support Windows the right way

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+tests/sample_data/** binary

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -28,5 +28,5 @@ tests_datadir = os.path.join(os.path.abspath(os.path.dirname(__file__)),
 def get_testdata(*paths):
     """Return test data"""
     path = os.path.join(tests_datadir, *paths)
-    with open(path, 'rb') as f:
+    with open(path, 'rb', newline='') as f:
         return f.read()

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -28,5 +28,5 @@ tests_datadir = os.path.join(os.path.abspath(os.path.dirname(__file__)),
 def get_testdata(*paths):
     """Return test data"""
     path = os.path.join(tests_datadir, *paths)
-    with open(path, 'rb', newline='') as f:
+    with open(path, 'rb') as f:
         return f.read()

--- a/tests/test_utils_iterators.py
+++ b/tests/test_utils_iterators.py
@@ -7,9 +7,6 @@ from scrapy.http import XmlResponse, TextResponse, Response
 from tests import get_testdata
 
 
-FOOBAR_NL = "foo{}bar".format(os.linesep)
-
-
 class XmliterTestCase(unittest.TestCase):
 
     xmliter = staticmethod(xmliter)
@@ -267,7 +264,7 @@ class UtilsCsvTestCase(unittest.TestCase):
         self.assertEqual(result,
                          [{'id': '1', 'name': 'alpha', 'value': 'foobar'},
                           {'id': '2', 'name': 'unicode', 'value': '\xfan\xedc\xf3d\xe9\u203d'},
-                          {'id': '3', 'name': 'multi', 'value': FOOBAR_NL},
+                          {'id': '3', 'name': 'multi', 'value': "foo\nbar"},
                           {'id': '4', 'name': 'empty', 'value': ''}])
 
         # explicit type check cuz' we no like stinkin' autocasting! yarrr
@@ -283,7 +280,7 @@ class UtilsCsvTestCase(unittest.TestCase):
         self.assertEqual([row for row in csv],
                          [{'id': '1', 'name': 'alpha', 'value': 'foobar'},
                           {'id': '2', 'name': 'unicode', 'value': '\xfan\xedc\xf3d\xe9\u203d'},
-                          {'id': '3', 'name': 'multi', 'value': FOOBAR_NL},
+                          {'id': '3', 'name': 'multi', 'value': "foo\nbar"},
                           {'id': '4', 'name': 'empty', 'value': ''}])
 
     def test_csviter_quotechar(self):
@@ -296,7 +293,7 @@ class UtilsCsvTestCase(unittest.TestCase):
         self.assertEqual([row for row in csv1],
                          [{'id': '1', 'name': 'alpha', 'value': 'foobar'},
                           {'id': '2', 'name': 'unicode', 'value': '\xfan\xedc\xf3d\xe9\u203d'},
-                          {'id': '3', 'name': 'multi', 'value': FOOBAR_NL},
+                          {'id': '3', 'name': 'multi', 'value': "foo\nbar"},
                           {'id': '4', 'name': 'empty', 'value': ''}])
 
         response2 = TextResponse(url="http://example.com/", body=body2)
@@ -305,7 +302,7 @@ class UtilsCsvTestCase(unittest.TestCase):
         self.assertEqual([row for row in csv2],
                          [{'id': '1', 'name': 'alpha', 'value': 'foobar'},
                           {'id': '2', 'name': 'unicode', 'value': '\xfan\xedc\xf3d\xe9\u203d'},
-                          {'id': '3', 'name': 'multi', 'value': FOOBAR_NL},
+                          {'id': '3', 'name': 'multi', 'value': "foo\nbar"},
                           {'id': '4', 'name': 'empty', 'value': ''}])
 
     def test_csviter_wrong_quotechar(self):
@@ -327,7 +324,7 @@ class UtilsCsvTestCase(unittest.TestCase):
         self.assertEqual([row for row in csv],
                          [{'id': '1', 'name': 'alpha', 'value': 'foobar'},
                           {'id': '2', 'name': 'unicode', 'value': '\xfan\xedc\xf3d\xe9\u203d'},
-                          {'id': '3', 'name': 'multi', 'value': FOOBAR_NL},
+                          {'id': '3', 'name': 'multi', 'value': "foo\nbar"},
                           {'id': '4', 'name': 'empty', 'value': ''}])
 
     def test_csviter_headers(self):
@@ -353,7 +350,7 @@ class UtilsCsvTestCase(unittest.TestCase):
         self.assertEqual([row for row in csv],
                          [{'id': '1', 'name': 'alpha', 'value': 'foobar'},
                           {'id': '2', 'name': 'unicode', 'value': '\xfan\xedc\xf3d\xe9\u203d'},
-                          {'id': '3', 'name': 'multi', 'value': FOOBAR_NL},
+                          {'id': '3', 'name': 'multi', 'value': "foo\nbar"},
                           {'id': '4', 'name': 'empty', 'value': ''}])
 
     def test_csviter_exception(self):


### PR DESCRIPTION
It should solve some issues caught by Conda Forge: https://github.com/conda-forge/scrapy-feedstock/pull/44

They were caught by Conda Forge because it uses the test files from the PyPI tarball, not from Git, so in Conda Forge the line endings of files are never changed.