### PR TITLE
Use Python 3.11 as the default in CI

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -8,10 +8,10 @@ jobs:
       fail-fast: false
       matrix:
         include:
-        - python-version: "3.10"
+        - python-version: "3.11"
           env:
             TOXENV: security
-        - python-version: "3.10"
+        - python-version: "3.11"
           env:
             TOXENV: flake8
         # Pylint requires installing reppy, which does not support Python 3.9
@@ -22,10 +22,10 @@ jobs:
         - python-version: 3.7
           env:
             TOXENV: typing
-        - python-version: "3.10"  # Keep in sync with .readthedocs.yml
+        - python-version: "3.11"  # Keep in sync with .readthedocs.yml
           env:
             TOXENV: docs
-        - python-version: "3.10"
+        - python-version: "3.11"
           env:
             TOXENV: twinecheck
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,7 +12,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: "3.10"
+        python-version: "3.11"
 
     - name: Check Tag
       id: check-release-tag

--- a/.github/workflows/tests-macos.yml
+++ b/.github/workflows/tests-macos.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/tests-ubuntu.yml
+++ b/.github/workflows/tests-ubuntu.yml
@@ -17,13 +17,10 @@ jobs:
         - python-version: "3.10"
           env:
             TOXENV: py
-        - python-version: "3.10"
-          env:
-            TOXENV: asyncio
-        - python-version: "3.11.0-rc.2"
+        - python-version: "3.11"
           env:
             TOXENV: py
-        - python-version: "3.11.0-rc.2"
+        - python-version: "3.11"
           env:
             TOXENV: asyncio
         - python-version: pypy3.9
@@ -57,7 +54,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
 
     - name: Install system libraries
-      if: matrix.python-version == 'pypy3.9' || contains(matrix.env.TOXENV, 'pinned') || matrix.python-version == '3.11.0-rc.2'
+      if: matrix.python-version == 'pypy3.9' || contains(matrix.env.TOXENV, 'pinned')
       run: |
         sudo apt-get update
         sudo apt-get install libxml2-dev libxslt-dev

--- a/.github/workflows/tests-windows.yml
+++ b/.github/workflows/tests-windows.yml
@@ -20,12 +20,16 @@ jobs:
         - python-version: "3.10"
           env:
             TOXENV: py
-        - python-version: "3.11"
-          env:
-            TOXENV: py
-        - python-version: "3.11"
+        - python-version: "3.10"
           env:
             TOXENV: asyncio
+# no binary package for lxml for 3.11 yet
+#        - python-version: "3.11"
+#          env:
+#            TOXENV: py
+#        - python-version: "3.11"
+#          env:
+#            TOXENV: asyncio
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/tests-windows.yml
+++ b/.github/workflows/tests-windows.yml
@@ -20,7 +20,10 @@ jobs:
         - python-version: "3.10"
           env:
             TOXENV: py
-        - python-version: "3.10"
+        - python-version: "3.11"
+          env:
+            TOXENV: py
+        - python-version: "3.11"
           env:
             TOXENV: asyncio
 

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -9,7 +9,7 @@ build:
   tools:
     # For available versions, see:
     # https://docs.readthedocs.io/en/stable/config-file/v2.html#build-tools-python
-    python: "3.10"  # Keep in sync with .github/workflows/checks.yml
+    python: "3.11"  # Keep in sync with .github/workflows/checks.yml
 
 python:
   install:


### PR DESCRIPTION
Except on Windows. Windows doesn't have lxml built yet.