### PR TITLE
use pathlib

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -18,10 +18,9 @@ collect_ignore = [
     *_py_files("tests/CrawlerRunner"),
 ]
 
-for line in open('tests/ignores.txt'):
-    file_path = line.strip()
-    if file_path and file_path[0] != '#':
-        collect_ignore.append(file_path)
+for file_path_line in Path('tests/ignores.txt').read_text().splitlines():
+    if file_path_line and not file_path_line.startswith('#'):
+        collect_ignore.append(str(Path(file_path_line)))
 
 
 @pytest.fixture()

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -86,8 +86,8 @@ coverage: BUILDER = coverage
 coverage: build
 
 htmlview: html
-	 $(PYTHON) -c "import webbrowser, os; webbrowser.open('file://' + \
-	 os.path.realpath('build/html/index.html'))"
+	 $(PYTHON) -c "import webbrowser, pathlib; webbrowser.open('file://' + \
+	 str(pathlib.Path('build/html/index.html').resolve()))"
 
 clean:
 	-rm -rf build/*

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -11,13 +11,13 @@
 
 import sys
 from datetime import datetime
-from os import path
+from pathlib import Path
 
 # If your extensions are in another directory, add it here. If the directory
-# is relative to the documentation root, use os.path.abspath to make it
+# is relative to the documentation root, use Path.resolve to make it
 # absolute, like shown here.
-sys.path.append(path.join(path.dirname(__file__), "_ext"))
-sys.path.insert(0, path.dirname(path.dirname(__file__)))
+sys.path.append(str(Path(__file__).resolve() / '_ext'))
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 
 # General configuration

--- a/docs/conftest.py
+++ b/docs/conftest.py
@@ -1,5 +1,5 @@
-import os
 from doctest import ELLIPSIS, NORMALIZE_WHITESPACE
+from pathlib import Path
 
 from scrapy.http.response.html import HtmlResponse
 from sybil import Sybil
@@ -9,9 +9,8 @@ from sybil.parsers.skip import skip
 
 
 def load_response(url, filename):
-    input_path = os.path.join(os.path.dirname(__file__), '_tests', filename)
-    with open(input_path, 'rb') as input_file:
-        return HtmlResponse(url, body=input_file.read())
+    input_path = Path(__file__).resolve().parent / '_tests' / filename
+    return HtmlResponse(url, body=input_path.read_bytes())
 
 
 def setup(namespace):

--- a/docs/intro/tutorial.rst
+++ b/docs/intro/tutorial.rst
@@ -101,9 +101,8 @@ This is the code for our first Spider. Save it in a file named
 
         def parse(self, response):
             page = response.url.split("/")[-2]
-            filename = f'quotes-{page}.html'
-            with open(filename, 'wb') as f:
-                f.write(response.body)
+            filename = Path(f'quotes-{page}.html')
+            filename.write_bytes(response.body)
             self.log(f'Saved file {filename}')
 
 
@@ -190,9 +189,8 @@ for your spider::
 
         def parse(self, response):
             page = response.url.split("/")[-2]
-            filename = f'quotes-{page}.html'
-            with open(filename, 'wb') as f:
-                f.write(response.body)
+            filename = Path(f'quotes-{page}.html')
+            filename.write_bytes(response.body)
 
 The :meth:`~scrapy.spiders.Spider.parse` method will be called to handle each
 of the requests for those URLs, even though we haven't explicitly told Scrapy

--- a/docs/topics/media-pipeline.rst
+++ b/docs/topics/media-pipeline.rst
@@ -433,7 +433,7 @@ See here the methods that you can override in your custom Files Pipeline:
       approach to download all files into the ``files`` folder with their
       original filenames (e.g. ``files/foo.png``)::
 
-        import os
+        from pathlib import Path
         from urllib.parse import urlparse
 
         from scrapy.pipelines.files import FilesPipeline
@@ -441,7 +441,7 @@ See here the methods that you can override in your custom Files Pipeline:
         class MyFilesPipeline(FilesPipeline):
 
             def file_path(self, request, response=None, info=None, *, item=None):
-                return 'files/' + os.path.basename(urlparse(request.url).path)
+                return Path('files') / Path(urlparse(request.url).path).name
 
       Similarly, you can use the ``item`` to determine the file path based on some item 
       property.
@@ -572,7 +572,7 @@ See here the methods that you can override in your custom Images Pipeline:
       approach to download all files into the ``files`` folder with their
       original filenames (e.g. ``files/foo.png``)::
 
-        import os
+        from pathlib import Path
         from urllib.parse import urlparse
 
         from scrapy.pipelines.images import ImagesPipeline
@@ -580,7 +580,7 @@ See here the methods that you can override in your custom Images Pipeline:
         class MyImagesPipeline(ImagesPipeline):
 
             def file_path(self, request, response=None, info=None, *, item=None):
-                return 'files/' + os.path.basename(urlparse(request.url).path)
+                return Path('files') / Path(urlparse(request.url).path).name
 
       Similarly, you can use the ``item`` to determine the file path based on some item 
       property.

--- a/docs/utils/linkfix.py
+++ b/docs/utils/linkfix.py
@@ -27,8 +27,7 @@ def main():
 
     # Read lines from the linkcheck output file
     try:
-        with open("build/linkcheck/output.txt") as out:
-            output_lines = out.readlines()
+        output_lines = Path("build/linkcheck/output.txt").read_text().splitlines()
     except IOError:
         print("linkcheck output not found; please run linkcheck first.")
         exit(1)
@@ -51,14 +50,12 @@ def main():
 
                     # Update the previous file
                     if _filename:
-                        with open(_filename, "w") as _file:
-                            _file.write(_contents)
+                        _filename.write_text(_contents)
 
                     _filename = newfilename
 
                     # Read the new file to memory
-                    with open(_filename) as _file:
-                        _contents = _file.read()
+                    _contents = _filename.read_text()
 
                 _contents = _contents.replace(match.group(3), match.group(4))
         else:

--- a/scrapy/commands/__init__.py
+++ b/scrapy/commands/__init__.py
@@ -3,6 +3,7 @@ Base class for Scrapy commands
 """
 import os
 from optparse import OptionGroup
+from pathlib import Path
 from twisted.python import failure
 
 from scrapy.utils.conf import arglist_to_dict, feed_process_params_from_cli
@@ -93,8 +94,7 @@ class ScrapyCommand:
             self.settings.set('LOG_ENABLED', False, priority='cmdline')
 
         if opts.pidfile:
-            with open(opts.pidfile, "w") as f:
-                f.write(str(os.getpid()) + os.linesep)
+            Path(opts.pidfile).write_text(str(os.getpid()) + os.linesep)
 
         if opts.pdb:
             failure.startDebugMode()

--- a/scrapy/commands/startproject.py
+++ b/scrapy/commands/startproject.py
@@ -2,7 +2,7 @@ import re
 import os
 import string
 from importlib import import_module
-from os.path import join, exists, abspath
+from pathlib import Path
 from shutil import ignore_patterns, move, copy2, copystat
 from stat import S_IWUSR as OWNER_WRITE_PERMISSION
 
@@ -67,19 +67,18 @@ class Command(ScrapyCommand):
         https://github.com/scrapy/scrapy/pull/2005
         """
         ignore = IGNORE
-        names = os.listdir(src)
+        names = list(src.iterdir())
         ignored_names = ignore(src, names)
 
-        if not os.path.exists(dst):
-            os.makedirs(dst)
+        dst.mkdir(parents=True, exist_ok=True)
 
         for name in names:
             if name in ignored_names:
                 continue
 
-            srcname = os.path.join(src, name)
-            dstname = os.path.join(dst, name)
-            if os.path.isdir(srcname):
+            srcname = src / name
+            dstname = dst / name
+            if srcname.is_dir():
                 self._copytree(srcname, dstname)
             else:
                 copy2(srcname, dstname)
@@ -93,36 +92,34 @@ class Command(ScrapyCommand):
             raise UsageError()
 
         project_name = args[0]
-        project_dir = args[0]
+        project_dir = Path(args[0])
 
         if len(args) == 2:
-            project_dir = args[1]
+            project_dir = Path(args[1])
 
-        if exists(join(project_dir, 'scrapy.cfg')):
+        if (project_dir / 'scrapy.cfg').exists():
             self.exitcode = 1
-            print(f'Error: scrapy.cfg already exists in {abspath(project_dir)}')
+            print(f'Error: scrapy.cfg already exists in {project_dir.resolve()}')
             return
 
         if not self._is_valid_name(project_name):
             self.exitcode = 1
             return
 
-        self._copytree(self.templates_dir, abspath(project_dir))
-        move(join(project_dir, 'module'), join(project_dir, project_name))
+        self._copytree(self.templates_dir, project_dir.resolve())
+        move(project_dir / "module", project_dir / project_name)
         for paths in TEMPLATES_TO_RENDER:
-            path = join(*paths)
-            tplfile = join(project_dir, string.Template(path).substitute(project_name=project_name))
+            path = Path().join(*paths)
+            tplfile = project_dir / string.Template(path).substitute(project_name=project_name)
             render_templatefile(tplfile, project_name=project_name, ProjectName=string_camelcase(project_name))
         print(f"New Scrapy project '{project_name}', using template directory "
               f"'{self.templates_dir}', created in:")
-        print(f"    {abspath(project_dir)}\n")
+        print(f"    {project_dir.resolve()}\n")
         print("You can start your first spider with:")
         print(f"    cd {project_dir}")
         print("    scrapy genspider example example.com")
 
     @property
     def templates_dir(self):
-        return join(
-            self.settings['TEMPLATES_DIR'] or join(scrapy.__path__[0], 'templates'),
-            'project'
-        )
+        parent = self.settings['TEMPLATES_DIR'] or Path(scrapy.__path__[0]) / 'templates'
+        return parent / 'project'

--- a/scrapy/core/downloader/handlers/file.py
+++ b/scrapy/core/downloader/handlers/file.py
@@ -10,7 +10,6 @@ class FileDownloadHandler:
     @defers
     def download_request(self, request, spider):
         filepath = file_uri_to_path(request.url)
-        with open(filepath, 'rb') as fo:
-            body = fo.read()
+        body = filepath.read_bytes()
         respcls = responsetypes.from_args(filename=filepath, body=body)
         return respcls(url=request.url, body=body)

--- a/scrapy/core/downloader/handlers/ftp.py
+++ b/scrapy/core/downloader/handlers/ftp.py
@@ -44,7 +44,7 @@ from scrapy.utils.python import to_bytes
 class ReceivedDataProtocol(Protocol):
     def __init__(self, filename=None):
         self.__filename = filename
-        self.body = open(filename, "wb") if filename else BytesIO()
+        self.body = filename.open("wb") if filename else BytesIO()
         self.size = 0
 
     def dataReceived(self, data):

--- a/scrapy/core/scheduler.py
+++ b/scrapy/core/scheduler.py
@@ -1,7 +1,5 @@
-import os
 import json
 import logging
-from os.path import join, exists
 
 from scrapy.utils.misc import load_object, create_instance
 from scrapy.utils.job import job_dir
@@ -153,18 +151,17 @@ class Scheduler:
     def _dqdir(self, jobdir):
         """ Return a folder name to keep disk queue state at """
         if jobdir:
-            dqdir = join(jobdir, 'requests.queue')
-            if not exists(dqdir):
-                os.makedirs(dqdir)
+            dqdir = jobdir / 'requests.queue'
+            dqdir.mkdir(parents=True, exist_ok=True)
             return dqdir
 
     def _read_dqs_state(self, dqdir):
-        path = join(dqdir, 'active.json')
-        if not exists(path):
+        path = dqdir / 'active.json'
+        if not path.exists():
             return ()
-        with open(path) as f:
+        with path.open() as f:
             return json.load(f)
 
     def _write_dqs_state(self, dqdir, state):
-        with open(join(dqdir, 'active.json'), 'w') as f:
+        with (dqdir / 'active.json').open('w') as f:
             json.dump(state, f)

--- a/scrapy/dupefilters.py
+++ b/scrapy/dupefilters.py
@@ -1,4 +1,3 @@
-import os
 import logging
 
 from scrapy.utils.job import job_dir
@@ -34,7 +33,7 @@ class RFPDupeFilter(BaseDupeFilter):
         self.debug = debug
         self.logger = logging.getLogger(__name__)
         if path:
-            self.file = open(os.path.join(path, 'requests.seen'), 'a+')
+            self.file = (path / 'requests.seen').open('a+')
             self.file.seek(0)
             self.fingerprints.update(x.rstrip() for x in self.file)
 

--- a/scrapy/extensions/feedexport.py
+++ b/scrapy/extensions/feedexport.py
@@ -5,7 +5,6 @@ See documentation in docs/topics/feed-exports.rst
 """
 
 import logging
-import os
 import re
 import sys
 import warnings
@@ -66,8 +65,8 @@ class BlockingFeedStorage:
 
     def open(self, spider):
         path = spider.crawler.settings['FEED_TEMPDIR']
-        if path and not os.path.isdir(path):
-            raise OSError('Not a Directory: ' + str(path))
+        if path and not path.is_dir():
+            raise OSError(f'Not a Directory: {path}')
 
         return NamedTemporaryFile(prefix='feed-', dir=path)
 
@@ -107,10 +106,8 @@ class FileFeedStorage:
         self.write_mode = 'wb' if feed_options.get('overwrite', False) else 'ab'
 
     def open(self, spider):
-        dirname = os.path.dirname(self.path)
-        if dirname and not os.path.exists(dirname):
-            os.makedirs(dirname)
-        return open(self.path, self.write_mode)
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        return self.path.open(self.write_mode)
 
     def store(self, file):
         file.close()

--- a/scrapy/extensions/spiderstate.py
+++ b/scrapy/extensions/spiderstate.py
@@ -1,4 +1,3 @@
-import os
 import pickle
 
 from scrapy import signals
@@ -25,16 +24,16 @@ class SpiderState:
 
     def spider_closed(self, spider):
         if self.jobdir:
-            with open(self.statefn, 'wb') as f:
+            with self.statefn.open('wb') as f:
                 pickle.dump(spider.state, f, protocol=4)
 
     def spider_opened(self, spider):
-        if self.jobdir and os.path.exists(self.statefn):
-            with open(self.statefn, 'rb') as f:
+        if self.jobdir and self.statefn.exists():
+            with self.statefn.open('rb') as f:
                 spider.state = pickle.load(f)
         else:
             spider.state = {}
 
     @property
     def statefn(self):
-        return os.path.join(self.jobdir, 'spider.state')
+        return self.jobdir / 'spider.state'

--- a/scrapy/settings/default_settings.py
+++ b/scrapy/settings/default_settings.py
@@ -15,7 +15,7 @@ Scrapy developers, if you add a setting here remember to:
 
 import sys
 from importlib import import_module
-from os.path import join, abspath, dirname
+from pathlib import Path
 
 AJAXCRAWL_ENABLED = False
 
@@ -283,7 +283,7 @@ STATS_DUMP = True
 
 STATSMAILER_RCPTS = []
 
-TEMPLATES_DIR = abspath(join(dirname(__file__), '..', 'templates'))
+TEMPLATES_DIR = Path(__file__).parents[1] / 'templates'
 
 URLLENGTH_LIMIT = 2083
 

--- a/scrapy/squeues.py
+++ b/scrapy/squeues.py
@@ -3,7 +3,6 @@ Scheduler queues
 """
 
 import marshal
-import os
 import pickle
 
 from queuelib import queue
@@ -16,9 +15,7 @@ def _with_mkdir(queue_class):
     class DirectoriesCreated(queue_class):
 
         def __init__(self, path, *args, **kwargs):
-            dirname = os.path.dirname(path)
-            if not os.path.exists(dirname):
-                os.makedirs(dirname, exist_ok=True)
+            path.parent.mkdir(parents=True, exist_ok=True)
 
             super().__init__(path, *args, **kwargs)
 

--- a/scrapy/utils/job.py
+++ b/scrapy/utils/job.py
@@ -1,8 +1,4 @@
-import os
-
-
 def job_dir(settings):
     path = settings['JOBDIR']
-    if path and not os.path.exists(path):
-        os.makedirs(path)
+    path.mkdir(parents=True, exist_ok=True)
     return path

--- a/scrapy/utils/project.py
+++ b/scrapy/utils/project.py
@@ -2,7 +2,7 @@ import os
 import warnings
 
 from importlib import import_module
-from os.path import join, dirname, abspath, isabs, exists
+from pathlib import Path
 
 from scrapy.utils.conf import closest_scrapy_cfg, get_config, init_env
 from scrapy.settings import Settings
@@ -36,9 +36,8 @@ def project_data_dir(project='default'):
         scrapy_cfg = closest_scrapy_cfg()
         if not scrapy_cfg:
             raise NotConfigured("Unable to find scrapy.cfg file to infer project data dir")
-        d = abspath(join(dirname(scrapy_cfg), '.scrapy'))
-    if not exists(d):
-        os.makedirs(d)
+        d = scrapy_cfg.resolve().with_name('.scrapy')
+    d.mkdir(parents=True, exist_ok=True)
     return d
 
 
@@ -47,13 +46,12 @@ def data_path(path, createdir=False):
     Return the given path joined with the .scrapy data directory.
     If given an absolute path, return it unmodified.
     """
-    if not isabs(path):
+    if not path.is_absolute():
         if inside_project():
-            path = join(project_data_dir(), path)
+            path = project_data_dir() / path
         else:
-            path = join('.scrapy', path)
-    if createdir and not exists(path):
-        os.makedirs(path)
+            path = Path('.scrapy') / path
+    path.mkdir(parents=True, exist_ok=True)
     return path
 
 

--- a/scrapy/utils/template.py
+++ b/scrapy/utils/template.py
@@ -1,23 +1,20 @@
 """Helper functions for working with templates"""
 
-import os
 import re
 import string
 
 
 def render_templatefile(path, **kwargs):
-    with open(path, 'rb') as fp:
-        raw = fp.read().decode('utf8')
+    raw = path.read_text(encoding='utf8')
 
     content = string.Template(raw).substitute(**kwargs)
 
-    render_path = path[:-len('.tmpl')] if path.endswith('.tmpl') else path
+    render_path = path.with_suffix('')
 
-    if path.endswith('.tmpl'):
-        os.rename(path, render_path)
+    if path.suffix == '.tmpl':
+        path.rename(path, render_path)
 
-    with open(render_path, 'wb') as fp:
-        fp.write(content.encode('utf8'))
+    render_path.write_text(content, encoding='utf8')
 
 
 CAMELCASE_INVALID_CHARS = re.compile(r'[^a-zA-Z\d]')

--- a/scrapy/utils/test.py
+++ b/scrapy/utils/test.py
@@ -4,6 +4,7 @@ This module contains some assorted functions used in tests
 
 import asyncio
 import os
+from pathlib import Path
 from posixpath import split
 from unittest import mock
 
@@ -69,8 +70,8 @@ def get_crawler(spidercls=None, settings_dict=None):
 def get_pythonpath():
     """Return a PYTHONPATH suitable to use in processes so that they find this
     installation of Scrapy"""
-    scrapy_path = import_module('scrapy').__path__[0]
-    return os.path.dirname(scrapy_path) + os.pathsep + os.environ.get('PYTHONPATH', '')
+    scrapy_path = Path(import_module('scrapy').__path__[0])
+    return scrapy_path.parent / os.environ.get('PYTHONPATH', '')
 
 
 def get_testenv():

--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,9 @@
-from os.path import dirname, join
+from pathlib import Path
 from pkg_resources import parse_version
 from setuptools import setup, find_packages, __version__ as setuptools_version
 
 
-with open(join(dirname(__file__), 'scrapy/VERSION'), 'rb') as f:
-    version = f.read().decode('ascii').strip()
+version = (Path(__file__).parent / 'scrapy' / 'VERSION').read_text(encoding='ascii').strip()
 
 
 def has_environment_marker_platform_impl_support():

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -5,6 +5,7 @@ see https://docs.scrapy.org/en/latest/contributing.html#running-tests
 """
 
 import os
+from pathlib import Path
 
 # ignore system-wide proxies for tests
 # which would send requests to a totally unsuspecting server
@@ -15,18 +16,14 @@ os.environ['ftp_proxy'] = ''
 
 # Absolutize paths to coverage config and output file because tests that
 # spawn subprocesses also changes current working directory.
-_sourceroot = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+_sourceroot = Path(__file__).resolve().parents[1]
 if 'COV_CORE_CONFIG' in os.environ:
-    os.environ['COVERAGE_FILE'] = os.path.join(_sourceroot, '.coverage')
-    os.environ['COV_CORE_CONFIG'] = os.path.join(_sourceroot,
-                                                 os.environ['COV_CORE_CONFIG'])
+    os.environ['COVERAGE_FILE'] = str(_sourceroot / '.coverage')
+    os.environ['COV_CORE_CONFIG'] = str(_sourceroot / os.environ['COV_CORE_CONFIG'])
 
-tests_datadir = os.path.join(os.path.abspath(os.path.dirname(__file__)),
-                             'sample_data')
+tests_datadir = Path(__file__).resolve().with_name('sample_data')
 
 
 def get_testdata(*paths):
     """Return test data"""
-    path = os.path.join(tests_datadir, *paths)
-    with open(path, 'rb') as f:
-        return f.read()
+    return tests_datadir.joinpath(*paths).read_bytes()

--- a/tests/keys/__init__.py
+++ b/tests/keys/__init__.py
@@ -1,5 +1,5 @@
-import os
 from datetime import datetime, timedelta
+from pathlib import Path
 
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives.asymmetric import rsa
@@ -22,21 +22,20 @@ from cryptography.x509.oid import NameOID
 
 # https://cryptography.io/en/latest/x509/tutorial/#creating-a-self-signed-certificate
 def generate_keys():
-    folder = os.path.dirname(__file__)
+    folder = Path(__file__).resolve().parent
 
     key = rsa.generate_private_key(
         public_exponent=65537,
         key_size=2048,
         backend=default_backend(),
     )
-    with open(os.path.join(folder, 'localhost.key'), "wb") as f:
-        f.write(
-            key.private_bytes(
-                encoding=Encoding.PEM,
-                format=PrivateFormat.TraditionalOpenSSL,
-                encryption_algorithm=NoEncryption(),
-            )
+    (folder / 'localhost.key').write_bytes(
+        key.private_bytes(
+            encoding=Encoding.PEM,
+            format=PrivateFormat.TraditionalOpenSSL,
+            encryption_algorithm=NoEncryption(),
         )
+    )
 
     subject = issuer = Name(
         [
@@ -59,5 +58,4 @@ def generate_keys():
         )
         .sign(key, SHA256(), default_backend())
     )
-    with open(os.path.join(folder, 'localhost.crt'), "wb") as f:
-        f.write(cert.public_bytes(Encoding.PEM))
+    (folder / 'localhost.crt').write_bytes(cert.public_bytes(Encoding.PEM))

--- a/tests/mockserver.py
+++ b/tests/mockserver.py
@@ -1,6 +1,5 @@
 import argparse
 import json
-import os
 import random
 import sys
 from pathlib import Path
@@ -191,7 +190,7 @@ class Root(Resource):
         self.putChild(b"alpayload", ArbitraryLengthPayloadResource())
         try:
             from tests import tests_datadir
-            self.putChild(b"files", File(os.path.join(tests_datadir, 'test_site/files/')))
+            self.putChild(b"files", File(tests_datadir / 'test_site/files/'))
         except Exception:
             pass
         self.putChild(b"redirect-to", RedirectTo())
@@ -283,10 +282,8 @@ class MockFTPServer:
 
 
 def ssl_context_factory(keyfile='keys/localhost.key', certfile='keys/localhost.crt', cipher_string=None):
-    factory = ssl.DefaultOpenSSLContextFactory(
-        os.path.join(os.path.dirname(__file__), keyfile),
-        os.path.join(os.path.dirname(__file__), certfile),
-    )
+    factory = ssl.DefaultOpenSSLContextFactory(str(Path(__file__).parent / keyfile),
+                                               str(Path(__file__).parent / certfile))
     if cipher_string:
         ctx = factory.getContext()
         # disabling TLS1.3 because it unconditionally enables some strong ciphers

--- a/tests/test_cmdline/__init__.py
+++ b/tests/test_cmdline/__init__.py
@@ -1,11 +1,11 @@
 import json
-import os
 import pstats
 import shutil
 import sys
 import tempfile
 import unittest
 from io import StringIO
+from pathlib import Path
 from subprocess import Popen, PIPE
 
 from scrapy.utils.test import get_testenv
@@ -36,18 +36,17 @@ class CmdlineTest(unittest.TestCase):
         self.assertEqual(self._execute('settings', '--get', 'TEST1'), 'override')
 
     def test_profiling(self):
-        path = tempfile.mkdtemp()
-        filename = os.path.join(path, 'res.prof')
+        path = Path(tempfile.mkdtemp())
+        filename = path / 'res.prof'
         try:
             self._execute('version', '--profile', filename)
-            self.assertTrue(os.path.exists(filename))
+            self.assertTrue(filename.exists())
             out = StringIO()
             stats = pstats.Stats(filename, stream=out)
             stats.print_stats()
             out.seek(0)
             stats = out.read()
-            self.assertIn(os.path.join('scrapy', 'commands', 'version.py'),
-                          stats)
+            self.assertIn((Path('scrapy') / 'commands' / 'version.py'), stats)
             self.assertIn('tottime', stats)
         finally:
             shutil.rmtree(path)

--- a/tests/test_cmdline_crawl_with_pipeline/__init__.py
+++ b/tests/test_cmdline_crawl_with_pipeline/__init__.py
@@ -1,6 +1,6 @@
-import os
 import sys
 import unittest
+from pathlib import Path
 from subprocess import Popen, PIPE
 
 
@@ -8,7 +8,7 @@ class CmdlineCrawlPipelineTest(unittest.TestCase):
 
     def _execute(self, spname):
         args = (sys.executable, '-m', 'scrapy.cmdline', 'crawl', spname)
-        cwd = os.path.dirname(os.path.abspath(__file__))
+        cwd = Path(__file__).resolve().parent
         proc = Popen(args, stdout=PIPE, stderr=PIPE, cwd=cwd)
         proc.communicate()
         return proc.returncode

--- a/tests/test_command_check.py
+++ b/tests/test_command_check.py
@@ -1,5 +1,3 @@
-from os.path import join, abspath
-
 from tests.test_commands import CommandTest
 
 
@@ -10,11 +8,10 @@ class CheckCommandTest(CommandTest):
     def setUp(self):
         super(CheckCommandTest, self).setUp()
         self.spider_name = 'check_spider'
-        self.spider = abspath(join(self.proj_mod_path, 'spiders', 'checkspider.py'))
+        self.spider = self.proj_mod_path.resolve() / 'spiders' / 'checkspider.py'
 
     def _write_contract(self, contracts, parse_def):
-        with open(self.spider, 'w') as file:
-            file.write(f"""
+        self.spider.write_bytes(f"""
 import scrapy
 
 class CheckSpider(scrapy.Spider):
@@ -27,7 +24,7 @@ class CheckSpider(scrapy.Spider):
         {contracts}
         \"\"\"
         {parse_def}
-            """)
+        """)
 
     def _test_contract(self, contracts='', parse_def='pass'):
         self._write_contract(contracts, parse_def)

--- a/tests/test_command_shell.py
+++ b/tests/test_command_shell.py
@@ -1,5 +1,3 @@
-from os.path import join
-
 from twisted.trial import unittest
 from twisted.internet import defer
 
@@ -96,7 +94,7 @@ class ShellTest(ProcessTest, SiteTest, unittest.TestCase):
 
     @defer.inlineCallbacks
     def test_local_file(self):
-        filepath = join(tests_datadir, 'test_site', 'index.html')
+        filepath = tests_datadir / 'test_site' / 'index.html'
         _, out, _ = yield self.execute([filepath, '-c', 'item'])
         assert b'{}' in out
 

--- a/tests/test_crawler.py
+++ b/tests/test_crawler.py
@@ -1,9 +1,9 @@
 import logging
-import os
 import platform
 import subprocess
 import sys
 import warnings
+from pathlib import Path
 from unittest import skipIf
 
 from pytest import raises, mark
@@ -116,8 +116,7 @@ class CrawlerLoggingTestCase(unittest.TestCase):
         logging.warning('warning message')
         logging.error('error message')
 
-        with open(log_file, 'rb') as fo:
-            logged = fo.read().decode('utf8')
+        logged = log_file.read_text(encoding='utf8')
 
         self.assertNotIn('debug message', logged)
         self.assertIn('info message', logged)
@@ -283,7 +282,7 @@ class CrawlerRunnerHasSpider(unittest.TestCase):
 
 class ScriptRunnerMixin:
     def run_script(self, script_name, *script_args):
-        script_path = os.path.join(self.script_dir, script_name)
+        script_path = self.script_dir / script_name
         args = [sys.executable, script_path] + list(script_args)
         p = subprocess.Popen(args, env=get_testenv(),
                              stdout=subprocess.PIPE, stderr=subprocess.PIPE)
@@ -292,7 +291,7 @@ class ScriptRunnerMixin:
 
 
 class CrawlerProcessSubprocess(ScriptRunnerMixin, unittest.TestCase):
-    script_dir = os.path.join(os.path.abspath(os.path.dirname(__file__)), 'CrawlerProcess')
+    script_dir = Path(__file__).resolve().with_name('CrawlerProcess')
 
     def test_simple(self):
         log = self.run_script('simple.py')
@@ -385,7 +384,7 @@ class CrawlerProcessSubprocess(ScriptRunnerMixin, unittest.TestCase):
 
 
 class CrawlerRunnerSubprocess(ScriptRunnerMixin, unittest.TestCase):
-    script_dir = os.path.join(os.path.abspath(os.path.dirname(__file__)), 'CrawlerRunner')
+    script_dir = Path(__file__).resolve().with_name('CrawlerRunner')
 
     def test_response_ip_address(self):
         log = self.run_script("ip_address.py")

--- a/tests/test_downloadermiddleware_httpcompression.py
+++ b/tests/test_downloadermiddleware_httpcompression.py
@@ -1,6 +1,5 @@
 from io import BytesIO
 from unittest import TestCase, SkipTest
-from os.path import join
 from gzip import GzipFile
 
 from scrapy.spiders import Spider
@@ -12,7 +11,7 @@ from tests import tests_datadir
 from w3lib.encoding import resolve_encoding
 
 
-SAMPLEDIR = join(tests_datadir, 'compressed')
+SAMPLEDIR = tests_datadir / 'compressed'
 
 FORMAT = {
     'gzip': ('html-gzip.bin', 'gzip'),
@@ -41,8 +40,7 @@ class HttpCompressionTest(TestCase):
 
         samplefile, contentencoding = FORMAT[coding]
 
-        with open(join(SAMPLEDIR, samplefile), 'rb') as sample:
-            body = sample.read()
+        body = (SAMPLEDIR / samplefile).read_bytes()
 
         headers = {
             'Server': 'Yaws/1.49 Yet Another Web Server',

--- a/tests/test_dupefilters.py
+++ b/tests/test_dupefilters.py
@@ -2,8 +2,8 @@ import hashlib
 import tempfile
 import unittest
 import shutil
-import os
 import sys
+from pathlib import Path
 from testfixtures import LogCapture
 
 from scrapy.dupefilters import RFPDupeFilter
@@ -141,14 +141,14 @@ class RFPDupeFilterTest(unittest.TestCase):
 
         r1 = Request('http://scrapytest.org/1')
 
-        path = tempfile.mkdtemp()
+        path = Path(tempfile.mkdtemp())
         try:
             df = RFPDupeFilter(path)
             df.open()
             df.request_seen(r1)
             df.close('finished')
 
-            with open(os.path.join(path, 'requests.seen'), 'rb') as seen_file:
+            with (path / 'requests.seen').open('rb') as seen_file:
                 line = next(seen_file).decode()
                 assert not line.endswith('\r\r\n')
                 if sys.platform == 'win32':

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -10,7 +10,6 @@ module with the ``runserver`` argument::
     python test_engine.py runserver
 """
 
-import os
 import re
 import sys
 from collections import defaultdict
@@ -118,7 +117,7 @@ class ItemZeroDivisionErrorSpider(TestSpider):
 
 
 def start_test_site(debug=False):
-    root_dir = os.path.join(tests_datadir, "test_site")
+    root_dir = tests_datadir / "test_site"
     r = static.File(root_dir)
     r.putChild(b"redirect", util.Redirect(b"/redirected"))
     r.putChild(b"redirected", static.Data(b"Redirected here", "text/plain"))

--- a/tests/test_pipeline_crawl.py
+++ b/tests/test_pipeline_crawl.py
@@ -1,5 +1,5 @@
-import os
 import shutil
+from pathlib import Path
 
 from testfixtures import LogCapture
 from twisted.internet import defer
@@ -61,8 +61,8 @@ class FileDownloadCrawlTestCase(TestCase):
         self.mockserver.__enter__()
 
         # prepare a directory for storing files
-        self.tmpmediastore = self.mktemp()
-        os.mkdir(self.tmpmediastore)
+        self.tmpmediastore = Path(self.mktemp())
+        self.tmpmediastore.mkdir()
         self.settings = {
             'ITEM_PIPELINES': {self.pipeline_class: 1},
             self.store_setting_key: self.tmpmediastore,
@@ -108,9 +108,7 @@ class FileDownloadCrawlTestCase(TestCase):
         # check that the image files where actually written to the media store
         for item in items:
             for i in item[self.media_key]:
-                self.assertTrue(
-                    os.path.exists(
-                        os.path.join(self.tmpmediastore, i['path'])))
+                self.assertTrue((self.tmpmediastore / i['path']).exists())
 
     def _assert_files_download_failure(self, crawler, items, code, logs):
 
@@ -130,7 +128,7 @@ class FileDownloadCrawlTestCase(TestCase):
         self.assertEqual(logs.count(file_dl_failure), 3)
 
         # check that no files were written to the media store
-        self.assertEqual(os.listdir(self.tmpmediastore), [])
+        self.assertEqual(list(self.tmpmediastore.iterdir()), [])
 
     @defer.inlineCallbacks
     def test_download_media(self):

--- a/tests/test_pipeline_files.py
+++ b/tests/test_pipeline_files.py
@@ -3,6 +3,7 @@ import random
 import time
 from datetime import datetime
 from io import BytesIO
+from pathlib import Path
 from shutil import rmtree
 from tempfile import mkdtemp
 from unittest import mock, skipIf
@@ -91,8 +92,8 @@ class FilesPipelineTestCase(unittest.TestCase):
         assert isinstance(self.pipeline.store, FSFilesStore)
         self.assertEqual(self.pipeline.store.basedir, self.tempdir)
 
-        path = 'some/image/key.jpg'
-        fullpath = os.path.join(self.tempdir, 'some', 'image', 'key.jpg')
+        path = Path('some/image/key.jpg')
+        fullpath = self.tempdir / 'some' / 'image' / 'key.jpg'
         self.assertEqual(self.pipeline.store._get_filesystem_path(path), fullpath)
 
     @defer.inlineCallbacks

--- a/tests/test_proxy_connect.py
+++ b/tests/test_proxy_connect.py
@@ -3,6 +3,7 @@ import os
 import platform
 import re
 import sys
+from pathlib import Path
 from subprocess import Popen, PIPE
 from urllib.parse import urlsplit, urlunsplit
 from unittest import skipIf
@@ -30,8 +31,7 @@ from mitmproxy.tools.main import mitmdump
 sys.argv[0] = "mitmdump"
 sys.exit(mitmdump())
         """
-        cert_path = os.path.join(os.path.abspath(os.path.dirname(__file__)),
-                                 'keys', 'mitmproxy-ca.pem')
+        cert_path = Path(__file__).resolve() / 'keys' / 'mitmproxy-ca.pem'
         self.proc = Popen([sys.executable,
                            '-c', script,
                            '--listen-host', '127.0.0.1',

--- a/tests/test_spiderloader/__init__.py
+++ b/tests/test_spiderloader/__init__.py
@@ -1,7 +1,8 @@
 import sys
-import os
 import shutil
 import warnings
+
+from pathlib import Path
 
 from zope.interface.verify import verifyObject
 from twisted.trial import unittest
@@ -17,7 +18,7 @@ from scrapy.settings import Settings
 from scrapy.http import Request
 from scrapy.crawler import CrawlerRunner
 
-module_dir = os.path.dirname(os.path.abspath(__file__))
+module_dir = Path(__file__).resolve().parent
 
 
 def _copytree(source, target):
@@ -30,11 +31,11 @@ def _copytree(source, target):
 class SpiderLoaderTest(unittest.TestCase):
 
     def setUp(self):
-        orig_spiders_dir = os.path.join(module_dir, 'test_spiders')
-        self.tmpdir = tempfile.mkdtemp()
-        self.spiders_dir = os.path.join(self.tmpdir, 'test_spiders_xxx')
+        orig_spiders_dir = module_dir / 'test_spiders'
+        self.tmpdir = Path(tempfile.mkdtemp())
+        self.spiders_dir = self.tmpdir / 'test_spiders_xxx'
         _copytree(orig_spiders_dir, self.spiders_dir)
-        sys.path.append(self.tmpdir)
+        sys.path.append(str(self.tmpdir))
         settings = Settings({'SPIDER_MODULES': ['test_spiders_xxx']})
         self.spider_loader = SpiderLoader.from_settings(settings)
 
@@ -127,22 +128,22 @@ class SpiderLoaderTest(unittest.TestCase):
 class DuplicateSpiderNameLoaderTest(unittest.TestCase):
 
     def setUp(self):
-        orig_spiders_dir = os.path.join(module_dir, 'test_spiders')
-        self.tmpdir = self.mktemp()
-        os.mkdir(self.tmpdir)
-        self.spiders_dir = os.path.join(self.tmpdir, 'test_spiders_xxx')
+        orig_spiders_dir = module_dir / 'test_spiders'
+        self.tmpdir = Path(self.mktemp())
+        self.tmpdir.mkdir()
+        self.spiders_dir = self.tmpdir / 'test_spiders_xxx'
         _copytree(orig_spiders_dir, self.spiders_dir)
-        sys.path.append(self.tmpdir)
+        sys.path.append(str(self.tmpdir))
         self.settings = Settings({'SPIDER_MODULES': ['test_spiders_xxx']})
 
     def tearDown(self):
         del sys.modules['test_spiders_xxx']
-        sys.path.remove(self.tmpdir)
+        sys.path.remove(str(self.tmpdir))
 
     def test_dupename_warning(self):
         # copy 1 spider module so as to have duplicate spider name
-        shutil.copyfile(os.path.join(self.tmpdir, 'test_spiders_xxx', 'spider3.py'),
-                        os.path.join(self.tmpdir, 'test_spiders_xxx', 'spider3dupe.py'))
+        shutil.copyfile(self.tmpdir / 'test_spiders_xxx' / 'spider3.py',
+                        self.tmpdir / 'test_spiders_xxx' / 'spider3dupe.py')
 
         with warnings.catch_warnings(record=True) as w:
             spider_loader = SpiderLoader.from_settings(self.settings)
@@ -163,10 +164,10 @@ class DuplicateSpiderNameLoaderTest(unittest.TestCase):
     def test_multiple_dupename_warning(self):
         # copy 2 spider modules so as to have duplicate spider name
         # This should issue 2 warning, 1 for each duplicate spider name
-        shutil.copyfile(os.path.join(self.tmpdir, 'test_spiders_xxx', 'spider1.py'),
-                        os.path.join(self.tmpdir, 'test_spiders_xxx', 'spider1dupe.py'))
-        shutil.copyfile(os.path.join(self.tmpdir, 'test_spiders_xxx', 'spider2.py'),
-                        os.path.join(self.tmpdir, 'test_spiders_xxx', 'spider2dupe.py'))
+        shutil.copyfile(self.tmpdir / 'test_spiders_xxx' / 'spider1.py',
+                        self.tmpdir / 'test_spiders_xxx' / 'spider1dupe.py')
+        shutil.copyfile(self.tmpdir / 'test_spiders_xxx' / 'spider2.py',
+                        self.tmpdir / 'test_spiders_xxx' / 'spider2dupe.py')
 
         with warnings.catch_warnings(record=True) as w:
             spider_loader = SpiderLoader.from_settings(self.settings)

--- a/tests/test_utils_gz.py
+++ b/tests/test_utils_gz.py
@@ -1,5 +1,4 @@
 import unittest
-from os.path import join
 
 from w3lib.encoding import html_to_unicode
 
@@ -8,46 +7,40 @@ from scrapy.http import Response
 from tests import tests_datadir
 
 
-SAMPLEDIR = join(tests_datadir, 'compressed')
+SAMPLEDIR = tests_datadir / 'compressed'
 
 
 class GunzipTest(unittest.TestCase):
 
     def test_gunzip_basic(self):
-        with open(join(SAMPLEDIR, 'feed-sample1.xml.gz'), 'rb') as f:
-            r1 = Response("http://www.example.com", body=f.read())
-            self.assertTrue(gzip_magic_number(r1))
+        r1 = Response("http://www.example.com", body=(SAMPLEDIR / 'feed-sample1.xml.gz').read_bytes())
+        self.assertTrue(gzip_magic_number(r1))
 
-            r2 = Response("http://www.example.com", body=gunzip(r1.body))
-            self.assertFalse(gzip_magic_number(r2))
-            self.assertEqual(len(r2.body), 9950)
+        r2 = Response("http://www.example.com", body=gunzip(r1.body))
+        self.assertFalse(gzip_magic_number(r2))
+        self.assertEqual(len(r2.body), 9950)
 
     def test_gunzip_truncated(self):
-        with open(join(SAMPLEDIR, 'truncated-crc-error.gz'), 'rb') as f:
-            text = gunzip(f.read())
-            assert text.endswith(b'</html')
+        text = gunzip((SAMPLEDIR / 'truncated-crc-error.gz').read_bytes())
+        assert text.endswith(b'</html')
 
     def test_gunzip_no_gzip_file_raises(self):
-        with open(join(SAMPLEDIR, 'feed-sample1.xml'), 'rb') as f:
-            self.assertRaises(IOError, gunzip, f.read())
+        self.assertRaises(IOError, gunzip, (SAMPLEDIR / 'feed-sample1.xml').read_bytes())
 
     def test_gunzip_truncated_short(self):
-        with open(join(SAMPLEDIR, 'truncated-crc-error-short.gz'), 'rb') as f:
-            r1 = Response("http://www.example.com", body=f.read())
-            self.assertTrue(gzip_magic_number(r1))
+        r1 = Response("http://www.example.com", body=(SAMPLEDIR / 'truncated-crc-error-short.gz').read_bytes())
+        self.assertTrue(gzip_magic_number(r1))
 
-            r2 = Response("http://www.example.com", body=gunzip(r1.body))
-            assert r2.body.endswith(b'</html>')
-            self.assertFalse(gzip_magic_number(r2))
+        r2 = Response("http://www.example.com", body=gunzip(r1.body))
+        assert r2.body.endswith(b'</html>')
+        self.assertFalse(gzip_magic_number(r2))
 
     def test_is_gzipped_empty(self):
         r1 = Response("http://www.example.com")
         self.assertFalse(gzip_magic_number(r1))
 
     def test_gunzip_illegal_eof(self):
-        with open(join(SAMPLEDIR, 'unexpected-eof.gz'), 'rb') as f:
-            text = html_to_unicode('charset=cp1252', gunzip(f.read()))[1]
-            with open(join(SAMPLEDIR, 'unexpected-eof-output.txt'), 'rb') as o:
-                expected_text = o.read().decode("utf-8")
-                self.assertEqual(len(text), len(expected_text))
-                self.assertEqual(text, expected_text)
+        text = html_to_unicode('charset=cp1252', gunzip((SAMPLEDIR / 'unexpected-eof.gz').read_bytes()))[1]
+        expected_text = (SAMPLEDIR / 'unexpected-eof-output.txt').read_text(encoding='utf-8')
+        self.assertEqual(len(text), len(expected_text))
+        self.assertEqual(text, expected_text)

--- a/tests/test_utils_iterators.py
+++ b/tests/test_utils_iterators.py
@@ -1,4 +1,4 @@
-import os
+from pathlib import Path
 
 from pytest import mark
 from twisted.trial import unittest
@@ -303,10 +303,10 @@ class LxmlXmliterTestCase(XmliterTestCase):
 
 
 class UtilsCsvTestCase(unittest.TestCase):
-    sample_feeds_dir = os.path.join(os.path.abspath(os.path.dirname(__file__)), 'sample_data', 'feeds')
-    sample_feed_path = os.path.join(sample_feeds_dir, 'feed-sample3.csv')
-    sample_feed2_path = os.path.join(sample_feeds_dir, 'feed-sample4.csv')
-    sample_feed3_path = os.path.join(sample_feeds_dir, 'feed-sample5.csv')
+    sample_feeds_dir = Path(__file__).resolve().parent / 'sample_data' / 'feeds'
+    sample_feed_path = sample_feeds_dir / 'feed-sample3.csv'
+    sample_feed2_path = sample_feeds_dir / 'feed-sample4.csv'
+    sample_feed3_path = sample_feeds_dir / 'feed-sample5.csv'
 
     def test_csviter_defaults(self):
         body = get_testdata('feeds', 'feed-sample3.csv')

--- a/tests/test_utils_misc/__init__.py
+++ b/tests/test_utils_misc/__init__.py
@@ -1,6 +1,7 @@
 import sys
 import os
 import unittest
+from pathlib import Path
 from unittest import mock
 
 from scrapy.item import Item, Field
@@ -55,7 +56,7 @@ class UtilsMiscTestCase(unittest.TestCase):
         self.assertRaises(ImportError, walk_modules, 'nomodule999')
 
     def test_walk_modules_egg(self):
-        egg = os.path.join(os.path.dirname(__file__), 'test.egg')
+        egg = str(Path(__file__).with_name('test.egg'))
         sys.path.append(egg)
         try:
             mods = walk_modules('testegg')

--- a/tests/test_utils_project.py
+++ b/tests/test_utils_project.py
@@ -1,8 +1,9 @@
-import unittest
-import os
-import tempfile
-import shutil
 import contextlib
+import os
+import shutil
+import tempfile
+import unittest
+from pathlib import Path
 
 from pytest import warns
 
@@ -17,9 +18,8 @@ def inside_a_project():
 
     try:
         os.chdir(project_dir)
-        with open('scrapy.cfg', 'w') as f:
-            # create an empty scrapy.cfg
-            f.close()
+        # create an empty scrapy.cfg
+        Path('scrapy.cfg').write_text('')
 
         yield project_dir
     finally:
@@ -29,21 +29,15 @@ def inside_a_project():
 
 class ProjectUtilsTest(unittest.TestCase):
     def test_data_path_outside_project(self):
-        self.assertEqual(
-            os.path.join('.scrapy', 'somepath'),
-            data_path('somepath')
-        )
-        abspath = os.path.join(os.path.sep, 'absolute', 'path')
+        self.assertEqual(Path('.scrapy') / 'somepath', data_path('somepath'))
+        abspath = Path.root / 'absolute' / 'path'
         self.assertEqual(abspath, data_path(abspath))
 
     def test_data_path_inside_project(self):
         with inside_a_project() as proj_path:
-            expected = os.path.join(proj_path, '.scrapy', 'somepath')
-            self.assertEqual(
-                os.path.realpath(expected),
-                os.path.realpath(data_path('somepath'))
-            )
-            abspath = os.path.join(os.path.sep, 'absolute', 'path')
+            expected = proj_path / '.scrapy' / 'somepath'
+            self.assertEqual(expected.resolve(), data_path('somepath').resolve())
+            abspath = Path.root / 'absolute' / 'path'
             self.assertEqual(abspath, data_path(abspath))
 
 

--- a/tests/test_utils_response.py
+++ b/tests/test_utils_response.py
@@ -1,5 +1,5 @@
-import os
 import unittest
+from pathlib import Path
 from urllib.parse import urlparse
 
 from scrapy.http import Response, TextResponse, HtmlResponse
@@ -29,11 +29,10 @@ class ResponseUtilsTest(unittest.TestCase):
         body = b"<html> <head> <title>test page</title> </head> <body>test body</body> </html>"
 
         def browser_open(burl):
-            path = urlparse(burl).path
-            if not os.path.exists(path):
-                path = burl.replace('file://', '')
-            with open(path, "rb") as f:
-                bbody = f.read()
+            path = Path(urlparse(burl).path)
+            if not path.exists():
+                path = Path(burl.replace('file://', ''))
+            bbody = path.read_bytes()
             self.assertIn(b'<base href="' + to_bytes(url) + b'">', bbody)
             return True
         response = HtmlResponse(url, body=body)

--- a/tests/test_utils_template.py
+++ b/tests/test_utils_template.py
@@ -1,4 +1,3 @@
-import os
 from shutil import rmtree
 from tempfile import mkdtemp
 import unittest
@@ -22,21 +21,19 @@ class UtilsRenderTemplateFileTestCase(unittest.TestCase):
         template = 'from ${project_name}.spiders.${name} import ${classname}'
         rendered = 'from proj.spiders.spi import TheSpider'
 
-        template_path = os.path.join(self.tmp_path, 'templ.py.tmpl')
-        render_path = os.path.join(self.tmp_path, 'templ.py')
+        template_path = self.tmp_path / 'templ.py.tmpl'
+        render_path = self.tmp_path / 'templ.py'
 
-        with open(template_path, 'wb') as tmpl_file:
-            tmpl_file.write(template.encode('utf8'))
-        assert os.path.isfile(template_path)  # Failure of test itself
+        template_path.write_text(template, encoding='utf8')
+        assert template_path.is_file()  # Failure of test itself
 
         render_templatefile(template_path, **context)
 
-        self.assertFalse(os.path.exists(template_path))
-        with open(render_path, 'rb') as result:
-            self.assertEqual(result.read().decode('utf8'), rendered)
+        self.assertFalse(template_path.exists())
+        self.assertEqual(render_path.read_text(encoding='utf8'), rendered)
 
-        os.remove(render_path)
-        assert not os.path.exists(render_path)  # Failure of test iself
+        render_path.unlink()
+        assert not render_path.exists()  # Failure of test iself
 
 
 if '__main__' == __name__:

--- a/tests/test_webclient.py
+++ b/tests/test_webclient.py
@@ -4,6 +4,7 @@ Tests borrowed from the twisted.web.client tests.
 """
 import os
 import shutil
+from pathlib import Path
 
 import OpenSSL.SSL
 from twisted.trial import unittest
@@ -230,8 +231,8 @@ class WebClientTestCase(unittest.TestCase):
         return reactor.listenTCP(0, site, interface="127.0.0.1")
 
     def setUp(self):
-        self.tmpname = self.mktemp()
-        os.mkdir(self.tmpname)
+        self.tmpname = Path(self.mktemp())
+        self.tmpname.mkdir()
         FilePath(self.tmpname).child("file").setContent(b"0123456789")
         r = static.File(self.tmpname)
         r.putChild(b"redirect", util.Redirect(b"/file"))


### PR DESCRIPTION
Since scrapy is a Python 3.6+ project, `pathlib.Path` may be used to improve readability of the directories/files manipulating code. This PR replaces most `os`/`glob`/`fnmatch`/`open` calls with `pathlib.Path` objects and methods.