### PR TITLE
dictionary parameter support

### DIFF
--- a/scrapy/cmdline.py
+++ b/scrapy/cmdline.py
@@ -12,6 +12,7 @@ from scrapy.exceptions import UsageError
 from scrapy.utils.misc import walk_modules
 from scrapy.utils.project import inside_project, get_project_settings
 from scrapy.utils.python import garbage_collect
+from scrapy.settings import Settings
 
 
 def _iter_command_classes(module_name):
@@ -119,6 +120,8 @@ def execute(argv=None, settings=None):
             pass
         else:
             settings['EDITOR'] = editor
+    elif isinstance(settings, dict):
+        settings = Settings(settings)
 
     inproject = inside_project()
     cmds = _get_commands_dict(settings, inproject)


### PR DESCRIPTION

```python
from scrapy.cmdline import execute

execute(
        ['scrapy', 'runspider', 'myspider.py', '-O', 'blogs.json'],
        {'BOT_NAME': 'blogbot'} 
    )
```

Make compatible with this writing style