### PR TITLE
Support Content-Length header in responses

### DIFF
--- a/tests/test_downloader_handlers.py
+++ b/tests/test_downloader_handlers.py
@@ -504,6 +504,13 @@ class Http11TestCase(HttpTestCase):
         d.addCallback(self.assertEqual, "HTTP/1.1")
         return d
 
+    def test_response_header_content_length(self):
+        request = Request(self.getURL("file"), method=b"GET")
+        d = self.download_request(request, Spider("foo"))
+        d.addCallback(lambda r: r.headers[b'content-length'])
+        d.addCallback(self.assertEqual, b'159')
+        return d
+
 
 class Https11TestCase(Http11TestCase):
     scheme = 'https'


### PR DESCRIPTION
Fixes #5009

To do:
- [ ] Stop relying on private parts of the Twisted API. It will require either getting the issue fixed upstream or copying a lot of private code from Twisted into Scrapy.
- [ ] Remove the documentation note added at #5045, assuming it was merged by the time this is merged. Otherwise, close #5009. Note, however, that the test approach in #5045 is better than here (it covers HTTP/1.0 as well, where the test passes).

