### PR TITLE
deprecate scrapy.pipelines.images.NoimagesDrop

### DIFF
--- a/docs/news.rst
+++ b/docs/news.rst
@@ -60,11 +60,9 @@ Scrapy 2.5.1 (2021-10-05)
     need to upgrade scrapy-splash to a greater version for it to continue to
     work.
 
-    Deprecations
-    ~~~~~~~~~~~~
-
-    -   The :class:`scrapy.pipelines.images.NoimagesDrop` class is now
-        deprecated as it is not being used in Scrapy code. (:issue:`5368`)
+*   **Deprecations:**
+    The :class:`scrapy.pipelines.images.NoimagesDrop` class is now
+    deprecated as it is not being used in Scrapy code. (:issue:`5368`)
 
 .. _scrapy-splash: https://github.com/scrapy-plugins/scrapy-splash
 

--- a/docs/news.rst
+++ b/docs/news.rst
@@ -60,6 +60,12 @@ Scrapy 2.5.1 (2021-10-05)
     need to upgrade scrapy-splash to a greater version for it to continue to
     work.
 
+    Deprecations
+    ~~~~~~~~~~~~
+
+    -   The :class:`scrapy.pipelines.images.NoimagesDrop` class is now
+        deprecated as it is not being used in Scrapy code. (:issue:`5368`)
+
 .. _scrapy-splash: https://github.com/scrapy-plugins/scrapy-splash
 
 

--- a/scrapy/pipelines/images.py
+++ b/scrapy/pipelines/images.py
@@ -17,11 +17,12 @@ from scrapy.pipelines.files import FileException, FilesPipeline
 from scrapy.settings import Settings
 from scrapy.utils.misc import md5sum
 from scrapy.utils.python import to_bytes
+from scrapy.utils.decorators import deprecated
 
 
+@deprecated("scrapy.pipelines.images.NoimagesDrop")
 class NoimagesDrop(DropItem):
     """Product with no images exception"""
-
 
 class ImageException(FileException):
     """General image error exception"""


### PR DESCRIPTION
Deprecate scrapy.pipelines.images.NoimagesDrop 

Resolved #5368 