### PR TITLE
Multiple-compressed responses support

### DIFF
--- a/scrapy/downloadermiddlewares/httpcompression.py
+++ b/scrapy/downloadermiddlewares/httpcompression.py
@@ -58,8 +58,10 @@ class HttpCompressionMiddleware:
         if isinstance(response, Response):
             content_encoding = response.headers.getlist('Content-Encoding')
             if content_encoding:
-                encoding = content_encoding.pop()
-                decoded_body = self._decode(response.body, encoding.lower())
+                decoded_body = response.body
+                for encodings in content_encoding:
+                    for encoding in encodings.split(b','):
+                        decoded_body = self._decode(decoded_body, encoding.strip().lower())
                 if self.stats:
                     self.stats.inc_value('httpcompression/response_bytes', len(decoded_body), spider=spider)
                     self.stats.inc_value('httpcompression/response_count', spider=spider)


### PR DESCRIPTION
HTTP response body can be compressed multiple times. In such cases `Content-Encoding` header contains a list of comma-separated encodings. Some servers instead can send multiple `Content-Encoding` headers.
This fix allows HttpCompressionMiddleware handle that.
See also: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Encoding