### PR TITLE
Added caution to follow_all method

### DIFF
--- a/docs/topics/request-response.rst
+++ b/docs/topics/request-response.rst
@@ -851,6 +851,9 @@ Response objects
 
     .. automethod:: Response.follow_all
 
+    .. caution:: Be careful when passing a mutable object (e.g. list) to :attr:`cb_kwargs`
+        while using ``follow_all``, as this might lead to mutation of the object in the
+        subsequent request generations.
 
 .. _topics-request-response-ref-response-subclasses:
 


### PR DESCRIPTION
I added a caution paragraph addressing the issue #4796.

I would add an example but I honestly don't believe this is related with scrapy. Like @Gallaecio said this is about passing a mutable object to any function call in python. So kept it short as a heads-up.

Fixes #4796.