### PR TITLE
ci: enforce f-string format

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,7 +1,7 @@
 [flake8]
 
 max-line-length = 119
-ignore = W503
+ignore = W503, SFS301
 
 exclude =
 # Exclude files that are meant to provide top-level imports

--- a/tox.ini
+++ b/tox.ini
@@ -59,6 +59,7 @@ deps =
     Twisted[http2]>=17.9.0
     pytest-flake8
     flake8==3.9.2  # https://github.com/tholo/pytest-flake8/issues/81
+    flake8-sfs
 commands =
     py.test --flake8 {posargs:docs scrapy tests}
 


### PR DESCRIPTION
I tried to put non f-string format to check it the changes work as expected. Yes, [the CI fails](https://github.com/azzamsa/scrapy/runs/3988603608?check_suite_focus=true#step:4:706)

Then, I removed non f-string format, [The CI passed](https://github.com/azzamsa/scrapy/actions/runs/1377773496
) 

fixes:  #5293