### PR TITLE
Remove scrapy.pipelines.images.NoimagesDrop

### DIFF
--- a/scrapy/pipelines/images.py
+++ b/scrapy/pipelines/images.py
@@ -18,6 +18,8 @@ from scrapy.settings import Settings
 from scrapy.utils.misc import md5sum
 from scrapy.utils.python import to_bytes
 
+#removed class NoimagesDrop(DropItem):
+
 class ImageException(FileException):
     """General image error exception"""
 

--- a/scrapy/pipelines/images.py
+++ b/scrapy/pipelines/images.py
@@ -18,11 +18,6 @@ from scrapy.settings import Settings
 from scrapy.utils.misc import md5sum
 from scrapy.utils.python import to_bytes
 
-
-class NoimagesDrop(DropItem):
-    """Product with no images exception"""
-
-
 class ImageException(FileException):
     """General image error exception"""
 


### PR DESCRIPTION
Read the issue seems that it might be a little pointless deprecating the class vs just removing it. Please review.

Left a comment in case you might want to deprecate it later.