### PR TITLE
Remove unnecessary reference to private parsel.Selector._default_type

### DIFF
--- a/scrapy/selector/unified.py
+++ b/scrapy/selector/unified.py
@@ -69,7 +69,7 @@ class Selector(_ParselSelector, object_ref):
             raise ValueError(f'{self.__class__.__name__}.__init__() received '
                              'both response and text')
 
-        st = _st(response, type or self._default_type)
+        st = _st(response, type)
 
         if text is not None:
             response = _response_from_text(text, st)


### PR DESCRIPTION
Resolves #4961, paving the way for https://github.com/scrapy/parsel/pull/181