### PR TITLE
Update PyPy links

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,7 +50,7 @@ install:
   - |
       if [[ ! -z "$PYPY_VERSION" ]]; then
         export PYPY_VERSION="pypy$PYPY_VERSION-linux64"
-        wget "https://bitbucket.org/pypy/pypy/downloads/${PYPY_VERSION}.tar.bz2"
+        wget "https://downloads.python.org/pypy/${PYPY_VERSION}.tar.bz2"
         tar -jxf ${PYPY_VERSION}.tar.bz2
         virtualenv --python="$PYPY_VERSION/bin/pypy3" "$HOME/virtualenvs/$PYPY_VERSION"
         source "$HOME/virtualenvs/$PYPY_VERSION/bin/activate"

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ if has_environment_marker_platform_impl_support():
     ]
     extras_require[':platform_python_implementation == "PyPy"'] = [
         # Earlier lxml versions are affected by
-        # https://bitbucket.org/pypy/pypy/issues/2498/cython-on-pypy-3-dict-object-has-no,
+        # https://foss.heptapod.net/pypy/pypy/-/issues/2498,
         # which was fixed in Cython 0.26, released on 2017-06-19, and used to
         # generate the C headers of lxml release tarballs published since then, the
         # first of which was:


### PR DESCRIPTION
https://bitbucket.org/pypy/pypy/ now says:

> ### Repository unavailable
> Bitbucket no longer supports Mercurial repositories.

PyPy source and issues has moved to https://foss.heptapod.net/pypy/pypy

Downloads are now at downloads.python.org:

* https://www.pypy.org/download.html
* https://downloads.python.org/pypy/
