### PR TITLE
Converted README.rst to README.md and made copy command available

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,75 @@
+[![image](https://scrapy.org/img/scrapylogo.png)](https://scrapy.org/)
+
+# Scrapy
+
+[![PyPI Version](https://img.shields.io/pypi/v/Scrapy.svg)](https://pypi.python.org/pypi/Scrapy)
+[![Supported Python Versions](https://img.shields.io/pypi/pyversions/Scrapy.svg)](https://pypi.python.org/pypi/Scrapy)
+[![Ubuntu](https://github.com/scrapy/scrapy/workflows/Ubuntu/badge.svg)](https://github.com/scrapy/scrapy/actions?query=workflow%3AUbuntu)
+[![macOS](https://github.com/scrapy/scrapy/workflows/macOS/badge.svg)](https://github.com/scrapy/scrapy/actions?query=workflow%3AmacOS)
+[![Windows](https://github.com/scrapy/scrapy/workflows/Windows/badge.svg)](https://github.com/scrapy/scrapy/actions?query=workflow%3AWindows)
+[![Wheel Status](https://img.shields.io/badge/wheel-yes-brightgreen.svg)](https://pypi.python.org/pypi/Scrapy)
+[![Coverage report](https://img.shields.io/codecov/c/github/scrapy/scrapy/master.svg)](https://codecov.io/github/scrapy/scrapy?branch=master)
+[![Conda Version](https://anaconda.org/conda-forge/scrapy/badges/version.svg)](https://anaconda.org/conda-forge/scrapy)
+
+## Overview
+
+Scrapy is a fast high-level web crawling and web scraping framework,
+used to crawl websites and extract structured data from their pages. It
+can be used for a wide range of purposes, from data mining to monitoring
+and automated testing.
+
+Scrapy is maintained by [Zyte](https://www.zyte.com/) (formerly
+Scrapinghub) and [many other
+contributors](https://github.com/scrapy/scrapy/graphs/contributors).
+
+Check the Scrapy homepage at <https://scrapy.org> for more information,
+including a list of features.
+
+## Requirements
+
+-   Python 3.7+
+-   Works on Linux, Windows, macOS, BSD
+
+## Install
+
+The quick way:
+```
+pip install scrapy
+```
+See the install section in the documentation at
+<https://docs.scrapy.org/en/latest/intro/install.html> for more details.
+
+## Documentation
+
+Documentation is available online at <https://docs.scrapy.org/> and in
+the `docs` directory.
+
+## Releases
+
+You can check <https://docs.scrapy.org/en/latest/news.html> for the
+release notes.
+
+## Community (blog, twitter, mail list, IRC)
+
+See <https://scrapy.org/community/> for details.
+
+## Contributing
+
+See <https://docs.scrapy.org/en/master/contributing.html> for details.
+
+### Code of Conduct
+
+Please note that this project is released with a Contributor Code of
+Conduct (see
+<https://github.com/scrapy/scrapy/blob/master/CODE_OF_CONDUCT.md>).
+
+By participating in this project you agree to abide by its terms. Please
+report unacceptable behavior to <opensource@zyte.com>.
+
+## Companies using Scrapy
+
+See <https://scrapy.org/companies/> for a list.
+
+## Commercial Support
+
+See <https://scrapy.org/support/> for details.


### PR DESCRIPTION
# Greetings!
> Referencing #5647 
- Converted README.rst to README.md.
- All links are redirecting to their previous links.
- The **install pip scrapy** pip command is now copyable.
## Should I remove the .rst file completely?

> This is me contributing to such a big project for the first time. 
> Hoping to get this PR merged and prove myself valuable!
> Hacktober was the main source of pushing myself to contribute and trying to understand the code. 
> Kudos to maintainers!