### PR TITLE
removed unnecessary parameters in _DictProxy.__iter__ following SonarCloud recommendations

### DIFF
--- a/scrapy/settings/__init__.py
+++ b/scrapy/settings/__init__.py
@@ -425,7 +425,7 @@ class _DictProxy(MutableMapping):
     def __delitem__(self, k):
         del self.o[k]
 
-    def __iter__(self, k, v):
+    def __iter__(self):
         return iter(self.o)
 
 


### PR DESCRIPTION
I've noticed that the method _iter_(self, k, v) in _DictProxy (Scrapy/Settings/_init_.py) had three arguments. This method is called by python with only the self parameter so I think this was unnecesary. Correct me if I'm wrong.