### PR TITLE
ci: add stalebot cron

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,17 @@
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 15,22 * * 1-5'
+jobs:
+  check_stale:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/stale@v6
+      with:
+        days-before-stale: 7
+        days-before-issue-stale: -1
+        days-before-close: 3
+        exempt-pr-labels: 'in progress'
+        stale-pr-message: >
+          This PR has been marked as stale after 7 or more days of inactivity and will be closed in 3 days.
+          To keep this PR open please request a maintainer to add the 'in progress' label.


### PR DESCRIPTION
At the moment there are 292 pull requests open dating back to 2015. These are likely stale and either would require large refactors to bring up to date in order to be compatible with the most recent code or closed all together. This PR adds a github workflow to run stalebot to automatically mark PRs that have been open 7+ days as stale and subsequently close them 3 days later if they are not marked as in progress.

I'm open to feedback on configuring these values (as well as the labels that bypass the stale check) to whatever fit the project.