### PR TITLE
Remove deprecated DictItem/BaseItem classes

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -272,7 +272,6 @@ coverage_ignore_pyobjects = [
     r'^scrapy\.extensions\.[a-z]\w*?\.[a-z]',  # helper functions
 
     # Never documented before, and deprecated now.
-    r'^scrapy\.item\.DictItem$',
     r'^scrapy\.linkextractors\.FilteringLinkExtractor$',
 
     # Implementation detail of LxmlLinkExtractor

--- a/scrapy/exporters.py
+++ b/scrapy/exporters.py
@@ -13,7 +13,7 @@ from xml.sax.saxutils import XMLGenerator
 from itemadapter import is_item, ItemAdapter
 
 from scrapy.exceptions import ScrapyDeprecationWarning
-from scrapy.item import _BaseItem
+from scrapy.item import Item
 from scrapy.utils.python import is_listlike, to_bytes, to_unicode
 from scrapy.utils.serialize import ScrapyJSONEncoder
 
@@ -315,7 +315,7 @@ class PythonItemExporter(BaseItemExporter):
         return serializer(value)
 
     def _serialize_value(self, value):
-        if isinstance(value, _BaseItem):
+        if isinstance(value, Item):
             return self.export_item(value)
         elif is_item(value):
             return dict(self._serialize_item(value))

--- a/scrapy/item.py
+++ b/scrapy/item.py
@@ -9,9 +9,7 @@ from collections.abc import MutableMapping
 from copy import deepcopy
 from pprint import pformat
 from typing import Dict
-from warnings import warn
 
-from scrapy.utils.deprecate import ScrapyDeprecationWarning
 from scrapy.utils.trackref import object_ref
 
 
@@ -46,15 +44,30 @@ class ItemMeta(ABCMeta):
         return super().__new__(mcs, class_name, bases, new_attrs)
 
 
-class DictItem(MutableMapping, object_ref):
+class Item(MutableMapping, object_ref, metaclass=ItemMeta):
+    """
+    Base class for scraped items.
 
-    fields: Dict[str, Field] = {}
+    In Scrapy, an object is considered an ``item`` if it is an instance of either
+    :class:`Item` or :class:`dict`, or any subclass. For example, when the output of a
+    spider callback is evaluated, only instances of :class:`Item` or
+    :class:`dict` are passed to :ref:`item pipelines <topics-item-pipeline>`.
 
-    def __new__(cls, *args, **kwargs):
-        if issubclass(cls, DictItem) and not issubclass(cls, Item):
-            warn('scrapy.item.DictItem is deprecated, please use scrapy.item.Item instead',
-                 ScrapyDeprecationWarning, stacklevel=2)
-        return super().__new__(cls, *args, **kwargs)
+    If you need instances of a custom class to be considered items by Scrapy,
+    you must inherit from either :class:`Item` or :class:`dict`.
+
+    Items must declare :class:`Field` attributes, which are processed and stored
+    in the ``fields`` attribute. This restricts the set of allowed field names
+    and prevents typos, raising ``KeyError`` when referring to undefined fields.
+    Additionally, fields can be used to define metadata and control the way
+    data is processed internally. Please refer to the :ref:`documentation
+    about fields <topics-items-fields>` for additional information.
+
+    Unlike instances of :class:`dict`, instances of :class:`Item` may be
+    :ref:`tracked <topics-leaks-trackrefs>` to debug memory leaks.
+    """
+
+    fields: Dict[str, Field]
 
     def __init__(self, *args, **kwargs):
         self._values = {}
@@ -105,27 +118,3 @@ class DictItem(MutableMapping, object_ref):
         """Return a :func:`~copy.deepcopy` of this item.
         """
         return deepcopy(self)
-
-
-class Item(DictItem, metaclass=ItemMeta):
-    """
-    Base class for scraped items.
-
-    In Scrapy, an object is considered an ``item`` if it is an instance of either
-    :class:`Item` or :class:`dict`, or any subclass. For example, when the output of a
-    spider callback is evaluated, only instances of :class:`Item` or
-    :class:`dict` are passed to :ref:`item pipelines <topics-item-pipeline>`.
-
-    If you need instances of a custom class to be considered items by Scrapy,
-    you must inherit from either :class:`Item` or :class:`dict`.
-
-    Items must declare :class:`Field` attributes, which are processed and stored
-    in the ``fields`` attribute. This restricts the set of allowed field names
-    and prevents typos, raising ``KeyError`` when referring to undefined fields.
-    Additionally, fields can be used to define metadata and control the way
-    data is processed internally. Please refer to the :ref:`documentation
-    about fields <topics-items-fields>` for additional information.
-
-    Unlike instances of :class:`dict`, instances of :class:`Item` may be
-    :ref:`tracked <topics-leaks-trackrefs>` to debug memory leaks.
-    """

--- a/scrapy/item.py
+++ b/scrapy/item.py
@@ -15,39 +15,11 @@ from scrapy.utils.deprecate import ScrapyDeprecationWarning
 from scrapy.utils.trackref import object_ref
 
 
-class _BaseItem(object_ref):
-    """
-    Temporary class used internally to avoid the deprecation
-    warning raised by isinstance checks using BaseItem.
-    """
-    pass
-
-
-class _BaseItemMeta(ABCMeta):
-    def __instancecheck__(cls, instance):
-        if cls is BaseItem:
-            warn('scrapy.item.BaseItem is deprecated, please use scrapy.item.Item instead',
-                 ScrapyDeprecationWarning, stacklevel=2)
-        return super().__instancecheck__(instance)
-
-
-class BaseItem(_BaseItem, metaclass=_BaseItemMeta):
-    """
-    Deprecated, please use :class:`scrapy.item.Item` instead
-    """
-
-    def __new__(cls, *args, **kwargs):
-        if issubclass(cls, BaseItem) and not issubclass(cls, (Item, DictItem)):
-            warn('scrapy.item.BaseItem is deprecated, please use scrapy.item.Item instead',
-                 ScrapyDeprecationWarning, stacklevel=2)
-        return super().__new__(cls, *args, **kwargs)
-
-
 class Field(dict):
     """Container of field metadata"""
 
 
-class ItemMeta(_BaseItemMeta):
+class ItemMeta(ABCMeta):
     """Metaclass_ of :class:`Item` that handles field definitions.
 
     .. _metaclass: https://realpython.com/python-metaclasses
@@ -74,7 +46,7 @@ class ItemMeta(_BaseItemMeta):
         return super().__new__(mcs, class_name, bases, new_attrs)
 
 
-class DictItem(MutableMapping, BaseItem):
+class DictItem(MutableMapping, object_ref):
 
     fields: Dict[str, Field] = {}
 
@@ -118,7 +90,7 @@ class DictItem(MutableMapping, BaseItem):
     def __iter__(self):
         return iter(self._values)
 
-    __hash__ = BaseItem.__hash__
+    __hash__ = object_ref.__hash__
 
     def keys(self):
         return self._values.keys()

--- a/scrapy/utils/misc.py
+++ b/scrapy/utils/misc.py
@@ -14,11 +14,11 @@ from w3lib.html import replace_entities
 
 from scrapy.utils.datatypes import LocalWeakReferencedCache
 from scrapy.utils.python import flatten, to_unicode
-from scrapy.item import _BaseItem
+from scrapy.item import Item
 from scrapy.utils.deprecate import ScrapyDeprecationWarning
 
 
-_ITERABLE_SINGLE_VALUES = dict, _BaseItem, str, bytes
+_ITERABLE_SINGLE_VALUES = dict, Item, str, bytes
 
 
 def arg_to_iter(arg):

--- a/tests/test_item.py
+++ b/tests/test_item.py
@@ -3,7 +3,7 @@ from unittest import mock
 from warnings import catch_warnings, filterwarnings
 
 from scrapy.exceptions import ScrapyDeprecationWarning
-from scrapy.item import ABCMeta, _BaseItem, BaseItem, DictItem, Field, Item, ItemMeta
+from scrapy.item import ABCMeta, DictItem, Field, Item, ItemMeta
 
 
 class ItemTest(unittest.TestCase):
@@ -317,79 +317,6 @@ class DictItemTest(unittest.TestCase):
             self.assertEqual(len(warnings), 1)
             self.assertEqual(warnings[0].category, ScrapyDeprecationWarning)
 
-
-class BaseItemTest(unittest.TestCase):
-
-    def test_isinstance_check(self):
-
-        class SubclassedBaseItem(BaseItem):
-            pass
-
-        class SubclassedItem(Item):
-            pass
-
-        with catch_warnings():
-            filterwarnings("ignore", category=ScrapyDeprecationWarning)
-            self.assertTrue(isinstance(BaseItem(), BaseItem))
-            self.assertTrue(isinstance(SubclassedBaseItem(), BaseItem))
-            self.assertTrue(isinstance(Item(), BaseItem))
-            self.assertTrue(isinstance(SubclassedItem(), BaseItem))
-
-            # make sure internal checks using private _BaseItem class succeed
-            self.assertTrue(isinstance(BaseItem(), _BaseItem))
-            self.assertTrue(isinstance(SubclassedBaseItem(), _BaseItem))
-            self.assertTrue(isinstance(Item(), _BaseItem))
-            self.assertTrue(isinstance(SubclassedItem(), _BaseItem))
-
-    def test_deprecation_warning(self):
-        """
-        Make sure deprecation warnings are logged whenever BaseItem is used,
-        either instantiated or in an isinstance check
-        """
-        with catch_warnings(record=True) as warnings:
-            BaseItem()
-            self.assertEqual(len(warnings), 1)
-            self.assertEqual(warnings[0].category, ScrapyDeprecationWarning)
-
-        with catch_warnings(record=True) as warnings:
-
-            class SubclassedBaseItem(BaseItem):
-                pass
-
-            SubclassedBaseItem()
-            self.assertEqual(len(warnings), 1)
-            self.assertEqual(warnings[0].category, ScrapyDeprecationWarning)
-
-        with catch_warnings(record=True) as warnings:
-            self.assertFalse(isinstance("foo", BaseItem))
-            self.assertEqual(len(warnings), 1)
-            self.assertEqual(warnings[0].category, ScrapyDeprecationWarning)
-
-        with catch_warnings(record=True) as warnings:
-            self.assertTrue(isinstance(BaseItem(), BaseItem))
-            self.assertEqual(len(warnings), 1)
-            self.assertEqual(warnings[0].category, ScrapyDeprecationWarning)
-
-
-class ItemNoDeprecationWarningTest(unittest.TestCase):
-    def test_no_deprecation_warning(self):
-        """
-        Make sure deprecation warnings are NOT logged whenever BaseItem subclasses are used.
-        """
-        class SubclassedItem(Item):
-            pass
-
-        with catch_warnings(record=True) as warnings:
-            Item()
-            SubclassedItem()
-            _BaseItem()
-            self.assertFalse(isinstance("foo", _BaseItem))
-            self.assertFalse(isinstance("foo", Item))
-            self.assertFalse(isinstance("foo", SubclassedItem))
-            self.assertTrue(isinstance(_BaseItem(), _BaseItem))
-            self.assertTrue(isinstance(Item(), Item))
-            self.assertTrue(isinstance(SubclassedItem(), SubclassedItem))
-            self.assertEqual(len(warnings), 0)
 
 
 if __name__ == "__main__":

--- a/tests/test_item.py
+++ b/tests/test_item.py
@@ -1,6 +1,6 @@
 import unittest
 from unittest import mock
-from warnings import catch_warnings, filterwarnings
+from warnings import catch_warnings
 
 from scrapy.exceptions import ScrapyDeprecationWarning
 from scrapy.item import ABCMeta, DictItem, Field, Item, ItemMeta
@@ -316,7 +316,6 @@ class DictItemTest(unittest.TestCase):
             SubclassedDictItem()
             self.assertEqual(len(warnings), 1)
             self.assertEqual(warnings[0].category, ScrapyDeprecationWarning)
-
 
 
 if __name__ == "__main__":

--- a/tests/test_item.py
+++ b/tests/test_item.py
@@ -1,9 +1,7 @@
 import unittest
 from unittest import mock
-from warnings import catch_warnings
 
-from scrapy.exceptions import ScrapyDeprecationWarning
-from scrapy.item import ABCMeta, DictItem, Field, Item, ItemMeta
+from scrapy.item import ABCMeta, Field, Item, ItemMeta
 
 
 class ItemTest(unittest.TestCase):
@@ -254,18 +252,6 @@ class ItemTest(unittest.TestCase):
         item['tags'].append('tag2')
         assert item['tags'] != copied_item['tags']
 
-    def test_dictitem_deprecation_warning(self):
-        """Make sure the DictItem deprecation warning is not issued for
-        Item"""
-        with catch_warnings(record=True) as warnings:
-            Item()
-            self.assertEqual(len(warnings), 0)
-
-            class SubclassedItem(Item):
-                pass
-            SubclassedItem()
-            self.assertEqual(len(warnings), 0)
-
 
 class ItemMetaTest(unittest.TestCase):
 
@@ -301,21 +287,6 @@ class ItemMetaClassCellRegression(unittest.TestCase):
                 # TypeError: __class__ set to <class '__main__.MyItem'>
                 # defining 'MyItem' as <class '__main__.MyItem'>
                 super().__init__(*args, **kwargs)
-
-
-class DictItemTest(unittest.TestCase):
-
-    def test_deprecation_warning(self):
-        with catch_warnings(record=True) as warnings:
-            DictItem()
-            self.assertEqual(len(warnings), 1)
-            self.assertEqual(warnings[0].category, ScrapyDeprecationWarning)
-        with catch_warnings(record=True) as warnings:
-            class SubclassedDictItem(DictItem):
-                pass
-            SubclassedDictItem()
-            self.assertEqual(len(warnings), 1)
-            self.assertEqual(warnings[0].category, ScrapyDeprecationWarning)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
More deprecation removals:
* `DictItem` deprecated on [1.8](https://docs.scrapy.org/en/latest/news.html#scrapy-1-8-0-2019-10-28)
* `BaseItem` deprecated on [2.2](https://docs.scrapy.org/en/latest/news.html#scrapy-2-2-0-2020-06-24)