### PR TITLE
Handle Check if single Image URL needs to be Downloaded

### DIFF
--- a/scrapy/pipelines/images.py
+++ b/scrapy/pipelines/images.py
@@ -160,6 +160,7 @@ class ImagesPipeline(FilesPipeline):
 
     def get_media_requests(self, item, info):
         urls = ItemAdapter(item).get(self.images_urls_field, [])
+        urls = urls if isinstance(urls, list) else [urls]
         return [Request(u) for u in urls]
 
     def item_completed(self, results, item, info):


### PR DESCRIPTION
- Previously, we need need to Download a single Image URL, still, we need to make that URL a list i.e. `image_urls: [URL]`
- After this fix, we don't need to make it a list, `image_urls: URL` will work.
- A better user experience.