### PR TITLE
Updated optparse to argparse

### DIFF
--- a/scrapy/cmdline.py
+++ b/scrapy/cmdline.py
@@ -1,6 +1,6 @@
 import sys
 import os
-import optparse
+import argparse
 import cProfile
 import inspect
 import pkg_resources
@@ -123,7 +123,7 @@ def execute(argv=None, settings=None):
     inproject = inside_project()
     cmds = _get_commands_dict(settings, inproject)
     cmdname = _pop_command_name(argv)
-    parser = optparse.OptionParser(formatter=optparse.TitledHelpFormatter(),
+    parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter,
                                    conflict_handler='resolve')
     if not cmdname:
         _print_commands(settings, inproject)
@@ -138,7 +138,7 @@ def execute(argv=None, settings=None):
     settings.setdict(cmd.default_settings, priority='command')
     cmd.settings = settings
     cmd.add_options(parser)
-    opts, args = parser.parse_args(args=argv[1:])
+    opts, args = parser.parse_known_args(args=argv[1:])
     _run_print_help(parser, cmd.process_options, args, opts)
 
     cmd.crawler_process = CrawlerProcess(settings)

--- a/scrapy/commands/__init__.py
+++ b/scrapy/commands/__init__.py
@@ -2,7 +2,7 @@
 Base class for Scrapy commands
 """
 import os
-from optparse import OptionGroup
+import argparse
 from typing import Any, Dict
 
 from twisted.python import failure
@@ -44,7 +44,7 @@ class ScrapyCommand:
     def long_desc(self):
         """A long description of the command. Return short description when not
         available. It cannot contain newlines since contents will be formatted
-        by optparser which removes newlines and wraps text.
+        by argparser which removes newlines and wraps text.
         """
         return self.short_desc()
 
@@ -59,22 +59,20 @@ class ScrapyCommand:
         """
         Populate option parse with options available for this command
         """
-        group = OptionGroup(parser, "Global Options")
-        group.add_option("--logfile", metavar="FILE",
+        group = parser.add_argument_group(title='Global Options')
+        group.add_argument("--logfile", metavar="FILE",
                          help="log file. if omitted stderr will be used")
-        group.add_option("-L", "--loglevel", metavar="LEVEL", default=None,
+        group.add_argument("-L", "--loglevel", metavar="LEVEL", default=None,
                          help=f"log level (default: {self.settings['LOG_LEVEL']})")
-        group.add_option("--nolog", action="store_true",
+        group.add_argument("--nolog", action="store_true",
                          help="disable logging completely")
-        group.add_option("--profile", metavar="FILE", default=None,
+        group.add_argument("--profile", metavar="FILE", default=None,
                          help="write python cProfile stats to FILE")
-        group.add_option("--pidfile", metavar="FILE",
+        group.add_argument("--pidfile", metavar="FILE",
                          help="write process ID to FILE")
-        group.add_option("-s", "--set", action="append", default=[], metavar="NAME=VALUE",
+        group.add_argument("-s", "--set", action="append", default=[], metavar="NAME=VALUE",
                          help="set/override setting (may be repeated)")
-        group.add_option("--pdb", action="store_true", help="enable pdb on failure")
-
-        parser.add_option_group(group)
+        group.add_argument("--pdb", action="store_true", help="enable pdb on failure")
 
     def process_options(self, args, opts):
         try:
@@ -114,13 +112,13 @@ class BaseRunSpiderCommand(ScrapyCommand):
     """
     def add_options(self, parser):
         ScrapyCommand.add_options(self, parser)
-        parser.add_option("-a", dest="spargs", action="append", default=[], metavar="NAME=VALUE",
+        parser.add_argument("-a", dest="spargs", action="append", default=[], metavar="NAME=VALUE",
                           help="set spider argument (may be repeated)")
-        parser.add_option("-o", "--output", metavar="FILE", action="append",
+        parser.add_argument("-o", "--output", metavar="FILE", action="append",
                           help="append scraped items to the end of FILE (use - for stdout)")
-        parser.add_option("-O", "--overwrite-output", metavar="FILE", action="append",
+        parser.add_argument("-O", "--overwrite-output", metavar="FILE", action="append",
                           help="dump scraped items into FILE, overwriting any existing file")
-        parser.add_option("-t", "--output-format", metavar="FORMAT",
+        parser.add_argument("-t", "--output-format", metavar="FORMAT",
                           help="format to use for dumping items")
 
     def process_options(self, args, opts):

--- a/scrapy/commands/check.py
+++ b/scrapy/commands/check.py
@@ -49,9 +49,9 @@ class Command(ScrapyCommand):
 
     def add_options(self, parser):
         ScrapyCommand.add_options(self, parser)
-        parser.add_option("-l", "--list", dest="list", action="store_true",
+        parser.add_argument("-l", "--list", dest="list", action="store_true",
                           help="only list contracts, without checking them")
-        parser.add_option("-v", "--verbose", dest="verbose", default=False, action='store_true',
+        parser.add_argument("-v", "--verbose", dest="verbose", default=False, action='store_true',
                           help="print contract tests for all spiders")
 
     def run(self, args, opts):

--- a/scrapy/commands/fetch.py
+++ b/scrapy/commands/fetch.py
@@ -26,10 +26,10 @@ class Command(ScrapyCommand):
 
     def add_options(self, parser):
         ScrapyCommand.add_options(self, parser)
-        parser.add_option("--spider", dest="spider", help="use this spider")
-        parser.add_option("--headers", dest="headers", action="store_true",
+        parser.add_argument("--spider", dest="spider", help="use this spider")
+        parser.add_argument("--headers", dest="headers", action="store_true",
                           help="print response HTTP headers instead of body")
-        parser.add_option("--no-redirect", dest="no_redirect", action="store_true", default=False,
+        parser.add_argument("--no-redirect", dest="no_redirect", action="store_true", default=False,
                           help="do not handle HTTP 3xx status codes and print response as-is")
 
     def _print_headers(self, headers, prefix):

--- a/scrapy/commands/genspider.py
+++ b/scrapy/commands/genspider.py
@@ -44,15 +44,15 @@ class Command(ScrapyCommand):
 
     def add_options(self, parser):
         ScrapyCommand.add_options(self, parser)
-        parser.add_option("-l", "--list", dest="list", action="store_true",
+        parser.add_argument("-l", "--list", dest="list", action="store_true",
                           help="List available templates")
-        parser.add_option("-e", "--edit", dest="edit", action="store_true",
+        parser.add_argument("-e", "--edit", dest="edit", action="store_true",
                           help="Edit spider after creating it")
-        parser.add_option("-d", "--dump", dest="dump", metavar="TEMPLATE",
+        parser.add_argument("-d", "--dump", dest="dump", metavar="TEMPLATE",
                           help="Dump template to standard output")
-        parser.add_option("-t", "--template", dest="template", default="basic",
+        parser.add_argument("-t", "--template", dest="template", default="basic",
                           help="Uses a custom template.")
-        parser.add_option("--force", dest="force", action="store_true",
+        parser.add_argument("--force", dest="force", action="store_true",
                           help="If the spider already exists, overwrite it with the template")
 
     def run(self, args, opts):

--- a/scrapy/commands/parse.py
+++ b/scrapy/commands/parse.py
@@ -32,27 +32,27 @@ class Command(BaseRunSpiderCommand):
 
     def add_options(self, parser):
         BaseRunSpiderCommand.add_options(self, parser)
-        parser.add_option("--spider", dest="spider", default=None,
+        parser.add_argument("--spider", dest="spider", default=None,
                           help="use this spider without looking for one")
-        parser.add_option("--pipelines", action="store_true",
+        parser.add_argument("--pipelines", action="store_true",
                           help="process items through pipelines")
-        parser.add_option("--nolinks", dest="nolinks", action="store_true",
+        parser.add_argument("--nolinks", dest="nolinks", action="store_true",
                           help="don't show links to follow (extracted requests)")
-        parser.add_option("--noitems", dest="noitems", action="store_true",
+        parser.add_argument("--noitems", dest="noitems", action="store_true",
                           help="don't show scraped items")
-        parser.add_option("--nocolour", dest="nocolour", action="store_true",
+        parser.add_argument("--nocolour", dest="nocolour", action="store_true",
                           help="avoid using pygments to colorize the output")
-        parser.add_option("-r", "--rules", dest="rules", action="store_true",
+        parser.add_argument("-r", "--rules", dest="rules", action="store_true",
                           help="use CrawlSpider rules to discover the callback")
-        parser.add_option("-c", "--callback", dest="callback",
+        parser.add_argument("-c", "--callback", dest="callback",
                           help="use this callback for parsing, instead looking for a callback")
-        parser.add_option("-m", "--meta", dest="meta",
+        parser.add_argument("-m", "--meta", dest="meta",
                           help="inject extra meta into the Request, it must be a valid raw json string")
-        parser.add_option("--cbkwargs", dest="cbkwargs",
+        parser.add_argument("--cbkwargs", dest="cbkwargs",
                           help="inject extra callback kwargs into the Request, it must be a valid raw json string")
-        parser.add_option("-d", "--depth", dest="depth", type="int", default=1,
+        parser.add_argument("-d", "--depth", dest="depth", type="int", default=1,
                           help="maximum depth for parsing requests [default: %default]")
-        parser.add_option("-v", "--verbose", dest="verbose", action="store_true",
+        parser.add_argument("-v", "--verbose", dest="verbose", action="store_true",
                           help="print each depth level one by one")
 
     @property

--- a/scrapy/commands/settings.py
+++ b/scrapy/commands/settings.py
@@ -18,15 +18,15 @@ class Command(ScrapyCommand):
 
     def add_options(self, parser):
         ScrapyCommand.add_options(self, parser)
-        parser.add_option("--get", dest="get", metavar="SETTING",
+        parser.add_argument("--get", dest="get", metavar="SETTING",
                           help="print raw setting value")
-        parser.add_option("--getbool", dest="getbool", metavar="SETTING",
+        parser.add_argument("--getbool", dest="getbool", metavar="SETTING",
                           help="print setting value, interpreted as a boolean")
-        parser.add_option("--getint", dest="getint", metavar="SETTING",
+        parser.add_argument("--getint", dest="getint", metavar="SETTING",
                           help="print setting value, interpreted as an integer")
-        parser.add_option("--getfloat", dest="getfloat", metavar="SETTING",
+        parser.add_argument("--getfloat", dest="getfloat", metavar="SETTING",
                           help="print setting value, interpreted as a float")
-        parser.add_option("--getlist", dest="getlist", metavar="SETTING",
+        parser.add_argument("--getlist", dest="getlist", metavar="SETTING",
                           help="print setting value, interpreted as a list")
 
     def run(self, args, opts):

--- a/scrapy/commands/shell.py
+++ b/scrapy/commands/shell.py
@@ -33,11 +33,11 @@ class Command(ScrapyCommand):
 
     def add_options(self, parser):
         ScrapyCommand.add_options(self, parser)
-        parser.add_option("-c", dest="code",
+        parser.add_argument("-c", dest="code",
                           help="evaluate the code in the shell, print the result and exit")
-        parser.add_option("--spider", dest="spider",
+        parser.add_argument("--spider", dest="spider",
                           help="use this spider")
-        parser.add_option("--no-redirect", dest="no_redirect", action="store_true", default=False,
+        parser.add_argument("--no-redirect", dest="no_redirect", action="store_true", default=False,
                           help="do not handle HTTP 3xx status codes and print response as-is")
 
     def update_vars(self, vars):

--- a/scrapy/commands/version.py
+++ b/scrapy/commands/version.py
@@ -16,8 +16,8 @@ class Command(ScrapyCommand):
 
     def add_options(self, parser):
         ScrapyCommand.add_options(self, parser)
-        parser.add_option("--verbose", "-v", dest="verbose", action="store_true",
-                          help="also display twisted/python/platform info (useful for bug reports)")
+        parser.add_argument("--verbose", "-v", dest="verbose", action="store_true",
+                            help="also display twisted/python/platform info (useful for bug reports)")
 
     def run(self, args, opts):
         if opts.verbose:

--- a/scrapy/commands/view.py
+++ b/scrapy/commands/view.py
@@ -1,3 +1,4 @@
+import argparse
 from scrapy.commands import fetch
 from scrapy.utils.response import open_in_browser
 
@@ -12,7 +13,7 @@ class Command(fetch.Command):
 
     def add_options(self, parser):
         super().add_options(parser)
-        parser.remove_option("--headers")
+        parser.add_argument("--headers", help=argparse.SUPPRESS)
 
     def _print_response(self, response, opts):
         open_in_browser(response)

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -1,6 +1,6 @@
 import inspect
 import json
-import optparse
+import argparse
 import os
 import platform
 import re
@@ -37,15 +37,13 @@ class CommandSettings(unittest.TestCase):
     def setUp(self):
         self.command = ScrapyCommand()
         self.command.settings = Settings()
-        self.parser = optparse.OptionParser(
-            formatter=optparse.TitledHelpFormatter(),
-            conflict_handler='resolve',
-        )
+        self.parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+                                              conflict_handler='resolve')
         self.command.add_options(self.parser)
 
     def test_settings_json_string(self):
         feeds_json = '{"data.json": {"format": "json"}, "data.xml": {"format": "xml"}}'
-        opts, args = self.parser.parse_args(args=['-s', f'FEEDS={feeds_json}', 'spider.py'])
+        opts, args = self.parser.parse_known_args(args=['-s', f'FEEDS={feeds_json}', 'spider.py'])
         self.command.process_options(args, opts)
         self.assertIsInstance(self.command.settings['FEEDS'], scrapy.settings.BaseSettings)
         self.assertEqual(dict(self.command.settings['FEEDS']), json.loads(feeds_json))


### PR DESCRIPTION
Resolves use of deprecated octparse to newer argparse. Similar to [#5374](https://github.com/scrapy/scrapy/pull/5374) but this commit keeps same behavior in scrapy/commands/view.py where "--header" option is removed. New syntax needed for removing an argument.