### PR TITLE
Adjust h2 version requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ install_requires = [
     'zope.interface>=4.1.3',
     'protego>=0.1.15',
     'itemadapter>=0.1.0',
-    'h2>=3.2.0',
+    'h2>=3.0,<4.0',
 ]
 extras_require = {}
 cpython_dependencies = [

--- a/tox.ini
+++ b/tox.ini
@@ -71,7 +71,7 @@ commands =
 deps =
     cryptography==2.0
     cssselect==0.9.1
-    h2==3.2.0
+    h2==3.0
     itemadapter==0.1.0
     parsel==1.5.0
     Protego==0.1.15


### PR DESCRIPTION
Closes #5058, fixes #5059

Taken from [`Twisted[http2]`](https://github.com/twisted/twisted/blob/twisted-21.2.0/setup.cfg#L83). The current `h2>=3.2.0` results in the installation of the latest `h2==4.0.0`, which then gets uninstalled because it doesn't comply with the Twisted constraints.

@Gallaecio @wRAR @kmike Not exactly what we discussed, but it works nonetheless.