### PR TITLE
[HTTP/1.1] Skip Content-Length header if its value is UNKNOWN_LENGTH

### DIFF
--- a/scrapy/core/downloader/handlers/http11.py
+++ b/scrapy/core/downloader/handlers/http11.py
@@ -361,10 +361,9 @@ class ScrapyAgent:
     @staticmethod
     def _headers_from_twisted_response(response):
         headers = Headers()
-        if response.length is not None:
+        if response.length is not None and response.length != UNKNOWN_LENGTH:
             headers[b'Content-Length'] = str(response.length).encode()
-        for key, value in response.headers.getAllRawHeaders():
-            headers[key] = value
+        headers.update(response.headers.getAllRawHeaders())
         return headers
 
     def _cb_bodyready(self, txresponse, request):

--- a/scrapy/core/downloader/handlers/http11.py
+++ b/scrapy/core/downloader/handlers/http11.py
@@ -361,7 +361,7 @@ class ScrapyAgent:
     @staticmethod
     def _headers_from_twisted_response(response):
         headers = Headers()
-        if response.length is not None and response.length != UNKNOWN_LENGTH:
+        if response.length != UNKNOWN_LENGTH:
             headers[b'Content-Length'] = str(response.length).encode()
         headers.update(response.headers.getAllRawHeaders())
         return headers


### PR DESCRIPTION
I wasn't fast enough to comment this on #5057 before it got merged.

The following happens with the current `master` (ec5a7918ec2d8888ba356f9e3295dcd1ee935884):
```python
$ scrapy shell http://quotes.toscrape.com
(...)
2021-03-22 10:42:40 [scrapy.core.engine] INFO: Spider opened
resp2021-03-22 10:42:41 [scrapy.core.engine] DEBUG: Crawled (200) <GET http://quotes.toscrape.com> (referer: None)
onse.2021-03-22 10:42:41 [asyncio] DEBUG: Using selector: EpollSelector
[s] Available Scrapy objects:
[s]   scrapy     scrapy module (contains scrapy.Request, scrapy.Selector, etc)
[s]   crawler    <scrapy.crawler.Crawler object at 0x7f24d38fc790>
[s]   item       {}
[s]   request    <GET http://quotes.toscrape.com>
[s]   response   <200 http://quotes.toscrape.com>
[s]   settings   <scrapy.settings.Settings object at 0x7f24d38fcee0>
[s]   spider     <DefaultSpider 'default' at 0x7f24d2b792e0>
[s] Useful shortcuts:
[s]   fetch(url[, redirect=True]) Fetch URL and update local objects (by default, redirects are followed)
[s]   fetch(req)                  Fetch a scrapy.Request and update local objects 
[s]   shelp()           Shell help (print this help)
[s]   view(response)    View response in a browser
2021-03-22 10:42:41 [asyncio] DEBUG: Using selector: EpollSelector
In [1]: response.headers["Content-Length"]
Out[1]: b'twisted.web.iweb.UNKNOWN_LENGTH'
```