### PR TITLE
UrlLengthMiddleware: don't skip silently

### DIFF
--- a/scrapy/spidermiddlewares/urllength.py
+++ b/scrapy/spidermiddlewares/urllength.py
@@ -14,17 +14,15 @@ logger = logging.getLogger(__name__)
 
 class UrlLengthMiddleware:
 
-    def __init__(self, maxlength, stats):
+    def __init__(self, maxlength):
         self.maxlength = maxlength
-        self.stats = stats
 
     @classmethod
-    def from_crawler(cls, crawler):
-        settings = crawler.settings
+    def from_settings(cls, settings):
         maxlength = settings.getint('URLLENGTH_LIMIT')
         if not maxlength:
             raise NotConfigured
-        return cls(maxlength, crawler.stats)
+        return cls(maxlength)
 
     def process_spider_output(self, response, result, spider):
         def _filter(request):
@@ -34,7 +32,7 @@ class UrlLengthMiddleware:
                     {'maxlength': self.maxlength, 'url': request.url},
                     extra={'spider': spider}
                 )
-                self.stats.inc_value('urllength/request_ignored_count', spider=spider)
+                spider.crawler.stats.inc_value('urllength/request_ignored_count', spider=spider)
                 return False
             else:
                 return True

--- a/scrapy/spidermiddlewares/urllength.py
+++ b/scrapy/spidermiddlewares/urllength.py
@@ -14,22 +14,27 @@ logger = logging.getLogger(__name__)
 
 class UrlLengthMiddleware:
 
-    def __init__(self, maxlength):
+    def __init__(self, maxlength, stats):
         self.maxlength = maxlength
+        self.stats = stats
 
     @classmethod
-    def from_settings(cls, settings):
+    def from_crawler(cls, crawler):
+        settings = crawler.settings
         maxlength = settings.getint('URLLENGTH_LIMIT')
         if not maxlength:
             raise NotConfigured
-        return cls(maxlength)
+        return cls(maxlength, crawler.stats)
 
     def process_spider_output(self, response, result, spider):
         def _filter(request):
             if isinstance(request, Request) and len(request.url) > self.maxlength:
-                logger.debug("Ignoring link (url length > %(maxlength)d): %(url)s ",
-                             {'maxlength': self.maxlength, 'url': request.url},
-                             extra={'spider': spider})
+                logger.info(
+                    "Ignoring link (url length > %(maxlength)d): %(url)s ",
+                    {'maxlength': self.maxlength, 'url': request.url},
+                    extra={'spider': spider}
+                )
+                self.stats.inc_value('urllength/request_ignored_count', spider=spider)
                 return False
             else:
                 return True

--- a/tests/test_spidermiddleware_urllength.py
+++ b/tests/test_spidermiddleware_urllength.py
@@ -1,20 +1,45 @@
 from unittest import TestCase
 
+from testfixtures import LogCapture
+
 from scrapy.spidermiddlewares.urllength import UrlLengthMiddleware
 from scrapy.http import Response, Request
 from scrapy.spiders import Spider
+from scrapy.statscollectors import StatsCollector
+from scrapy.utils.test import get_crawler
 
 
 class TestUrlLengthMiddleware(TestCase):
 
-    def test_process_spider_output(self):
-        res = Response('http://scrapytest.org')
+    def setUp(self):
+        crawler = get_crawler(Spider)
+        self.spider = crawler._create_spider('foo')
 
-        short_url_req = Request('http://scrapytest.org/')
-        long_url_req = Request('http://scrapytest.org/this_is_a_long_url')
-        reqs = [short_url_req, long_url_req]
+        self.stats = StatsCollector(crawler)
+        self.stats.open_spider(self.spider)
 
-        mw = UrlLengthMiddleware(maxlength=25)
-        spider = Spider('foo')
-        out = list(mw.process_spider_output(res, reqs, spider))
-        self.assertEqual(out, [short_url_req])
+        self.maxlength = 25
+        self.mw = UrlLengthMiddleware(maxlength=self.maxlength, stats=self.stats)
+
+        self.response = Response('http://scrapytest.org')
+        self.short_url_req = Request('http://scrapytest.org/')
+        self.long_url_req = Request('http://scrapytest.org/this_is_a_long_url')
+        self.reqs = [self.short_url_req, self.long_url_req]
+
+    def tearDown(self):
+        self.stats.close_spider(self.spider, '')
+
+    def process_spider_output(self):
+        return list(self.mw.process_spider_output(self.response, self.reqs, self.spider))
+
+    def test_middleware_works(self):
+        self.assertEqual(self.process_spider_output(), [self.short_url_req])
+
+    def test_logging(self):
+        with LogCapture() as log:
+            self.process_spider_output()
+
+        ric = self.stats.get_value('urllength/request_ignored_count', spider=self.spider)
+        self.assertEqual(ric, 1)
+
+        self.assertIn(f'Ignoring link (url length > {self.maxlength})', str(log))

--- a/tests/test_spidermiddleware_urllength.py
+++ b/tests/test_spidermiddleware_urllength.py
@@ -5,7 +5,6 @@ from testfixtures import LogCapture
 from scrapy.spidermiddlewares.urllength import UrlLengthMiddleware
 from scrapy.http import Response, Request
 from scrapy.spiders import Spider
-from scrapy.statscollectors import StatsCollector
 from scrapy.utils.test import get_crawler
 
 
@@ -14,20 +13,15 @@ class TestUrlLengthMiddleware(TestCase):
     def setUp(self):
         crawler = get_crawler(Spider)
         self.spider = crawler._create_spider('foo')
-
-        self.stats = StatsCollector(crawler)
-        self.stats.open_spider(self.spider)
+        self.stats = self.spider.crawler.stats
 
         self.maxlength = 25
-        self.mw = UrlLengthMiddleware(maxlength=self.maxlength, stats=self.stats)
+        self.mw = UrlLengthMiddleware(maxlength=self.maxlength)
 
         self.response = Response('http://scrapytest.org')
         self.short_url_req = Request('http://scrapytest.org/')
         self.long_url_req = Request('http://scrapytest.org/this_is_a_long_url')
         self.reqs = [self.short_url_req, self.long_url_req]
-
-    def tearDown(self):
-        self.stats.close_spider(self.spider, '')
 
     def process_spider_output(self):
         return list(self.mw.process_spider_output(self.response, self.reqs, self.spider))

--- a/tests/test_spidermiddleware_urllength.py
+++ b/tests/test_spidermiddleware_urllength.py
@@ -17,7 +17,7 @@ class TestUrlLengthMiddleware(TestCase):
 
         crawler = get_crawler(Spider)
         self.spider = crawler._create_spider('foo')
-        self.stats = self.spider.crawler.stats
+        self.stats = crawler.stats
         self.mw = UrlLengthMiddleware.from_settings(settings)
 
         self.response = Response('http://scrapytest.org')

--- a/tests/test_spidermiddleware_urllength.py
+++ b/tests/test_spidermiddleware_urllength.py
@@ -6,17 +6,19 @@ from scrapy.spidermiddlewares.urllength import UrlLengthMiddleware
 from scrapy.http import Response, Request
 from scrapy.spiders import Spider
 from scrapy.utils.test import get_crawler
+from scrapy.settings import Settings
 
 
 class TestUrlLengthMiddleware(TestCase):
 
     def setUp(self):
+        self.maxlength = 25
+        settings = Settings({'URLLENGTH_LIMIT': self.maxlength})
+
         crawler = get_crawler(Spider)
         self.spider = crawler._create_spider('foo')
         self.stats = self.spider.crawler.stats
-
-        self.maxlength = 25
-        self.mw = UrlLengthMiddleware(maxlength=self.maxlength)
+        self.mw = UrlLengthMiddleware.from_settings(settings)
 
         self.response = Response('http://scrapytest.org')
         self.short_url_req = Request('http://scrapytest.org/')


### PR DESCRIPTION
I guess it's a good idea to not just send the skipped info to debug, since it could be critical and not so obvious to debug in case of accidental long url generating.

So it's better to log to `INFO` at least, and add count to crawler stats.