### PR TITLE
Use pip<20.3 to fix ReadTheDocs builds

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -12,5 +12,6 @@ python:
   # https://docs.readthedocs.io/en/stable/config-file/v2.html#build-image
   version: 3.8  # Keep in sync with .github/workflows/checks.yml
   install:
+    - requirements: docs/pip.txt
     - requirements: docs/requirements.txt
     - path: .

--- a/docs/pip.txt
+++ b/docs/pip.txt
@@ -1,0 +1,3 @@
+# In pip 20.3-21.0, the default dependency resolver causes the build in
+# ReadTheDocs to fail due to memory exhaustion or timeout.
+pip<20.3


### PR DESCRIPTION
Tested in a custom ReadTheDocs project.