### PR TITLE
Fix charset handling in MailSender

### DIFF
--- a/scrapy/mail.py
+++ b/scrapy/mail.py
@@ -77,6 +77,9 @@ class MailSender:
             rcpts.extend(cc)
             msg['Cc'] = COMMASPACE.join(cc)
 
+        if charset:
+            msg.set_charset(charset)
+
         if attachs:
             msg.attach(MIMEText(body, 'plain', charset or 'us-ascii'))
             for attach_name, mimetype, f in attachs:

--- a/scrapy/mail.py
+++ b/scrapy/mail.py
@@ -89,7 +89,6 @@ class MailSender:
                 Encoders.encode_base64(part)
                 part.add_header('Content-Disposition', 'attachment', filename=attach_name)
                 msg.attach(part)
-
         else:
             msg.set_payload(body)
             msg.set_charset(charset)

--- a/scrapy/mail.py
+++ b/scrapy/mail.py
@@ -77,19 +77,16 @@ class MailSender:
             rcpts.extend(cc)
             msg['Cc'] = COMMASPACE.join(cc)
 
-        if charset:
-            msg.set_charset(charset)
-
         if attachs:
             msg.attach(MIMEText(body, 'plain', charset or 'us-ascii'))
             for attach_name, mimetype, f in attachs:
                 part = MIMEBase(*mimetype.split('/'))
-                part.set_payload(f.read())
+                part.set_payload(f.read(), charset)
                 Encoders.encode_base64(part)
                 part.add_header('Content-Disposition', 'attachment', filename=attach_name)
                 msg.attach(part)
         else:
-            msg.set_payload(body)
+            msg.set_payload(body, charset)
 
         if _callback:
             _callback(to=to, subject=subject, body=body, cc=cc, attach=attachs, msg=msg)

--- a/scrapy/mail.py
+++ b/scrapy/mail.py
@@ -77,11 +77,14 @@ class MailSender:
             rcpts.extend(cc)
             msg['Cc'] = COMMASPACE.join(cc)
 
+        if charset:
+            msg.set_charset(charset)
+
         if attachs:
             msg.attach(MIMEText(body, 'plain', charset or 'us-ascii'))
             for attach_name, mimetype, f in attachs:
                 part = MIMEBase(*mimetype.split('/'))
-                part.set_payload(f.read(), charset)
+                part.set_payload(f.read())
                 Encoders.encode_base64(part)
                 part.add_header('Content-Disposition', 'attachment', filename=attach_name)
                 msg.attach(part)

--- a/scrapy/mail.py
+++ b/scrapy/mail.py
@@ -77,19 +77,19 @@ class MailSender:
             rcpts.extend(cc)
             msg['Cc'] = COMMASPACE.join(cc)
 
-        if charset:
-            msg.set_charset(charset)
-
         if attachs:
             msg.attach(MIMEText(body, 'plain', charset or 'us-ascii'))
             for attach_name, mimetype, f in attachs:
                 part = MIMEBase(*mimetype.split('/'))
                 part.set_payload(f.read())
+                part.set_charset(charset)
                 Encoders.encode_base64(part)
                 part.add_header('Content-Disposition', 'attachment', filename=attach_name)
                 msg.attach(part)
+
         else:
-            msg.set_payload(body, charset)
+            msg.set_payload(body)
+            msg.set_charset(charset)
 
         if _callback:
             _callback(to=to, subject=subject, body=body, cc=cc, attach=attachs, msg=msg)

--- a/tests/test_mail.py
+++ b/tests/test_mail.py
@@ -85,7 +85,7 @@ class MailSenderTest(unittest.TestCase):
 
         msg = self.catched_msg['msg']
         self.assertEqual(msg['subject'], subject)
-        self.assertEqual(self.catched_msg['body'], body)
+        self.assertEqual(msg.get_payload(), body)
         self.assertEqual(msg.get_charset(), Charset('utf-8'))
         self.assertEqual(msg.get('Content-Type'), 'text/plain; charset="utf-8"')
 

--- a/tests/test_mail.py
+++ b/tests/test_mail.py
@@ -25,7 +25,6 @@ class MailSenderTest(unittest.TestCase):
         self.assertEqual(msg['subject'], 'subject')
         self.assertEqual(msg.get_payload(), 'body')
         self.assertEqual(msg.get('Content-Type'), 'text/plain')
-        self.assertEqual(msg.get_charset(), None)
 
     def test_send_single_values_to_and_cc(self):
         mailsender = MailSender(debug=True)
@@ -41,7 +40,6 @@ class MailSenderTest(unittest.TestCase):
         msg = self.catched_msg['msg']
         self.assertEqual(msg.get_payload(), '<p>body</p>')
         self.assertEqual(msg.get('Content-Type'), 'text/html')
-        self.assertEqual(msg.get_charset(), None)
 
     def test_send_attach(self):
         attach = BytesIO()
@@ -87,21 +85,10 @@ class MailSenderTest(unittest.TestCase):
 
         msg = self.catched_msg['msg']
         self.assertEqual(msg['subject'], subject)
-        self.assertEqual(msg.get_payload(decode=True).decode('utf-8'), body)
+        self.assertEqual(self.catched_msg['body'], body)
         self.assertEqual(msg.get_charset(), Charset('utf-8'))
         self.assertEqual(msg.get('Content-Type'), 'text/plain; charset="utf-8"')
 
-    def test_send_utf8_and_verify_body_message_encoding (self):
-        subject = 'sübjèçt'
-        body = 'bödÿ-àéïöñß'
-        mailsender = MailSender(debug=True)
-        mailsender.send(to=['test@scrapy.org'], subject=subject, body=body,
-                        charset='utf-8', _callback=self._catch_mail_sent)
-
-        assert self.catched_msg
-        msg = self.catched_msg['msg']
-        self.assertEqual(msg.get_payload(decode=True).decode('utf-8'), body)
-        self.assertEqual(msg.get('Content-Type'), 'text/plain; charset="utf-8"')
 
     def test_send_attach_utf8(self):
         subject = 'sübjèçt'

--- a/tests/test_mail.py
+++ b/tests/test_mail.py
@@ -89,7 +89,6 @@ class MailSenderTest(unittest.TestCase):
         self.assertEqual(msg.get_charset(), Charset('utf-8'))
         self.assertEqual(msg.get('Content-Type'), 'text/plain; charset="utf-8"')
 
-
     def test_send_attach_utf8(self):
         subject = 'sübjèçt'
         body = 'bödÿ-àéïöñß'

--- a/tests/test_mail.py
+++ b/tests/test_mail.py
@@ -85,7 +85,7 @@ class MailSenderTest(unittest.TestCase):
 
         msg = self.catched_msg['msg']
         self.assertEqual(msg['subject'], subject)
-        self.assertEqual(msg.get_payload(), body)
+        self.assertEqual(msg.get_payload(), Charset('utf-8').body_encode(body))
         self.assertEqual(msg.get_charset(), Charset('utf-8'))
         self.assertEqual(msg.get('Content-Type'), 'text/plain; charset="utf-8"')
 
@@ -108,9 +108,8 @@ class MailSenderTest(unittest.TestCase):
 
         msg = self.catched_msg['msg']
         self.assertEqual(msg['subject'], subject)
-        self.assertEqual(msg.get_charset(), Charset('utf-8'))
-        self.assertEqual(msg.get('Content-Type'),
-                         'multipart/mixed; charset="utf-8"')
+        self.assertEqual(msg.get_charset(), None)
+        self.assertEqual(msg.get('Content-Type'), 'multipart/mixed')
 
         payload = msg.get_payload()
         assert isinstance(payload, list)

--- a/tests/test_mail.py
+++ b/tests/test_mail.py
@@ -91,6 +91,18 @@ class MailSenderTest(unittest.TestCase):
         self.assertEqual(msg.get_charset(), Charset('utf-8'))
         self.assertEqual(msg.get('Content-Type'), 'text/plain; charset="utf-8"')
 
+    def test_send_utf8_and_verify_body_message_encoding (self):
+        subject = 'sübjèçt'
+        body = 'bödÿ-àéïöñß'
+        mailsender = MailSender(debug=True)
+        mailsender.send(to=['test@scrapy.org'], subject=subject, body=body,
+                        charset='utf-8', _callback=self._catch_mail_sent)
+
+        assert self.catched_msg
+        msg = self.catched_msg['msg']
+        self.assertEqual(msg.get_payload(decode=True).decode('utf-8'), body)
+        self.assertEqual(msg.get('Content-Type'), 'text/plain; charset="utf-8"')
+
     def test_send_attach_utf8(self):
         subject = 'sübjèçt'
         body = 'bödÿ-àéïöñß'
@@ -110,9 +122,9 @@ class MailSenderTest(unittest.TestCase):
 
         msg = self.catched_msg['msg']
         self.assertEqual(msg['subject'], subject)
-        self.assertEqual(msg.get_charset(), None)
+        self.assertEqual(msg.get_charset(), Charset('utf-8'))
         self.assertEqual(msg.get('Content-Type'),
-                         'multipart/mixed')
+                         'multipart/mixed; charset="utf-8"')
 
         payload = msg.get_payload()
         assert isinstance(payload, list)

--- a/tests/test_mail.py
+++ b/tests/test_mail.py
@@ -108,6 +108,7 @@ class MailSenderTest(unittest.TestCase):
 
         msg = self.catched_msg['msg']
         self.assertEqual(msg['subject'], subject)
+        self.assertEqual(msg.get_charset(), Charset('utf-8'))
         self.assertEqual(msg.get('Content-Type'),
                          'multipart/mixed; charset="utf-8"')
 

--- a/tests/test_mail.py
+++ b/tests/test_mail.py
@@ -25,6 +25,7 @@ class MailSenderTest(unittest.TestCase):
         self.assertEqual(msg['subject'], 'subject')
         self.assertEqual(msg.get_payload(), 'body')
         self.assertEqual(msg.get('Content-Type'), 'text/plain')
+        self.assertEqual(msg.get_charset(), None)
 
     def test_send_single_values_to_and_cc(self):
         mailsender = MailSender(debug=True)
@@ -40,6 +41,7 @@ class MailSenderTest(unittest.TestCase):
         msg = self.catched_msg['msg']
         self.assertEqual(msg.get_payload(), '<p>body</p>')
         self.assertEqual(msg.get('Content-Type'), 'text/html')
+        self.assertEqual(msg.get_charset(), None)
 
     def test_send_attach(self):
         attach = BytesIO()
@@ -85,7 +87,7 @@ class MailSenderTest(unittest.TestCase):
 
         msg = self.catched_msg['msg']
         self.assertEqual(msg['subject'], subject)
-        self.assertEqual(msg.get_payload(), body)
+        self.assertEqual(msg.get_payload(decode=True).decode('utf-8'), body)
         self.assertEqual(msg.get_charset(), Charset('utf-8'))
         self.assertEqual(msg.get('Content-Type'), 'text/plain; charset="utf-8"')
 
@@ -108,9 +110,9 @@ class MailSenderTest(unittest.TestCase):
 
         msg = self.catched_msg['msg']
         self.assertEqual(msg['subject'], subject)
-        self.assertEqual(msg.get_charset(), Charset('utf-8'))
+        self.assertEqual(msg.get_charset(), None)
         self.assertEqual(msg.get('Content-Type'),
-                         'multipart/mixed; charset="utf-8"')
+                         'multipart/mixed')
 
         payload = msg.get_payload()
         assert isinstance(payload, list)

--- a/tests/test_mail.py
+++ b/tests/test_mail.py
@@ -86,7 +86,6 @@ class MailSenderTest(unittest.TestCase):
         msg = self.catched_msg['msg']
         self.assertEqual(msg['subject'], subject)
         self.assertEqual(msg.get_payload(), body)
-        self.assertEqual(msg.get_payload(), body)
         self.assertEqual(msg.get_charset(), Charset('utf-8'))
         self.assertEqual(msg.get('Content-Type'), 'text/plain; charset="utf-8"')
 
@@ -108,10 +107,9 @@ class MailSenderTest(unittest.TestCase):
         self.assertEqual(self.catched_msg['body'], body)
 
         msg = self.catched_msg['msg']
-        self.assertEqual(msg.get_charset(), Charset('utf-8'))
+        self.assertEqual(msg['subject'], subject)
         self.assertEqual(msg.get('Content-Type'),
                          'multipart/mixed; charset="utf-8"')
-        self.assertEqual(msg.get('Content-Type'), 'multipart/mixed; charset="utf-8"')
 
         payload = msg.get_payload()
         assert isinstance(payload, list)


### PR DESCRIPTION
Changes:
  
Implementation
- Set encoding utf-8 for payload inside send

Fixes #5096, closes #5118