### PR TITLE
fix: `CodeBlockParser` has been renamed to `PythonCodeBlockParser`

### DIFF
--- a/docs/conftest.py
+++ b/docs/conftest.py
@@ -3,7 +3,11 @@ from doctest import ELLIPSIS, NORMALIZE_WHITESPACE
 
 from scrapy.http.response.html import HtmlResponse
 from sybil import Sybil
-from sybil.parsers.codeblock import CodeBlockParser
+try:
+    # >2.0.1
+    from sybil.parsers.codeblock import PythonCodeBlockParser
+except ImportError:
+    from sybil.parsers.codeblock import CodeBlockParser as PythonCodeBlockParser
 from sybil.parsers.doctest import DocTestParser
 from sybil.parsers.skip import skip
 
@@ -21,7 +25,7 @@ def setup(namespace):
 pytest_collect_file = Sybil(
     parsers=[
         DocTestParser(optionflags=ELLIPSIS | NORMALIZE_WHITESPACE),
-        CodeBlockParser(future_imports=['print_function']),
+        PythonCodeBlockParser(future_imports=['print_function']),
         skip,
     ],
     pattern='*.rst',


### PR DESCRIPTION
fixes #5298