### PR TITLE
Update UsageError message

### DIFF
--- a/scrapy/commands/crawl.py
+++ b/scrapy/commands/crawl.py
@@ -16,7 +16,7 @@ class Command(BaseRunSpiderCommand):
         if len(args) < 1:
             raise UsageError()
         elif len(args) > 1:
-            raise UsageError("running 'scrapy crawl' with more than one spider is no longer supported")
+            raise UsageError("running 'scrapy crawl' with more than one spider is not supported")
         spname = args[0]
 
         crawl_defer = self.crawler_process.crawl(spname, **opts.spargs)


### PR DESCRIPTION
This message was added 10 years ago (`Scrapy 0.25.1`), and I think that we can update it like this, as the feature of running more than one spider was deprecated a long time ago.

However, as this appears when we write more than one `arg`, it could be also a good idea to reformulate the whole message to give a hint like _"did you forget to add `-a` / `-s` , etc"_. Or something similar. 

Let me know what you think. :)