### PR TITLE
Python 3.11 support

### DIFF
--- a/.github/workflows/tests-ubuntu.yml
+++ b/.github/workflows/tests-ubuntu.yml
@@ -20,6 +20,12 @@ jobs:
         - python-version: "3.10"
           env:
             TOXENV: asyncio
+        - python-version: "3.11.0-rc.2"
+          env:
+            TOXENV: py
+        - python-version: "3.11.0-rc.2"
+          env:
+            TOXENV: asyncio
         - python-version: pypy3
           env:
             TOXENV: pypy3
@@ -53,7 +59,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
 
     - name: Install system libraries
-      if: matrix.python-version == 'pypy3' || contains(matrix.env.TOXENV, 'pinned') || matrix.python-version == '3.10.0-beta.4'
+      if: matrix.python-version == 'pypy3' || contains(matrix.env.TOXENV, 'pinned') || matrix.python-version == '3.11.0-rc.2'
       run: |
         sudo apt-get update
         # libxml2 2.9.12 from ondrej/php PPA breaks lxml so we pin it to the bionic-updates repo version

--- a/scrapy/utils/python.py
+++ b/scrapy/utils/python.py
@@ -180,23 +180,6 @@ def binary_is_text(data):
     return all(c not in _BINARYCHARS for c in data)
 
 
-def _getargspec_py23(func):
-    """_getargspec_py23(function) -> named tuple ArgSpec(args, varargs, keywords,
-                                                        defaults)
-
-    Was identical to inspect.getargspec() in python2, but uses
-    inspect.getfullargspec() for python3 behind the scenes to avoid
-    DeprecationWarning.
-
-    >>> def f(a, b=2, *ar, **kw):
-    ...     pass
-
-    >>> _getargspec_py23(f)
-    ArgSpec(args=['a', 'b'], varargs='ar', keywords='kw', defaults=(2,))
-    """
-    return inspect.ArgSpec(*inspect.getfullargspec(func)[:4])
-
-
 def get_func_args(func, stripself=False):
     """Return the argument name list of a callable"""
     if inspect.isfunction(func):
@@ -248,9 +231,9 @@ def get_spec(func):
     """
 
     if inspect.isfunction(func) or inspect.ismethod(func):
-        spec = _getargspec_py23(func)
+        spec = inspect.getfullargspec(func)
     elif hasattr(func, '__call__'):
-        spec = _getargspec_py23(func.__call__)
+        spec = inspect.getfullargspec(func.__call__)
     else:
         raise TypeError(f'{type(func)} is not callable')
 


### PR DESCRIPTION
It looks like we can finally run CI on 3.11 and it fails. So this is the first step for adding support for 3.11.