### PR TITLE
Support for delegated methods as callbacks

### DIFF
--- a/scrapy/utils/reqser.py
+++ b/scrapy/utils/reqser.py
@@ -71,23 +71,19 @@ def request_from_dict(d, spider=None):
 
 
 def _find_method(obj, func):
-    if obj:
-        try:
-            func.__func__
-        except AttributeError:  # func is not a instance method. Not supported.
-            pass
-        else:
-            members = inspect.getmembers(obj, predicate=inspect.ismethod)
-            for name, obj_func in members:
-                # We need to use __func__ to access the original
-                # function object because instance method objects
-                # are generated each time attribute is retrieved from
-                # instance.
-                #
-                # Reference: The standard type hierarchy
-                # https://docs.python.org/3/reference/datamodel.html
-                if obj_func.__func__ is func.__func__:
-                    return name
+    # Only instance methods contain ``__func__``
+    if obj and hasattr(func, '__func__'):
+        members = inspect.getmembers(obj, predicate=inspect.ismethod)
+        for name, obj_func in members:
+            # We need to use __func__ to access the original
+            # function object because instance method objects
+            # are generated each time attribute is retrieved from
+            # instance.
+            #
+            # Reference: The standard type hierarchy
+            # https://docs.python.org/3/reference/datamodel.html
+            if obj_func.__func__ is func.__func__:
+                return name
     raise ValueError("Function %s is not an instance method in: %s" % (func, obj))
 
 

--- a/scrapy/utils/reqser.py
+++ b/scrapy/utils/reqser.py
@@ -73,23 +73,22 @@ def request_from_dict(d, spider=None):
 def _find_method(obj, func):
     if obj:
         try:
-            func_self = func.__self__
-        except AttributeError:  # func has no __self__
+            func.__func__
+        except AttributeError:  # func is not a instance method. Not supported.
             pass
         else:
-            if func_self is obj:
-                members = inspect.getmembers(obj, predicate=inspect.ismethod)
-                for name, obj_func in members:
-                    # We need to use __func__ to access the original
-                    # function object because instance method objects
-                    # are generated each time attribute is retrieved from
-                    # instance.
-                    #
-                    # Reference: The standard type hierarchy
-                    # https://docs.python.org/3/reference/datamodel.html
-                    if obj_func.__func__ is func.__func__:
-                        return name
-    raise ValueError("Function %s is not a method of: %s" % (func, obj))
+            members = inspect.getmembers(obj, predicate=inspect.ismethod)
+            for name, obj_func in members:
+                # We need to use __func__ to access the original
+                # function object because instance method objects
+                # are generated each time attribute is retrieved from
+                # instance.
+                #
+                # Reference: The standard type hierarchy
+                # https://docs.python.org/3/reference/datamodel.html
+                if obj_func.__func__ is func.__func__:
+                    return name
+    raise ValueError("Function %s is not an instance method in: %s" % (func, obj))
 
 
 def _get_method(obj, name):

--- a/tests/test_utils_reqser.py
+++ b/tests/test_utils_reqser.py
@@ -137,9 +137,11 @@ class TestSpiderMixin:
     def __mixin_callback(self, response):
         pass
 
+
 class TestSpiderDelegation:
     def delegated_callback(self, response):
         pass
+
 
 def parse_item(response):
     pass

--- a/tests/test_utils_reqser.py
+++ b/tests/test_utils_reqser.py
@@ -102,6 +102,12 @@ class RequestSerializationTest(unittest.TestCase):
                     errback=self.spider.handle_error)
         self._assert_serializes_ok(r, spider=self.spider)
 
+    def test_delegated_callback_serialization(self):
+        r = Request("http://www.example.com",
+                    callback=self.spider.delegated_callback,
+                    errback=self.spider.handle_error)
+        self._assert_serializes_ok(r, spider=self.spider)
+
     def test_unserializable_callback1(self):
         r = Request("http://www.example.com", callback=lambda x: x)
         self.assertRaises(ValueError, request_to_dict, r)
@@ -131,6 +137,9 @@ class TestSpiderMixin:
     def __mixin_callback(self, response):
         pass
 
+class TestSpiderDelegation:
+    def delegated_callback(self, response):
+        pass
 
 def parse_item(response):
     pass
@@ -154,6 +163,9 @@ class TestSpider(Spider, TestSpiderMixin):
     handle_error_reference = handle_error
     __parse_item_reference = private_parse_item
     __handle_error_reference = private_handle_error
+
+    def __init__(self):
+        self.delegated_callback = TestSpiderDelegation().delegated_callback
 
     def parse_item(self, response):
         pass


### PR DESCRIPTION
It is useful to split the spider code around some helper classes if the spider code is too big. Using inheritance and mixings is the regular approach in this case. But using callback delegation could be a useful alternative in some cases but Scrapy does not support it. For example, this is not allowed currently:

```py
class UKHomepageParser:
  def parse(self, response):
    ...

class USHomepageParser:
  def parse(self, response):
    ...

class MySpider(Spider):
  def __init__(self, location):
    if location == "UK:
      self.parse = UKHomepageParser().parse
    else:
      self.parse = USHomepageParser().parse

  ...
```

Nothing prevents Scrapy to support this case. This PR changes the function `_find_method` in `reqser.py` removing the constraint that forces a callback `self` to be the spider. Being a method from a different class is not a problem as long as this method is a member of spider class. The required change to support this is pretty small.