### PR TITLE
added decoding of bytes for non text responses

### DIFF
--- a/scrapy/selector/unified.py
+++ b/scrapy/selector/unified.py
@@ -75,7 +75,11 @@ class Selector(_ParselSelector, object_ref):
             response = _response_from_text(text, st)
 
         if response is not None:
-            text = response.text
+            try:
+                text = response.text
+            except AttributeError:
+                if isinstance(response.body, bytes):
+                    text = response.body.decode('latin-1')
             kwargs.setdefault('base_url', response.url)
 
         self.response = response


### PR DESCRIPTION
Fixes #5145 

In this pull request, I have implemented a potential fix for the issue **ItemLoader: support non-TextResponse**. I have added support for non-TextResponse by trying to decode the body of the response using `latin-1` encoding.

Please provide feedback so that I can resolve this issue
