### PR TITLE
Pin old markupsafe when we pin old mitmproxy.

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -17,6 +17,8 @@ deps =
     #mitmproxy >= 5.3.0; python_version >= '3.9' and implementation_name != 'pypy'
     mitmproxy >= 4.0.4; python_version >= '3.7' and python_version < '3.9' and implementation_name != 'pypy'
     mitmproxy >= 4.0.4, < 5; python_version >= '3.6' and python_version < '3.7' and platform_system != 'Windows' and implementation_name != 'pypy'
+    # newer markupsafe is incompatible with deps of old mitmproxy (which we get on Python 3.7 and lower)
+    markupsafe < 2.1.0; python_version >= '3.6' and python_version < '3.8' and implementation_name != 'pypy'
     # Extras
     botocore>=1.4.87
 passenv =
@@ -127,6 +129,9 @@ deps =
     robotexclusionrulesparser
     Pillow>=4.0.0
     Twisted[http2]>=17.9.0
+    # Twisted[http2] currently forces old mitmproxy because of h2 version restrictions in their deps,
+    # so we need to pin old markupsafe here too
+    markupsafe < 2.1.0
 
 [testenv:asyncio]
 commands =


### PR DESCRIPTION
Fixes #5425 