### PR TITLE
Fix SMTP STARTTLS for Twisted >= 21.2.0 (5386)

### DIFF
--- a/scrapy/mail.py
+++ b/scrapy/mail.py
@@ -12,7 +12,7 @@ from email.mime.text import MIMEText
 from email.utils import formatdate
 from io import BytesIO
 
-from incremental import Version
+from twisted.python.versions import Version
 from twisted.internet import defer, ssl
 from twisted import version as twisted_version
 

--- a/scrapy/mail.py
+++ b/scrapy/mail.py
@@ -129,12 +129,19 @@ class MailSender:
         # Import twisted.mail here because it is not available in python3
         from twisted.internet import reactor
         from twisted.mail.smtp import ESMTPSenderFactory
+        from twisted import copyright
+        from packaging import version
         msg = BytesIO(msg)
         d = defer.Deferred()
         factory = ESMTPSenderFactory(
             self.smtpuser, self.smtppass, self.mailfrom, to_addrs, msg, d,
             heloFallback=True, requireAuthentication=False, requireTransportSecurity=self.smtptls,
         )
+
+        # Newer versions of twisted require the hostname to use STARTTLS
+        if version.parse(copyright.version) >= version.parse('21.2.0'):
+            factory.hostname = self.smtphost
+
         factory.noisy = False
 
         if self.smtpssl:

--- a/scrapy/mail.py
+++ b/scrapy/mail.py
@@ -129,18 +129,28 @@ class MailSender:
         # Import twisted.mail here because it is not available in python3
         from twisted.internet import reactor
         from twisted.mail.smtp import ESMTPSenderFactory
-        from twisted import copyright
-        from packaging import version
-        msg = BytesIO(msg)
+        from twisted import version as twisted_version
+        from distutils.version import Version
+
         d = defer.Deferred()
-        factory = ESMTPSenderFactory(
-            self.smtpuser, self.smtppass, self.mailfrom, to_addrs, msg, d,
-            heloFallback=True, requireAuthentication=False, requireTransportSecurity=self.smtptls,
-        )
+
+        factory_config = {
+            'username': self.smtpuser,
+            'password': self.smtppass,
+            'fromEmail': self.mailfrom,
+            'toEmail': to_addrs,
+            'file': BytesIO(msg),
+            'deferred': defer.Deferred(),
+            'heloFallback': True,
+            'requireAuthentication': False,
+            'requireTransportSecurity': self.smtptls
+        }
 
         # Newer versions of twisted require the hostname to use STARTTLS
-        if version.parse(copyright.version) >= version.parse('21.2.0'):
-            factory.hostname = self.smtphost
+        if twisted_version >= Version('21.2.0'):
+            factory_config['hostname'] = self.smtphost
+
+        factory = ESMTPSenderFactory(**factory_config)
 
         factory.noisy = False
 

--- a/tests/test_mail.py
+++ b/tests/test_mail.py
@@ -4,6 +4,9 @@ import unittest
 from io import BytesIO
 from email.charset import Charset
 
+from twisted.python.versions import Version
+from twisted.internet import defer
+from twisted import version as twisted_version
 from scrapy.mail import MailSender
 
 
@@ -120,6 +123,17 @@ class MailSenderTest(unittest.TestCase):
         self.assertEqual(text.get_payload(decode=True).decode('utf-8'), body)
         self.assertEqual(text.get_charset(), Charset('utf-8'))
         self.assertEqual(attach.get_payload(decode=True).decode('utf-8'), body)
+
+    def test_create_sender_factory_with_host(self):
+        mailsender = MailSender(debug=False, smtphost='smtp.testhost.com')
+
+        factory = mailsender._create_sender_factory(to_addrs=['test@scrapy.org'], msg='test', d=defer.Deferred())
+
+        if twisted_version >= Version('twisted', 21, 2, 0):
+            self.assertTrue(hasattr(factory, '_hostname'))
+            self.assertEqual('smtp.testhost.com', factory._hostname)
+        else:
+            self.assertFalse(hasattr(factory, '_hostname'))
 
 
 if __name__ == "__main__":

--- a/tests/test_mail.py
+++ b/tests/test_mail.py
@@ -4,6 +4,8 @@ import unittest
 from io import BytesIO
 from email.charset import Charset
 
+from twisted.internet._sslverify import ClientTLSOptions
+from twisted.internet.ssl import ClientContextFactory
 from twisted.python.versions import Version
 from twisted.internet import defer
 from twisted import version as twisted_version
@@ -129,11 +131,11 @@ class MailSenderTest(unittest.TestCase):
 
         factory = mailsender._create_sender_factory(to_addrs=['test@scrapy.org'], msg='test', d=defer.Deferred())
 
+        context = factory.buildProtocol('test@scrapy.org').context
         if twisted_version >= Version('twisted', 21, 2, 0):
-            self.assertTrue(hasattr(factory, '_hostname'))
-            self.assertEqual('smtp.testhost.com', factory._hostname)
+            self.assertIsInstance(context, ClientTLSOptions)
         else:
-            self.assertFalse(hasattr(factory, '_hostname'))
+            self.assertIsInstance(context, ClientContextFactory)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Pass hostname to the ESMTPSenderFactory when the twisted version is higher than 21.2.0 to use STARTTLS.

Fixes #5386