### PR TITLE
Document using settings with CrawlerRunner

### DIFF
--- a/docs/topics/practices.rst
+++ b/docs/topics/practices.rst
@@ -112,6 +112,8 @@ Running multiple spiders in the same process
 By default, Scrapy runs a single spider per process when you run ``scrapy
 crawl``. However, Scrapy supports running multiple spiders per process using
 the :ref:`internal API <topics-api>`.
+The CrawlerProcess object must be instantiated with a 
+:class:`~scrapy.settings.Settings` object as it is defaulted to ``None``.
 
 Here is an example that runs multiple spiders simultaneously:
 


### PR DESCRIPTION
This pull request  mentions passing  settings explicitly to the CrawlerProcess class as they are not loaded implicitly. Fixes scrapy/scrapy#4864 