### PR TITLE
Use pathlib.Path to create directories

### DIFF
--- a/scrapy/commands/startproject.py
+++ b/scrapy/commands/startproject.py
@@ -3,6 +3,7 @@ import os
 import string
 from importlib import import_module
 from os.path import join, exists, abspath
+from pathlib import Path
 from shutil import ignore_patterns, move, copy2, copystat
 from stat import S_IWUSR as OWNER_WRITE_PERMISSION
 
@@ -70,8 +71,7 @@ class Command(ScrapyCommand):
         names = os.listdir(src)
         ignored_names = ignore(src, names)
 
-        if not os.path.exists(dst):
-            os.makedirs(dst)
+        Path(dst).mkdir(parents=True, exist_ok=True)
 
         for name in names:
             if name in ignored_names:

--- a/scrapy/core/scheduler.py
+++ b/scrapy/core/scheduler.py
@@ -1,7 +1,7 @@
-import os
 import json
 import logging
 from os.path import join, exists
+from pathlib import Path
 
 from scrapy.utils.misc import load_object, create_instance
 from scrapy.utils.job import job_dir
@@ -154,8 +154,7 @@ class Scheduler:
         """ Return a folder name to keep disk queue state at """
         if jobdir:
             dqdir = join(jobdir, 'requests.queue')
-            if not exists(dqdir):
-                os.makedirs(dqdir)
+            Path(dqdir).mkdir(parents=True, exist_ok=True)
             return dqdir
 
     def _read_dqs_state(self, dqdir):

--- a/scrapy/extensions/feedexport.py
+++ b/scrapy/extensions/feedexport.py
@@ -10,6 +10,7 @@ import re
 import sys
 import warnings
 from datetime import datetime
+from pathlib import Path
 from tempfile import NamedTemporaryFile
 from urllib.parse import unquote, urlparse
 
@@ -108,8 +109,8 @@ class FileFeedStorage:
 
     def open(self, spider):
         dirname = os.path.dirname(self.path)
-        if dirname and not os.path.exists(dirname):
-            os.makedirs(dirname)
+        if dirname:
+            Path(dirname).mkdir(parents=True, exist_ok=True)
         return open(self.path, self.write_mode)
 
     def store(self, file):

--- a/scrapy/extensions/httpcache.py
+++ b/scrapy/extensions/httpcache.py
@@ -4,6 +4,7 @@ import os
 import pickle
 from email.utils import mktime_tz, parsedate_tz
 from importlib import import_module
+from pathlib import Path
 from time import time
 from weakref import WeakKeyDictionary
 
@@ -306,8 +307,7 @@ class FilesystemCacheStorage:
     def store_response(self, spider, request, response):
         """Store the given response in the cache."""
         rpath = self._get_request_path(spider, request)
-        if not os.path.exists(rpath):
-            os.makedirs(rpath)
+        Path(rpath).mkdir(parents=True, exist_ok=True)
         metadata = {
             'url': request.url,
             'method': request.method,

--- a/scrapy/pipelines/files.py
+++ b/scrapy/pipelines/files.py
@@ -13,6 +13,7 @@ from collections import defaultdict
 from contextlib import suppress
 from ftplib import FTP
 from io import BytesIO
+from pathlib import Path
 from urllib.parse import urlparse
 
 from itemadapter import ItemAdapter
@@ -71,8 +72,7 @@ class FSFilesStore:
     def _mkdir(self, dirname, domain=None):
         seen = self.created_directories[domain] if domain else set()
         if dirname not in seen:
-            if not os.path.exists(dirname):
-                os.makedirs(dirname)
+            Path(dirname).mkdir(parents=True, exist_ok=True)
             seen.add(dirname)
 
 

--- a/scrapy/squeues.py
+++ b/scrapy/squeues.py
@@ -3,8 +3,9 @@ Scheduler queues
 """
 
 import marshal
-import os
 import pickle
+
+from pathlib import Path
 
 from queuelib import queue
 
@@ -16,9 +17,7 @@ def _with_mkdir(queue_class):
     class DirectoriesCreated(queue_class):
 
         def __init__(self, path, *args, **kwargs):
-            dirname = os.path.dirname(path)
-            if not os.path.exists(dirname):
-                os.makedirs(dirname, exist_ok=True)
+            Path(path).parent.mkdir(parents=True, exist_ok=True)
 
             super().__init__(path, *args, **kwargs)
 

--- a/scrapy/utils/job.py
+++ b/scrapy/utils/job.py
@@ -1,8 +1,8 @@
-import os
+from pathlib import Path
 
 
 def job_dir(settings):
     path = settings['JOBDIR']
-    if path and not os.path.exists(path):
-        os.makedirs(path)
+    if path:
+        Path(path).mkdir(parents=True, exist_ok=True)
     return path

--- a/scrapy/utils/project.py
+++ b/scrapy/utils/project.py
@@ -2,7 +2,8 @@ import os
 import warnings
 
 from importlib import import_module
-from os.path import join, dirname, abspath, isabs, exists
+from os.path import join, isabs
+from pathlib import Path
 
 from scrapy.utils.conf import closest_scrapy_cfg, get_config, init_env
 from scrapy.settings import Settings
@@ -31,15 +32,14 @@ def project_data_dir(project='default'):
         raise NotConfigured("Not inside a project")
     cfg = get_config()
     if cfg.has_option(DATADIR_CFG_SECTION, project):
-        d = cfg.get(DATADIR_CFG_SECTION, project)
+        path = Path(cfg.get(DATADIR_CFG_SECTION, project))
     else:
         scrapy_cfg = closest_scrapy_cfg()
         if not scrapy_cfg:
             raise NotConfigured("Unable to find scrapy.cfg file to infer project data dir")
-        d = abspath(join(dirname(scrapy_cfg), '.scrapy'))
-    if not exists(d):
-        os.makedirs(d)
-    return d
+        path = Path(scrapy_cfg).resolve().with_name('.scrapy')
+    path.mkdir(parents=True, exist_ok=True)
+    return str(path)
 
 
 def data_path(path, createdir=False):
@@ -52,8 +52,8 @@ def data_path(path, createdir=False):
             path = join(project_data_dir(), path)
         else:
             path = join('.scrapy', path)
-    if createdir and not exists(path):
-        os.makedirs(path)
+    if createdir:
+        Path(path).mkdir(parents=True, exist_ok=True)
     return path
 
 

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -291,8 +291,8 @@ class StartprojectTemplatesTest(ProjectTest):
                 0o444, 0o555, 0o644, 0o666, 0o755, 0o777,
             )
         }
-        os.mkdir(project_dir)
         project_dir_path = Path(project_dir)
+        project_dir_path.mkdir()
         for node, permissions in existing_nodes.items():
             path = project_dir_path / node
             if node.endswith('.d'):
@@ -522,7 +522,7 @@ class BadSpider(scrapy.Spider):
     @contextmanager
     def _create_file(self, content, name=None):
         tmpdir = self.mktemp()
-        os.mkdir(tmpdir)
+        Path(tmpdir).mkdir()
         if name:
             fname = abspath(join(tmpdir, name))
         else:

--- a/tests/test_downloader_handlers.py
+++ b/tests/test_downloader_handlers.py
@@ -2,6 +2,7 @@ import contextlib
 import os
 import shutil
 import tempfile
+from pathlib import Path
 from unittest import mock
 
 from testfixtures import LogCapture
@@ -213,7 +214,7 @@ class HttpTestCase(unittest.TestCase):
 
     def setUp(self):
         self.tmpname = self.mktemp()
-        os.mkdir(self.tmpname)
+        Path(self.tmpname).mkdir()
         FilePath(self.tmpname).child("file").setContent(b"0123456789")
         r = static.File(self.tmpname)
         r.putChild(b"redirect", util.Redirect(b"/file"))
@@ -576,7 +577,7 @@ class Https11CustomCiphers(unittest.TestCase):
 
     def setUp(self):
         self.tmpname = self.mktemp()
-        os.mkdir(self.tmpname)
+        Path(self.tmpname).mkdir()
         FilePath(self.tmpname).child("file").setContent(b"0123456789")
         r = static.File(self.tmpname)
         self.site = server.Site(r, timeout=None)
@@ -934,9 +935,8 @@ class BaseFTPTestCase(unittest.TestCase):
 
         # setup dirs and test file
         self.directory = self.mktemp()
-        os.mkdir(self.directory)
         userdir = os.path.join(self.directory, self.username)
-        os.mkdir(userdir)
+        Path(userdir).mkdir(parents=True)
         fp = FilePath(userdir)
         fp.child('file.txt').setContent(b"I have the power!")
         fp.child('file with spaces.txt').setContent(b"Moooooooooo power!")
@@ -1050,7 +1050,7 @@ class AnonymousFTPTestCase(BaseFTPTestCase):
 
         # setup dir and test file
         self.directory = self.mktemp()
-        os.mkdir(self.directory)
+        Path(self.directory).mkdir()
 
         fp = FilePath(self.directory)
         fp.child('file.txt').setContent(b"I have the power!")

--- a/tests/test_feedexport.py
+++ b/tests/test_feedexport.py
@@ -520,8 +520,8 @@ class DummyBlockingFeedStorage(BlockingFeedStorage):
 
     def _store_in_thread(self, file):
         dirname = os.path.dirname(self.path)
-        if dirname and not os.path.exists(dirname):
-            os.makedirs(dirname)
+        if dirname:
+            Path(dirname).mkdir(parents=True, exist_ok=True)
         with open(self.path, 'ab') as output_file:
             output_file.write(file.read())
 

--- a/tests/test_pipeline_crawl.py
+++ b/tests/test_pipeline_crawl.py
@@ -1,5 +1,6 @@
 import os
 import shutil
+from pathlib import Path
 
 from testfixtures import LogCapture
 from twisted.internet import defer
@@ -62,7 +63,7 @@ class FileDownloadCrawlTestCase(TestCase):
 
         # prepare a directory for storing files
         self.tmpmediastore = self.mktemp()
-        os.mkdir(self.tmpmediastore)
+        Path(self.tmpmediastore).mkdir()
         self.settings = {
             'ITEM_PIPELINES': {self.pipeline_class: 1},
             self.store_setting_key: self.tmpmediastore,

--- a/tests/test_spiderloader/__init__.py
+++ b/tests/test_spiderloader/__init__.py
@@ -2,6 +2,7 @@ import sys
 import os
 import shutil
 import warnings
+from pathlib import Path
 
 from zope.interface.verify import verifyObject
 from twisted.trial import unittest
@@ -129,7 +130,7 @@ class DuplicateSpiderNameLoaderTest(unittest.TestCase):
     def setUp(self):
         orig_spiders_dir = os.path.join(module_dir, 'test_spiders')
         self.tmpdir = self.mktemp()
-        os.mkdir(self.tmpdir)
+        Path(self.tmpdir).mkdir()
         self.spiders_dir = os.path.join(self.tmpdir, 'test_spiders_xxx')
         _copytree(orig_spiders_dir, self.spiders_dir)
         sys.path.append(self.tmpdir)

--- a/tests/test_spiderstate.py
+++ b/tests/test_spiderstate.py
@@ -1,6 +1,6 @@
-import os
 from datetime import datetime
 import shutil
+from pathlib import Path
 from twisted.trial import unittest
 
 from scrapy.extensions.spiderstate import SpiderState
@@ -13,7 +13,7 @@ class SpiderStateTest(unittest.TestCase):
 
     def test_store_load(self):
         jobdir = self.mktemp()
-        os.mkdir(jobdir)
+        Path(jobdir).mkdir()
         try:
             spider = Spider(name='default')
             dt = datetime.now()

--- a/tests/test_webclient.py
+++ b/tests/test_webclient.py
@@ -2,10 +2,10 @@
 from twisted.internet import defer
 Tests borrowed from the twisted.web.client tests.
 """
-import os
 import shutil
 import sys
 from pkg_resources import parse_version
+from pathlib import Path
 
 import cryptography
 import OpenSSL.SSL
@@ -234,7 +234,7 @@ class WebClientTestCase(unittest.TestCase):
 
     def setUp(self):
         self.tmpname = self.mktemp()
-        os.mkdir(self.tmpname)
+        Path(self.tmpname).mkdir()
         FilePath(self.tmpname).child("file").setContent(b"0123456789")
         r = static.File(self.tmpname)
         r.putChild(b"redirect", util.Redirect(b"/file"))
@@ -383,7 +383,7 @@ class WebClientSSLTestCase(unittest.TestCase):
 
     def setUp(self):
         self.tmpname = self.mktemp()
-        os.mkdir(self.tmpname)
+        Path(self.tmpname).mkdir()
         FilePath(self.tmpname).child("file").setContent(b"0123456789")
         r = static.File(self.tmpname)
         r.putChild(b"payload", PayloadResource())


### PR DESCRIPTION
This is the first part of the series discussed in #4916 on using `pathlib.Path` for directory/file manipulation. It converts all `os.mkdir` and `os.makedirs` calls to `Path.mkdir` without leaving the context of the modified lines, i.e. no method signatures or object attributes are affected.