### PR TITLE
Process cookies from header only once

### DIFF
--- a/scrapy/downloadermiddlewares/cookies.py
+++ b/scrapy/downloadermiddlewares/cookies.py
@@ -102,7 +102,7 @@ class CookiesMiddleware:
         """
         def get_cookies_from_header(jar, request):
             cookie_header = request.headers.get("Cookie")
-            if not cookie_header:
+            if not cookie_header or request.meta.get("_cookie_header_processed"):
                 return []
             cookie_gen_bytes = (s.strip() for s in cookie_header.split(b";"))
             cookie_list_unicode = []
@@ -128,4 +128,5 @@ class CookiesMiddleware:
             response = Response(request.url, headers={"Set-Cookie": formatted})
             return jar.make_cookies(response, request)
 
+        request.meta["_cookie_header_processed"] = True
         return get_cookies_from_header(jar, request) + get_cookies_from_attribute(jar, request)

--- a/scrapy/downloadermiddlewares/cookies.py
+++ b/scrapy/downloadermiddlewares/cookies.py
@@ -115,6 +115,7 @@ class CookiesMiddleware:
                     cookie_unicode = cookie_bytes.decode("latin1", errors="replace")
                 cookie_list_unicode.append(cookie_unicode)
             response = Response(request.url, headers={"Set-Cookie": cookie_list_unicode})
+            request.meta["_cookie_header_processed"] = True
             return jar.make_cookies(response, request)
 
         def get_cookies_from_attribute(jar, request):
@@ -128,5 +129,4 @@ class CookiesMiddleware:
             response = Response(request.url, headers={"Set-Cookie": formatted})
             return jar.make_cookies(response, request)
 
-        request.meta["_cookie_header_processed"] = True
         return get_cookies_from_header(jar, request) + get_cookies_from_attribute(jar, request)


### PR DESCRIPTION
:construction: _Work in progress_ :construction: 

A first approach to solving #4717. The idea is to process cookies from the header only once, the actual method of solving it can vary (meta key, request attribute, etc). I know it's not much, but I'd like your opinions @Gallaecio @kmike @wRAR.

The following spider works with this patch, while it breaks with the current master (5a386393) - I'm working on some tests to reproduce this behaviour.
```python
import scrapy

class LoginSpider(scrapy.Spider):
    name = "login"
    start_urls = ["http://quotes.toscrape.com/login"]
    custom_settings = {"COOKIES_DEBUG": True}

    def parse(self, response):
        csrf_token = response.xpath("//input[@name='csrf_token']/@value").get()
        return scrapy.FormRequest.from_response(
            response=response,
            formxpath="//form",
            formdata={
                "csrf_token": csrf_token,
                "username": "admin",
                "password": "admin"
            },
            callback=self.after_login,
        )

    def after_login(self, response):
        logout = response.xpath("//a[text()='Logout']/text()").get()
        assert logout is not None
```

Fixes #1992