### PR TITLE
Fix FileFeedStoragePreFeedOptionsTest fails in CI/CD pipeline (#5157)

### DIFF
--- a/tests/test_feedexport.py
+++ b/tests/test_feedexport.py
@@ -1780,8 +1780,9 @@ class FileFeedStoragePreFeedOptionsTest(unittest.TestCase):
     maxDiff = None
 
     def test_init(self):
+        temp = tempfile.NamedTemporaryFile().name
         settings_dict = {
-            'FEED_URI': 'file:///tmp/foobar',
+            'FEED_URI': f'file:///{temp}',
             'FEED_STORAGES': {
                 'file': FileFeedStorageWithoutFeedOptions
             },


### PR DESCRIPTION
FileFeedStoragePreFeedOptionsTest fails due to missing permissions to the file, as in CI/CD pipeline random users are created. I have used tempfile.NamedTemporaryFile to generate a random file on every test run.