### PR TITLE
Fix type for urlencode's doseq argument

### DIFF
--- a/scrapy/commands/bench.py
+++ b/scrapy/commands/bench.py
@@ -50,7 +50,7 @@ class _BenchSpider(scrapy.Spider):
 
     def start_requests(self):
         qargs = {'total': self.total, 'show': self.show}
-        url = f'{self.baseurl}?{urlencode(qargs, doseq=1)}'
+        url = f'{self.baseurl}?{urlencode(qargs, doseq=True)}'
         return [scrapy.Request(url, dont_filter=True)]
 
     def parse(self, response):

--- a/tests/spiders.py
+++ b/tests/spiders.py
@@ -45,7 +45,7 @@ class FollowAllSpider(MetaSpider):
         self.urls_visited = []
         self.times = []
         qargs = {'total': total, 'show': show, 'order': order, 'maxlatency': maxlatency}
-        url = self.mockserver.url(f"/follow?{urlencode(qargs, doseq=1)}")
+        url = self.mockserver.url(f"/follow?{urlencode(qargs, doseq=True)}")
         self.start_urls = [url]
 
     def parse(self, response):
@@ -245,7 +245,7 @@ class BrokenStartRequestsSpider(FollowAllSpider):
 
         for s in range(100):
             qargs = {'total': 10, 'seed': s}
-            url = self.mockserver.url(f"/follow?{urlencode(qargs, doseq=1)}")
+            url = self.mockserver.url(f"/follow?{urlencode(qargs, doseq=True)}")
             yield Request(url, meta={'seed': s})
             if self.fail_yielding:
                 2 / 0


### PR DESCRIPTION
Continuation of #4950 (https://github.com/scrapy/scrapy/pull/4950#pullrequestreview-564527188)