### PR TITLE
Correct distutils deprecation warning

### DIFF
--- a/scrapy/utils/display.py
+++ b/scrapy/utils/display.py
@@ -5,7 +5,7 @@ pprint and pformat wrappers with colorization support
 import ctypes
 import platform
 import sys
-from distutils.version import LooseVersion as parse_version
+from packaging.version import Version as parse_version
 from pprint import pformat as pformat_
 
 

--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,7 @@ install_requires = [
     'protego>=0.1.15',
     'itemadapter>=0.1.0',
     'setuptools',
+    'packaging',
     'tldextract',
     'lxml>=4.3.0',
 ]


### PR DESCRIPTION
Signed-off-by: Gábor Lipták <gliptak@gmail.com>

```
DeprecationWarning: distutils Version classes are deprecated. Use packaging.version instead.
```