### PR TITLE
Update PyPy version in documentation

### DIFF
--- a/docs/intro/install.rst
+++ b/docs/intro/install.rst
@@ -10,7 +10,7 @@ Supported Python versions
 =========================
 
 Scrapy requires Python 3.7+, either the CPython implementation (default) or
-the PyPy 7.3.5+ implementation (see :ref:`python:implementations`).
+the PyPy 7.3.9+ implementation (see :ref:`python:implementations`).
 
 .. _intro-install-scrapy:
 
@@ -219,7 +219,7 @@ After any of these workarounds you should be able to install Scrapy::
 PyPy
 ----
 
-We recommend using the latest PyPy version. The version tested is 5.9.0.
+We recommend using the latest PyPy version. The version tested is 7.3.9.
 For PyPy3, only Linux installation was tested.
 
 Most Scrapy dependencies now have binary wheels for CPython, but not for PyPy.

--- a/docs/intro/install.rst
+++ b/docs/intro/install.rst
@@ -10,7 +10,7 @@ Supported Python versions
 =========================
 
 Scrapy requires Python 3.7+, either the CPython implementation (default) or
-the PyPy 7.3.9+ implementation (see :ref:`python:implementations`).
+the PyPy implementation (see :ref:`python:implementations`).
 
 .. _intro-install-scrapy:
 
@@ -219,7 +219,7 @@ After any of these workarounds you should be able to install Scrapy::
 PyPy
 ----
 
-We recommend using the latest PyPy version. The version tested is 7.3.9.
+We recommend using the latest PyPy version.
 For PyPy3, only Linux installation was tested.
 
 Most Scrapy dependencies now have binary wheels for CPython, but not for PyPy.


### PR DESCRIPTION
The first one i bumped to match the same version of pypy3.7, after this PR was merged:
- https://github.com/scrapy/scrapy/pull/5667

I was in doubt about what version to use in second statement but both pypy3.7 and pypy3.9 use the same version, maybe we could remove this paragraph altogether since now is redundant? Version 5.9.0 is from 2017-10-05.