### PR TITLE
Pin the libxml2 version in CI as a newer one breaks lxml.

### DIFF
--- a/.github/workflows/tests-ubuntu.yml
+++ b/.github/workflows/tests-ubuntu.yml
@@ -57,7 +57,8 @@ jobs:
       if: matrix.python-version == 'pypy3' || contains(matrix.env.TOXENV, 'pinned')
       run: |
         sudo apt-get update
-        sudo apt-get install libxml2-dev libxslt-dev
+        # libxml2 2.9.12 from ondrej/php PPA breaks lxml so we pin it to the bionic-updates repo version
+        sudo apt-get install libxml2-dev/bionic-updates libxslt-dev
 
     - name: Run tests
       env: ${{ matrix.env }}


### PR DESCRIPTION
[libxml2 bug report](https://gitlab.gnome.org/GNOME/libxml2/-/issues/255)

[lxml bug report](https://bugs.launchpad.net/lxml/+bug/1928795)