### PR TITLE
When running the installer, I wasn't sure where to put the 'pip insta…

### DIFF
--- a/docs/intro/install.rst
+++ b/docs/intro/install.rst
@@ -26,7 +26,7 @@ To install Scrapy using ``conda``, run::
   conda install -c conda-forge scrapy
 
 Alternatively, if you’re already familiar with installation of Python packages,
-you can install Scrapy and its dependencies from PyPI with::
+you can install Scrapy and its dependencies from PyPI inside of the Python terminal with::
 
     pip install Scrapy
 


### PR DESCRIPTION
…ll Scrapy' command, so I added the 'inside of the Python terminal' part to line 29.