### PR TITLE
Remove unnecessary pytest-azurepipelines package

### DIFF
--- a/tests/requirements-py3.txt
+++ b/tests/requirements-py3.txt
@@ -6,7 +6,6 @@ mitmproxy >= 4.0.4, < 5; python_version >= '3.6' and python_version < '3.7'
 pyftpdlib
 # https://github.com/pytest-dev/pytest-twisted/issues/93
 pytest != 5.4, != 5.4.1
-pytest-azurepipelines
 pytest-cov
 pytest-twisted >= 1.11
 pytest-xdist


### PR DESCRIPTION
This should have been removed in #4869, I didn't realize it was there.