### PR TITLE
Fixes when there is more than one spider #5467

### DIFF
--- a/scrapy/crawler.py
+++ b/scrapy/crawler.py
@@ -78,8 +78,10 @@ class Crawler:
             if reactor_class:
                 install_reactor(reactor_class, self.settings["ASYNCIO_EVENT_LOOP"])
             else:
-                from twisted.internet import default
-                default.install()
+                from contextlib import suppress
+                from twisted.internet import default, error
+                with suppress(error.ReactorAlreadyInstalledError):
+                    default.install()
             log_reactor_info()
         if reactor_class:
             verify_installed_reactor(reactor_class)


### PR DESCRIPTION
This is a simple solution to fix #5467 

After following these steps:
1. pip install scrapy
2. scrapy startproject myproject
3. scrapy genspider example1 example.com
4. scrapy genspider example2 example.com
5. Replace the method parse for both spiders

This is the output:
```
[example1] parse (@returns post-hook) ... ok
[example2] parse (@returns post-hook) ... ok

----------------------------------------------------------------------
Ran 2 contracts in 0.491s

OK
```
