### PR TITLE
make Scrapy testing suite more robust in environments where non-existing hosts are resolvable

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -5,6 +5,7 @@ see https://docs.scrapy.org/en/latest/contributing.html#running-tests
 """
 
 import os
+import socket
 
 # ignore system-wide proxies for tests
 # which would send requests to a totally unsuspecting server
@@ -23,6 +24,15 @@ if 'COV_CORE_CONFIG' in os.environ:
 
 tests_datadir = os.path.join(os.path.abspath(os.path.dirname(__file__)),
                              'sample_data')
+
+
+# In some environments accessing a non-existing host doesn't raise an
+# error. In such cases we're going to skip tests which rely on it.
+try:
+    socket.getaddrinfo('non-existing-host', 80)
+    NON_EXISTING_RESOLVABLE = True
+except socket.gaierror:
+    NON_EXISTING_RESOLVABLE = False
 
 
 def get_testdata(*paths):

--- a/tests/test_command_shell.py
+++ b/tests/test_command_shell.py
@@ -6,7 +6,7 @@ from twisted.internet import defer
 from scrapy.utils.testsite import SiteTest
 from scrapy.utils.testproc import ProcessTest
 
-from tests import tests_datadir
+from tests import tests_datadir, NON_EXISTING_RESOLVABLE
 
 
 class ShellTest(ProcessTest, SiteTest, unittest.TestCase):
@@ -109,6 +109,8 @@ class ShellTest(ProcessTest, SiteTest, unittest.TestCase):
 
     @defer.inlineCallbacks
     def test_dns_failures(self):
+        if NON_EXISTING_RESOLVABLE:
+            raise unittest.SkipTest("Non-existing hosts are resolvable")
         url = 'www.somedomainthatdoesntexi.st'
         errcode, out, err = yield self.execute([url, '-c', 'item'], check_code=False)
         self.assertEqual(errcode, 1, out or err)

--- a/tests/test_crawl.py
+++ b/tests/test_crawl.py
@@ -3,6 +3,7 @@ import logging
 from ipaddress import IPv4Address
 from socket import gethostbyname
 from urllib.parse import urlparse
+import unittest
 
 from pytest import mark
 from testfixtures import LogCapture
@@ -17,6 +18,7 @@ from scrapy.exceptions import StopDownload
 from scrapy.http import Request
 from scrapy.http.response import Response
 from scrapy.utils.python import to_unicode
+from tests import NON_EXISTING_RESOLVABLE
 from tests.mockserver import MockServer
 from tests.spiders import (
     AsyncDefAsyncioGenComplexSpider,
@@ -137,6 +139,8 @@ class CrawlTestCase(TestCase):
 
     @defer.inlineCallbacks
     def test_retry_dns_error(self):
+        if NON_EXISTING_RESOLVABLE:
+            raise unittest.SkipTest("Non-existing hosts are resolvable")
         crawler = self.runner.create_crawler(SimpleSpider)
         with LogCapture() as log:
             # try to fetch the homepage of a non-existent domain

--- a/tests/test_downloader_handlers.py
+++ b/tests/test_downloader_handlers.py
@@ -4,7 +4,7 @@ import shutil
 import sys
 import tempfile
 from typing import Optional, Type
-from unittest import mock
+from unittest import mock, SkipTest
 
 from testfixtures import LogCapture
 from twisted.cred import checkers, credentials, portal
@@ -32,6 +32,7 @@ from scrapy.spiders import Spider
 from scrapy.utils.misc import create_instance
 from scrapy.utils.python import to_bytes
 from scrapy.utils.test import get_crawler, skip_if_no_boto
+from tests import NON_EXISTING_RESOLVABLE
 from tests.mockserver import (
     Echo,
     ForeverTakingResource,
@@ -791,6 +792,8 @@ class Http11ProxyTestCase(HttpProxyTestCase):
     @defer.inlineCallbacks
     def test_download_with_proxy_https_timeout(self):
         """ Test TunnelingTCP4ClientEndpoint """
+        if NON_EXISTING_RESOLVABLE:
+            raise SkipTest("Non-existing hosts are resolvable")
         http_proxy = self.getURL('')
         domain = 'https://no-such-domain.nosuch'
         request = Request(


### PR DESCRIPTION
This is an attempt to fix https://github.com/scrapy/scrapy/runs/7377071488?check_suite_focus=true failure.

```
================================== FAILURES ===================================
_________ Http11ProxyTestCase.test_download_with_proxy_https_timeout __________
self = <tests.test_downloader_handlers.Http11ProxyTestCase testMethod=test_download_with_proxy_https_timeout>
    @defer.inlineCallbacks
    def test_download_with_proxy_https_timeout(self):
        """ Test TunnelingTCP4ClientEndpoint """
        http_proxy = self.getURL('')
        domain = 'https://no-such-domain.nosuch/'
        request = Request(
            domain, meta={'proxy': http_proxy, 'download_timeout': 0.2})
        d = self.download_request(request, Spider('foo'))
>       timeout = yield self.assertFailure(d, error.TimeoutError)
D:\a\scrapy\scrapy\tests\test_downloader_handlers.py:799: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
D:\a\scrapy\scrapy\.tox\py\lib\site-packages\twisted\internet\defer.py:857: in _runCallbacks
    current.result = callback(  # type: ignore[misc]
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
failure = <twisted.python.failure.Failure twisted.web._newclient.ResponseNeverReceived: [<twisted.python.failure.Failure OpenSSL.SSL.Error: [('SSL routines', 'ssl3_get_record', 'wrong version number')]>]>
    def _eb(failure):
        if failure.check(*expectedFailures):
            return failure.value
        else:
            output = "\nExpected: {!r}\nGot:\n{}".format(
                expectedFailures, str(failure)
            )
>           raise self.failureException(output)
E           twisted.trial.unittest.FailTest: 
E           Expected: (<class 'twisted.internet.error.TimeoutError'>,)
E           Got:
E           [Failure instance: Traceback (failure with no frames): <class 'twisted.web._newclient.ResponseNeverReceived'>: [<twisted.python.failure.Failure OpenSSL.SSL.Error: [('SSL routines', 'ssl3_get_record', 'wrong version number')]>]
E           ]
D:\a\scrapy\scrapy\.tox\py\lib\site-packages\twisted\trial\_asynctest.py:76: FailTest
---------------------------- Captured stderr call -----------------------------
2022-07-17 11:16:25 [scrapy.crawler] INFO: Overridden settings:
{'REQUEST_FINGERPRINTER_IMPLEMENTATION': 'VERSION'}
2022-07-17 11:16:25 [scrapy.extensions.telnet] INFO: Telnet Password: 4d4fc6ef73c68a39
2022-07-17 11:16:25 [scrapy.middleware] INFO: Enabled extensions:
['scrapy.extensions.corestats.CoreStats',
 'scrapy.extensions.telnet.TelnetConsole',
 'scrapy.extensions.logstats.LogStats']
------------------------------ Captured log call ------------------------------
INFO     scrapy.crawler:crawler.py:61 Overridden settings:
{'REQUEST_FINGERPRINTER_IMPLEMENTATION': 'VERSION'}
INFO     scrapy.extensions.telnet:telnet.py:55 Telnet Password: 4d4fc6ef73c68a39
INFO     scrapy.middleware:middleware.py:51 Enabled extensions:
['scrapy.extensions.corestats.CoreStats',
 'scrapy.extensions.telnet.TelnetConsole',
 'scrapy.extensions.logstats.LogStats']
```

I've found a few places where it can be an issue, not sure if that's all of them.

Implementation is ported from Splash testing suite, where there was a similar issue - on some CI environments DNS resolution was successful for non-existing hosts.

The issue with this PR is that in the run above it only failed at one spot, not at all of them. It seems to be related to SSL. So, I'm not sure the fix in this PR is valid :)