### PR TITLE
Update AWS credentials creation behavior to be consistent across the project

### DIFF
--- a/docs/topics/settings.rst
+++ b/docs/topics/settings.rst
@@ -730,6 +730,24 @@ The default HTTPS handler uses HTTP/1.1. To use HTTP/2:
 .. _http2 faq: https://http2.github.io/faq/#does-http2-require-encryption
 .. _server pushes: https://tools.ietf.org/html/rfc7540#section-8.2
 
+.. setting:: DOWNLOAD_HANDLERS_S3_ANONYMOUS
+
+DOWNLOAD_HANDLERS_S3_ANONYMOUS
+------------------------------
+
+Default: ``False``
+
+Disable security credential in `S3DownloadHandler` explicitly and access `s3://`
+resources anonymously.
+
+`S3DownloadHandler` not only uses credential info from settings
+:setting:`AWS_ACCESS_KEY_ID`, :setting:`AWS_SECRET_ACCESS_KEY`,
+:setting:`AWS_SESSION_TOKEN`. Even these `AWS_*` settings are set as `None`, it
+still searches for credential from other `aws credential providers`_. This setting
+is introduced to disable credential creation in `S3DownloadHandler` completely.
+
+.. _aws credential providers: https://boto3.amazonaws.com/v1/documentation/api/latest/guide/credentials.html#configuring-credentials
+
 .. setting:: DOWNLOAD_TIMEOUT
 
 DOWNLOAD_TIMEOUT

--- a/scrapy/core/downloader/handlers/s3.py
+++ b/scrapy/core/downloader/handlers/s3.py
@@ -1,5 +1,7 @@
+import warnings
+
 from scrapy.core.downloader.handlers.http import HTTPDownloadHandler
-from scrapy.exceptions import NotConfigured
+from scrapy.exceptions import NotConfigured, ScrapyDeprecationWarning
 from scrapy.utils.boto import is_botocore_available
 from scrapy.utils.httpobj import urlparse_cached
 from scrapy.utils.misc import create_instance
@@ -12,6 +14,13 @@ class S3DownloadHandler:
                  aws_access_key_id=None, aws_secret_access_key=None,
                  aws_session_token=None,
                  httpdownloadhandler=HTTPDownloadHandler, **kw):
+        if kw:
+            warnings.warn(
+                "'kw' args are deprecated. If you're trying to set s3 request anonymous."
+                " Use setting 'DOWNLOAD_HANDLERS_S3_ANONYMOUS = True' instead.",
+                category=ScrapyDeprecationWarning,
+                stacklevel=2,
+            )
         if not is_botocore_available():
             raise NotConfigured('missing botocore library')
 
@@ -23,6 +32,8 @@ class S3DownloadHandler:
             aws_session_token = settings['AWS_SESSION_TOKEN']
 
         self.anon = kw.pop('anon', None)
+        if self.anon is None:
+            self.anon = settings.getbool('DOWNLOAD_HANDLERS_S3_ANONYMOUS')
         if kw:
             raise TypeError(f'Unexpected keyword arguments: {kw}')
 

--- a/scrapy/core/downloader/handlers/s3.py
+++ b/scrapy/core/downloader/handlers/s3.py
@@ -13,11 +13,11 @@ class S3DownloadHandler:
                  crawler=None,
                  aws_access_key_id=None, aws_secret_access_key=None,
                  aws_session_token=None,
-                 httpdownloadhandler=HTTPDownloadHandler, **kw):
-        if kw:
+                 httpdownloadhandler=HTTPDownloadHandler, anon=None):
+        if anon is not None:
             warnings.warn(
-                "'kw' args are deprecated. If you're trying to set s3 request anonymous."
-                " Use setting 'DOWNLOAD_HANDLERS_S3_ANONYMOUS = True' instead.",
+                "Argument 'anon' is deprecated. Use setting"
+                " 'DOWNLOAD_HANDLERS_S3_ANONYMOUS = True' instead.",
                 category=ScrapyDeprecationWarning,
                 stacklevel=2,
             )
@@ -31,11 +31,9 @@ class S3DownloadHandler:
         if not aws_session_token:
             aws_session_token = settings['AWS_SESSION_TOKEN']
 
-        self.anon = kw.pop('anon', None)
+        self.anon = anon
         if self.anon is None:
             self.anon = settings.getbool('DOWNLOAD_HANDLERS_S3_ANONYMOUS')
-        if kw:
-            raise TypeError(f'Unexpected keyword arguments: {kw}')
 
         self._signer = None
         import botocore.auth

--- a/tests/test_downloader_handlers.py
+++ b/tests/test_downloader_handlers.py
@@ -788,7 +788,9 @@ class S3AnonTestCase(unittest.TestCase):
 
     def setUp(self):
         skip_if_no_boto()
-        crawler = get_crawler()
+        crawler = get_crawler(
+            settings_dict={'DOWNLOAD_HANDLERS_S3_ANONYMOUS': True}
+        )
         self.s3reqh = create_instance(
             objcls=S3DownloadHandler,
             settings=None,
@@ -845,20 +847,6 @@ class S3TestCase(unittest.TestCase):
             with mock.patch('botocore.auth.formatdate') as mock_formatdate:
                 mock_formatdate.return_value = date
                 yield
-
-    def test_extra_kw(self):
-        try:
-            crawler = get_crawler()
-            create_instance(
-                objcls=S3DownloadHandler,
-                settings=None,
-                crawler=crawler,
-                extra_kw=True,
-            )
-        except Exception as e:
-            self.assertIsInstance(e, (TypeError, NotConfigured))
-        else:
-            assert False
 
     def test_request_signing1(self):
         # gets an object from the johnsmith bucket.


### PR DESCRIPTION
Currently we have two ways to create AWS credentials in `scrapy`

- `Session.create_client()` in pipelines, feed exporter
- `Credentials.__init__()` in `S3DownloadHandler`

And `Session.create_client()` searches credentials from:

1. Credentials parameters passed in `Session.create_client()`
2. Environment variables
3. Shared credential file (`~/.aws/credentials`)
4. AWS config file (`~/.aws/config`)
5. Assume Role provider
6. Boto2 config file (`/etc/boto.cfg` and `~/.boto`)
7. Instance metadata service on an Amazon EC2 instance that has an IAM role configured.

Related credentials creation strategy in `Session.create_client()`.
https://github.com/boto/botocore/blob/c329fd23d3672b724a6dbd152f738de0b4d5a7ac/botocore/session.py#L825-L839

The problem is credentials creation in `S3DownloadHandler` behaves differently from credentials creation in other places. 

`Credentials.__init__()` in `S3DownloadHandler` only uses passed in credentials parameters (`AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`).

References

- [Configuring credentials](https://boto3.amazonaws.com/v1/documentation/api/latest/guide/credentials.html#configuring-credentials)
- #7607