### PR TITLE
Fix - Image left open in image pipeline

### DIFF
--- a/scrapy/pipelines/images.py
+++ b/scrapy/pipelines/images.py
@@ -137,6 +137,7 @@ class ImagesPipeline(FilesPipeline):
                                  f"{self.min_width}x{self.min_height})")
 
         image, buf = self.convert_image(orig_image)
+        orig_image.close()
         yield path, image, buf
 
         for thumb_id, size in self.thumbs.items():


### PR DESCRIPTION
In get_images() the original image is explicitly opened and nowhere does it get closed (that I can see).
This causes an issue when a high volume of images are downloaded maxing out the ulimit on the Linux systems (for me at least).