### PR TITLE
Document the Scrapy component API

### DIFF
--- a/docs/topics/api.rst
+++ b/docs/topics/api.rst
@@ -167,16 +167,6 @@ SpiderLoader API
     the :class:`scrapy.interfaces.ISpiderLoader` interface to guarantee an
     errorless execution.
 
-    .. method:: from_settings(settings)
-
-       This class method is used by Scrapy to create an instance of the class.
-       It's called with the current project settings, and it loads the spiders
-       found recursively in the modules of the :setting:`SPIDER_MODULES`
-       setting.
-
-       :param settings: project settings
-       :type settings: :class:`~scrapy.settings.Settings` instance
-
     .. method:: load(spider_name)
 
        Get the Spider class with the given name. It'll look into the previously
@@ -197,6 +187,13 @@ SpiderLoader API
 
        :param request: queried request
        :type request: :class:`~scrapy.Request` instance
+
+    :meth:`from_settings`:
+
+       This class method is used by Scrapy to create an instance of the class.
+       It's called with the current project settings, and it loads the spiders
+       found recursively in the modules of the :setting:`SPIDER_MODULES`
+       setting.
 
 .. _topics-api-signals:
 

--- a/docs/topics/class-methods.rst
+++ b/docs/topics/class-methods.rst
@@ -1,0 +1,29 @@
+===========================
+Class Instantiation Methods
+===========================
+
+These methods create an instance of their implementer class by 
+extracting the components needed for it from the argument that the method takes.
+
+.. py:classmethod:: from_crawler(cls, crawler)
+
+    Factory method that if present, is used to create an instance of the implementer class
+    using a :class:`~scrapy.crawler.Crawler`. It must return a new instance
+    of the implementer class. The Crawler object is needed in order to provide 
+    access to all Scrapy core components like settings and signals; It is a 
+    way for the implenter class to access them and hook its functionality into Scrapy.
+
+    :param crawler: crawler that uses this middleware
+    :type crawler: :class:`~scrapy.crawler.Crawler` object
+
+
+.. py:classmethod:: from_settings(cls, settings)
+
+    This class method is used by Scrapy to create an instance of the implementer class
+    using the settings passed as arguments.
+    In most implementations of this method, not all settings given will be used 
+    to instantiate the class, but only the ones needed in the specific scenario.
+
+
+    :param settings: project settings
+    :type settings: :class:`~scrapy.settings.Settings` instance

--- a/docs/topics/downloader-middleware.rst
+++ b/docs/topics/downloader-middleware.rst
@@ -163,16 +163,10 @@ object gives you access, for example, to the :ref:`settings <topics-settings>`.
       :param spider: the spider for which this request is intended
       :type spider: :class:`~scrapy.Spider` object
 
-   .. method:: from_crawler(cls, crawler)
+   :meth:`from_crawler`:
 
-      If present, this classmethod is called to create a middleware instance
-      from a :class:`~scrapy.crawler.Crawler`. It must return a new instance
-      of the middleware. Crawler object provides access to all Scrapy core
-      components like settings and signals; it is a way for middleware to
-      access them and hook its functionality into Scrapy.
-
-      :param crawler: crawler that uses this middleware
-      :type crawler: :class:`~scrapy.crawler.Crawler` object
+   	Class method that if present, is used to create a middleware 
+   	instance using a :class:`~scrapy.crawler.Crawler`.
 
 .. _topics-downloader-middleware-ref:
 

--- a/docs/topics/email.rst
+++ b/docs/topics/email.rst
@@ -67,14 +67,6 @@ rest of the framework.
     :param smtpssl: enforce using a secure SSL connection
     :type smtpssl: bool
 
-    .. classmethod:: from_settings(settings)
-
-        Instantiate using a Scrapy settings object, which will respect
-        :ref:`these Scrapy settings <topics-email-settings>`.
-
-        :param settings: the e-mail recipients
-        :type settings: :class:`scrapy.settings.Settings` object
-
     .. method:: send(to, subject, body, cc=None, attachs=(), mimetype='text/plain', charset=None)
 
         Send email to the given recipients.
@@ -102,8 +94,12 @@ rest of the framework.
         :type mimetype: str
 
         :param charset: the character encoding to use for the e-mail contents
-        :type charset: str
+        :type charset: str 
+    
+    :meth:`from_settings`:
 
+        Instantiate a MailSender using a Scrapy settings object, which will respect
+        :ref:`these Scrapy settings <topics-email-settings>`.
 
 .. _topics-email-settings:
 

--- a/docs/topics/item-pipeline.rst
+++ b/docs/topics/item-pipeline.rst
@@ -60,16 +60,10 @@ Additionally, they may also implement the following methods:
    :param spider: the spider which was closed
    :type spider: :class:`~scrapy.Spider` object
 
-.. method:: from_crawler(cls, crawler)
+:meth:`from_crawler`: 
 
-   If present, this classmethod is called to create a pipeline instance
-   from a :class:`~scrapy.crawler.Crawler`. It must return a new instance
-   of the pipeline. Crawler object provides access to all Scrapy core
-   components like settings and signals; it is a way for pipeline to
-   access them and hook its functionality into Scrapy.
-
-   :param crawler: crawler that uses this pipeline
-   :type crawler: :class:`~scrapy.crawler.Crawler` object
+   Class method that if present, is used to create a pipeline 
+   instance using a :class:`~scrapy.crawler.Crawler`.
 
 
 Item pipeline example

--- a/docs/topics/spider-middleware.rst
+++ b/docs/topics/spider-middleware.rst
@@ -169,16 +169,10 @@ object gives you access, for example, to the :ref:`settings <topics-settings>`.
         :param spider: the spider to whom the start requests belong
         :type spider: :class:`~scrapy.Spider` object
 
-    .. method:: from_crawler(cls, crawler)
-
-       If present, this classmethod is called to create a middleware instance
-       from a :class:`~scrapy.crawler.Crawler`. It must return a new instance
-       of the middleware. Crawler object provides access to all Scrapy core
-       components like settings and signals; it is a way for middleware to
-       access them and hook its functionality into Scrapy.
-
-       :param crawler: crawler that uses this middleware
-       :type crawler: :class:`~scrapy.crawler.Crawler` object
+    :meth:`from_crawler`: 
+    
+    	Class method that if present, is used to create a middleware 
+    	instance using a :class:`~scrapy.crawler.Crawler`.
 
 .. _topics-spider-middleware-ref:
 


### PR DESCRIPTION
Remove duplicate definition of from_crawler and from_settings method. Make them refer to the centralized definitions in class-methods.rst where the explanation of the methods is elaborated. Closes #5110 