### PR TITLE
Handle deprecated warning with try except block

### DIFF
--- a/scrapy/pipelines/images.py
+++ b/scrapy/pipelines/images.py
@@ -164,7 +164,7 @@ class ImagesPipeline(FilesPipeline):
                 # Image.Resampling.LANCZOS was added in Pillow 9.1.0
                 # remove this try except block,
                 # when updating the minimum requirements for Pillow.
-                resampling_filter =  self._Image.Resampling.LANCZOS
+                resampling_filter = self._Image.Resampling.LANCZOS
             except AttributeError:
                 resampling_filter = self._Image.ANTIALIAS
             image.thumbnail(size, resampling_filter)

--- a/scrapy/pipelines/images.py
+++ b/scrapy/pipelines/images.py
@@ -160,7 +160,14 @@ class ImagesPipeline(FilesPipeline):
 
         if size:
             image = image.copy()
-            image.thumbnail(size, self._Image.ANTIALIAS)
+            try:
+                # Image.Resampling.LANCZOS was added in Pillow 9.1.0
+                # remove this try except block,
+                # when updating the minimum requirements for Pillow.
+                resampling_filter =  self._Image.Resampling.LANCZOS
+            except AttributeError:
+                resampling_filter = self._Image.ANTIALIAS
+            image.thumbnail(size, resampling_filter)
 
         buf = BytesIO()
         image.save(buf, 'JPEG')


### PR DESCRIPTION
fixes #5684 
Using try except block to support backward compablility of order version of Pillow. It can we removed when the minimum requirement of Pillow is updated. 