### PR TITLE
Find bash from PATH instead of /bin/bash

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -8,7 +8,7 @@ PYTHON       = python
 SPHINXOPTS   =
 PAPER        =
 SOURCES      =
-SHELL        = /bin/bash
+SHELL        = /usr/bin/env bash
 
 ALLSPHINXOPTS = -b $(BUILDER) -d build/doctrees \
                 -D latex_elements.papersize=$(PAPER) \


### PR DESCRIPTION
Instead of hard coding executable path, we can use `/usr/bin/env` 
It searches for bash in $PATH: https://unix.stackexchange.com/a/29620/420806

This fixes #5080 