### PR TITLE
Added response bytes as a metric to LogStats extension (#4969)

### DIFF
--- a/docs/topics/extensions.rst
+++ b/docs/topics/extensions.rst
@@ -162,7 +162,7 @@ Log Stats extension
 
 .. class:: LogStats
 
-Log basic stats like crawled pages and scraped items.
+Log basic stats like crawled pages, scraped items and received responde bytes.
 
 Core Stats extension
 ~~~~~~~~~~~~~~~~~~~~

--- a/scrapy/extensions/logstats.py
+++ b/scrapy/extensions/logstats.py
@@ -30,25 +30,24 @@ class LogStats:
     def spider_opened(self, spider):
         self.pagesprev = 0
         self.itemsprev = 0
-        self.bandwidthprev = 0.0
+        self.response_bytesprev = 0.0
         self.task = task.LoopingCall(self.log, spider)
         self.task.start(self.interval)
 
     def log(self, spider):
         items = self.stats.get_value('item_scraped_count', 0)
         pages = self.stats.get_value('response_received_count', 0)
-        bandwidth = self.stats.get_value('downloader/response_bytes', 0) / float(1000)
+        response_bytes = self.stats.get_value('downloader/response_bytes', 0) / float(1000)
         irate = (items - self.itemsprev) * self.multiplier
         prate = (pages - self.pagesprev) * self.multiplier
-        brate = (bandwidth - self.bandwidthprev)
-        self.pagesprev, self.itemsprev, self.bandwidthprev = pages, items, bandwidth
-
+        brate = (response_bytes - self.response_bytesprev)
+        self.pagesprev, self.itemsprev, self.response_bytesprev = pages, items, response_bytes
         msg = ("Crawled %(pages)d pages (at %(pagerate)d pages/min), "
                "scraped %(items)d items (at %(itemrate)d items/min), "
-               "used %(bandwidth)d KB of bandwidth (at %(brate)d KB/s)")
+               "received %(response_bytes)d KB of response bytes (at %(brate)d KB/s)")
         log_args = {'pages': pages, 'pagerate': prate,
                     'items': items, 'itemrate': irate,
-                    'bandwidth': bandwidth, 'brate': brate}
+                    'response_bytes': response_bytes, 'brate': brate}
         logger.info(msg, log_args, extra={'spider': spider})
 
     def spider_closed(self, spider, reason):

--- a/scrapy/extensions/logstats.py
+++ b/scrapy/extensions/logstats.py
@@ -43,8 +43,9 @@ class LogStats:
         brate = (response_bytes - self.response_bytesprev)
         self.pagesprev, self.itemsprev, self.response_bytesprev = pages, items, response_bytes
         msg = ("Crawled %(pages)d pages (at %(pagerate)d pages/min), "
-               "scraped %(items)d items (at %(itemrate)d items/min), "
-               "received %(response_bytes)d KB of response bytes (at %(brate)d KB/s)")
+               "scraped %(items)d items (at %(itemrate)d items/min)")
+        if self.stats.get_value('downloader/response_bytes') is not None:
+            msg = msg + ", received %(response_bytes)d KB of response bytes (at %(brate)d KB/s)"
         log_args = {'pages': pages, 'pagerate': prate,
                     'items': items, 'itemrate': irate,
                     'response_bytes': response_bytes, 'brate': brate}

--- a/scrapy/extensions/logstats.py
+++ b/scrapy/extensions/logstats.py
@@ -30,7 +30,7 @@ class LogStats:
     def spider_opened(self, spider):
         self.pagesprev = 0
         self.itemsprev = 0
-        self.bandwidthprev = 0
+        self.bandwidthprev = 0.0
         
         self.task = task.LoopingCall(self.log, spider)
         self.task.start(self.interval)
@@ -38,15 +38,15 @@ class LogStats:
     def log(self, spider):
         items = self.stats.get_value('item_scraped_count', 0)
         pages = self.stats.get_value('response_received_count', 0)
-        bandwidth = self.stats.get_value('downloader/response_bytes', 0)/float(1000*8)
+        bandwidth = self.stats.get_value('downloader/response_bytes', 0)/float(1000)
         irate = (items - self.itemsprev) * self.multiplier
         prate = (pages - self.pagesprev) * self.multiplier
-        brate = (bandwidth - self.bandwidthprev) * self.multiplier
+        brate = (bandwidth - self.bandwidthprev)
         self.pagesprev, self.itemsprev, self.bandwidthprev = pages, items, bandwidth
 
         msg = ("Crawled %(pages)d pages (at %(pagerate)d pages/min), "
                "scraped %(items)d items (at %(itemrate)d items/min), "
-               "used %(bandwidth)d KB of bandwidth (at %(brate)d KB/min)")
+               "used %(bandwidth)d KB of bandwidth (at %(brate)d KB/s)")
         log_args = {'pages': pages, 'pagerate': prate,
                     'items': items, 'itemrate': irate,
                     'bandwidth': bandwidth, 'brate': brate}

--- a/scrapy/extensions/logstats.py
+++ b/scrapy/extensions/logstats.py
@@ -31,14 +31,13 @@ class LogStats:
         self.pagesprev = 0
         self.itemsprev = 0
         self.bandwidthprev = 0.0
-        
         self.task = task.LoopingCall(self.log, spider)
         self.task.start(self.interval)
 
     def log(self, spider):
         items = self.stats.get_value('item_scraped_count', 0)
         pages = self.stats.get_value('response_received_count', 0)
-        bandwidth = self.stats.get_value('downloader/response_bytes', 0)/float(1000)
+        bandwidth = self.stats.get_value('downloader/response_bytes', 0) / float(1000)
         irate = (items - self.itemsprev) * self.multiplier
         prate = (pages - self.pagesprev) * self.multiplier
         brate = (bandwidth - self.bandwidthprev)


### PR DESCRIPTION
Modified the Log Stats extension to include response byte (both total amount and rate) in the logged message by reading data from `stats`, more specifically the `downloader/response_bytes` value.
If the setting DOWNLOADER_STATS is disabled, the amount and rate (defaulted to 0) will not be included in the message that is being logged. 
Example:
When `DOWNLOADER_STATS = True`:
```
2021-03-06 12:20:20 [scrapy.extensions.logstats] INFO: Crawled 78 pages (at 4680 pages/min), scraped 0 items (at 0 items/min), received 139 KB of response bytes (at 139 KB/s)
```
When `DOWNLOADER_STATS = False`:
```
2021-03-06 12:20:53 [scrapy.extensions.logstats] INFO: Crawled 98 pages (at 5880 pages/min), scraped 0 items (at 0 items/min)
```
 