### PR TITLE
Include loading settings in `Running multiple spiders in the same precess` section

### DIFF
--- a/docs/topics/practices.rst
+++ b/docs/topics/practices.rst
@@ -118,8 +118,8 @@ Here is an example that runs multiple spiders simultaneously:
 ::
 
     import scrapy
-    from scrapy.utils.project import get_project_settings
     from scrapy.crawler import CrawlerProcess
+    from scrapy.utils.project import get_project_settings
 
     class MySpider1(scrapy.Spider):
         # Your first spider definition
@@ -143,6 +143,7 @@ Same example using :class:`~scrapy.crawler.CrawlerRunner`:
     from twisted.internet import reactor
     from scrapy.crawler import CrawlerRunner
     from scrapy.utils.log import configure_logging
+    from scrapy.utils.project import get_project_settings
 
     class MySpider1(scrapy.Spider):
         # Your first spider definition
@@ -153,7 +154,8 @@ Same example using :class:`~scrapy.crawler.CrawlerRunner`:
         ...
 
     configure_logging()
-    runner = CrawlerRunner()
+    settings = get_project_settings()
+    runner = CrawlerRunner(settings)
     runner.crawl(MySpider1)
     runner.crawl(MySpider2)
     d = runner.join()
@@ -168,6 +170,7 @@ Same example but running the spiders sequentially by chaining the deferreds:
     from twisted.internet import reactor, defer
     from scrapy.crawler import CrawlerRunner
     from scrapy.utils.log import configure_logging
+    from scrapy.utils.project import get_project_settings
 
     class MySpider1(scrapy.Spider):
         # Your first spider definition
@@ -178,7 +181,8 @@ Same example but running the spiders sequentially by chaining the deferreds:
         ...
 
     configure_logging()
-    runner = CrawlerRunner()
+    settings = get_project_settings()
+    runner = CrawlerRunner(settings)
 
     @defer.inlineCallbacks
     def crawl():

--- a/docs/topics/practices.rst
+++ b/docs/topics/practices.rst
@@ -118,6 +118,7 @@ Here is an example that runs multiple spiders simultaneously:
 ::
 
     import scrapy
+    from scrapy.utils.project import get_project_settings
     from scrapy.crawler import CrawlerProcess
 
     class MySpider1(scrapy.Spider):
@@ -128,7 +129,8 @@ Here is an example that runs multiple spiders simultaneously:
         # Your second spider definition
         ...
 
-    process = CrawlerProcess()
+    settings = get_project_settings()
+    process = CrawlerProcess(settings)
     process.crawl(MySpider1)
     process.crawl(MySpider2)
     process.start() # the script will block here until all crawling jobs are finished


### PR DESCRIPTION
The example in the documentation doesn't take into account how to load the project's settings.

I assume most people want to load the settings when running multiple spiders concurrently. If they don't, it's at least more straightforward to remove that functionality than to notice the settings are being ignored and then find out how to fix it.

I had to find it in a third-party example: https://botproxy.net/docs/how-to/scrapy-crawl-multiple-spiders-sharing-same-items-pipeline-and-settings-but-with-separa/