### PR TITLE
Re-enable Windows tests for Python 3.9 and 3.10.

### DIFF
--- a/.github/workflows/tests-windows.yml
+++ b/.github/workflows/tests-windows.yml
@@ -17,10 +17,12 @@ jobs:
         - python-version: 3.8
           env:
             TOXENV: py
-        # https://twistedmatrix.com/trac/ticket/9990
-        #- python-version: 3.9
-          #env:
-            #TOXENV: py
+        - python-version: 3.9
+          env:
+            TOXENV: py
+        - python-version: "3.10"
+          env:
+            TOXENV: py
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
Looks like the Twisted build bug was fixed (or it just uses pre-built wheels).