### PR TITLE
[Do NOT merge] Use SQLite queues

### DIFF
--- a/scrapy/squeues.py
+++ b/scrapy/squeues.py
@@ -12,23 +12,18 @@ from scrapy.utils.reqser import request_to_dict, request_from_dict
 
 
 def _with_mkdir(queue_class):
-
     class DirectoriesCreated(queue_class):
-
         def __init__(self, path, *args, **kwargs):
             dirname = os.path.dirname(path)
             if not os.path.exists(dirname):
                 os.makedirs(dirname, exist_ok=True)
-
             super().__init__(path, *args, **kwargs)
 
     return DirectoriesCreated
 
 
 def _serializable_queue(queue_class, serialize, deserialize):
-
     class SerializableQueue(queue_class):
-
         def push(self, obj):
             s = serialize(obj)
             super().push(s)
@@ -42,9 +37,7 @@ def _serializable_queue(queue_class, serialize, deserialize):
 
 
 def _scrapy_serialization_queue(queue_class):
-
     class ScrapyRequestQueue(queue_class):
-
         def __init__(self, crawler, key):
             self.spider = crawler.spider
             super().__init__(key)
@@ -59,10 +52,8 @@ def _scrapy_serialization_queue(queue_class):
 
         def pop(self):
             request = super().pop()
-
             if not request:
                 return None
-
             request = request_from_dict(request, self.spider)
             return request
 
@@ -70,7 +61,6 @@ def _scrapy_serialization_queue(queue_class):
 
 
 def _scrapy_non_serialization_queue(queue_class):
-
     class ScrapyRequestQueue(queue_class):
         @classmethod
         def from_crawler(cls, crawler, *args, **kwargs):
@@ -89,37 +79,30 @@ def _pickle_serialize(obj):
 
 
 PickleFifoDiskQueueNonRequest = _serializable_queue(
-    _with_mkdir(queue.FifoDiskQueue),
-    _pickle_serialize,
-    pickle.loads
+    queue_class=_with_mkdir(queue.FifoSQLiteQueue),
+    serialize=_pickle_serialize,
+    deserialize=pickle.loads,
 )
 PickleLifoDiskQueueNonRequest = _serializable_queue(
-    _with_mkdir(queue.LifoDiskQueue),
-    _pickle_serialize,
-    pickle.loads
+    queue_class=_with_mkdir(queue.LifoSQLiteQueue),
+    serialize=_pickle_serialize,
+    deserialize=pickle.loads,
 )
 MarshalFifoDiskQueueNonRequest = _serializable_queue(
-    _with_mkdir(queue.FifoDiskQueue),
-    marshal.dumps,
-    marshal.loads
+    queue_class=_with_mkdir(queue.FifoSQLiteQueue),
+    serialize=marshal.dumps,
+    deserialize=marshal.loads,
 )
 MarshalLifoDiskQueueNonRequest = _serializable_queue(
-    _with_mkdir(queue.LifoDiskQueue),
-    marshal.dumps,
-    marshal.loads
+    queue_class=_with_mkdir(queue.LifoSQLiteQueue),
+    serialize=marshal.dumps,
+    deserialize=marshal.loads,
 )
 
-PickleFifoDiskQueue = _scrapy_serialization_queue(
-    PickleFifoDiskQueueNonRequest
-)
-PickleLifoDiskQueue = _scrapy_serialization_queue(
-    PickleLifoDiskQueueNonRequest
-)
-MarshalFifoDiskQueue = _scrapy_serialization_queue(
-    MarshalFifoDiskQueueNonRequest
-)
-MarshalLifoDiskQueue = _scrapy_serialization_queue(
-    MarshalLifoDiskQueueNonRequest
-)
+PickleFifoDiskQueue = _scrapy_serialization_queue(PickleFifoDiskQueueNonRequest)
+PickleLifoDiskQueue = _scrapy_serialization_queue(PickleLifoDiskQueueNonRequest)
+MarshalFifoDiskQueue = _scrapy_serialization_queue(MarshalFifoDiskQueueNonRequest)
+MarshalLifoDiskQueue = _scrapy_serialization_queue(MarshalLifoDiskQueueNonRequest)
+
 FifoMemoryQueue = _scrapy_non_serialization_queue(queue.FifoMemoryQueue)
 LifoMemoryQueue = _scrapy_non_serialization_queue(queue.LifoMemoryQueue)


### PR DESCRIPTION
Some `scrapy-bench` benchmarks using the SQLite queues provided by `queuelib`. So far the performance is not as good as the current queues :confused: 

## SQLite queues

`sqlite3_disk_queues` branch, 88e14bc0abe52c32a8c48f713bf2c08d05d0129d

`time scrapy-bench --n-runs=20 -s JOBDIR=/tmp/scrapy-sqlite --book_url=http://localhost:8880/index.html bookworm`

```
The results of the benchmark are (all speeds in items/sec) :
Test = 'Book Spider' Iterations = '20'
Mean : 31.230399856681878 Median : 31.20090573945453 Std Dev : 0.3071817909414564

real	11m39,213s
user	7m26,736s
sys	0m22,739s
```

## Disk queues

`master` branch, 8c5a3a5189022f2f6ed60f5cdd2f711dda7a7eb7

`time scrapy-bench --n-runs=20 -s JOBDIR=/tmp/scrapy-disk --book_url=http://localhost:8880/index.html bookworm`

```
The results of the benchmark are (all speeds in items/sec) :
Test = 'Book Spider' Iterations = '20'
Mean : 54.0295915429987 Median : 53.9979278118807 Std Dev : 0.7036448451912827

real	6m53,225s
user	5m53,194s
sys	0m3,331s
```

I had to make the following small change to the `followall` spider from `scrapy-bench`, in order to start from scratch on each iteration:
```diff
diff --git books/books/spiders/followall.py books/books/spiders/followall.py
index e47452e..3cc6b23 100644
--- books/books/spiders/followall.py
+++ books/books/spiders/followall.py
@@ -60,6 +60,9 @@ class FollowAllSpider(scrapy.Spider):
                 (self.items * (1 / self.timesec.total_seconds()))))
         click.secho("\nThe average speed of the spider is {0} items/sec\n".format(
             self.items * (1 / self.timesec.total_seconds())), bold=True)
+        if self.crawler.settings.get("JOBDIR"):
+            import shutil
+            shutil.rmtree(self.crawler.settings["JOBDIR"])

     def _get_item(self, response):
         item = Page(
```
