### PR TITLE
overwrite an output file with -O, (FeedExporter updated)

### DIFF
--- a/scrapy/extensions/feedexport.py
+++ b/scrapy/extensions/feedexport.py
@@ -452,7 +452,7 @@ class FeedExporter:
         crawler = getattr(self, 'crawler', None)
 
         def build_instance(builder, *preargs):
-            return build_storage(builder, uri, preargs=preargs)
+            return build_storage(builder, uri, feed_options=feed_options, preargs=preargs)
 
         if crawler and hasattr(feedcls, 'from_crawler'):
             instance = build_instance(feedcls.from_crawler, crawler)

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -680,9 +680,14 @@ class MySpider(scrapy.Spider):
         )
         return []
 """
+        with open(os.path.join(self.cwd, "example.json"), "w") as file:
+            file.write("not empty")
         args = ['-O', 'example.json']
         log = self.get_log(spider_code, args=args)
         self.assertIn('[myspider] DEBUG: FEEDS: {"example.json": {"format": "json", "overwrite": true}}', log)
+        with open(os.path.join(self.cwd, "example.json")) as file:
+            first_line = file.readline()
+        self.assertNotEqual(first_line, "not empty")
 
     def test_output_and_overwrite_output(self):
         spider_code = """

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -818,9 +818,14 @@ class MySpider(scrapy.Spider):
         )
         return []
 """
+        with open(os.path.join(self.cwd, "example.json"), "w") as file:
+            file.write("not empty")
         args = ['-O', 'example.json']
         log = self.get_log(spider_code, args=args)
         self.assertIn('[myspider] DEBUG: FEEDS: {"example.json": {"format": "json", "overwrite": true}}', log)
+        with open(os.path.join(self.cwd, "example.json")) as file:
+            first_line = file.readline()
+        self.assertNotEqual(first_line, "not empty")
 
     def test_output_and_overwrite_output(self):
         spider_code = """

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -680,13 +680,13 @@ class MySpider(scrapy.Spider):
         )
         return []
 """
-        with open(os.path.join(self.cwd, "example.json"), "w") as file:
-            file.write("not empty")
+        with open(os.path.join(self.cwd, "example.json"), "w") as f1:
+            f1.write("not empty")
         args = ['-O', 'example.json']
         log = self.get_log(spider_code, args=args)
         self.assertIn('[myspider] DEBUG: FEEDS: {"example.json": {"format": "json", "overwrite": true}}', log)
-        with open(os.path.join(self.cwd, "example.json")) as file:
-            first_line = file.readline()
+        with open(os.path.join(self.cwd, "example.json")) as f2:
+            first_line = f2.readline()
         self.assertNotEqual(first_line, "not empty")
 
     def test_output_and_overwrite_output(self):
@@ -818,13 +818,13 @@ class MySpider(scrapy.Spider):
         )
         return []
 """
-        with open(os.path.join(self.cwd, "example.json"), "w") as file:
-            file.write("not empty")
+        with open(os.path.join(self.cwd, "example.json"), "w") as f1:
+            f1.write("not empty")
         args = ['-O', 'example.json']
         log = self.get_log(spider_code, args=args)
         self.assertIn('[myspider] DEBUG: FEEDS: {"example.json": {"format": "json", "overwrite": true}}', log)
-        with open(os.path.join(self.cwd, "example.json")) as file:
-            first_line = file.readline()
+        with open(os.path.join(self.cwd, "example.json")) as f2:
+            first_line = f2.readline()
         self.assertNotEqual(first_line, "not empty")
 
     def test_output_and_overwrite_output(self):


### PR DESCRIPTION
related to #4857  and #4845 

`FeedExporter._get_storage()` updated - `feed_options` successfully passed to Storage objects

`CrawlCommandTest.test_overwrite_output` and
`RunSpiderCommandTest.test_overwrite_output` aimed to test `-O` arg - updated.