### PR TITLE
completing the urllength tests

### DIFF
--- a/tests/test_spidermiddleware_urllength.py
+++ b/tests/test_spidermiddleware_urllength.py
@@ -7,6 +7,7 @@ from scrapy.http import Response, Request
 from scrapy.spiders import Spider
 from scrapy.utils.test import get_crawler
 from scrapy.settings import Settings
+from scrapy.exceptions import NotConfigured
 
 
 class TestUrlLengthMiddleware(TestCase):
@@ -39,3 +40,14 @@ class TestUrlLengthMiddleware(TestCase):
         self.assertEqual(ric, 1)
 
         self.assertIn(f'Ignoring link (url length > {self.maxlength})', str(log))
+
+    def test_setting(self):
+        length = 10
+        settings = Settings({'URLLENGTH_LIMIT': length})
+        test_ok = UrlLengthMiddleware.from_settings(settings)
+        settings_error = Settings({'URLLENGTH_LIMIT': 0})
+        with self.assertRaises(NotConfigured) as cm:
+            UrlLengthMiddleware.from_settings(settings_error)
+        the_exception = cm.exception
+        self.assertEquals(type(the_exception), type(NotConfigured()))
+        self.assertEquals(test_ok.maxlength, length)

--- a/tests/test_spidermiddleware_urllength.py
+++ b/tests/test_spidermiddleware_urllength.py
@@ -45,9 +45,11 @@ class TestUrlLengthMiddleware(TestCase):
         length = 10
         settings = Settings({'URLLENGTH_LIMIT': length})
         test_ok = UrlLengthMiddleware.from_settings(settings)
+        self.assertEquals(test_ok.maxlength, length)
+
+    def test_setting_error(self):
         settings_error = Settings({'URLLENGTH_LIMIT': 0})
         with self.assertRaises(NotConfigured) as cm:
             UrlLengthMiddleware.from_settings(settings_error)
         the_exception = cm.exception
         self.assertEquals(type(the_exception), type(NotConfigured()))
-        self.assertEquals(test_ok.maxlength, length)


### PR DESCRIPTION
This is my attempt to contribute. Analyzing the tests in the [codecov](https://codecov.io/gh/scrapy/scrapy/src/master/scrapy/spidermiddlewares/urllength.py), I decided to complete the test coverage in the [Urllength](https://github.com/scrapy/scrapy/blob/master/scrapy/spidermiddlewares/urllength.py) module, in an attempt to make the code 100% covered. For this, I created the function `test_setting`, which tests the `from_setting` function of Urllength, checking the case in which it is successful and the case of failure.