### PR TITLE
Check for unparseable no_proxy values

### DIFF
--- a/scrapy/downloadermiddlewares/httpproxy.py
+++ b/scrapy/downloadermiddlewares/httpproxy.py
@@ -13,7 +13,12 @@ class HttpProxyMiddleware:
         self.auth_encoding = auth_encoding
         self.proxies = {}
         for type_, url in getproxies().items():
-            self.proxies[type_] = self._get_proxy(url, type_)
+            try:
+                self.proxies[type_] = self._get_proxy(url, type_)
+            # some values such as '/var/run/docker.sock' can't be parsed
+            # by _parse_proxy and as such should be skipped
+            except ValueError:
+                continue
 
     @classmethod
     def from_crawler(cls, crawler):

--- a/tests/test_downloadermiddleware_httpproxy.py
+++ b/tests/test_downloadermiddleware_httpproxy.py
@@ -123,11 +123,7 @@ class TestHttpProxyMiddleware(TestCase):
 
     def test_no_proxy(self):
         os.environ['http_proxy'] = 'https://proxy.for.http:3128'
-        os.environ['no_proxy'] = '/var/run/docker.sock'
         mw = HttpProxyMiddleware()
-        # '/var/run/docker.sock' may be used by the user for
-        # no_proxy value but is not parseable and should be skipped
-        assert 'no' not in mw.proxies
 
         os.environ['no_proxy'] = '*'
         req = Request('http://noproxy.com')
@@ -149,3 +145,10 @@ class TestHttpProxyMiddleware(TestCase):
         req = Request('http://noproxy.com', meta={'proxy': 'http://proxy.com'})
         assert mw.process_request(req, spider) is None
         self.assertEqual(req.meta, {'proxy': 'http://proxy.com'})
+
+    def test_no_proxy_invalid_values(self):
+        os.environ['no_proxy'] = '/var/run/docker.sock'
+        mw = HttpProxyMiddleware()
+        # '/var/run/docker.sock' may be used by the user for
+        # no_proxy value but is not parseable and should be skipped
+        assert 'no' not in mw.proxies

--- a/tests/test_downloadermiddleware_httpproxy.py
+++ b/tests/test_downloadermiddleware_httpproxy.py
@@ -123,7 +123,11 @@ class TestHttpProxyMiddleware(TestCase):
 
     def test_no_proxy(self):
         os.environ['http_proxy'] = 'https://proxy.for.http:3128'
+        os.environ['no_proxy'] = '/var/run/docker.sock'
         mw = HttpProxyMiddleware()
+        # '/var/run/docker.sock' may be used by the user for
+        # no_proxy value but is not parseable and should be skipped
+        assert 'no' not in mw.proxies
 
         os.environ['no_proxy'] = '*'
         req = Request('http://noproxy.com')


### PR DESCRIPTION
Fixes #3331 

`/var/run/docker.sock` seemed an exceptional case when a socket file is used in `no_proxy` env variable which is unparseable by the `urllib.request._parse_proxy` method.

