### PR TITLE
Allow comma-separated values in the rel attribute

### DIFF
--- a/scrapy/utils/misc.py
+++ b/scrapy/utils/misc.py
@@ -138,7 +138,7 @@ def md5sum(file):
 
 def rel_has_nofollow(rel):
     """Return True if link rel attribute has nofollow type"""
-    return rel is not None and 'nofollow' in rel.split()
+    return rel is not None and 'nofollow' in rel.replace(',', ' ').split()
 
 
 def create_instance(objcls, settings, crawler, *args, **kwargs):

--- a/tests/test_utils_misc/__init__.py
+++ b/tests/test_utils_misc/__init__.py
@@ -163,10 +163,9 @@ class UtilsMiscTestCase(unittest.TestCase):
         assert os.environ.get('some_test_environ') == 'test'
 
     def test_rel_has_nofollow(self):
-        assert os.environ.get('some_test_environ') is None
-        asert rel_has_nofollow('ugc nofollow') == True
-        asert rel_has_nofollow('ugc,nofollow') == True
-        asert rel_has_nofollow('ugc') == False
+        assert rel_has_nofollow('ugc nofollow') == True
+        assert rel_has_nofollow('ugc,nofollow') == True
+        assert rel_has_nofollow('ugc') == False
 
 
 if __name__ == "__main__":

--- a/tests/test_utils_misc/__init__.py
+++ b/tests/test_utils_misc/__init__.py
@@ -163,9 +163,9 @@ class UtilsMiscTestCase(unittest.TestCase):
         assert os.environ.get('some_test_environ') == 'test'
 
     def test_rel_has_nofollow(self):
-        assert rel_has_nofollow('ugc nofollow') == True
-        assert rel_has_nofollow('ugc,nofollow') == True
-        assert rel_has_nofollow('ugc') == False
+        assert rel_has_nofollow('ugc nofollow') is True
+        assert rel_has_nofollow('ugc,nofollow') is True
+        assert rel_has_nofollow('ugc') is False
 
 
 if __name__ == "__main__":

--- a/tests/test_utils_misc/__init__.py
+++ b/tests/test_utils_misc/__init__.py
@@ -4,7 +4,7 @@ import unittest
 from unittest import mock
 
 from scrapy.item import Item, Field
-from scrapy.utils.misc import arg_to_iter, create_instance, load_object, set_environ, walk_modules
+from scrapy.utils.misc import arg_to_iter, create_instance, load_object, rel_has_nofollow, set_environ, walk_modules
 
 
 __doctests__ = ['scrapy.utils.misc']
@@ -161,6 +161,12 @@ class UtilsMiscTestCase(unittest.TestCase):
         with set_environ(some_test_environ='test_value'):
             assert os.environ.get('some_test_environ') == 'test_value'
         assert os.environ.get('some_test_environ') == 'test'
+
+    def test_rel_has_nofollow(self):
+        assert os.environ.get('some_test_environ') is None
+        asert rel_has_nofollow('ugc nofollow') == True
+        asert rel_has_nofollow('ugc,nofollow') == True
+        asert rel_has_nofollow('ugc') == False
 
 
 if __name__ == "__main__":

--- a/tests/test_utils_misc/__init__.py
+++ b/tests/test_utils_misc/__init__.py
@@ -166,6 +166,10 @@ class UtilsMiscTestCase(unittest.TestCase):
         assert rel_has_nofollow('ugc nofollow') is True
         assert rel_has_nofollow('ugc,nofollow') is True
         assert rel_has_nofollow('ugc') is False
+        assert rel_has_nofollow('nofollow') is True
+        assert rel_has_nofollow('nofollowfoo') is False
+        assert rel_has_nofollow('foonofollow') is False
+        assert rel_has_nofollow('ugc,  ,  nofollow') is True
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Comma-separated `rel` values are often seen in the wild, because Google allows it (see https://developers.google.com/search/docs/advanced/guidelines/qualify-outbound-links).