### PR TITLE
Include Content-Length in HTTP/1.1 responses

### DIFF
--- a/tests/test_downloader_handlers.py
+++ b/tests/test_downloader_handlers.py
@@ -364,6 +364,13 @@ class HttpTestCase(unittest.TestCase):
         d.addCallback(self.assertEqual, body)
         return d
 
+    def test_response_header_content_length(self):
+        request = Request(self.getURL("file"), method=b"GET")
+        d = self.download_request(request, Spider("foo"))
+        d.addCallback(lambda r: r.headers[b'content-length'])
+        d.addCallback(self.assertEqual, b'159')
+        return d
+
 
 class Http10TestCase(HttpTestCase):
     """HTTP 1.0 test case"""


### PR DESCRIPTION
Alternative to #5034 to deal with #5009 without changes in Twisted, based on https://github.com/scrapy/scrapy/pull/5034#issuecomment-803297647

Fixes #5009, closes #5034, closes #5045