### PR TITLE
removed datatype specification for *args & ** kwargs

### DIFF
--- a/scrapy/crawler.py
+++ b/scrapy/crawler.py
@@ -180,9 +180,9 @@ class CrawlerRunner:
         :type crawler_or_spidercls: :class:`~scrapy.crawler.Crawler` instance,
             :class:`~scrapy.spiders.Spider` subclass or string
 
-        :param list args: arguments to initialize the spider
+        :param args: arguments to initialize the spider
 
-        :param dict kwargs: keyword arguments to initialize the spider
+        :param kwargs: keyword arguments to initialize the spider
         """
         if isinstance(crawler_or_spidercls, Spider):
             raise ValueError(


### PR DESCRIPTION
I have opened this pull request in accordance to #4805 
I have essentially removed the data type specification for *args and **kwargs as it had some unforeseen consequences.(refer to #4805 )

Fixes #4805