### PR TITLE
Fix bug #5145 - Removing Selector for Response's that are not Http or Xml

### DIFF
--- a/scrapy/loader/__init__.py
+++ b/scrapy/loader/__init__.py
@@ -83,6 +83,9 @@ class ItemLoader(itemloaders.ItemLoader):
 
     def __init__(self, item=None, selector=None, response=None, parent=None, **context):
         if selector is None and response is not None:
-            selector = self.default_selector_class(response)
+            try:
+                selector = self.default_selector_class(response)
+            except AttributeError:
+                selector = None
         context.update(response=response)
         super().__init__(item=item, selector=selector, parent=parent, **context)

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -4,7 +4,7 @@ import attr
 from itemadapter import ItemAdapter
 from itemloaders.processors import Compose, Identity, MapCompose, TakeFirst
 
-from scrapy.http import HtmlResponse
+from scrapy.http import HtmlResponse, Response
 from scrapy.item import Item, Field
 from scrapy.loader import ItemLoader
 from scrapy.selector import Selector
@@ -304,6 +304,12 @@ class SelectortemLoaderTest(unittest.TestCase):
 
         l.add_css('name', 'div::text')
         self.assertEqual(l.get_output_value('name'), ['Marta'])
+    
+    def test_init_method_with_base_response(self):
+        """Selector should be None after initialization"""
+        response = Response("https://scrapy.org")
+        l = TestItemLoader(response=response)
+        self.assertIs(l.selector, None)
 
     def test_init_method_with_response(self):
         l = TestItemLoader(response=self.response)


### PR DESCRIPTION
Fixes #5145

* set **Selector** to None when the response is of type base-response **Response**

Please provide feedback