### PR TITLE
Simplify TLS logging for the modern pyOpenSSL.

### DIFF
--- a/scrapy/core/downloader/tls.py
+++ b/scrapy/core/downloader/tls.py
@@ -55,18 +55,11 @@ class ScrapyClientTLSOptions(ClientTLSOptions):
             set_tlsext_host_name(connection, self._hostnameBytes)
         elif where & SSL.SSL_CB_HANDSHAKE_DONE:
             if self.verbose_logging:
-                if hasattr(connection, 'get_cipher_name'):  # requires pyOPenSSL 0.15
-                    if hasattr(connection, 'get_protocol_version_name'):  # requires pyOPenSSL 16.0.0
-                        logger.debug('SSL connection to %s using protocol %s, cipher %s',
-                                     self._hostnameASCII,
-                                     connection.get_protocol_version_name(),
-                                     connection.get_cipher_name(),
-                                     )
-                    else:
-                        logger.debug('SSL connection to %s using cipher %s',
-                                     self._hostnameASCII,
-                                     connection.get_cipher_name(),
-                                     )
+                logger.debug('SSL connection to %s using protocol %s, cipher %s',
+                             self._hostnameASCII,
+                             connection.get_protocol_version_name(),
+                             connection.get_cipher_name(),
+                             )
                 server_cert = connection.get_peer_certificate()
                 logger.debug('SSL connection certificate: issuer "%s", subject "%s"',
                              x509name_to_string(server_cert.get_issuer()),


### PR DESCRIPTION
We now require pyOpenSSL>=16.2.0 so the code can be simplified.

There is another conditional that is used by this feature, in utils.ssl, it checks `hasattr(pyOpenSSLutil.lib, 'SSL_get_server_tmp_key')` which requires OpenSSL 1.0.2. I don't know how does Scrapy itself work on systems with older OpenSSL, and how many such systems are there, but I decided to keep it for now.