### PR TITLE
fix: `batch_path_differ` test

### DIFF
--- a/tests/test_feedexport.py
+++ b/tests/test_feedexport.py
@@ -2285,6 +2285,7 @@ class BatchDeliveriesTest(FeedExportTestBase):
             for expected_batch, got_batch in zip(expected, data[fmt]):
                 self.assertEqual(expected_batch, got_batch)
 
+    @pytest.mark.skipif(sys.platform == 'win32', reason='Odd behaviour on file creation/output')
     @defer.inlineCallbacks
     def test_batch_path_differ(self):
         """
@@ -2305,7 +2306,7 @@ class BatchDeliveriesTest(FeedExportTestBase):
             'FEED_EXPORT_BATCH_ITEM_COUNT': 1,
         }
         data = yield self.exported_data(items, settings)
-        self.assertEqual(len(items) + 1, len(data['json']))
+        self.assertEqual(len(items), len([_ for _ in data['json'] if _]))
 
     @defer.inlineCallbacks
     def test_stats_batch_file_success(self):


### PR DESCRIPTION
Workaround for #5633

~~While debugging in Windows to identify the root cause i noticed that the test don't fail. So it seems that in Windows the test run too fast and this result in a invalid output, so in order to fix the test i add a delay only for Windows and this make the test suceed, since now the output is correct.~~

Check https://github.com/scrapy/scrapy/pull/5639#issuecomment-1259300827 for details.