### PR TITLE
Fix FileFeedStoragePreFeedOptionsTest fails in CI/CD pipeline

### DIFF
--- a/tests/test_feedexport.py
+++ b/tests/test_feedexport.py
@@ -1780,8 +1780,9 @@ class FileFeedStoragePreFeedOptionsTest(unittest.TestCase):
     maxDiff = None
 
     def test_init(self):
+        temp = tempfile.NamedTemporaryFile().name
         settings_dict = {
-            'FEED_URI': 'file:///tmp/foobar',
+            'FEED_URI': f'file:///{temp}',
             'FEED_STORAGES': {
                 'file': FileFeedStorageWithoutFeedOptions
             },

--- a/tests/test_feedexport.py
+++ b/tests/test_feedexport.py
@@ -1782,7 +1782,7 @@ class FileFeedStoragePreFeedOptionsTest(unittest.TestCase):
     def test_init(self):
         with tempfile.NamedTemporaryFile() as temp:
             settings_dict = {
-                'FEED_URI': f'file:///{temp.name}',
+                'FEED_URI': f'file://{temp.name}',
                 'FEED_STORAGES': {
                     'file': FileFeedStorageWithoutFeedOptions
                 },

--- a/tests/test_feedexport.py
+++ b/tests/test_feedexport.py
@@ -1780,9 +1780,9 @@ class FileFeedStoragePreFeedOptionsTest(unittest.TestCase):
     maxDiff = None
 
     def test_init(self):
-        with tempfile.NamedTemporaryFile().name as temp:
+        with tempfile.NamedTemporaryFile() as temp:
             settings_dict = {
-                'FEED_URI': f'file:///{temp}',
+                'FEED_URI': f'file:///{temp.name}',
                 'FEED_STORAGES': {
                     'file': FileFeedStorageWithoutFeedOptions
                 },

--- a/tests/test_feedexport.py
+++ b/tests/test_feedexport.py
@@ -1780,15 +1780,15 @@ class FileFeedStoragePreFeedOptionsTest(unittest.TestCase):
     maxDiff = None
 
     def test_init(self):
-        temp = tempfile.NamedTemporaryFile().name
-        settings_dict = {
-            'FEED_URI': f'file:///{temp}',
-            'FEED_STORAGES': {
-                'file': FileFeedStorageWithoutFeedOptions
-            },
-        }
-        crawler = get_crawler(settings_dict=settings_dict)
-        feed_exporter = FeedExporter.from_crawler(crawler)
+        with tempfile.NamedTemporaryFile().name as temp:
+            settings_dict = {
+                'FEED_URI': f'file:///{temp}',
+                'FEED_STORAGES': {
+                    'file': FileFeedStorageWithoutFeedOptions
+                },
+            }
+            crawler = get_crawler(settings_dict=settings_dict)
+            feed_exporter = FeedExporter.from_crawler(crawler)
         spider = scrapy.Spider("default")
         with warnings.catch_warnings(record=True) as w:
             feed_exporter.open_spider(spider)

--- a/tests/test_feedexport.py
+++ b/tests/test_feedexport.py
@@ -1782,7 +1782,7 @@ class FileFeedStoragePreFeedOptionsTest(unittest.TestCase):
     def test_init(self):
         with tempfile.NamedTemporaryFile() as temp:
             settings_dict = {
-                'FEED_URI': f'file://{temp.name}',
+                'FEED_URI': f'file:///{temp.name}',
                 'FEED_STORAGES': {
                     'file': FileFeedStorageWithoutFeedOptions
                 },


### PR DESCRIPTION
FileFeedStoragePreFeedOptionsTest fails due to missing permissions to the file, as in CI/CD pipeline random users are created. I have used tempfile.NamedTemporaryFile to generate a random file on every test run.
Fixes #5157 