### PR TITLE
fix: stray `commands`

### DIFF
--- a/scrapy/cmdline.py
+++ b/scrapy/cmdline.py
@@ -7,7 +7,7 @@ import pkg_resources
 
 import scrapy
 from scrapy.crawler import CrawlerProcess
-from scrapy.commands import ScrapyCommand, ScrapyHelpFormatter
+from scrapy.commands import ScrapyCommand, ScrapyHelpFormatter, BaseRunSpiderCommand
 from scrapy.exceptions import UsageError
 from scrapy.utils.misc import walk_modules
 from scrapy.utils.project import inside_project, get_project_settings
@@ -32,7 +32,7 @@ def _iter_command_classes(module_name):
                 inspect.isclass(obj)
                 and issubclass(obj, ScrapyCommand)
                 and obj.__module__ == module.__name__
-                and not obj == ScrapyCommand
+                and not obj in (ScrapyCommand, BaseRunSpiderCommand)
             ):
                 yield obj
 


### PR DESCRIPTION
This behaviour was introduced on: #4552

We created a new class that inherit from `ScrapyCommand` but forget to check on `_iter_command_classes` function, this is the reason that `command` was appearing.

Fixes: #5711 