### PR TITLE
Making sure we can run async def tests

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -2,6 +2,8 @@ from pathlib import Path
 
 import pytest
 
+from scrapy.utils.reactor import install_reactor
+
 from tests.keys import generate_keys
 
 
@@ -40,6 +42,14 @@ def pytest_collection_modifyitems(session, config, items):
         pass
 
 
+def pytest_addoption(parser):
+    parser.addoption(
+        "--reactor",
+        default="default",
+        choices=["default", "asyncio"],
+    )
+
+
 @pytest.fixture(scope='class')
 def reactor_pytest(request):
     if not request.cls:
@@ -53,6 +63,11 @@ def reactor_pytest(request):
 def only_asyncio(request, reactor_pytest):
     if request.node.get_closest_marker('only_asyncio') and reactor_pytest != 'asyncio':
         pytest.skip('This test is only run with --reactor=asyncio')
+
+
+def pytest_configure(config):
+    if config.getoption("--reactor") == "asyncio":
+        install_reactor("twisted.internet.asyncioreactor.AsyncioSelectorReactor")
 
 
 # Generate localhost certificate files, needed by some tests

--- a/pytest.ini
+++ b/pytest.ini
@@ -18,7 +18,6 @@ addopts =
     --ignore=docs/topics/stats.rst
     --ignore=docs/topics/telnetconsole.rst
     --ignore=docs/utils
-twisted = 1
 markers =
     only_asyncio: marks tests as only enabled when --reactor=asyncio is passed
 flake8-max-line-length = 119

--- a/tests/requirements-py3.txt
+++ b/tests/requirements-py3.txt
@@ -2,10 +2,8 @@
 attrs
 dataclasses; python_version == '3.6'
 pyftpdlib
-# https://github.com/pytest-dev/pytest-twisted/issues/93
-pytest != 5.4, != 5.4.1
+pytest
 pytest-cov
-pytest-twisted >= 1.11
 pytest-xdist
 sybil >= 1.3.0  # https://github.com/cjw296/sybil/issues/20#issuecomment-605433422
 testfixtures

--- a/tests/test_utils_defer.py
+++ b/tests/test_utils_defer.py
@@ -1,8 +1,10 @@
+from pytest import mark
 from twisted.trial import unittest
 from twisted.internet import reactor, defer
 from twisted.python.failure import Failure
 
 from scrapy.utils.defer import (
+    deferred_f_from_coro_f,
     iter_errback,
     mustbe_deferred,
     process_chain,
@@ -117,3 +119,18 @@ class IterErrbackTest(unittest.TestCase):
         self.assertEqual(out, [0, 1, 2, 3, 4])
         self.assertEqual(len(errors), 1)
         self.assertIsInstance(errors[0].value, ZeroDivisionError)
+
+
+class AsyncDefTestsuiteTest(unittest.TestCase):
+    @deferred_f_from_coro_f
+    async def test_deferred_f_from_coro_f(self):
+        pass
+
+    @deferred_f_from_coro_f
+    async def test_deferred_f_from_coro_f_generator(self):
+        yield
+
+    @mark.xfail(reason="Checks that the test is actually executed", strict=True)
+    @deferred_f_from_coro_f
+    async def test_deferred_f_from_coro_f_xfail(self):
+        raise Exception("This is expected to be raised")


### PR DESCRIPTION
With `twisted.trial` we are able to write asynchronous test functions by returning a Deferred from them. We also have the `deferred_f_from_coro_f` higher order function that can be used as a decorator for an `async def` test function and everything should work as expected. So I'm adding this small test case to check that we indeed can write working tests this way.

Unfortunately, a naked `async def` test function will always succeed, with a warning that a coroutine was not awaited (ideally we should get rid if warnings from tests, but this is still easy to miss).

I added these tests because I've just found for #4978 that such tests fail with old Twisted. So this PR should fail too.