### PR TITLE
Response.protocol attribute

### DIFF
--- a/docs/topics/request-response.rst
+++ b/docs/topics/request-response.rst
@@ -706,7 +706,7 @@ Response objects
     .. versionadded:: 2.1.0
        The ``ip_address`` parameter.
 
-    .. versionadded:: 2.X.X
+    .. versionadded:: VERSION
        The ``protocol`` parameter.
 
     .. attribute:: Response.url
@@ -812,7 +812,7 @@ Response objects
 
     .. attribute:: Response.protocol
 
-        .. versionadded:: 2.X.X
+        .. versionadded:: VERSION
 
         A tuple containing information about the protocol that was used
         to download the response. Taken from the ``version`` attribute of the

--- a/docs/topics/request-response.rst
+++ b/docs/topics/request-response.rst
@@ -693,8 +693,21 @@ Response objects
     :param ip_address: The IP address of the server from which the Response originated.
     :type ip_address: :class:`ipaddress.IPv4Address` or :class:`ipaddress.IPv6Address`
 
+    :param protocol: A tuple containing information about the protocol that was used
+        to download the response. Taken from the ``version`` attribute of the
+        corresponding :class:`twisted.web.client.Response` object, it will tipically
+        consist of the protocol and version numbers, e.g. ``(b"HTTP", 1, 1)``
+        to represent "HTTP/1.1".
+    :type protocol: :class:`tuple`
+
+    .. versionadded:: 2.X.X
+       The ``protocol`` parameter.
+
     .. versionadded:: 2.1.0
        The ``ip_address`` parameter.
+
+    .. versionadded:: 2.0.0
+       The ``certificate`` parameter.
 
     .. attribute:: Response.url
 
@@ -780,6 +793,8 @@ Response objects
 
     .. attribute:: Response.certificate
 
+        .. versionadded:: 2.0.0
+
         A :class:`twisted.internet.ssl.Certificate` object representing
         the server's SSL certificate.
 
@@ -794,6 +809,20 @@ Response objects
         This attribute is currently only populated by the HTTP 1.1 download
         handler, i.e. for ``http(s)`` responses. For other handlers,
         :attr:`ip_address` is always ``None``.
+
+    .. attribute:: Response.protocol
+
+        .. versionadded:: 2.X.X
+
+        A tuple containing information about the protocol that was used
+        to download the response. Taken from the ``version`` attribute of the
+        corresponding :class:`twisted.web.client.Response` object, it will tipically
+        consist of the protocol and version numbers, e.g. ``(b"HTTP", 1, 1)``
+        to represent "HTTP/1.1".
+
+        This attribute is currently only populated by the HTTP 1.1 download
+        handler, i.e. for ``http(s)`` responses. For other handlers,
+        :attr:`protocol` is always ``None``.
 
     .. method:: Response.copy()
 

--- a/docs/topics/request-response.rst
+++ b/docs/topics/request-response.rst
@@ -693,12 +693,9 @@ Response objects
     :param ip_address: The IP address of the server from which the Response originated.
     :type ip_address: :class:`ipaddress.IPv4Address` or :class:`ipaddress.IPv6Address`
 
-    :param protocol: A tuple containing information about the protocol that was used
-        to download the response. Taken from the ``version`` attribute of the
-        corresponding :class:`twisted.web.client.Response` object, it will tipically
-        consist of the protocol and version numbers, e.g. ``(b"HTTP", 1, 1)``
-        to represent "HTTP/1.1".
-    :type protocol: :class:`tuple`
+    :param protocol: The protocol that was used to download the response.
+        For instance: "HTTP/1.0", "HTTP/1.1"
+    :type protocol: :class:`str`
 
     .. versionadded:: 2.0.0
        The ``certificate`` parameter.
@@ -814,14 +811,11 @@ Response objects
 
         .. versionadded:: VERSION
 
-        A tuple containing information about the protocol that was used
-        to download the response. Taken from the ``version`` attribute of the
-        corresponding :class:`twisted.web.client.Response` object, it will tipically
-        consist of the protocol and version numbers, e.g. ``(b"HTTP", 1, 1)``
-        to represent "HTTP/1.1".
+        The protocol that was used to download the response.
+        For instance: "HTTP/1.0", "HTTP/1.1"
 
-        This attribute is currently only populated by the HTTP 1.1 download
-        handler, i.e. for ``http(s)`` responses. For other handlers,
+        This attribute is currently only populated by the HTTP download
+        handlers, i.e. for ``http(s)`` responses. For other handlers,
         :attr:`protocol` is always ``None``.
 
     .. method:: Response.copy()

--- a/docs/topics/request-response.rst
+++ b/docs/topics/request-response.rst
@@ -700,14 +700,14 @@ Response objects
         to represent "HTTP/1.1".
     :type protocol: :class:`tuple`
 
-    .. versionadded:: 2.X.X
-       The ``protocol`` parameter.
+    .. versionadded:: 2.0.0
+       The ``certificate`` parameter.
 
     .. versionadded:: 2.1.0
        The ``ip_address`` parameter.
 
-    .. versionadded:: 2.0.0
-       The ``certificate`` parameter.
+    .. versionadded:: 2.X.X
+       The ``protocol`` parameter.
 
     .. attribute:: Response.url
 

--- a/scrapy/core/downloader/handlers/http11.py
+++ b/scrapy/core/downloader/handlers/http11.py
@@ -442,6 +442,7 @@ class ScrapyAgent:
             flags=result["flags"],
             certificate=result["certificate"],
             ip_address=result["ip_address"],
+            protocol=getattr(result["txresponse"], "version", None),
         )
         if result.get("failure"):
             result["failure"].value.response = response

--- a/scrapy/core/downloader/handlers/http11.py
+++ b/scrapy/core/downloader/handlers/http11.py
@@ -434,6 +434,11 @@ class ScrapyAgent:
     def _cb_bodydone(self, result, request, url):
         headers = Headers(result["txresponse"].headers.getAllRawHeaders())
         respcls = responsetypes.from_args(headers=headers, url=url, body=result["body"])
+        try:
+            version = result["txresponse"].version
+            protocol = f"{to_unicode(version[0])}/{version[1]}.{version[2]}"
+        except (AttributeError, TypeError):
+            protocol = None
         response = respcls(
             url=url,
             status=int(result["txresponse"].code),
@@ -442,7 +447,7 @@ class ScrapyAgent:
             flags=result["flags"],
             certificate=result["certificate"],
             ip_address=result["ip_address"],
-            protocol=getattr(result["txresponse"], "version", None),
+            protocol=protocol,
         )
         if result.get("failure"):
             result["failure"].value.response = response

--- a/scrapy/core/downloader/handlers/http11.py
+++ b/scrapy/core/downloader/handlers/http11.py
@@ -437,7 +437,7 @@ class ScrapyAgent:
         try:
             version = result["txresponse"].version
             protocol = f"{to_unicode(version[0])}/{version[1]}.{version[2]}"
-        except (AttributeError, TypeError):
+        except (AttributeError, TypeError, IndexError):
             protocol = None
         response = respcls(
             url=url,

--- a/scrapy/core/downloader/webclient.py
+++ b/scrapy/core/downloader/webclient.py
@@ -7,7 +7,7 @@ from twisted.internet.protocol import ClientFactory
 
 from scrapy.http import Headers
 from scrapy.utils.httpobj import urlparse_cached
-from scrapy.utils.python import to_bytes
+from scrapy.utils.python import to_bytes, to_unicode
 from scrapy.responsetypes import responsetypes
 
 
@@ -110,7 +110,7 @@ class ScrapyHTTPClientFactory(ClientFactory):
         status = int(self.status)
         headers = Headers(self.response_headers)
         respcls = responsetypes.from_args(headers=headers, url=self._url)
-        return respcls(url=self._url, status=status, headers=headers, body=body)
+        return respcls(url=self._url, status=status, headers=headers, body=body, protocol=to_unicode(self.version))
 
     def _set_connection_attributes(self, request):
         parsed = urlparse_cached(request)

--- a/scrapy/http/response/__init__.py
+++ b/scrapy/http/response/__init__.py
@@ -17,8 +17,18 @@ from scrapy.utils.trackref import object_ref
 
 class Response(object_ref):
 
-    def __init__(self, url, status=200, headers=None, body=b'', flags=None,
-                 request=None, certificate=None, ip_address=None):
+    def __init__(
+        self,
+        url,
+        status=200,
+        headers=None,
+        body=b"",
+        flags=None,
+        request=None,
+        certificate=None,
+        ip_address=None,
+        protocol=None,
+    ):
         self.headers = Headers(headers or {})
         self.status = int(status)
         self._set_body(body)
@@ -27,6 +37,7 @@ class Response(object_ref):
         self.flags = [] if flags is None else list(flags)
         self.certificate = certificate
         self.ip_address = ip_address
+        self.protocol = protocol
 
     @property
     def cb_kwargs(self):
@@ -90,7 +101,7 @@ class Response(object_ref):
         given new values.
         """
         for x in ['url', 'status', 'headers', 'body',
-                  'request', 'flags', 'certificate', 'ip_address']:
+                  'request', 'flags', 'certificate', 'ip_address', 'protocol']:
             kwargs.setdefault(x, getattr(self, x))
         cls = kwargs.pop('cls', self.__class__)
         return cls(*args, **kwargs)

--- a/scrapy/http/response/__init__.py
+++ b/scrapy/http/response/__init__.py
@@ -100,8 +100,9 @@ class Response(object_ref):
         """Create a new Response with the same attributes except for those
         given new values.
         """
-        for x in ['url', 'status', 'headers', 'body',
-                  'request', 'flags', 'certificate', 'ip_address', 'protocol']:
+        for x in [
+            "url", "status", "headers", "body", "request", "flags", "certificate", "ip_address", "protocol",
+        ]:
             kwargs.setdefault(x, getattr(self, x))
         cls = kwargs.pop('cls', self.__class__)
         return cls(*args, **kwargs)

--- a/tests/test_downloader_handlers.py
+++ b/tests/test_downloader_handlers.py
@@ -489,6 +489,13 @@ class Http11TestCase(HttpTestCase):
     def test_download_broken_chunked_content_allow_data_loss_via_setting(self):
         return self.test_download_broken_content_allow_data_loss_via_setting('broken-chunked')
 
+    def test_protocol(self):
+        request = Request(self.getURL("host"), method="GET")
+        d = self.download_request(request, Spider("foo"))
+        d.addCallback(lambda r: r.protocol)
+        d.addCallback(self.assertEqual, (b"HTTP", 1, 1))
+        return d
+
 
 class Https11TestCase(Http11TestCase):
     scheme = 'https'

--- a/tests/test_downloader_handlers.py
+++ b/tests/test_downloader_handlers.py
@@ -360,6 +360,13 @@ class Http10TestCase(HttpTestCase):
     """HTTP 1.0 test case"""
     download_handler_cls = HTTP10DownloadHandler
 
+    def test_protocol(self):
+        request = Request(self.getURL("host"), method="GET")
+        d = self.download_request(request, Spider("foo"))
+        d.addCallback(lambda r: r.protocol)
+        d.addCallback(self.assertEqual, "HTTP/1.0")
+        return d
+
 
 class Https10TestCase(Http10TestCase):
     scheme = 'https'
@@ -493,7 +500,7 @@ class Http11TestCase(HttpTestCase):
         request = Request(self.getURL("host"), method="GET")
         d = self.download_request(request, Spider("foo"))
         d.addCallback(lambda r: r.protocol)
-        d.addCallback(self.assertEqual, (b"HTTP", 1, 1))
+        d.addCallback(self.assertEqual, "HTTP/1.1")
         return d
 
 

--- a/tests/test_downloader_handlers.py
+++ b/tests/test_downloader_handlers.py
@@ -115,6 +115,7 @@ class FileTestCase(unittest.TestCase):
             self.assertEqual(response.url, request.url)
             self.assertEqual(response.status, 200)
             self.assertEqual(response.body, b'0123456789')
+            self.assertEqual(response.protocol, None)
 
         request = Request(path_to_file_uri(self.tmpname + '^'))
         assert request.url.upper().endswith('%5E')
@@ -976,6 +977,7 @@ class BaseFTPTestCase(unittest.TestCase):
             self.assertEqual(r.status, 200)
             self.assertEqual(r.body, b'I have the power!')
             self.assertEqual(r.headers, {b'Local Filename': [b''], b'Size': [b'17']})
+            self.assertIsNone(r.protocol)
         return self._add_test_callbacks(d, _test)
 
     def test_ftp_download_path_with_spaces(self):
@@ -1133,4 +1135,11 @@ class DataURITestCase(unittest.TestCase):
             self.assertEqual(response.text, 'Hello, world.')
 
         request = Request('data:text/plain;base64,SGVsbG8sIHdvcmxkLg%3D%3D')
+        return self.download_request(request, self.spider).addCallback(_test)
+
+    def test_protocol(self):
+        def _test(response):
+            self.assertIsNone(response.protocol)
+
+        request = Request("data:,")
         return self.download_request(request, self.spider).addCallback(_test)


### PR DESCRIPTION
Motivated by #4769 and #4770

```
$ scrapy shell https://example.org
(...)
>>> response.protocol
'HTTP/1.1'
>>> 
```
