### PR TITLE
Deprecate scrapy.utils.py36 module

### DIFF
--- a/scrapy/utils/asyncgen.py
+++ b/scrapy/utils/asyncgen.py
@@ -1,0 +1,5 @@
+async def collect_asyncgen(result):
+    results = []
+    async for x in result:
+        results.append(x)
+    return results

--- a/scrapy/utils/py36.py
+++ b/scrapy/utils/py36.py
@@ -1,10 +1,11 @@
-"""
-Helpers using Python 3.6+ syntax (ignore SyntaxError on import).
-"""
+import warnings
+
+from scrapy.exceptions import ScrapyDeprecationWarning
+from scrapy.utils.python import collect_asyncgen  # noqa: F401
 
 
-async def collect_asyncgen(result):
-    results = []
-    async for x in result:
-        results.append(x)
-    return results
+warnings.warn(
+    "Module `scrapy.utils.py36` is deprecated, please import from `scrapy.utils.python` instead.",
+    category=ScrapyDeprecationWarning,
+    stacklevel=2,
+)

--- a/scrapy/utils/py36.py
+++ b/scrapy/utils/py36.py
@@ -1,11 +1,11 @@
 import warnings
 
 from scrapy.exceptions import ScrapyDeprecationWarning
-from scrapy.utils.python import collect_asyncgen  # noqa: F401
+from scrapy.utils.asyncgen import collect_asyncgen  # noqa: F401
 
 
 warnings.warn(
-    "Module `scrapy.utils.py36` is deprecated, please import from `scrapy.utils.python` instead.",
+    "Module `scrapy.utils.py36` is deprecated, please import from `scrapy.utils.asyncgen` instead.",
     category=ScrapyDeprecationWarning,
     stacklevel=2,
 )

--- a/scrapy/utils/python.py
+++ b/scrapy/utils/python.py
@@ -355,3 +355,10 @@ class MutableChain:
     @deprecated("scrapy.utils.python.MutableChain.__next__")
     def next(self):
         return self.__next__()
+
+
+async def collect_asyncgen(result):
+    results = []
+    async for x in result:
+        results.append(x)
+    return results

--- a/scrapy/utils/python.py
+++ b/scrapy/utils/python.py
@@ -355,10 +355,3 @@ class MutableChain:
     @deprecated("scrapy.utils.python.MutableChain.__next__")
     def next(self):
         return self.__next__()
-
-
-async def collect_asyncgen(result):
-    results = []
-    async for x in result:
-        results.append(x)
-    return results

--- a/scrapy/utils/spider.py
+++ b/scrapy/utils/spider.py
@@ -4,7 +4,7 @@ import logging
 from scrapy.spiders import Spider
 from scrapy.utils.defer import deferred_from_coro
 from scrapy.utils.misc import arg_to_iter
-from scrapy.utils.python import collect_asyncgen
+from scrapy.utils.asyncgen import collect_asyncgen
 
 
 logger = logging.getLogger(__name__)

--- a/scrapy/utils/spider.py
+++ b/scrapy/utils/spider.py
@@ -4,17 +4,14 @@ import logging
 from scrapy.spiders import Spider
 from scrapy.utils.defer import deferred_from_coro
 from scrapy.utils.misc import arg_to_iter
-try:
-    from scrapy.utils.py36 import collect_asyncgen
-except SyntaxError:
-    collect_asyncgen = None
+from scrapy.utils.python import collect_asyncgen
 
 
 logger = logging.getLogger(__name__)
 
 
 def iterate_spider_output(result):
-    if collect_asyncgen and hasattr(inspect, 'isasyncgen') and inspect.isasyncgen(result):
+    if inspect.isasyncgen(result):
         d = deferred_from_coro(collect_asyncgen(result))
         d.addCallback(iterate_spider_output)
         return d

--- a/setup.cfg
+++ b/setup.cfg
@@ -55,9 +55,6 @@ ignore_errors = True
 [mypy-scrapy.utils.response]
 ignore_errors = True
 
-[mypy-scrapy.utils.spider]
-ignore_errors = True
-
 [mypy-scrapy.utils.trackref]
 ignore_errors = True
 


### PR DESCRIPTION
Now that the minimum Python version is 3.6, there is no need to keep this helper in a different file and catch the `SyntaxError` when importing.