### PR TITLE
Use mocking for S3 tests that currently need server credentials

### DIFF
--- a/scrapy/utils/test.py
+++ b/scrapy/utils/test.py
@@ -23,18 +23,6 @@ def skip_if_no_boto():
         raise SkipTest('missing botocore library')
 
 
-def get_s3_content_and_delete(bucket, path, with_key=False):
-    """ Get content from s3 key, and delete key afterwards.
-    """
-    import botocore.session
-    session = botocore.session.get_session()
-    client = session.create_client('s3')
-    key = client.get_object(Bucket=bucket, Key=path)
-    content = key['Body'].read()
-    client.delete_object(Bucket=bucket, Key=path)
-    return (content, key) if with_key else content
-
-
 def get_gcs_content_and_delete(bucket, path):
     from google.cloud import storage
     client = storage.Client(project=os.environ.get('GCS_PROJECT_ID'))

--- a/scrapy/utils/test.py
+++ b/scrapy/utils/test.py
@@ -13,15 +13,6 @@ from twisted.trial.unittest import SkipTest
 from scrapy.utils.boto import is_botocore_available
 
 
-def assert_aws_environ():
-    """Asserts the current environment is suitable for running AWS testsi.
-    Raises SkipTest with the reason if it's not.
-    """
-    skip_if_no_boto()
-    if 'AWS_ACCESS_KEY_ID' not in os.environ:
-        raise SkipTest("AWS keys not found")
-
-
 def assert_gcs_environ():
     if 'GCS_PROJECT_ID' not in os.environ:
         raise SkipTest("GCS_PROJECT_ID not found")

--- a/tests/test_downloader_handlers.py
+++ b/tests/test_downloader_handlers.py
@@ -868,29 +868,6 @@ class S3TestCase(unittest.TestCase):
         self.assertEqual(httpreq.headers['Authorization'],
                          b'AWS 0PN5J17HBGZHT7JJ3X82:thdUi9VAkzhkniLj96JIrOPGi0g=')
 
-    def test_request_signing5(self):
-        try:
-            import botocore  # noqa: F401
-        except ImportError:
-            pass
-        else:
-            raise unittest.SkipTest(
-                'botocore does not support overriding date with x-amz-date')
-        # deletes an object from the 'johnsmith' bucket using the
-        # path-style and Date alternative.
-        date = 'Tue, 27 Mar 2007 21:20:27 +0000'
-        req = Request(
-            's3://johnsmith/photos/puppy.jpg', method='DELETE', headers={
-                'Date': date,
-                'x-amz-date': 'Tue, 27 Mar 2007 21:20:26 +0000',
-            })
-        with self._mocked_date(date):
-            httpreq = self.download_request(req, self.spider)
-        # botocore does not override Date with x-amz-date
-        self.assertEqual(
-            httpreq.headers['Authorization'],
-            b'AWS 0PN5J17HBGZHT7JJ3X82:k3nL7gH3+PadhTEVn5Ip83xlYzk=')
-
     def test_request_signing6(self):
         # uploads an object to a CNAME style virtual hosted bucket with metadata.
         date = 'Tue, 27 Mar 2007 21:06:08 +0000'

--- a/tests/test_feedexport.py
+++ b/tests/test_feedexport.py
@@ -41,7 +41,6 @@ from scrapy.extensions.feedexport import (
 from scrapy.settings import Settings
 from scrapy.utils.python import to_unicode
 from scrapy.utils.test import (
-    get_s3_content_and_delete,
     get_crawler,
     mock_google_cloud_storage,
     skip_if_no_boto,
@@ -1577,7 +1576,7 @@ class BatchDeliveriesTest(FeedExportTestBase):
             TestSpider.start_urls = [server.url('/')]
             yield runner.crawl(TestSpider)
 
-        self.assertEqual(len(CustomS3FeedStorage.stubs), len(items)+1)
+        self.assertEqual(len(CustomS3FeedStorage.stubs), len(items) + 1)
         for stub in CustomS3FeedStorage.stubs[:-1]:
             stub.assert_no_pending_responses()
 

--- a/tests/test_feedexport.py
+++ b/tests/test_feedexport.py
@@ -13,7 +13,7 @@ from logging import getLogger
 from pathlib import Path
 from string import ascii_letters, digits
 from unittest import mock
-from urllib.parse import urljoin, urlparse, quote
+from urllib.parse import urljoin, quote
 from urllib.request import pathname2url
 
 import lxml.etree

--- a/tests/test_pipeline_files.py
+++ b/tests/test_pipeline_files.py
@@ -469,6 +469,7 @@ class TestS3FilesStore(unittest.TestCase):
         key = 'export.csv'
         uri = f's3://{bucket}/{key}'
         checksum = '3187896a9657a28163abb31667df64c8'
+        last_modified = datetime(2019, 12, 1)
 
         store = S3FilesStore(uri)
         from botocore.stub import Stubber
@@ -481,7 +482,7 @@ class TestS3FilesStore(unittest.TestCase):
                 },
                 service_response={
                     'ETag': f'"{checksum}"',
-                    'LastModified': datetime(2019, 12, 1),
+                    'LastModified': last_modified,
                 },
             )
 
@@ -490,7 +491,7 @@ class TestS3FilesStore(unittest.TestCase):
                 file_stats,
                 {
                     'checksum': checksum,
-                    'last_modified': 1575154800,
+                    'last_modified': last_modified.timestamp(),
                 },
             )
 

--- a/tests/test_pipeline_files.py
+++ b/tests/test_pipeline_files.py
@@ -27,7 +27,6 @@ from scrapy.utils.test import (
     assert_gcs_environ,
     get_ftp_content_and_delete,
     get_gcs_content_and_delete,
-    get_s3_content_and_delete,
     skip_if_no_boto,
 )
 

--- a/tests/test_pipeline_files.py
+++ b/tests/test_pipeline_files.py
@@ -1,6 +1,7 @@
 import os
 import random
 import time
+from datetime import datetime
 from io import BytesIO
 from shutil import rmtree
 from tempfile import mkdtemp
@@ -23,11 +24,11 @@ from scrapy.pipelines.files import (
 )
 from scrapy.settings import Settings
 from scrapy.utils.test import (
-    assert_aws_environ,
     assert_gcs_environ,
     get_ftp_content_and_delete,
     get_gcs_content_and_delete,
     get_s3_content_and_delete,
+    skip_if_no_boto,
 )
 
 
@@ -414,32 +415,87 @@ class FilesPipelineTestCaseCustomSettings(unittest.TestCase):
 
 
 class TestS3FilesStore(unittest.TestCase):
+
     @defer.inlineCallbacks
     def test_persist(self):
-        assert_aws_environ()
-        uri = os.environ.get('S3_TEST_FILE_URI')
-        if not uri:
-            raise unittest.SkipTest("No S3 URI available for testing")
-        data = b"TestS3FilesStore: \xe2\x98\x83"
-        buf = BytesIO(data)
+        skip_if_no_boto()
+
+        bucket = 'mybucket'
+        key = 'export.csv'
+        uri = f's3://{bucket}/{key}'
+        buffer = mock.MagicMock()
         meta = {'foo': 'bar'}
         path = ''
+        content_type = 'image/png'
+
         store = S3FilesStore(uri)
-        yield store.persist_file(
-            path, buf, info=None, meta=meta,
-            headers={'Content-Type': 'image/png'})
-        s = yield store.stat_file(path, info=None)
-        self.assertIn('last_modified', s)
-        self.assertIn('checksum', s)
-        self.assertEqual(s['checksum'], '3187896a9657a28163abb31667df64c8')
-        u = urlparse(uri)
-        content, key = get_s3_content_and_delete(
-            u.hostname, u.path[1:], with_key=True)
-        self.assertEqual(content, data)
-        self.assertEqual(key['Metadata'], {'foo': 'bar'})
-        self.assertEqual(
-            key['CacheControl'], S3FilesStore.HEADERS['Cache-Control'])
-        self.assertEqual(key['ContentType'], 'image/png')
+        from botocore.stub import Stubber
+        with Stubber(store.s3_client) as stub:
+            stub.add_response(
+                'put_object',
+                expected_params={
+                    'ACL': S3FilesStore.POLICY,
+                    'Body': buffer,
+                    'Bucket': bucket,
+                    'CacheControl': S3FilesStore.HEADERS['Cache-Control'],
+                    'ContentType': content_type,
+                    'Key': key,
+                    'Metadata': meta,
+                },
+                service_response={},
+            )
+
+            yield store.persist_file(
+                path,
+                buffer,
+                info=None,
+                meta=meta,
+                headers={'Content-Type': content_type},
+            )
+
+            stub.assert_no_pending_responses()
+            self.assertEqual(
+                buffer.method_calls,
+                [
+                    mock.call.seek(0),
+                    # The call to read does not happen with Stubber
+                ]
+            )
+
+    @defer.inlineCallbacks
+    def test_stat(self):
+        skip_if_no_boto()
+
+        bucket = 'mybucket'
+        key = 'export.csv'
+        uri = f's3://{bucket}/{key}'
+        checksum = '3187896a9657a28163abb31667df64c8'
+
+        store = S3FilesStore(uri)
+        from botocore.stub import Stubber
+        with Stubber(store.s3_client) as stub:
+            stub.add_response(
+                'head_object',
+                expected_params={
+                    'Bucket': bucket,
+                    'Key': key,
+                },
+                service_response={
+                    'ETag': f'"{checksum}"',
+                    'LastModified': datetime(2019, 12, 1),
+                },
+            )
+
+            file_stats = yield store.stat_file('', info=None)
+            self.assertEqual(
+                file_stats,
+                {
+                    'checksum': checksum,
+                    'last_modified': 1575154800,
+                },
+            )
+
+            stub.assert_no_pending_responses()
 
 
 class TestGCSFilesStore(unittest.TestCase):

--- a/tox.ini
+++ b/tox.ini
@@ -12,7 +12,6 @@ deps =
     -ctests/constraints.txt
     -rtests/requirements-py3.txt
     # Extras
-    boto3>=1.13.0
     botocore>=1.4.87
     Pillow>=4.0.0
 passenv =


### PR DESCRIPTION
Fixes #1790

I used the built-in mocking mechanism from `botocore`, the client library we use.

-   [x] `tests/test_downloader_handlers.py::S3TestCase::test_request_signing5` (removed, only meant to work on Python 2)
-   [x] `tests/test_feedexport.py::S3FeedStorageTest::test_store`
-   [x] `tests/test_feedexport.py::BatchDeliveriesTest::test_s3_export`
-   [x] `tests/test_pipeline_files.py::TestS3FilesStore::test_persist`