### PR TITLE
documentation update for multiple spiders

### DIFF
--- a/docs/topics/practices.rst
+++ b/docs/topics/practices.rst
@@ -180,8 +180,8 @@ Same example but running the spiders sequentially by chaining the deferreds:
         # Your second spider definition
         ...
 
-    configure_logging()
     settings = get_project_settings()
+    configure_logging(settings)
     runner = CrawlerRunner(settings)
 
     @defer.inlineCallbacks


### PR DESCRIPTION
i noticed passing settings to configure logging function made weird output go away. checked documentation and it says first parameter is settings file. Is this correct?