### PR TITLE
Limit tests to Twisted < 21

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -18,6 +18,8 @@ deps =
     # Extras
     botocore>=1.4.87
     Pillow>=4.0.0
+    # Twisted 21+ causes issues in tests that use skipIf
+    Twisted<21
 passenv =
     S3_TEST_FILE_URI
     AWS_ACCESS_KEY_ID


### PR DESCRIPTION
@kmike @wRAR @elacuesta I figured out this package upgrade was the issue so far.

According to the [Twisted 21.2.0 release notes](https://github.com/twisted/twisted/releases/tag/twisted-21.2.0):

> trial now allows the @unittest.skipIf decorator to specify that an entire test class should be skipped. (#9829)

This confuses me greatly, as what is failing now are tests that were already using this feature that is supposed to be new in Twisted 21.2.0.

I’ll continue looking into it later.

Fixes #5020