### PR TITLE
Allow customization of retry middleware

### DIFF
--- a/scrapy/downloadermiddlewares/retry.py
+++ b/scrapy/downloadermiddlewares/retry.py
@@ -41,11 +41,12 @@ class RetryMiddleware:
     SETTING_PREFIX = ""
     META_PREFIX = ""
     STATS_PREFIX = ""
+    LOGGER_NAME = __name__
 
     def __init__(self, settings):
         if not settings.getbool(f"{self.SETTING_PREFIX}RETRY_ENABLED"):
             raise NotConfigured
-        self.logger = logging.getLogger(__name__)
+        self.logger = logging.getLogger(self.LOGGER_NAME)
         self.max_retry_times = settings.getint(f"{self.SETTING_PREFIX}RETRY_TIMES")
         self.retry_http_codes = set(int(x) for x in settings.getlist(f"{self.SETTING_PREFIX}RETRY_HTTP_CODES"))
         self.priority_adjust = settings.getint(f"{self.SETTING_PREFIX}RETRY_PRIORITY_ADJUST")

--- a/scrapy/downloadermiddlewares/retry.py
+++ b/scrapy/downloadermiddlewares/retry.py
@@ -38,18 +38,18 @@ class RetryMiddleware:
                            ConnectionLost, TCPTimedOutError, ResponseFailed,
                            IOError, TunnelError)
 
-    SETTING_PREFIX = ""
+    SETTINGS_PREFIX = ""
     META_PREFIX = ""
     STATS_PREFIX = ""
     LOGGER_NAME = __name__
 
     def __init__(self, settings):
-        if not settings.getbool(f"{self.SETTING_PREFIX}RETRY_ENABLED"):
+        if not settings.getbool(f"{self.SETTINGS_PREFIX}RETRY_ENABLED"):
             raise NotConfigured
         self.logger = logging.getLogger(self.LOGGER_NAME)
-        self.max_retry_times = settings.getint(f"{self.SETTING_PREFIX}RETRY_TIMES")
-        self.retry_http_codes = set(int(x) for x in settings.getlist(f"{self.SETTING_PREFIX}RETRY_HTTP_CODES"))
-        self.priority_adjust = settings.getint(f"{self.SETTING_PREFIX}RETRY_PRIORITY_ADJUST")
+        self.max_retry_times = settings.getint(f"{self.SETTINGS_PREFIX}RETRY_TIMES")
+        self.retry_http_codes = set(int(x) for x in settings.getlist(f"{self.SETTINGS_PREFIX}RETRY_HTTP_CODES"))
+        self.priority_adjust = settings.getint(f"{self.SETTINGS_PREFIX}RETRY_PRIORITY_ADJUST")
 
     @classmethod
     def from_crawler(cls, crawler):


### PR DESCRIPTION
I've been tasked with adding [retrying functionality to an external middleware](https://github.com/scrapy-plugins/scrapy-crawlera-fetch/issues/12), and I thought about leveraging the existing retrying middleware to avoid reinventing the wheel. Unfortunately, it contains many things that are specific to the general purpose case, which makes it hard to extend:
* the logger is a module-level variable named after `__name__`, so it's always `scrapy.downloadermiddlewares.retry`
* the setting, meta and stats names are hardcoded, which does not allow custom messages (stats like `my_own_retry/count`, for instance)

Let me know if this makes any sense, I didn't want to add tests and docs yet in case this is not deemed useful.
