### PR TITLE
spiders.rst: indent warnings into class descriptions

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -12,6 +12,5 @@ python:
   # https://docs.readthedocs.io/en/stable/config-file/v2.html#build-image
   version: 3.8  # Keep in sync with .github/workflows/checks.yml
   install:
-    - requirements: docs/pip.txt
     - requirements: docs/requirements.txt
     - path: .

--- a/docs/pip.txt
+++ b/docs/pip.txt
@@ -1,3 +1,0 @@
-# In pip 20.3-21.0, the default dependency resolver causes the build in
-# ReadTheDocs to fail due to memory exhaustion or timeout.
-pip<20.3

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,4 @@
 Sphinx>=3.0
 sphinx-hoverxref>=0.2b1
 sphinx-notfound-page>=0.4
-sphinx_rtd_theme>=0.4
+sphinx-rtd-theme>=0.5.2

--- a/docs/topics/spiders.rst
+++ b/docs/topics/spiders.rst
@@ -414,10 +414,9 @@ Crawling rules
    It receives a :class:`Twisted Failure <twisted.python.failure.Failure>`
    instance as first parameter.
 
-
-.. warning:: Because of its internal implementation, you must explicitly set
-   callbacks for new requests when writing :class:`CrawlSpider`-based spiders;
-   unexpected behaviour can occur otherwise.
+   .. warning:: Because of its internal implementation, you must explicitly set
+      callbacks for new requests when writing :class:`CrawlSpider`-based spiders;
+      unexpected behaviour can occur otherwise.
 
    .. versionadded:: 2.0
       The *errback* parameter.
@@ -549,10 +548,9 @@ XMLFeedSpider
         item IDs. It receives a list of results and the response which originated
         those results. It must return a list of results (items or requests).
 
-
-.. warning:: Because of its internal implementation, you must explicitly set
-   callbacks for new requests when writing :class:`XMLFeedSpider`-based spiders;
-   unexpected behaviour can occur otherwise.
+   .. warning:: Because of its internal implementation, you must explicitly set
+      callbacks for new requests when writing :class:`XMLFeedSpider`-based spiders;
+      unexpected behaviour can occur otherwise.
 
 
 XMLFeedSpider example


### PR DESCRIPTION
Fixes #5180, closes #5181