### PR TITLE
Get eventloop from event_loop_policy to avoid deprecation warning.

### DIFF
--- a/scrapy/utils/defer.py
+++ b/scrapy/utils/defer.py
@@ -269,7 +269,8 @@ def deferred_from_coro(o) -> Any:
             return ensureDeferred(o)
         else:
             # wrapping the coroutine into a Future and then into a Deferred, this requires AsyncioSelectorReactor
-            return Deferred.fromFuture(asyncio.ensure_future(o))
+            event_loop = get_asyncio_event_loop_policy().get_event_loop()
+            return Deferred.fromFuture(asyncio.ensure_future(o, loop=event_loop))
     return o
 
 

--- a/scrapy/utils/defer.py
+++ b/scrapy/utils/defer.py
@@ -26,7 +26,7 @@ from twisted.python import failure
 from twisted.python.failure import Failure
 
 from scrapy.exceptions import IgnoreRequest
-from scrapy.utils.reactor import is_asyncio_reactor_installed
+from scrapy.utils.reactor import is_asyncio_reactor_installed, get_asyncio_event_loop_policy
 
 
 def defer_fail(_failure: Failure) -> Deferred:
@@ -320,7 +320,8 @@ def deferred_to_future(d: Deferred) -> Future:
                 d = treq.get('https://example.com/additional')
                 additional_response = await deferred_to_future(d)
     """
-    return d.asFuture(asyncio.get_event_loop())
+    policy = get_asyncio_event_loop_policy()
+    return d.asFuture(policy.get_event_loop())
 
 
 def maybe_deferred_to_future(d: Deferred) -> Union[Deferred, Future]:

--- a/scrapy/utils/reactor.py
+++ b/scrapy/utils/reactor.py
@@ -51,6 +51,19 @@ class CallLaterOnce:
         return self._func(*self._a, **self._kw)
 
 
+def get_asyncio_event_loop_policy():
+    policy = asyncio.get_event_loop_policy()
+    if (
+        sys.version_info >= (3, 8)
+        and sys.platform == "win32"
+        and not isinstance(policy, asyncio.WindowsSelectorEventLoopPolicy)
+    ):
+        policy = asyncio.WindowsSelectorEventLoopPolicy()
+        asyncio.set_event_loop_policy(policy)
+
+    return policy
+
+
 def install_reactor(reactor_path, event_loop_path=None):
     """Installs the :mod:`~twisted.internet.reactor` with the specified
     import path. Also installs the asyncio event loop with the specified import
@@ -58,15 +71,7 @@ def install_reactor(reactor_path, event_loop_path=None):
     reactor_class = load_object(reactor_path)
     if reactor_class is asyncioreactor.AsyncioSelectorReactor:
         with suppress(error.ReactorAlreadyInstalledError):
-            policy = asyncio.get_event_loop_policy()
-            if (
-                sys.version_info >= (3, 8)
-                and sys.platform == "win32"
-                and not isinstance(policy, asyncio.WindowsSelectorEventLoopPolicy)
-            ):
-                policy = asyncio.WindowsSelectorEventLoopPolicy()
-                asyncio.set_event_loop_policy(policy)
-
+            policy = get_asyncio_event_loop_policy()
             if event_loop_path is not None:
                 event_loop_class = load_object(event_loop_path)
                 event_loop = event_loop_class()

--- a/scrapy/utils/reactor.py
+++ b/scrapy/utils/reactor.py
@@ -59,8 +59,11 @@ def install_reactor(reactor_path, event_loop_path=None):
     if reactor_class is asyncioreactor.AsyncioSelectorReactor:
         with suppress(error.ReactorAlreadyInstalledError):
             policy = asyncio.get_event_loop_policy()
-            if sys.version_info >= (3, 8) and sys.platform == "win32":
-                if not isinstance(policy, asyncio.WindowsSelectorEventLoopPolicy):
+            if (
+                sys.version_info >= (3, 8)
+                and sys.platform == "win32"
+                and not isinstance(policy, asyncio.WindowsSelectorEventLoopPolicy)
+            ):
                     policy = asyncio.WindowsSelectorEventLoopPolicy()
                     asyncio.set_event_loop_policy(policy)
 

--- a/scrapy/utils/reactor.py
+++ b/scrapy/utils/reactor.py
@@ -58,16 +58,19 @@ def install_reactor(reactor_path, event_loop_path=None):
     reactor_class = load_object(reactor_path)
     if reactor_class is asyncioreactor.AsyncioSelectorReactor:
         with suppress(error.ReactorAlreadyInstalledError):
+            policy = asyncio.get_event_loop_policy()
             if sys.version_info >= (3, 8) and sys.platform == "win32":
-                policy = asyncio.get_event_loop_policy()
                 if not isinstance(policy, asyncio.WindowsSelectorEventLoopPolicy):
-                    asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
+                    policy = asyncio.WindowsSelectorEventLoopPolicy()
+                    asyncio.set_event_loop_policy(policy)
+
             if event_loop_path is not None:
                 event_loop_class = load_object(event_loop_path)
                 event_loop = event_loop_class()
                 asyncio.set_event_loop(event_loop)
             else:
-                event_loop = asyncio.get_event_loop()
+                event_loop = policy.get_event_loop()
+
             asyncioreactor.install(eventloop=event_loop)
     else:
         *module, _ = reactor_path.split(".")

--- a/scrapy/utils/reactor.py
+++ b/scrapy/utils/reactor.py
@@ -64,8 +64,8 @@ def install_reactor(reactor_path, event_loop_path=None):
                 and sys.platform == "win32"
                 and not isinstance(policy, asyncio.WindowsSelectorEventLoopPolicy)
             ):
-                    policy = asyncio.WindowsSelectorEventLoopPolicy()
-                    asyncio.set_event_loop_policy(policy)
+                policy = asyncio.WindowsSelectorEventLoopPolicy()
+                asyncio.set_event_loop_policy(policy)
 
             if event_loop_path is not None:
                 event_loop_class = load_object(event_loop_path)

--- a/tests/test_utils_asyncio.py
+++ b/tests/test_utils_asyncio.py
@@ -1,3 +1,4 @@
+import warnings
 from unittest import TestCase
 
 from pytest import mark
@@ -13,5 +14,6 @@ class AsyncioTest(TestCase):
         self.assertEqual(is_asyncio_reactor_installed(), self.reactor_pytest == 'asyncio')
 
     def test_install_asyncio_reactor(self):
-        # this should do nothing
-        install_reactor("twisted.internet.asyncioreactor.AsyncioSelectorReactor")
+        with warnings.catch_warnings(record=True) as w:
+            install_reactor("twisted.internet.asyncioreactor.AsyncioSelectorReactor")
+            self.assertEqual(len(w), 0)


### PR DESCRIPTION
Fixes #5685

Use `policy.get_event_loop()` instead of `asyncio.get_event_loop()`.  
If there is no event loop running, policy will create new_event_loop.

