### PR TITLE
refactor: use `pytest` command as the recommended entry point

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -29,7 +29,7 @@ passenv =
 #allow tox virtualenv to upgrade pip/wheel/setuptools
 download = true
 commands =
-    py.test --cov=scrapy --cov-report=xml --cov-report= {posargs:--durations=10 docs scrapy tests}
+    pytest --cov=scrapy --cov-report=xml --cov-report= {posargs:--durations=10 docs scrapy tests}
 install_command =
     pip install -U -ctests/upper-constraints.txt {opts} {packages}
 
@@ -60,7 +60,7 @@ deps =
     pytest-flake8
     flake8==3.9.2  # https://github.com/tholo/pytest-flake8/issues/81
 commands =
-    py.test --flake8 {posargs:docs scrapy tests}
+    pytest --flake8 {posargs:docs scrapy tests}
 
 [testenv:pylint]
 basepython = python3
@@ -142,7 +142,7 @@ setenv =
 [testenv:pypy3]
 basepython = pypy3
 commands =
-    py.test {posargs:--durations=10 docs scrapy tests}
+    pytest {posargs:--durations=10 docs scrapy tests}
 
 [testenv:pypy3-pinned]
 basepython = {[testenv:pypy3]basepython}


### PR DESCRIPTION
`pytest` is recommended command since pytest 3.0.
There is a possibility for `py.test` to be deprecated or even removed.

https://github.com/pytest-dev/pytest/issues/1629