### PR TITLE
docs: Clarify there's one extension instance per crawler

### DIFF
--- a/docs/topics/extensions.rst
+++ b/docs/topics/extensions.rst
@@ -7,8 +7,7 @@ Extensions
 The extensions framework provides a mechanism for inserting your own
 custom functionality into Scrapy.
 
-Extensions are just regular classes that are instantiated at Scrapy startup,
-when extensions are initialized.
+Extensions are just regular classes.
 
 Extension settings
 ==================
@@ -27,8 +26,8 @@ Loading & activating extensions
 ===============================
 
 Extensions are loaded and activated at startup by instantiating a single
-instance of the extension class. Therefore, all the extension initialization
-code must be performed in the class ``__init__`` method.
+instance of the extension class per spider being run. All the extension
+initialization code must be performed in the class ``__init__`` method.
 
 To make an extension available, add it to the :setting:`EXTENSIONS` setting in
 your Scrapy settings. In :setting:`EXTENSIONS`, each extension is represented


### PR DESCRIPTION
The previous documentation suggested there was a single instance of each extension. This is not the case. For example, when [running multiple spiders in the same process](https://docs.scrapy.org/en/latest/topics/practices.html#running-multiple-spiders-in-the-same-process), the [LogStats extension](https://docs.scrapy.org/en/latest/_modules/scrapy/extensions/logstats.html#LogStats) still works correctly, and it doesn't track stats per spider.