### PR TITLE
WIP: Add functionality to auto cast int, float and bools passed as in…

### DIFF
--- a/scrapy/utils/python.py
+++ b/scrapy/utils/python.py
@@ -225,6 +225,21 @@ def get_func_args(func, stripself=False):
     return func_args
 
 
+def strtobool(val):
+    """Convert a string representation of truth to true or false.
+    True values are 'y', 'yes', 't', 'true', 'on', and '1'; false values
+    are 'n', 'no', 'f', 'false', 'off', and '0'.  Raises ValueError if
+    'val' is anything else.
+    """
+    val = val.lower()
+    if val in ('y', 'yes', 't', 'true', 'on', '1'):
+        return True
+    elif val in ('n', 'no', 'f', 'false', 'off', '0'):
+        return False
+    else:
+        raise ValueError("invalid truth value %r" % (val,))
+
+
 def get_spec(func):
     """Returns (args, kwargs) tuple for a function
     >>> import re

--- a/tests/test_utils_python.py
+++ b/tests/test_utils_python.py
@@ -13,7 +13,9 @@ from scrapy.utils.defer import deferred_f_from_coro_f, aiter_errback
 from scrapy.utils.python import (
     memoizemethod_noargs, binary_is_text, equal_attributes,
     WeakKeyCache, get_func_args, to_bytes, to_unicode,
-    without_none_values, MutableChain, MutableAsyncChain)
+    without_none_values, MutableChain, MutableAsyncChain,
+    strtobool
+)
 
 
 __doctests__ = ['scrapy.utils.python']
@@ -285,6 +287,14 @@ class UtilsPythonTestCase(unittest.TestCase):
         self.assertEqual(
             without_none_values({'one': 1, 'none': None, 'three': 3, 'four': 4}),
             {'one': 1, 'three': 3, 'four': 4})
+
+    def test_strtobool(self):
+        for yes in ('y', 'yes', 't', 'true', 'on', '1'):
+            self.assertTrue(strtobool(yes))
+        for no in ('n', 'no', 'f', 'false', 'off', '0'):
+            self.assertFalse(strtobool(no))
+        for no_valid in ('nope', 'yepe', 'foo', 'bar'):
+            self.assertRaises(ValueError, strtobool, no_valid)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Add functionality to cast int, float and bools passed as inputs args to the spider if they are typed class attributes or typed parameters of __init__ method
