### PR TITLE
docs: require sphinx-rtd-theme>=0.5.2 and the latest pip…

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -12,6 +12,5 @@ python:
   # https://docs.readthedocs.io/en/stable/config-file/v2.html#build-image
   version: 3.8  # Keep in sync with .github/workflows/checks.yml
   install:
-    - requirements: docs/pip.txt
     - requirements: docs/requirements.txt
     - path: .

--- a/docs/pip.txt
+++ b/docs/pip.txt
@@ -1,3 +1,0 @@
-# In pip 20.3-21.0, the default dependency resolver causes the build in
-# ReadTheDocs to fail due to memory exhaustion or timeout.
-pip<20.3

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,4 @@
 Sphinx>=3.0
 sphinx-hoverxref>=0.2b1
 sphinx-notfound-page>=0.4
-sphinx_rtd_theme>=0.4
+sphinx-rtd-theme>=0.5.2


### PR DESCRIPTION
…to prevent installing breaking docutils>=0.17

We originally though this might have been caused by https://github.com/scrapy/scrapy/pull/4974, but it turned out it was an upstream issue: https://github.com/readthedocs/readthedocs.org/issues/8070

Once merged, we should backport this to the Scrapy 2.5 branch (no need for a 2.5.1 release, though).