### PR TITLE
Set an upper limit for the cache, otherwise it will cause oom

### DIFF
--- a/scrapy/pipelines/media.py
+++ b/scrapy/pipelines/media.py
@@ -1,6 +1,6 @@
 import functools
 import logging
-from collections import defaultdict, OrderedDict
+from collections import defaultdict
 from inspect import signature
 from warnings import warn
 
@@ -8,7 +8,7 @@ from twisted.internet.defer import Deferred, DeferredList
 from twisted.python.failure import Failure
 
 from scrapy.settings import Settings
-from scrapy.utils.datatypes import SequenceExclude
+from scrapy.utils.datatypes import SequenceExclude, LocalCache
 from scrapy.utils.defer import mustbe_deferred, defer_result
 from scrapy.utils.deprecate import ScrapyDeprecationWarning
 from scrapy.utils.misc import arg_to_iter
@@ -18,13 +18,14 @@ logger = logging.getLogger(__name__)
 
 
 class MediaPipeline:
+
     LOG_FAILED_RESULTS = True
 
     class SpiderInfo:
         def __init__(self, spider):
             self.spider = spider
             self.downloading = set()
-            self.downloaded = OrderedDict()
+            self.downloaded = LocalCache(10000)
             self.waiting = defaultdict(list)
 
     def __init__(self, download_func=None, settings=None):
@@ -39,10 +40,6 @@ class MediaPipeline:
         self.allow_redirects = settings.getbool(
             resolve('MEDIA_ALLOW_REDIRECTS'), False
         )
-        self.cache_downloaded_size = settings.getint(
-            resolve('CACHE_DOWNLOADED_SIZE'), 10000
-        )
-
         self._handle_statuses(self.allow_redirects)
 
         # Check if deprecated methods are being used and make them compatible
@@ -65,9 +62,9 @@ class MediaPipeline:
         class_name = self.__class__.__name__
         formatted_key = f"{class_name.upper()}_{key}"
         if (
-                not base_class_name
-                or class_name == base_class_name
-                or settings and not settings.get(formatted_key)
+            not base_class_name
+            or class_name == base_class_name
+            or settings and not settings.get(formatted_key)
         ):
             return key
         return formatted_key
@@ -118,7 +115,7 @@ class MediaPipeline:
         dfd.addBoth(self._cache_result_and_execute_waiters, fp, info)
         dfd.addErrback(lambda f: logger.error(
             f.value, exc_info=failure_to_exc_info(f), extra={'spider': info.spider})
-                       )
+        )
         return dfd.addBoth(lambda _: wad)  # it must return wad at last
 
     def _make_compatible(self):
@@ -215,8 +212,6 @@ class MediaPipeline:
                 setattr(result.value, '__context__', None)
 
         info.downloading.remove(fp)
-        if len(info.downloaded) >= self.cache_downloaded_size:
-            info.downloaded.popitem()
         info.downloaded[fp] = result  # cache result
         for wad in info.waiting.pop(fp):
             defer_result(result).chainDeferred(wad)


### PR DESCRIPTION
Sorry, this is my first time to submit PR for a large project, so it's a little nonstandard, this is a very serious problem. When a user associates scrapy with Redis or Kafka, or crawls a large number of tasks, it will lead to info.downloaded becomes very large, especially when the exception object is stored, it will cause OOM and cause the crawler to be killed by the system