### PR TITLE
Match the styles of empty container initializations

### DIFF
--- a/scrapy/core/downloader/__init__.py
+++ b/scrapy/core/downloader/__init__.py
@@ -73,7 +73,7 @@ class Downloader:
     def __init__(self, crawler):
         self.settings = crawler.settings
         self.signals = crawler.signals
-        self.slots = {}
+        self.slots = dict()
         self.active = set()
         self.handlers = DownloadHandlers(crawler)
         self.total_concurrency = self.settings.getint('CONCURRENT_REQUESTS')

--- a/scrapy/pipelines/media.py
+++ b/scrapy/pipelines/media.py
@@ -26,12 +26,12 @@ class MediaPipeline:
         def __init__(self, spider):
             self.spider = spider
             self.downloading = set()
-            self.downloaded = {}
+            self.downloaded = dict()
             self.waiting = defaultdict(list)
 
     def __init__(self, download_func=None, settings=None):
         self.download_func = download_func
-        self._expects_item = {}
+        self._expects_item = dict()
 
         if isinstance(settings, dict) or settings is None:
             settings = Settings(settings)


### PR DESCRIPTION
We use `set()` to initialize an empty set, and I'm wondering if turning `{}` into `dict()` looks more consistent.

The codebase does have this, in `scrapy/utils/conf.py` ([reference](https://github.com/scrapy/scrapy/blob/63becd1bc89395750b39139e2114193607f3ca61/scrapy/utils/conf.py#L124))

There are tens of those scattered in the codebase, some of which probably should keep `{}` though.
I propose we replace those that appear in initializers and class definitions, ignore those in function returns.
I can push the other commits if you think this change is a good idea.