### PR TITLE
added typing.io and typing.re in pytest warning filter to ignore

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -24,3 +24,5 @@ markers =
 filterwarnings =
     ignore:scrapy.downloadermiddlewares.decompression is deprecated
     ignore:Module scrapy.utils.reqser is deprecated
+    ignore:typing.re is deprecated
+    ignore:typing.io is deprecated


### PR DESCRIPTION
fixes #5686  

Added typing.io and typing.re in pytest warning filter to ignore.