### PR TITLE
changing dunder-str to dunder-repr

### DIFF
--- a/scrapy/core/http2/stream.py
+++ b/scrapy/core/http2/stream.py
@@ -150,11 +150,9 @@ class Stream:
                 self.close(StreamCloseReason.CANCELLED)
 
         self._deferred_response = Deferred(_cancel)
-
-    def __str__(self) -> str:
+    
+    def __repr__(self):
         return f'Stream(id={self.stream_id!r})'
-
-    __repr__ = __str__
 
     @property
     def _log_warnsize(self) -> bool:

--- a/scrapy/core/http2/stream.py
+++ b/scrapy/core/http2/stream.py
@@ -150,7 +150,7 @@ class Stream:
                 self.close(StreamCloseReason.CANCELLED)
 
         self._deferred_response = Deferred(_cancel)
-    
+
     def __repr__(self):
         return f'Stream(id={self.stream_id!r})'
 

--- a/scrapy/core/http2/stream.py
+++ b/scrapy/core/http2/stream.py
@@ -151,7 +151,7 @@ class Stream:
 
         self._deferred_response = Deferred(_cancel)
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f'Stream(id={self.stream_id!r})'
 
     @property

--- a/scrapy/http/request/__init__.py
+++ b/scrapy/http/request/__init__.py
@@ -109,10 +109,8 @@ class Request(object_ref):
     def encoding(self):
         return self._encoding
 
-    def __str__(self):
+    def __repr__(self):
         return f"<{self.method} {self.url}>"
-
-    __repr__ = __str__
 
     def copy(self):
         """Return a copy of this Request"""

--- a/scrapy/http/request/__init__.py
+++ b/scrapy/http/request/__init__.py
@@ -121,7 +121,7 @@ class Request(object_ref):
     def encoding(self) -> str:
         return self._encoding
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f"<{self.method} {self.url}>"
 
     def copy(self) -> "Request":

--- a/scrapy/http/response/__init__.py
+++ b/scrapy/http/response/__init__.py
@@ -87,10 +87,8 @@ class Response(object_ref):
 
     body = property(_get_body, obsolete_setter(_set_body, 'body'))
 
-    def __str__(self):
+    def __repr__(self):
         return f"<{self.status} {self.url}>"
-
-    __repr__ = __str__
 
     def copy(self):
         """Return a copy of this Response"""

--- a/scrapy/settings/__init__.py
+++ b/scrapy/settings/__init__.py
@@ -51,10 +51,8 @@ class SettingsAttribute:
             self.value = value
             self.priority = priority
 
-    def __str__(self):
+    def __repr__(self):
         return f"<SettingsAttribute value={self.value!r} priority={self.priority}>"
-
-    __repr__ = __str__
 
 
 class BaseSettings(MutableMapping):

--- a/scrapy/spiders/__init__.py
+++ b/scrapy/spiders/__init__.py
@@ -106,10 +106,8 @@ class Spider(object_ref):
         if callable(closed):
             return closed(reason)
 
-    def __str__(self):
+    def __repr__(self):
         return f"<{type(self).__name__} {self.name!r} at 0x{id(self):0x}>"
-
-    __repr__ = __str__
 
 
 # Top-level imports


### PR DESCRIPTION
### **What:**
Changing all dunder-str to dunder-repr
### **Why:**
Some **\_\_repr__** were being set as **\_\_repr__** = **\_\_str__**, we actually dont need this because if the compiler does not find \_\_str__, then it will get **\_\_repr__** as an alternative. 

### **Proof**:
https://onecompiler.com/python/3wxqqch57