### PR TITLE
logformatter_adapter - do not return args if not provided

### DIFF
--- a/scrapy/utils/log.py
+++ b/scrapy/utils/log.py
@@ -215,8 +215,6 @@ def logformatter_adapter(logkws):
 
     level = logkws.get('level', logging.INFO)
     message = logkws.get('format', logkws.get('msg'))
-    # NOTE: This also handles 'args' being an empty dict, that case doesn't
-    # play well in logger.log calls
-    args = logkws if not logkws.get('args') else logkws['args']
+    args = logkws.get('args')
 
-    return (level, message, args)
+    return (level, message, args) if args else (level, message)         # do not return args if they are not provided

--- a/scrapy/utils/log.py
+++ b/scrapy/utils/log.py
@@ -204,7 +204,7 @@ def logformatter_adapter(logkws):
     and adapts it into a tuple of positional arguments for logger.log calls,
     handling backward compatibility as well.
     """
-    if not {'level', 'msg', 'args'} <= set(logkws):
+    if not {'level', 'msg'} <= set(logkws):
         warnings.warn('Missing keys in LogFormatter method',
                       ScrapyDeprecationWarning)
 

--- a/scrapy/utils/log.py
+++ b/scrapy/utils/log.py
@@ -204,7 +204,7 @@ def logformatter_adapter(logkws):
     and adapts it into a tuple of positional arguments for logger.log calls,
     handling backward compatibility as well.
     """
-    if not {'level', 'msg'} <= set(logkws):
+    if not {'level', 'msg', 'args'} <= set(logkws):
         warnings.warn('Missing keys in LogFormatter method',
                       ScrapyDeprecationWarning)
 

--- a/tests/test_utils_log.py
+++ b/tests/test_utils_log.py
@@ -1,16 +1,17 @@
-import sys
 import logging
+import sys
 import unittest
+from warnings import catch_warnings
 
 from testfixtures import LogCapture
 from twisted.python.failure import Failure
 
-from scrapy.utils.log import (failure_to_exc_info, TopLevelFormatter,
-                              LogCounterHandler, StreamLogger, logformatter_adapter)
-from scrapy.utils.test import get_crawler
-from scrapy.extensions import telnet
 from scrapy.exceptions import ScrapyDeprecationWarning
-from warnings import catch_warnings
+from scrapy.extensions import telnet
+from scrapy.utils.log import (LogCounterHandler, StreamLogger,
+                              TopLevelFormatter, failure_to_exc_info,
+                              logformatter_adapter)
+from scrapy.utils.test import get_crawler
 
 
 class FailureToExcInfoTest(unittest.TestCase):

--- a/tests/test_utils_log.py
+++ b/tests/test_utils_log.py
@@ -1,17 +1,16 @@
-import logging
 import sys
+import logging
 import unittest
-from warnings import catch_warnings
 
 from testfixtures import LogCapture
 from twisted.python.failure import Failure
 
-from scrapy.exceptions import ScrapyDeprecationWarning
-from scrapy.extensions import telnet
-from scrapy.utils.log import (LogCounterHandler, StreamLogger,
-                              TopLevelFormatter, failure_to_exc_info,
-                              logformatter_adapter)
+from scrapy.utils.log import (failure_to_exc_info, TopLevelFormatter,
+                              LogCounterHandler, StreamLogger, logformatter_adapter)
 from scrapy.utils.test import get_crawler
+from scrapy.extensions import telnet
+from scrapy.exceptions import ScrapyDeprecationWarning
+from warnings import catch_warnings
 
 
 class FailureToExcInfoTest(unittest.TestCase):

--- a/tests/test_utils_log.py
+++ b/tests/test_utils_log.py
@@ -121,6 +121,6 @@ class LogFormatterAdapterTest(unittest.TestCase):
     def test_adapter_input_values(self):
         with catch_warnings(record=True) as _warnings:
             logformatter_adapter({'level': 20, 'msg': 'This is a message.', 'args': None, 'format': 'deprecated'})
-            logformatter_adapter({'level': 20, 'msg': 'This is a message.'})
+            logformatter_adapter({'msg': 'This is a message.'})
             self.assertEqual(len(_warnings), 2)
             self.assertTrue(all(i.category == ScrapyDeprecationWarning for i in _warnings))


### PR DESCRIPTION
This change corrects an issue where `args` are passed to `logging.log` no matter what Falsy-evaluated value is passed as the `args`.

Fixes #5570