### PR TITLE
Made CsvItemExporter flushes bytestream (solves Issue #4829)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ htmlcov/
 .mypy_cache/
 /tests/keys/localhost.crt
 /tests/keys/localhost.key
+.vscode
 
 # Windows
 Thumbs.db

--- a/scrapy/exporters.py
+++ b/scrapy/exporters.py
@@ -234,6 +234,9 @@ class CsvItemExporter(BaseItemExporter):
         values = list(self._build_row(x for _, x in fields))
         self.csv_writer.writerow(values)
 
+    def finish_exporting(self):
+        self.stream.flush()
+
     def _build_row(self, values):
         for s in values:
             try:


### PR DESCRIPTION
In response to issue #4829 I added an implementationt to the method `finish_exporting()` in CsvItemExporter which flushes the bytestream after it finishes exporting.