### PR TITLE
Fix graceful stop for Downloader.close()

### DIFF
--- a/scrapy/core/engine.py
+++ b/scrapy/core/engine.py
@@ -127,7 +127,7 @@ class ExecutionEngine:
             return self.stop()  # will also close spider and downloader
         if self.spider is not None:
             return self.close_spider(self.spider, reason="shutdown")  # will also close downloader
-        return succeed(self.downloader.close())
+        return self.downloader.close()
 
     def pause(self) -> None:
         self.paused = True


### PR DESCRIPTION
Former `Downloader.stop()` contradicted the design of **graceful stop**. It force closed the `DelayedCall` of `Downloader._process_queue()`. It may cause theses delayed requests still held on `Downloader` when the process stops. And all held requests will be lost. We should wait all requests to be downloaded.

Now `Downloader.close()` returns a `Deferred` and the `Deferred` is fired only after all requests done in downloader. Similar strategies are seen in `CrawlerRunner.stop()`, `ExecutionEngine.close_spider()`, `Scraper.close_spider()`.