### PR TITLE
Fix tests that expect a specific warning

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -18,6 +18,7 @@ jobs:
         - python-version: 3.8
           env:
             TOXENV: pylint
+            TOX_PIP_VERSION: 20.3.3
         - python-version: 3.9
           env:
             TOXENV: typing
@@ -36,5 +37,8 @@ jobs:
     - name: Run check
       env: ${{ matrix.env }}
       run: |
+        if [[ ! -z "$TOX_PIP_VERSION" ]]; then
+            pip install tox-pip-version
+        fi
         pip install -U tox
         tox

--- a/.github/workflows/tests-ubuntu.yml
+++ b/.github/workflows/tests-ubuntu.yml
@@ -39,6 +39,7 @@ jobs:
         - python-version: 3.8
           env:
             TOXENV: extra-deps
+            TOX_PIP_VERSION: 20.3.3
         - python-version: 3.9
           env:
             TOXENV: asyncio
@@ -66,6 +67,9 @@ jobs:
           tar -jxf ${PYPY_VERSION}.tar.bz2
           $PYPY_VERSION/bin/pypy3 -m venv "$HOME/virtualenvs/$PYPY_VERSION"
           source "$HOME/virtualenvs/$PYPY_VERSION/bin/activate"
+        fi
+        if [[ ! -z "$TOX_PIP_VERSION" ]]; then
+            pip install tox-pip-version
         fi
         pip install -U tox
         tox

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -477,7 +477,8 @@ class EngineTest(unittest.TestCase):
             assert _find_in_warning_list(
                 warning_list,
                 ScrapyDeprecationWarning,
-                "ExecutionEngine.schedule is deprecated, please use ExecutionEngine.crawl or ExecutionEngine.download instead",
+                "ExecutionEngine.schedule is deprecated, please use "
+                "ExecutionEngine.crawl or ExecutionEngine.download instead",
             )
 
     @defer.inlineCallbacks

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -222,6 +222,17 @@ class CrawlerRun:
         self.signals_caught[sig] = signalargs
 
 
+def _find_in_warning_list(warning_list, category, message):
+    for warning in warning_list:
+        if warning.category != category:
+            continue
+        if str(warning.message) != message:
+            continue
+
+        return True
+
+    return False
+
 class EngineTest(unittest.TestCase):
     @defer.inlineCallbacks
     def test_crawler(self):
@@ -401,9 +412,9 @@ class EngineTest(unittest.TestCase):
             self.assertEqual(len(e.open_spiders), 1)
             yield e.close()
             self.assertEqual(len(e.open_spiders), 0)
-            self.assertEqual(warning_list[0].category, ScrapyDeprecationWarning)
-            self.assertEqual(
-                str(warning_list[0].message),
+            assert _find_in_warning_list(
+                warning_list,
+                ScrapyDeprecationWarning,
                 "ExecutionEngine.open_spiders is deprecated, please use ExecutionEngine.spider instead",
             )
 
@@ -417,9 +428,9 @@ class EngineTest(unittest.TestCase):
             yield e.close()
             self.assertFalse(e.running)
             self.assertEqual(len(e.open_spiders), 0)
-            self.assertEqual(warning_list[0].category, ScrapyDeprecationWarning)
-            self.assertEqual(
-                str(warning_list[0].message),
+            assert _find_in_warning_list(
+                warning_list,
+                ScrapyDeprecationWarning,
                 "ExecutionEngine.open_spiders is deprecated, please use ExecutionEngine.spider instead",
             )
 
@@ -432,9 +443,9 @@ class EngineTest(unittest.TestCase):
             e.start()
             e.crawl(Request("data:,"), spider)
             yield e.close()
-            self.assertEqual(warning_list[0].category, ScrapyDeprecationWarning)
-            self.assertEqual(
-                str(warning_list[0].message),
+            assert _find_in_warning_list(
+                warning_list,
+                ScrapyDeprecationWarning,
                 "Passing a 'spider' argument to ExecutionEngine.crawl is deprecated",
             )
 
@@ -447,9 +458,9 @@ class EngineTest(unittest.TestCase):
             e.start()
             e.download(Request("data:,"), spider)
             yield e.close()
-            self.assertEqual(warning_list[0].category, ScrapyDeprecationWarning)
-            self.assertEqual(
-                str(warning_list[0].message),
+            assert _find_in_warning_list(
+                warning_list,
+                ScrapyDeprecationWarning,
                 "Passing a 'spider' argument to ExecutionEngine.download is deprecated",
             )
 
@@ -462,11 +473,10 @@ class EngineTest(unittest.TestCase):
             e.start()
             e.schedule(Request("data:,"), spider)
             yield e.close()
-            self.assertEqual(warning_list[0].category, ScrapyDeprecationWarning)
-            self.assertEqual(
-                str(warning_list[0].message),
-                "ExecutionEngine.schedule is deprecated, please use "
-                "ExecutionEngine.crawl or ExecutionEngine.download instead",
+            assert _find_in_warning_list(
+                warning_list,
+                ScrapyDeprecationWarning,
+                "ExecutionEngine.schedule is deprecated, please use ExecutionEngine.crawl or ExecutionEngine.download instead",
             )
 
     @defer.inlineCallbacks
@@ -480,8 +490,11 @@ class EngineTest(unittest.TestCase):
             e.start()
             yield e.close()
             self.assertTrue(e.has_capacity())
-            self.assertEqual(warning_list[0].category, ScrapyDeprecationWarning)
-            self.assertEqual(str(warning_list[0].message), "ExecutionEngine.has_capacity is deprecated")
+            assert _find_in_warning_list(
+                warning_list,
+                ScrapyDeprecationWarning,
+                "ExecutionEngine.has_capacity is deprecated",
+            )
 
 
 if __name__ == "__main__":

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -233,6 +233,7 @@ def _find_in_warning_list(warning_list, category, message):
 
     return False
 
+
 class EngineTest(unittest.TestCase):
     @defer.inlineCallbacks
     def test_crawler(self):


### PR DESCRIPTION
Two fixes a here:
- solution for https://github.com/pypa/pip/issues/9215 in our python3.8 environment. https://github.com/scrapy/scrapy/pull/5146/checks?check_run_id=2570524886 python3.8 runs are killed by 6 hours timeout now.
- don't rely on warnings order in tests