### PR TITLE
Correcting path in `GCSFilesStore`

### DIFF
--- a/scrapy/pipelines/files.py
+++ b/scrapy/pipelines/files.py
@@ -223,7 +223,7 @@ class GCSFilesStore:
             else:
                 return {}
 
-        return threads.deferToThread(self.bucket.get_blob, path).addCallback(_onsuccess)
+        return threads.deferToThread(self.bucket.get_blob, self.prefix + path).addCallback(_onsuccess)
 
     def _get_content_type(self, headers):
         if headers and 'Content-Type' in headers:


### PR DESCRIPTION
There is a simple bug when checking if a file already exists (so that it is not downloaded anymore) in `GCSFilesStore`.

Because of that, it was redownloading files even if it was not needed, every single time.

On another note, I always get the warning that I do not have the `storage.objects.get` IAM permission (even if I absolutely have it). But to be faire that is probably more an issue on `google-storage` side.