### PR TITLE
Added to the microsoft download instructions, instructions for WSL

### DIFF
--- a/docs/intro/install.rst
+++ b/docs/intro/install.rst
@@ -130,6 +130,8 @@ To install Scrapy on Windows using ``pip``:
 
 Now, you should be able to :ref:`install Scrapy <intro-install-scrapy>` using ``pip``.
 
+To install Scrapy on Windows with `WSL`_, follow the Unbuntu instructions.
+
 .. _intro-install-ubuntu:
 
 Ubuntu 14.04 or above


### PR DESCRIPTION
I added the instructions to direct the user to the Unbuntu instructions if they are using WSL, but for the pip installation without compiling modules, it was too inconsistent to include it for now and the same for the lxml stuff, but I will likely come back to that.