### PR TITLE
Fix Warning - Usually first parameter of a method is named 'self'

### DIFF
--- a/scrapy/extensions/telnet.py
+++ b/scrapy/extensions/telnet.py
@@ -75,7 +75,7 @@ class TelnetConsole(protocol.ServerFactory):
         class Portal:
             """An implementation of IPortal"""
             @defers
-            def login(self_, credentials, mind, *interfaces):
+            def login(self, credentials, mind, *interfaces):
                 if not (
                     credentials.username == self.username.encode('utf8')
                     and credentials.checkPassword(self.password.encode('utf8'))

--- a/scrapy/pipelines/media.py
+++ b/scrapy/pipelines/media.py
@@ -86,7 +86,7 @@ class MediaPipeline:
         info = self.spiderinfo
         requests = arg_to_iter(self.get_media_requests(item, info))
         dlist = [self._process_request(r, info, item) for r in requests]
-        dfd = DeferredList(dlist, consumeErrors=1)
+        dfd = DeferredList(dlist, consumeErrors=True)
         return dfd.addCallback(self.item_completed, item, info)
 
     def _process_request(self, request, info, item):

--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,7 @@ setup(
     name='Scrapy',
     version=version,
     url='https://scrapy.org',
-    project_urls = {
+    project_urls={
         'Documentation': 'https://docs.scrapy.org/',
         'Source': 'https://github.com/scrapy/scrapy',
         'Tracker': 'https://github.com/scrapy/scrapy/issues',


### PR DESCRIPTION
Fix Warning - Usually first parameter of a method is named 'self'

Parameter renamed from **self_** to **self**.