### PR TITLE
Engine tests: fix item class spider, add minimal type hints

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -43,9 +43,6 @@ ignore_errors = True
 [mypy-tests.test_downloader_handlers]
 ignore_errors = True
 
-[mypy-tests.test_engine]
-ignore_errors = True
-
 [mypy-tests.test_exporters]
 ignore_errors = True
 

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -97,12 +97,10 @@ except ImportError:
 else:
     TestDataClass = make_dataclass("TestDataClass", [("name", str), ("url", str), ("price", int)])
 
-    class _dataclass_spider(DictItemsSpider):
+    class DataClassItemsSpider(DictItemsSpider):  # type: ignore[no-redef]
         def parse_item(self, response):
             item = super().parse_item(response)
             return TestDataClass(**item)
-
-    DataClassItemsSpider = _dataclass_spider
 
 
 class ItemZeroDivisionErrorSpider(TestSpider):

--- a/tox.ini
+++ b/tox.ini
@@ -37,7 +37,7 @@ basepython = python3
 deps =
     mypy==0.780
 commands =
-    mypy {posargs: scrapy tests}
+    mypy --show-error-codes {posargs: scrapy tests}
 
 [testenv:security]
 basepython = python3


### PR DESCRIPTION
Currently the `AttrsItemsSpider` is using an item class that inherits from `scrapy.item.Item`