### PR TITLE
Fix doc: `scrapy.exporter` to `scrapy.exporters`

### DIFF
--- a/docs/topics/exporters.rst
+++ b/docs/topics/exporters.rst
@@ -117,7 +117,7 @@ after your custom code.
 
 Example::
 
-      from scrapy.exporter import XmlItemExporter
+      from scrapy.exporters import XmlItemExporter
 
       class ProductXmlExporter(XmlItemExporter):
 


### PR DESCRIPTION
Fix the import in the example.