### PR TITLE
Remove dead boto2 code, deprecate is_botocore().

### DIFF
--- a/scrapy/core/downloader/handlers/s3.py
+++ b/scrapy/core/downloader/handlers/s3.py
@@ -2,33 +2,9 @@ from urllib.parse import unquote
 
 from scrapy.core.downloader.handlers.http import HTTPDownloadHandler
 from scrapy.exceptions import NotConfigured
-from scrapy.utils.boto import is_botocore
+from scrapy.utils.boto import is_botocore_available
 from scrapy.utils.httpobj import urlparse_cached
 from scrapy.utils.misc import create_instance
-
-
-def _get_boto_connection():
-    from boto.s3.connection import S3Connection
-
-    class _v19_S3Connection(S3Connection):
-        """A dummy S3Connection wrapper that doesn't do any synchronous download"""
-        def _mexe(self, method, bucket, key, headers, *args, **kwargs):
-            return headers
-
-    class _v20_S3Connection(S3Connection):
-        """A dummy S3Connection wrapper that doesn't do any synchronous download"""
-        def _mexe(self, http_request, *args, **kwargs):
-            http_request.authorize(connection=self)
-            return http_request.headers
-
-    try:
-        import boto.auth  # noqa: F401
-    except ImportError:
-        _S3Connection = _v19_S3Connection
-    else:
-        _S3Connection = _v20_S3Connection
-
-    return _S3Connection
 
 
 class S3DownloadHandler:
@@ -37,6 +13,9 @@ class S3DownloadHandler:
                  crawler=None,
                  aws_access_key_id=None, aws_secret_access_key=None,
                  httpdownloadhandler=HTTPDownloadHandler, **kw):
+        if not is_botocore_available():
+            raise NotConfigured('missing botocore library')
+
         if not aws_access_key_id:
             aws_access_key_id = settings['AWS_ACCESS_KEY_ID']
         if not aws_secret_access_key:
@@ -51,23 +30,15 @@ class S3DownloadHandler:
         self.anon = kw.get('anon')
 
         self._signer = None
-        if is_botocore():
-            import botocore.auth
-            import botocore.credentials
-            kw.pop('anon', None)
-            if kw:
-                raise TypeError(f'Unexpected keyword arguments: {kw}')
-            if not self.anon:
-                SignerCls = botocore.auth.AUTH_TYPE_MAPS['s3']
-                self._signer = SignerCls(botocore.credentials.Credentials(
-                    aws_access_key_id, aws_secret_access_key))
-        else:
-            _S3Connection = _get_boto_connection()
-            try:
-                self.conn = _S3Connection(
-                    aws_access_key_id, aws_secret_access_key, **kw)
-            except Exception as ex:
-                raise NotConfigured(str(ex))
+        import botocore.auth
+        import botocore.credentials
+        kw.pop('anon', None)
+        if kw:
+            raise TypeError(f'Unexpected keyword arguments: {kw}')
+        if not self.anon:
+            SignerCls = botocore.auth.AUTH_TYPE_MAPS['s3']
+            self._signer = SignerCls(botocore.credentials.Credentials(
+                aws_access_key_id, aws_secret_access_key))
 
         _http_handler = create_instance(
             objcls=httpdownloadhandler,

--- a/scrapy/utils/boto.py
+++ b/scrapy/utils/boto.py
@@ -1,11 +1,32 @@
 """Boto/botocore helpers"""
+import warnings
 
-from scrapy.exceptions import NotConfigured
+from scrapy.exceptions import NotConfigured, ScrapyDeprecationWarning
 
 
 def is_botocore():
+    """ Returns True if botocore is available, otherwise raises NotConfigured. Never returns False.
+
+    Previously, when boto was supported in addition to botocore, this returned False if boto was available
+    but botocore wasn't.
+    """
+    message = (
+        'is_botocore() is deprecated and always returns True or raises an Exception, '
+        'so it cannot be used for checking if boto is available instead of botocore. '
+        'You can use scrapy.utils.boto.is_botocore_available() to check if botocore '
+        'is available.'
+    )
+    warnings.warn(message, ScrapyDeprecationWarning, stacklevel=2)
     try:
         import botocore  # noqa: F401
         return True
     except ImportError:
         raise NotConfigured('missing botocore library')
+
+
+def is_botocore_available():
+    try:
+        import botocore  # noqa: F401
+        return True
+    except ImportError:
+        return False

--- a/tests/test_pipeline_files.py
+++ b/tests/test_pipeline_files.py
@@ -22,7 +22,6 @@ from scrapy.pipelines.files import (
     S3FilesStore,
 )
 from scrapy.settings import Settings
-from scrapy.utils.boto import is_botocore
 from scrapy.utils.test import (
     assert_aws_environ,
     assert_gcs_environ,
@@ -437,16 +436,10 @@ class TestS3FilesStore(unittest.TestCase):
         content, key = get_s3_content_and_delete(
             u.hostname, u.path[1:], with_key=True)
         self.assertEqual(content, data)
-        if is_botocore():
-            self.assertEqual(key['Metadata'], {'foo': 'bar'})
-            self.assertEqual(
-                key['CacheControl'], S3FilesStore.HEADERS['Cache-Control'])
-            self.assertEqual(key['ContentType'], 'image/png')
-        else:
-            self.assertEqual(key.metadata, {'foo': 'bar'})
-            self.assertEqual(
-                key.cache_control, S3FilesStore.HEADERS['Cache-Control'])
-            self.assertEqual(key.content_type, 'image/png')
+        self.assertEqual(key['Metadata'], {'foo': 'bar'})
+        self.assertEqual(
+            key['CacheControl'], S3FilesStore.HEADERS['Cache-Control'])
+        self.assertEqual(key['ContentType'], 'image/png')
 
 
 class TestGCSFilesStore(unittest.TestCase):


### PR DESCRIPTION
This:

* deprecates is_botocore() and adds an explanation how does it currently work (return True if `botocore` is available, raise an exception otherwise) and that it cannot help with boto/botocore code path choice.
* adds is_botocore_available() that should be used to check if `botocore` is available.
* for all `if is_botocore(): code1 else: code2` keeps just `code1`, adding `if not is_botocore_available(): raise NotConfigured()` (or `skip_if_no_boto()` in tests) where it makes sense.
* removes two tests which tested some dead code but were not skipped because they mock things.

Note that we currently don't run tests without `botocore` installed and because of that not all tests that need it are properly skipped and fail instead. This PR doesn't fix this.

Consider tagging `discuss` if you think it needs it.

Fixes #4734. Related to #1866.