### PR TITLE
Fixed deprecetion warning happening all the time from #5469

### DIFF
--- a/scrapy/pipelines/images.py
+++ b/scrapy/pipelines/images.py
@@ -8,7 +8,6 @@ import hashlib
 from contextlib import suppress
 from io import BytesIO
 
-
 from itemadapter import ItemAdapter
 
 from scrapy.exceptions import DropItem, NotConfigured

--- a/scrapy/pipelines/images.py
+++ b/scrapy/pipelines/images.py
@@ -17,11 +17,21 @@ from scrapy.pipelines.files import FileException, FilesPipeline
 from scrapy.settings import Settings
 from scrapy.utils.misc import md5sum
 from scrapy.utils.python import to_bytes
-from deprecated import deprecated
+from warnings import warn
 
-@deprecated("This class is deprecated.")
+
 class NoimagesDrop(DropItem):
     """Product with no images exception"""
+    
+    def __init__(self, *args, **kwargs):
+        warn(f'{self.__class__.__name__} will be deprecated',
+             DeprecationWarning, stacklevel=2)
+        super().__init__(*args, **kwargs)
+
+    def __init_subclass__(cls,  **kwargs):
+        warn(f'{cls.__name__} will be deprecated',
+             DeprecationWarning, stacklevel=2)
+        super().__init_subclass__(**kwargs)
 
 
 class ImageException(FileException):

--- a/scrapy/pipelines/images.py
+++ b/scrapy/pipelines/images.py
@@ -18,15 +18,11 @@ from scrapy.pipelines.files import FileException, FilesPipeline
 from scrapy.settings import Settings
 from scrapy.utils.misc import md5sum
 from scrapy.utils.python import to_bytes
+from deprecated import deprecated
 
-
+@deprecated("This class is deprecated.")
 class NoimagesDrop(DropItem):
     """Product with no images exception"""
-    def depreceation(message):
-        warnings.warn(
-            message, 
-            category=ScrapyDeprecationWarning,
-            stacklevel=2)
 
 
 class ImageException(FileException):

--- a/scrapy/pipelines/images.py
+++ b/scrapy/pipelines/images.py
@@ -7,10 +7,11 @@ import functools
 import hashlib
 from contextlib import suppress
 from io import BytesIO
+import warnings
 
 from itemadapter import ItemAdapter
 
-from scrapy.exceptions import DropItem, NotConfigured
+from scrapy.exceptions import DropItem, NotConfigured, ScrapyDeprecationWarning
 from scrapy.http import Request
 from scrapy.pipelines.files import FileException, FilesPipeline
 # TODO: from scrapy.pipelines.media import MediaPipeline
@@ -21,6 +22,11 @@ from scrapy.utils.python import to_bytes
 
 class NoimagesDrop(DropItem):
     """Product with no images exception"""
+    def depreceation(message):
+        warnings.warn(
+            message, 
+            category=ScrapyDeprecationWarning,
+            stacklevel=2)
 
 
 class ImageException(FileException):

--- a/scrapy/pipelines/images.py
+++ b/scrapy/pipelines/images.py
@@ -7,11 +7,11 @@ import functools
 import hashlib
 from contextlib import suppress
 from io import BytesIO
-import warnings
+
 
 from itemadapter import ItemAdapter
 
-from scrapy.exceptions import DropItem, NotConfigured, ScrapyDeprecationWarning
+from scrapy.exceptions import DropItem, NotConfigured
 from scrapy.http import Request
 from scrapy.pipelines.files import FileException, FilesPipeline
 # TODO: from scrapy.pipelines.media import MediaPipeline


### PR DESCRIPTION
Fixed the depreciation warning happening all the time when the library was loaded (see [5469](https://github.com/scrapy/scrapy/pull/5469))