### PR TITLE
Add DataURI download handler in DOWNLOAD_HANDLERS_BASE documentation

### DIFF
--- a/docs/topics/settings.rst
+++ b/docs/topics/settings.rst
@@ -657,6 +657,7 @@ DOWNLOAD_HANDLERS_BASE
 Default::
 
     {
+        'data': 'scrapy.core.downloader.handlers.datauri.DataURIDownloadHandler',
         'file': 'scrapy.core.downloader.handlers.file.FileDownloadHandler',
         'http': 'scrapy.core.downloader.handlers.http.HTTPDownloadHandler',
         'https': 'scrapy.core.downloader.handlers.http.HTTPDownloadHandler',


### PR DESCRIPTION
`DOWNLOAD_HANDLERS_BASE` default setting [mentioned in docs](https://docs.scrapy.org/en/master/topics/settings.html#download-handlers-base) is missing DataURI download handler, that is present in `scrapy/settings/default_settings.py` 