### PR TITLE
added feed_options parameter to GCS feed initializer and added logging/documentation about the overwrite=True parameter

### DIFF
--- a/scrapy/extensions/feedexport.py
+++ b/scrapy/extensions/feedexport.py
@@ -172,7 +172,7 @@ class S3FeedStorage(BlockingFeedStorage):
             aws_secret_access_key=self.secret_key,
             aws_session_token=self.session_token,
             endpoint_url=self.endpoint_url)
-        if feed_options and feed_options.get('overwrite', True) is False:
+        if feed_options is not None and feed_options.get('overwrite', True) is False:
             logger.warning('S3 does not support appending to files. To '
                            'suppress this warning, remove the overwrite '
                            'option from your FEEDS setting or set it to True.')
@@ -201,12 +201,16 @@ class S3FeedStorage(BlockingFeedStorage):
 
 class GCSFeedStorage(BlockingFeedStorage):
 
-    def __init__(self, uri, project_id, acl):
+    def __init__(self, uri, project_id, acl, feed_options=None):
         self.project_id = project_id
         self.acl = acl
         u = urlparse(uri)
         self.bucket_name = u.hostname
         self.blob_name = u.path[1:]  # remove first "/"
+        if feed_options is not None and feed_options.get('overwrite', True) is False:
+            logger.warning('Google Cloud Storage does not support appending to files. To '
+                           'suppress this warning, remove the overwrite '
+                           'option from your FEEDS setting or set it to True.')
 
     @classmethod
     def from_crawler(cls, crawler, uri):

--- a/scrapy/extensions/feedexport.py
+++ b/scrapy/extensions/feedexport.py
@@ -86,7 +86,9 @@ class IFeedStorage(Interface):
 
     def __init__(uri, *, feed_options=None):
         """Initialize the storage with the parameters given in the URI and the
-        feed-specific options (see :setting:`FEEDS`)"""
+        feed-specific options (see :setting:`FEEDS`).
+        CAREFUL: in `feed_options` the default `overwrite=True` will cause you to 
+        lose the previous version of your data"""
 
     def open(spider):
         """Open the storage for the given spider. It must return a file-like


### PR DESCRIPTION
- added documentation warning that using the overwrite parameter in the IFeedStorage class can cause data deletion
- Added the feed_options parameter to the GCS Feed storage class initializer
- Added logging in the GCS feed storage class saying that overwrite=False is not available

Resolves https://github.com/scrapy/scrapy/issues/5579