### PR TITLE
Match pyOpenSSL and service_identity to Twisted

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,13 +20,13 @@ def has_environment_marker_platform_impl_support():
 
 install_requires = [
     'Twisted>=18.9.0',
-    'cryptography>=2.8',
+    'cryptography>=3.3',
     'cssselect>=0.9.1',
     'itemloaders>=1.0.1',
     'parsel>=1.5.0',
-    'pyOpenSSL>=19.1.0',
+    'pyOpenSSL>=21.0.0',
     'queuelib>=1.4.2',
-    'service_identity>=16.0.0',
+    'service_identity>=18.1.0',
     'w3lib>=1.17.0',
     'zope.interface>=5.1.0',
     'protego>=0.1.15',

--- a/tests/test_crawler.py
+++ b/tests/test_crawler.py
@@ -327,7 +327,7 @@ class CrawlerProcessSubprocess(ScriptRunnerMixin, unittest.TestCase):
 
     def test_reactor_default_twisted_reactor_select(self):
         log = self.run_script('reactor_default_twisted_reactor_select.py')
-        if platform.system() == 'Windows':
+        if platform.system() in ['Windows', 'Darwin']:
             # The goal of this test function is to test that, when a reactor is
             # installed (the default one here) and a different reactor is
             # configured (select here), an error raises.

--- a/tox.ini
+++ b/tox.ini
@@ -73,15 +73,15 @@ commands =
 
 [pinned]
 deps =
-    cryptography==2.8
+    cryptography==3.3
     cssselect==0.9.1
     h2==3.0
     itemadapter==0.1.0
     parsel==1.5.0
     Protego==0.1.15
-    pyOpenSSL==19.1.0
+    pyOpenSSL==21.0.0
     queuelib==1.4.2
-    service_identity==16.0.0
+    service_identity==18.1.0
     Twisted[http2]==18.9.0
     w3lib==1.17.0
     zope.interface==5.1.0


### PR DESCRIPTION
Resolves #5621

Signed-off-by: Gábor Lipták <gliptak@gmail.com>

Correcting https://github.com/scrapy/scrapy/actions/runs/3052958225/jobs/4922962575

```
    from twisted.internet import error, tcp, udp
.tox/py/lib/python3.8/site-packages/twisted/internet/tcp.py:38: in <module>
    from twisted.internet._newtls import (
.tox/py/lib/python3.8/site-packages/twisted/internet/_newtls.py:18: in <module>
    from twisted.protocols.tls import TLSMemoryBIOFactory, TLSMemoryBIOProtocol
.tox/py/lib/python3.8/site-packages/twisted/protocols/tls.py:45: in <module>
    from twisted.internet._sslverify import _setAcceptableProtocols
.tox/py/lib/python3.8/site-packages/twisted/internet/_sslverify.py:1828: in <module>
    defaultCiphers = OpenSSLAcceptableCiphers.fromOpenSSLCipherString(
.tox/py/lib/python3.8/site-packages/twisted/internet/_sslverify.py:1807: in fromOpenSSLCipherString
    SSL.TLS_METHOD,
E   AttributeError: module 'OpenSSL.SSL' has no attribute 'TLS_METHOD'
```