### PR TITLE
Update tutorial.rst

### DIFF
--- a/docs/intro/tutorial.rst
+++ b/docs/intro/tutorial.rst
@@ -274,7 +274,7 @@ When you know you just want the first result, as in this case, you can do:
 
 As an alternative, you could've written:
 
->>> response.css('title::text')[0].get()
+>>> response.css('title::text').getall()[0]
 'Quotes to Scrape'
 
 Accessing an index on a :class:`~scrapy.selector.SelectorList` instance will 


### PR DESCRIPTION
1. 
```
>>> response.css('title::text').get()
'Quotes to Scrape'
```
2.
```
>>> response.css('title::text')[0].get()
'Quotes to Scrape'
```
Both 1st and 2nd line of code base returns the same response, The Alternative what i think should be:
```
>>> response.css('title::text').getall()[0]
'Quotes to Scrape'
```
Because as `getall()` returns a list and we can select the very first item from it. 
However 2. being the the alternative to 1. doesn't make any sense.