### PR TITLE
Fixed documentation example

### DIFF
--- a/docs/topics/exporters.rst
+++ b/docs/topics/exporters.rst
@@ -122,7 +122,7 @@ Example::
       class ProductXmlExporter(XmlItemExporter):
 
           def serialize_field(self, field, name, value):
-              if field == 'price':
+              if name == 'price':
                   return f'$ {str(value)}'
               return super().serialize_field(field, name, value)
 


### PR DESCRIPTION
I think here the `name` parameter should be compared with the `'price'`.