### PR TITLE
Reference MailSender in StatsMailer

### DIFF
--- a/docs/topics/extensions.rst
+++ b/docs/topics/extensions.rst
@@ -323,6 +323,15 @@ domain has finished scraping, including the Scrapy stats collected. The email
 will be sent to all recipients specified in the :setting:`STATSMAILER_RCPTS`
 setting.
 
+Emails can be sent using the MailSender class
+
+.. module:: scrapy.mail
+   :synopsis: MailSender class
+
+.. class:: MailSender(smtphost=None, mailfrom=None, smtpuser=None, smtppass=None, smtpport=None)
+
+To see a full list of parameters, including examples on how to instantiate MailSender and using mail settings, see :ref:`topics-email`
+
 .. module:: scrapy.extensions.debug
    :synopsis: Extensions for debugging Scrapy
 


### PR DESCRIPTION
Closes #5199 Added a reference to MailSender in the StatsMailer extension description and included a link to the document detailing how to instantiate MailSender and using Scrapy settings objects.

If there is any issue with my pull request please don't hesitate to tell me and I'll be happy to address/fix them.