### PR TITLE
Fixed a bug in Feed Export doc

### DIFF
--- a/docs/topics/feed-exports.rst
+++ b/docs/topics/feed-exports.rst
@@ -751,7 +751,7 @@ source spider in the feed URI:
 
         # myproject/utils.py
         def uri_params(params, spider):
-            return {**params, 'spider_name': spider.name}
+            params.update({'spider_name': spider.name})
 
 #.  Point :setting:`FEED_URI_PARAMS` to that function in your settings::
 


### PR DESCRIPTION
The source code does not use return value of uri_params function and the params should be updated in place.
The document was misleading about this.