### PR TITLE
Add FAQ to code of Conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -72,3 +72,7 @@ available at [http://contributor-covenant.org/version/1/4][version].
 
 [homepage]: http://contributor-covenant.org
 [version]: http://contributor-covenant.org/version/1/4/
+
+For answers to common questions about this code of conduct, see
+https://www.contributor-covenant.org/faq
+

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -75,4 +75,3 @@ available at [http://contributor-covenant.org/version/1/4][version].
 
 For answers to common questions about this code of conduct, see
 https://www.contributor-covenant.org/faq
-


### PR DESCRIPTION
The contributor covenant at http://contributor-covenant.org/version/1/4/ includes a link to FAQ under Attribution at the bottom of the page. I added the link to update the CODE_OF_CONDUCT.md file to be consistent with the contributor-covenant page.