### PR TITLE
CrawlSpider: pass cb_kwargs from process_request

### DIFF
--- a/scrapy/spiders/crawl.py
+++ b/scrapy/spiders/crawl.py
@@ -102,9 +102,9 @@ class CrawlSpider(Spider):
                 request = self._build_request(rule_index, link)
                 yield rule.process_request(request, response)
 
-    def _callback(self, response):
+    def _callback(self, response, **cb_kwargs):
         rule = self._rules[response.meta['rule']]
-        return self._parse_response(response, rule.callback, rule.cb_kwargs, rule.follow)
+        return self._parse_response(response, rule.callback, {**rule.cb_kwargs, **cb_kwargs}, rule.follow)
 
     def _errback(self, failure):
         rule = self._rules[failure.request.meta['rule']]

--- a/tests/spiders.py
+++ b/tests/spiders.py
@@ -419,6 +419,17 @@ class CrawlSpiderWithErrback(CrawlSpiderWithParseMethod):
         self.logger.info('[errback] status %i', failure.value.response.status)
 
 
+class CrawlSpiderWithProcessRequestCallbackKeywordArguments(CrawlSpiderWithParseMethod):
+    name = 'crawl_spider_with_process_request_cb_kwargs'
+    rules = (
+        Rule(LinkExtractor(), callback='parse', follow=True, process_request="process_request"),
+    )
+
+    def process_request(self, request, response):
+        request.cb_kwargs["foo"] = "process_request"
+        return request
+
+
 class BytesReceivedCallbackSpider(MetaSpider):
 
     full_response_length = 2**18

--- a/tests/test_crawl.py
+++ b/tests/test_crawl.py
@@ -41,6 +41,7 @@ from tests.spiders import (
     CrawlSpiderWithAsyncGeneratorCallback,
     CrawlSpiderWithErrback,
     CrawlSpiderWithParseMethod,
+    CrawlSpiderWithProcessRequestCallbackKeywordArguments,
     DelaySpider,
     DuplicateStartRequestsSpider,
     FollowAllSpider,
@@ -425,6 +426,16 @@ class CrawlSpiderTestCase(TestCase):
         self.assertIn("[errback] status 404", str(log))
         self.assertIn("[errback] status 500", str(log))
         self.assertIn("[errback] status 501", str(log))
+
+    @defer.inlineCallbacks
+    def test_crawlspider_process_request_cb_kwargs(self):
+        crawler = get_crawler(CrawlSpiderWithProcessRequestCallbackKeywordArguments)
+        with LogCapture() as log:
+            yield crawler.crawl(mockserver=self.mockserver)
+
+        self.assertIn("[parse] status 200 (foo: process_request)", str(log))
+        self.assertIn("[parse] status 201 (foo: process_request)", str(log))
+        self.assertIn("[parse] status 202 (foo: bar)", str(log))
 
     @defer.inlineCallbacks
     def test_async_def_parse(self):


### PR DESCRIPTION
`CrawlSpider._callback` is not passing any keyword arguments it might receive to `CrawlSpider._parse_response`.
I'm currently giving priority to the arguments set in `process_request` over the ones set in the rule, this could be open to discussion.

~~Missing tests, will add them soon.~~ Added

Sample spider:
```python
from scrapy.spiders import CrawlSpider, Rule

class ExampleSpider(CrawlSpider):
    name = "example"
    start_urls = ["https://example.org"]
    rules = (
        Rule(
            process_request="process_request",
            callback="parse_item",
        ),
    )

    def process_request(self, request, response):
        request.cb_kwargs["foo"] = "bar"
        return request

    def parse_item(self, response, foo):
        return {"url": response.url, "foo": foo}
```

Without this patch, at 9077d0f9b490114f117c668f115240c16afccedf (latest `master` branch)
```
2022-10-30 13:15:04 [scrapy.core.engine] INFO: Spider opened
2022-10-30 13:15:04 [scrapy.extensions.logstats] INFO: Crawled 0 pages (at 0 pages/min), scraped 0 items (at 0 items/min)
2022-10-30 13:15:04 [scrapy.extensions.telnet] INFO: Telnet console listening on 127.0.0.1:6023
2022-10-30 13:15:05 [scrapy.core.engine] DEBUG: Crawled (200) <GET https://example.org> (referer: None)
2022-10-30 13:15:06 [scrapy.downloadermiddlewares.redirect] DEBUG: Redirecting (301) to <GET http://www.iana.org/domains/reserved> from <GET https://www.iana.org/domains/example>
2022-10-30 13:15:06 [scrapy.core.engine] DEBUG: Crawled (200) <GET http://www.iana.org/domains/reserved> (referer: None)
2022-10-30 13:15:06 [scrapy.core.scraper] ERROR: Spider error processing <GET http://www.iana.org/domains/reserved> (referer: None)
Traceback (most recent call last):
  File "/home/eugenio/zyte/scrapy/venv-scrapy/lib/python3.9/site-packages/twisted/internet/defer.py", line 858, in _runCallbacks
    current.result = callback(  # type: ignore[misc]
TypeError: _callback() got an unexpected keyword argument 'foo'
2022-10-30 13:15:06 [scrapy.core.engine] INFO: Closing spider (finished)
```

After this patch:
```
2022-10-30 13:16:00 [scrapy.core.engine] INFO: Spider opened
2022-10-30 13:16:00 [scrapy.extensions.logstats] INFO: Crawled 0 pages (at 0 pages/min), scraped 0 items (at 0 items/min)
2022-10-30 13:16:00 [scrapy.extensions.telnet] INFO: Telnet console listening on 127.0.0.1:6023
2022-10-30 13:16:00 [scrapy.core.engine] DEBUG: Crawled (200) <GET https://example.org> (referer: None)
2022-10-30 13:16:01 [scrapy.downloadermiddlewares.redirect] DEBUG: Redirecting (301) to <GET http://www.iana.org/domains/reserved> from <GET https://www.iana.org/domains/example>
2022-10-30 13:16:01 [scrapy.core.engine] DEBUG: Crawled (200) <GET http://www.iana.org/domains/reserved> (referer: None)
2022-10-30 13:16:01 [scrapy.core.scraper] DEBUG: Scraped from <200 http://www.iana.org/domains/reserved>
{'url': 'http://www.iana.org/domains/reserved', 'foo': 'bar'}
2022-10-30 13:16:01 [scrapy.core.engine] INFO: Closing spider (finished)
```

```
$ scrapy version -v
Scrapy       : 2.7.0
lxml         : 4.7.1.0
libxml2      : 2.9.12
cssselect    : 1.1.0
parsel       : 1.6.0
w3lib        : 1.22.0
Twisted      : 21.7.0
Python       : 3.9.6 (default, Sep  6 2021, 10:09:19) - [GCC 7.5.0]
pyOpenSSL    : 21.0.0 (OpenSSL 1.1.1m  14 Dec 2021)
cryptography : 36.0.1
Platform     : Linux-5.4.0-125-generic-x86_64-with-glibc2.31
```