### PR TITLE
The Request object adds the params parameter

### DIFF
--- a/scrapy/http/request/__init__.py
+++ b/scrapy/http/request/__init__.py
@@ -6,6 +6,7 @@ See documentation in docs/topics/request-response.rst
 """
 import inspect
 from typing import Callable, List, Optional, Tuple, Type, TypeVar, Union
+from urllib.parse import urlencode
 
 from w3lib.url import safe_url_string
 
@@ -44,6 +45,7 @@ class Request(object_ref):
         url: str,
         callback: Optional[Callable] = None,
         method: str = "GET",
+        params: Optional[Union[dict, tuple]] = None,
         headers: Optional[dict] = None,
         body: Optional[Union[bytes, str]] = None,
         cookies: Optional[Union[dict, List[dict]]] = None,
@@ -57,6 +59,8 @@ class Request(object_ref):
     ) -> None:
         self._encoding = encoding  # this one has to be set first
         self.method = str(method).upper()
+        if params:
+            url = f"{url[:-1] if url.endswith('?') else url}?{urlencode(params)}"
         self._set_url(url)
         self._set_body(body)
         if not isinstance(priority, int):


### PR DESCRIPTION
###  The Request object adds the params parameter

example：
```
url = "https://www.google.com.hk/search?"
params = {
     "q": "facebook",
     "tbm": "isch",
     "hl": "zh-CN",
     "safe": "strict",
     "chips": "q:facebook,online_chips:fb logo",
     "sa": "X",
     "ved": "2ahUKEwiE5_3z7sn3AhV_ATQIHV9lBZEQ4lYoBHoECAEQJQ",
     "biw": 1440,
     "bih": 708
}
url = f"{url[:-1] if url.endswith('?') else url}?{urlencode(params)}"
```
<img width="1361" alt="image" src="https://user-images.githubusercontent.com/32383804/167059314-e4ebbe05-b4ed-49f2-920d-9bde206bdf48.png">

<img width="604" alt="image" src="https://user-images.githubusercontent.com/32383804/167060295-75cf499b-b08c-4bcb-9700-45e240fbe743.png">
