### PR TITLE
Fix running tests with Twisted 22.1.0

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -21,5 +21,3 @@ addopts =
 markers =
     only_asyncio: marks tests as only enabled when --reactor=asyncio is passed
     only_not_asyncio: marks tests as only enabled when --reactor=asyncio is not passed
-filterwarnings=
-    ignore::DeprecationWarning:twisted.web.test.test_webclient

--- a/tests/test_downloader_handlers.py
+++ b/tests/test_downloader_handlers.py
@@ -15,8 +15,6 @@ from twisted.trial import unittest
 from twisted.web import resource, server, static, util
 from twisted.web._newclient import ResponseFailed
 from twisted.web.http import _DataLoss
-from twisted.web.test.test_webclient import (ForeverTakingResource, HostHeaderResource,
-                                             NoLengthResource, PayloadResource)
 from w3lib.url import path_to_file_uri
 
 from scrapy.core.downloader.handlers import DownloadHandlers
@@ -34,7 +32,15 @@ from scrapy.spiders import Spider
 from scrapy.utils.misc import create_instance
 from scrapy.utils.python import to_bytes
 from scrapy.utils.test import get_crawler, skip_if_no_boto
-from tests.mockserver import MockServer, ssl_context_factory, Echo
+from tests.mockserver import (
+    Echo,
+    ForeverTakingResource,
+    HostHeaderResource,
+    MockServer,
+    NoLengthResource,
+    PayloadResource,
+    ssl_context_factory,
+)
 from tests.spiders import SingleRequestSpider
 
 

--- a/tests/test_webclient.py
+++ b/tests/test_webclient.py
@@ -21,14 +21,6 @@ except ImportError:
 from twisted.python.filepath import FilePath
 from twisted.protocols.policies import WrappingFactory
 from twisted.internet.defer import inlineCallbacks
-from twisted.web.test.test_webclient import (
-    ForeverTakingResource,
-    ErrorResource,
-    NoLengthResource,
-    HostHeaderResource,
-    PayloadResource,
-    BrokenDownloadResource,
-)
 
 from scrapy.core.downloader import webclient as client
 from scrapy.core.downloader.contextfactory import ScrapyClientContextFactory
@@ -36,7 +28,15 @@ from scrapy.http import Request, Headers
 from scrapy.settings import Settings
 from scrapy.utils.misc import create_instance
 from scrapy.utils.python import to_bytes, to_unicode
-from tests.mockserver import ssl_context_factory
+from tests.mockserver import (
+    BrokenDownloadResource,
+    ErrorResource,
+    ForeverTakingResource,
+    HostHeaderResource,
+    NoLengthResource,
+    PayloadResource,
+    ssl_context_factory,
+)
 
 
 def getPage(url, contextFactory=None, response_transform=None, *args, **kwargs):

--- a/tox.ini
+++ b/tox.ini
@@ -19,8 +19,6 @@ deps =
     mitmproxy >= 4.0.4, < 5; python_version >= '3.6' and python_version < '3.7' and platform_system != 'Windows' and implementation_name != 'pypy'
     # Extras
     botocore>=1.4.87
-    # Temporary until the tests are updated
-    Twisted<22.1.0
 passenv =
     S3_TEST_FILE_URI
     AWS_ACCESS_KEY_ID


### PR DESCRIPTION
Fixes #5400, see the explanation there.

I've decided to put the classes into mockserver.py because it already has a resource class and other two files already import from it. But it's possible to move them into a separate file (in which case I'd discuss if we want to keep those supplementary modules in tests/ or move them into a subdir).