### PR TITLE
Fix Feed Exporter issue with Post Processing

### DIFF
--- a/scrapy/extensions/feedexport.py
+++ b/scrapy/extensions/feedexport.py
@@ -350,13 +350,19 @@ class FeedExporter:
         return defer.DeferredList(deferred_list) if deferred_list else None
 
     def _close_slot(self, slot, spider):
+
+        def get_file(slot_):
+            if isinstance(slot_.file, PostProcessingManager):
+                return slot_.file.file
+            return slot_.file
+
         if not slot.itemcount and not slot.store_empty:
             # We need to call slot.storage.store nonetheless to get the file
             # properly closed.
-            return defer.maybeDeferred(slot.storage.store, slot.file)
+            return defer.maybeDeferred(slot.storage.store, get_file(slot))
         slot.finish_exporting()
         logmsg = f"{slot.format} feed ({slot.itemcount} items) in: {slot.uri}"
-        d = defer.maybeDeferred(slot.storage.store, slot.file)
+        d = defer.maybeDeferred(slot.storage.store, get_file(slot))
 
         d.addCallback(
             self._handle_store_success, logmsg, spider, type(slot.storage).__name__


### PR DESCRIPTION
#5500 

It fixes the issue above. It happens because when dealing with Post Processing, _file_ is wrapped around a `PostProcessingManager`, which becomes the *arg for the following procedures that will happen in `FeedExporter`. Those procedures believe they are handling directly the file: this is not the case when Post Processing is involved, since the file becomes an attribute of the `PostProcessingManager`  in these cases.

We need to test this, but it's a very straightforward bug nevertheless.