### PR TITLE
CloseSpider can be raised on spider_idle signal handler to set the closing reason

### DIFF
--- a/docs/topics/signals.rst
+++ b/docs/topics/signals.rst
@@ -268,6 +268,9 @@ spider_idle
     You may raise a :exc:`~scrapy.exceptions.DontCloseSpider` exception to
     prevent the spider from being closed.
 
+    Alternatively, you may raise a :exc:`~scrapy.exceptions.CloseSpider`
+    exception to provide a custom spider closing reason.
+
     This signal does not support returning deferreds from its handlers.
 
     :param spider: the spider which has gone idle

--- a/docs/topics/signals.rst
+++ b/docs/topics/signals.rst
@@ -269,7 +269,11 @@ spider_idle
     prevent the spider from being closed.
 
     Alternatively, you may raise a :exc:`~scrapy.exceptions.CloseSpider`
-    exception to provide a custom spider closing reason.
+    exception to provide a custom spider closing reason. An
+    idle handler is the perfect place to put some code that assesses
+    the final spider results and update the final closing reason
+    accordingly (e.g. setting it to 'too_few_results' instead of
+    'finished').
 
     This signal does not support returning deferreds from its handlers.
 

--- a/scrapy/core/engine.py
+++ b/scrapy/core/engine.py
@@ -15,8 +15,11 @@ from twisted.python.failure import Failure
 
 from scrapy import signals
 from scrapy.core.scraper import Scraper
-from scrapy.exceptions import DontCloseSpider, ScrapyDeprecationWarning, \
-    CloseSpider
+from scrapy.exceptions import (
+    CloseSpider,
+    DontCloseSpider, 
+    ScrapyDeprecationWarning,
+)   
 from scrapy.http import Response, Request
 from scrapy.settings import BaseSettings
 from scrapy.spiders import Spider

--- a/scrapy/core/engine.py
+++ b/scrapy/core/engine.py
@@ -17,9 +17,9 @@ from scrapy import signals
 from scrapy.core.scraper import Scraper
 from scrapy.exceptions import (
     CloseSpider,
-    DontCloseSpider, 
+    DontCloseSpider,
     ScrapyDeprecationWarning,
-)   
+)
 from scrapy.http import Response, Request
 from scrapy.settings import BaseSettings
 from scrapy.spiders import Spider

--- a/scrapy/core/engine.py
+++ b/scrapy/core/engine.py
@@ -334,9 +334,12 @@ class ExecutionEngine:
         assert self.spider is not None  # typing
         expected_ex = (DontCloseSpider, CloseSpider)
         res = self.signals.send_catch_log(signals.spider_idle, spider=self.spider, dont_log=expected_ex)
-        detected_ex = {ex: x.value
-                       for _, x in res for ex in expected_ex
-                       if isinstance(x, Failure) and isinstance(x.value, ex)}
+        detected_ex = {
+            ex: x.value
+            for _, x in res
+            for ex in expected_ex
+            if isinstance(x, Failure) and isinstance(x.value, ex)
+        }
         if DontCloseSpider in detected_ex:
             return None
         if self.spider_is_idle():

--- a/scrapy/core/engine.py
+++ b/scrapy/core/engine.py
@@ -326,7 +326,7 @@ class ExecutionEngine:
         Called when a spider gets idle, i.e. when there are no remaining requests to download or schedule.
         It can be called multiple times. If a handler for the spider_idle signal raises a DontCloseSpider
         exception, the spider is not closed until the next loop and this function is guaranteed to be called
-        (at least) once again. A handler can raise CloseSpider to provide a custom closing reason
+        (at least) once again. A handler can raise CloseSpider to provide a custom closing reason.
         """
         assert self.spider is not None  # typing
         expected_ex = (DontCloseSpider, CloseSpider)

--- a/scrapy/core/engine.py
+++ b/scrapy/core/engine.py
@@ -337,8 +337,9 @@ class ExecutionEngine:
         if DontCloseSpider in detected_ex:
             return None
         if self.spider_is_idle():
-            reason = detected_ex[CloseSpider].reason if CloseSpider in detected_ex else 'finished'
-            self.close_spider(self.spider, reason=reason)
+            ex = detected_ex.get(CloseSpider, CloseSpider(reason='finished'))
+            assert isinstance(ex, CloseSpider)  # typing
+            self.close_spider(self.spider, reason=ex.reason)
 
     def close_spider(self, spider: Spider, reason: str = "cancelled") -> Deferred:
         """Close (cancel) spider and clear all its outstanding requests"""

--- a/scrapy/utils/signal.py
+++ b/scrapy/utils/signal.py
@@ -1,5 +1,5 @@
 """Helper functions for working with signals"""
-
+import collections
 import logging
 
 from twisted.internet.defer import DeferredList, Deferred
@@ -16,15 +16,13 @@ from scrapy.utils.log import failure_to_exc_info
 logger = logging.getLogger(__name__)
 
 
-class _IgnoredException(Exception):
-    pass
-
-
 def send_catch_log(signal=Any, sender=Anonymous, *arguments, **named):
     """Like pydispatcher.robust.sendRobust but it also logs errors and returns
     Failures instead of exceptions.
     """
-    dont_log = (named.pop('dont_log', _IgnoredException), StopDownload)
+    dont_log = named.pop('dont_log', ())
+    dont_log = tuple(dont_log) if isinstance(dont_log, collections.Sequence) else (dont_log,)
+    dont_log += (StopDownload, )
     spider = named.get('spider', None)
     responses = []
     for receiver in liveReceivers(getAllReceivers(sender, signal)):

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -26,7 +26,7 @@ from twisted.web import server, static, util
 
 from scrapy import signals
 from scrapy.core.engine import ExecutionEngine
-from scrapy.exceptions import ScrapyDeprecationWarning, CloseSpider
+from scrapy.exceptions import CloseSpider, ScrapyDeprecationWarning
 from scrapy.http import Request
 from scrapy.item import Item, Field
 from scrapy.linkextractors import LinkExtractor

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -26,7 +26,7 @@ from twisted.web import server, static, util
 
 from scrapy import signals
 from scrapy.core.engine import ExecutionEngine
-from scrapy.exceptions import ScrapyDeprecationWarning
+from scrapy.exceptions import ScrapyDeprecationWarning, CloseSpider
 from scrapy.http import Request
 from scrapy.item import Item, Field
 from scrapy.linkextractors import LinkExtractor
@@ -111,6 +111,18 @@ class ItemZeroDivisionErrorSpider(TestSpider):
             "tests.pipelines.ProcessWithZeroDivisionErrorPipiline": 300,
         }
     }
+
+
+class ChangeCloseReasonSpider(TestSpider):
+    @classmethod
+    def from_crawler(cls, crawler, *args, **kwargs):
+        spider = cls(*args, **kwargs)
+        spider._set_crawler(crawler)
+        crawler.signals.connect(spider.spider_idle, signals.spider_idle)
+        return spider
+
+    def spider_idle(self):
+        raise CloseSpider(reason="custom_reason")
 
 
 def start_test_site(debug=False):
@@ -250,6 +262,13 @@ class EngineTest(unittest.TestCase):
         self.run = CrawlerRun(ItemZeroDivisionErrorSpider)
         yield self.run.run()
         self._assert_items_error()
+
+    @defer.inlineCallbacks
+    def test_crawler_change_close_reason_on_idle(self):
+        self.run = CrawlerRun(ChangeCloseReasonSpider)
+        yield self.run.run()
+        self.assertEqual({'spider': self.run.spider, 'reason': 'custom_reason'},
+                         self.run.signals_caught[signals.spider_closed])
 
     def _assert_visited_urls(self):
         must_be_visited = ["/", "/redirect", "/redirected",


### PR DESCRIPTION
The execution of a spider might have been successful or not depending on many conditions. For example, you might have expected many items to be extracted but none were extracted. It might be useful to be able to evaluate at the end of the crawling if the results are successful, and if not, close the spider using the appropriate message (e.g. "too_few_results") instead of the regular one "finished".

The `spider_idle` signal handler looks like the perfect place to put such logic. At this stage, all the work has been done, so all the stats are ready to be queried to decide the final status. The problem I found is that is not possible to set the closing reason in this handler. 

In this PR I propose to reuse the exception `CloseSpider` to provide the closing reason. The required changes are not so big, and it seems to fit. 

Let me know what do you think, and if you agree on the functionality, what else would be required (tests, etc). 
 
