### PR TITLE
Re-enable TLS 1.2 in cipher tests.

### DIFF
--- a/tests/mockserver.py
+++ b/tests/mockserver.py
@@ -289,8 +289,8 @@ def ssl_context_factory(keyfile='keys/localhost.key', certfile='keys/localhost.c
     )
     if cipher_string:
         ctx = factory.getContext()
-        # disabling TLS1.2+ because it unconditionally enables some strong ciphers
-        ctx.set_options(SSL.OP_CIPHER_SERVER_PREFERENCE | SSL.OP_NO_TLSv1_2 | SSL_OP_NO_TLSv1_3)
+        # disabling TLS1.3 because it unconditionally enables some strong ciphers
+        ctx.set_options(SSL.OP_CIPHER_SERVER_PREFERENCE | SSL_OP_NO_TLSv1_3)
         ctx.set_cipher_list(to_bytes(cipher_string))
     return factory
 


### PR DESCRIPTION
This should fix cipher tests on platforms where TLS 1.2 is the minimum supported version such as modern Debian. I don't remember why I disabled 1.2 initially as only 1.3 adds ciphers unconditionally (check `openssl ciphers -s -tls1_2 CAMELLIA256-SHA` and `openssl ciphers -s -tls1_3 CAMELLIA256-SHA`).

We'll need to do something else (and probably in Scrapy too, not just in tests) when TLS version reqs are even stricter.

Fixes #4726.

Note that `tests/test_downloader_handlers.py::Https11CustomCiphers` is fine when additional ciphers are enabled (so e.g. won't fail when `SSL_OP_NO_TLSv1_3` is removed) while `tests/test_webclient.py::WebClientCustomCiphersSSLTestCase` also checks for an error when the ciphers don't match (and will fail without `SSL_OP_NO_TLSv1_3` as in that case the custom ciphers will be ignored).