### PR TITLE
Update link for reasoning value of URLLENGTH_LIMIT

### DIFF
--- a/docs/topics/settings.rst
+++ b/docs/topics/settings.rst
@@ -1619,7 +1619,7 @@ Default: ``2083``
 Scope: ``spidermiddlewares.urllength``
 
 The maximum URL length to allow for crawled URLs. For more information about
-the default value for this setting see: https://boutell.com/newfaq/misc/urllength.html
+the default value for this setting see: https://support.microsoft.com/en-us/topic/maximum-url-length-is-2-083-characters-in-internet-explorer-174e7c8a-6666-f4e0-6fd6-908b53c12246
 
 .. setting:: USER_AGENT
 
@@ -1641,7 +1641,6 @@ The following settings are documented elsewhere, please check each specific
 case to see how to enable and use them.
 
 .. settingslist::
-
 
 .. _Amazon web services: https://aws.amazon.com/
 .. _breadth-first order: https://en.wikipedia.org/wiki/Breadth-first_search


### PR DESCRIPTION
Previous link doesn't exist anymore.
Looking into the content of archived content (https://web.archive.org/web/20180308145804/https://boutell.com/newfaq/misc/urllength.html) I realized that this default value is related to the article of Microsoft support.
Perhaps we should reconsider this default (or this middleware in future), but at least it will be good to have an updated doc.