### PR TITLE
Fix TypeError in parse command

### DIFF
--- a/scrapy/commands/parse.py
+++ b/scrapy/commands/parse.py
@@ -51,7 +51,7 @@ class Command(BaseRunSpiderCommand):
         parser.add_argument("--cbkwargs", dest="cbkwargs",
                             help="inject extra callback kwargs into the Request, it must be a valid raw json string")
         parser.add_argument("-d", "--depth", dest="depth", type=int, default=1,
-                            help=f"maximum depth for parsing requests [default: {self.max_level}]")
+                            help="maximum depth for parsing requests [default: 1]")
         parser.add_argument("-v", "--verbose", dest="verbose", action="store_true",
                             help="print each depth level one by one")
 

--- a/scrapy/commands/parse.py
+++ b/scrapy/commands/parse.py
@@ -51,7 +51,7 @@ class Command(BaseRunSpiderCommand):
         parser.add_argument("--cbkwargs", dest="cbkwargs",
                             help="inject extra callback kwargs into the Request, it must be a valid raw json string")
         parser.add_argument("-d", "--depth", dest="depth", type=int, default=1,
-                            help="maximum depth for parsing requests [default: %default]")
+                            help=f"maximum depth for parsing requests [default: {self.max_level}]")
         parser.add_argument("-v", "--verbose", dest="verbose", action="store_true",
                             help="print each depth level one by one")
 

--- a/scrapy/commands/parse.py
+++ b/scrapy/commands/parse.py
@@ -51,7 +51,7 @@ class Command(BaseRunSpiderCommand):
         parser.add_argument("--cbkwargs", dest="cbkwargs",
                             help="inject extra callback kwargs into the Request, it must be a valid raw json string")
         parser.add_argument("-d", "--depth", dest="depth", type=int, default=1,
-                            help="maximum depth for parsing requests [default: 1]")
+                            help="maximum depth for parsing requests [default: %(default)s]")
         parser.add_argument("-v", "--verbose", dest="verbose", action="store_true",
                             help="print each depth level one by one")
 

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -930,3 +930,17 @@ class MySpider(scrapy.Spider):
         args = ['-o', 'example1.json', '-O', 'example2.json']
         log = self.get_log(spider_code, args=args)
         self.assertIn("error: Please use only one of -o/--output and -O/--overwrite-output", log)
+
+
+class HelpMessageTest(CommandTest):
+
+    def setUp(self):
+        super().setUp()
+        self.commands = ["parse", "startproject", "view", "crawl", "edit",
+                         "list", "fetch", "settings", "shell", "runspider",
+                         "version", "genspider", "check", "bench"]
+
+    def test_help_messages(self):
+        for command in self.commands:
+            _, out, _ = self.proc(command, "-h")
+            self.assertIn("Usage", out)


### PR DESCRIPTION
Fixes #5481 

`scrapy parse -h`   now displays the appropriate help message.