### PR TITLE
[CI] fail-fast: false

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -5,6 +5,7 @@ jobs:
   checks:
     runs-on: ubuntu-18.04
     strategy:
+      fail-fast: false
       matrix:
         include:
         - python-version: 3.9

--- a/.github/workflows/tests-macos.yml
+++ b/.github/workflows/tests-macos.yml
@@ -5,6 +5,7 @@ jobs:
   tests:
     runs-on: macos-10.15
     strategy:
+      fail-fast: false
       matrix:
         python-version: [3.6, 3.7, 3.8, 3.9]
 

--- a/.github/workflows/tests-ubuntu.yml
+++ b/.github/workflows/tests-ubuntu.yml
@@ -5,6 +5,7 @@ jobs:
   tests:
     runs-on: ubuntu-18.04
     strategy:
+      fail-fast: false
       matrix:
         include:
         - python-version: 3.7

--- a/.github/workflows/tests-windows.yml
+++ b/.github/workflows/tests-windows.yml
@@ -5,6 +5,7 @@ jobs:
   tests:
     runs-on: windows-latest
     strategy:
+      fail-fast: false
       matrix:
         include:
         - python-version: 3.6


### PR DESCRIPTION
Allow remaining jobs to keep running even if some of them fail (https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idstrategyfail-fast).

As discussed with @Gallaecio 