### PR TITLE
scrapy -h outputs a stray commands #5709

### DIFF
--- a/scrapy/utils/misc.py
+++ b/scrapy/utils/misc.py
@@ -79,7 +79,6 @@ def walk_modules(path):
 
     mods = []
     mod = import_module(path)
-    mods.append(mod)
     if hasattr(mod, '__path__'):
         for _, subpath, ispkg in iter_modules(mod.__path__):
             fullpath = path + '.' + subpath


### PR DESCRIPTION
__init__.py was being passed as a module from scrapy/commands when walk_modules was called from function def _iter_command_classes in cmdline.py