### PR TITLE
Fixed intersphinx references

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -291,9 +291,9 @@ intersphinx_mapping = {
     'pytest': ('https://docs.pytest.org/en/latest', None),
     'python': ('https://docs.python.org/3', None),
     'sphinx': ('https://www.sphinx-doc.org/en/master', None),
-    'tox': ('https://tox.readthedocs.io/en/latest', None),
-    'twisted': ('https://twistedmatrix.com/documents/current', None),
-    'twistedapi': ('https://twistedmatrix.com/documents/current/api', None),
+    'tox': ('https://tox.wiki/en/latest/', None),
+    'twisted': ('https://docs.twisted.org/en/stable/', None),
+    'twistedapi': ('https://docs.twisted.org/en/stable/api/', None),
     'w3lib': ('https://w3lib.readthedocs.io/en/latest', None),
 }
 intersphinx_disabled_reftypes = []


### PR DESCRIPTION
Build is failing at master because a few pages changed their location. It should be fixed in this PR.