### PR TITLE
Remove deprecated SCRAPY_PICKLED_SETTINGS_TO_OVERRIDE

### DIFF
--- a/scrapy/utils/project.py
+++ b/scrapy/utils/project.py
@@ -68,18 +68,10 @@ def get_project_settings():
     if settings_module_path:
         settings.setmodule(settings_module_path, priority='project')
 
-    pickled_settings = os.environ.get("SCRAPY_PICKLED_SETTINGS_TO_OVERRIDE")
-    if pickled_settings:
-        warnings.warn("Use of environment variable "
-                      "'SCRAPY_PICKLED_SETTINGS_TO_OVERRIDE' "
-                      "is deprecated.", ScrapyDeprecationWarning)
-        settings.setdict(pickle.loads(pickled_settings), priority='project')
-
     scrapy_envvars = {k[7:]: v for k, v in os.environ.items() if
                       k.startswith('SCRAPY_')}
     valid_envvars = {
         'CHECK',
-        'PICKLED_SETTINGS_TO_OVERRIDE',
         'PROJECT',
         'PYTHON_SHELL',
         'SETTINGS_MODULE',

--- a/scrapy/utils/project.py
+++ b/scrapy/utils/project.py
@@ -1,5 +1,4 @@
 import os
-import pickle
 import warnings
 
 from importlib import import_module


### PR DESCRIPTION
Deprecated in #3910, released as part of [`1.8`](https://docs.scrapy.org/en/latest/news.html#scrapy-1-8-0-2019-10-28)