### PR TITLE
Make the build reproducible

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -9,6 +9,8 @@
 # All configuration values have a default; values that are commented out
 # serve to show the default.
 
+import os
+import time
 import sys
 from datetime import datetime
 from os import path
@@ -49,7 +51,10 @@ master_doc = 'index'
 
 # General information about the project.
 project = 'Scrapy'
-copyright = f'2008–{datetime.now().year}, Scrapy developers'
+build_date = datetime.utcfromtimestamp(
+    int(os.environ.get('SOURCE_DATE_EPOCH', time.time()))
+)
+copyright = f'2008\u2013{build_date.year}, Scrapy developers'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -54,7 +54,7 @@ project = 'Scrapy'
 build_date = datetime.utcfromtimestamp(
     int(os.environ.get('SOURCE_DATE_EPOCH', time.time()))
 )
-copyright = f'2008\u2013{build_date.year}, Scrapy developers'
+copyright = f'2008–{build_date.year}, Scrapy developers'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -10,8 +10,8 @@
 # serve to show the default.
 
 import os
-import time
 import sys
+import time
 from datetime import datetime
 from os import path
 


### PR DESCRIPTION
Whilst working on the [Reproducible Builds](https://reproducible-builds.org/) effort I noticed that scrapy could not be built reproducibly

This is due to the documentation embedding the current build year in the generated files, therefore making the build vary depending on when you build it. The fix is to use [`SOURCE_DATE_EPOCH`](https://reproducible-builds.org/specs/source-date-epoch/) if it is exported to the surrounding environment.

I originally filed this in Debian as bug [#983852](https://bugs.debian.org/983852).