### PR TITLE
Remove deprecated code

### DIFF
--- a/scrapy/utils/boto.py
+++ b/scrapy/utils/boto.py
@@ -1,27 +1,4 @@
 """Boto/botocore helpers"""
-import warnings
-
-from scrapy.exceptions import NotConfigured, ScrapyDeprecationWarning
-
-
-def is_botocore():
-    """ Returns True if botocore is available, otherwise raises NotConfigured. Never returns False.
-
-    Previously, when boto was supported in addition to botocore, this returned False if boto was available
-    but botocore wasn't.
-    """
-    message = (
-        'is_botocore() is deprecated and always returns True or raises an Exception, '
-        'so it cannot be used for checking if boto is available instead of botocore. '
-        'You can use scrapy.utils.boto.is_botocore_available() to check if botocore '
-        'is available.'
-    )
-    warnings.warn(message, ScrapyDeprecationWarning, stacklevel=2)
-    try:
-        import botocore  # noqa: F401
-        return True
-    except ImportError:
-        raise NotConfigured('missing botocore library')
 
 
 def is_botocore_available():

--- a/scrapy/utils/gz.py
+++ b/scrapy/utils/gz.py
@@ -2,17 +2,6 @@ import struct
 from gzip import GzipFile
 from io import BytesIO
 
-from scrapy.utils.decorators import deprecated
-
-
-# - GzipFile's read() has issues returning leftover uncompressed data when
-#   input is corrupted
-# - read1(), which fetches data before raising EOFError on next call
-#   works here
-@deprecated('GzipFile.read1')
-def read1(gzf, size=-1):
-    return gzf.read1(size)
-
 
 def gunzip(data):
     """Gunzip the given data and return as much data as possible.

--- a/scrapy/utils/python.py
+++ b/scrapy/utils/python.py
@@ -1,20 +1,16 @@
 """
 This module contains essential stuff that should've come with Python itself ;)
 """
-import errno
 import gc
 import inspect
 import re
 import sys
-import warnings
 import weakref
 from functools import partial, wraps
 from itertools import chain
 from typing import AsyncGenerator, AsyncIterable, Iterable, Union
 
-from scrapy.exceptions import ScrapyDeprecationWarning
 from scrapy.utils.asyncgen import as_async_generator
-from scrapy.utils.decorators import deprecated
 
 
 def flatten(x):
@@ -110,12 +106,6 @@ def to_bytes(text, encoding=None, errors='strict'):
     if encoding is None:
         encoding = 'utf-8'
     return text.encode(encoding, errors)
-
-
-@deprecated('to_unicode')
-def to_native_str(text, encoding=None, errors='strict'):
-    """ Return str representation of ``text``. """
-    return to_unicode(text, encoding, errors)
 
 
 def re_rsearch(pattern, text, chunk_size=1024):
@@ -263,30 +253,6 @@ def equal_attributes(obj1, obj2, attributes):
     return True
 
 
-class WeakKeyCache:
-
-    def __init__(self, default_factory):
-        warnings.warn("The WeakKeyCache class is deprecated", category=ScrapyDeprecationWarning, stacklevel=2)
-        self.default_factory = default_factory
-        self._weakdict = weakref.WeakKeyDictionary()
-
-    def __getitem__(self, key):
-        if key not in self._weakdict:
-            self._weakdict[key] = self.default_factory(key)
-        return self._weakdict[key]
-
-
-@deprecated
-def retry_on_eintr(function, *args, **kw):
-    """Run a function and retry it while getting EINTR errors"""
-    while True:
-        try:
-            return function(*args, **kw)
-        except IOError as e:
-            if e.errno != errno.EINTR:
-                raise
-
-
 def without_none_values(iterable):
     """Return a copy of ``iterable`` with all ``None`` entries removed.
 
@@ -336,10 +302,6 @@ class MutableChain(Iterable):
 
     def __next__(self):
         return next(self.data)
-
-    @deprecated("scrapy.utils.python.MutableChain.__next__")
-    def next(self):
-        return self.__next__()
 
 
 async def _async_chain(*iterables: Union[Iterable, AsyncIterable]) -> AsyncGenerator:

--- a/tests/test_utils_python.py
+++ b/tests/test_utils_python.py
@@ -1,18 +1,14 @@
 import functools
-import gc
 import operator
 import platform
-from itertools import count
-from warnings import catch_warnings, filterwarnings
 
 from twisted.trial import unittest
 
-from scrapy.exceptions import ScrapyDeprecationWarning
 from scrapy.utils.asyncgen import as_async_generator, collect_asyncgen
 from scrapy.utils.defer import deferred_f_from_coro_f, aiter_errback
 from scrapy.utils.python import (
     memoizemethod_noargs, binary_is_text, equal_attributes,
-    WeakKeyCache, get_func_args, to_bytes, to_unicode,
+    get_func_args, to_bytes, to_unicode,
     without_none_values, MutableChain, MutableAsyncChain)
 
 
@@ -27,11 +23,6 @@ class MutableChainTest(unittest.TestCase):
         m.extend([9, 10], (11, 12))
         self.assertEqual(next(m), 0)
         self.assertEqual(m.__next__(), 1)
-        with catch_warnings(record=True) as warnings:
-            self.assertEqual(m.next(), 2)
-            self.assertEqual(len(warnings), 1)
-            self.assertIn('scrapy.utils.python.MutableChain.__next__',
-                          str(warnings[0].message))
         self.assertEqual(list(m), list(range(3, 13)))
 
 
@@ -208,27 +199,6 @@ class UtilsPythonTestCase(unittest.TestCase):
         # fail z equality
         a.meta['z'] = 2
         self.assertFalse(equal_attributes(a, b, [compare_z, 'x']))
-
-    def test_weakkeycache(self):
-        class _Weakme:
-            pass
-
-        _values = count()
-
-        with catch_warnings():
-            filterwarnings("ignore", category=ScrapyDeprecationWarning)
-            wk = WeakKeyCache(lambda k: next(_values))
-
-        k = _Weakme()
-        v = wk[k]
-        self.assertEqual(v, wk[k])
-        self.assertNotEqual(v, wk[_Weakme()])
-        self.assertEqual(v, wk[k])
-        del k
-        for _ in range(100):
-            if wk._weakdict:
-                gc.collect()
-        self.assertFalse(len(wk._weakdict))
 
     def test_get_func_args(self):
         def f1(a, b, c):

--- a/tests/test_utils_python.py
+++ b/tests/test_utils_python.py
@@ -23,7 +23,7 @@ class MutableChainTest(unittest.TestCase):
         m.extend([9, 10], (11, 12))
         self.assertEqual(next(m), 0)
         self.assertEqual(m.__next__(), 1)
-        self.assertEqual(list(m), list(range(3, 13)))
+        self.assertEqual(list(m), list(range(2, 13)))
 
 
 class MutableAsyncChainTest(unittest.TestCase):


### PR DESCRIPTION
The [Deprecation policy](https://docs.scrapy.org/en/latest/versioning.html#deprecation-policy) of Scrapy state:
> We aim to maintain support for deprecated Scrapy features **for at least 1 year**.

Here the list of deprecated functions/class and they correspond release notes/date:

- [x] `scrapy.utils.gz.read1` and `scrapy.utils.python.to_native_str` deprecated on [2020-03-03](https://docs.scrapy.org/en/2.0/news.html#backward-incompatible-changes)
- [x] `scrapy.utils.python.MutableChain.next` deprecated on [2020-03-03](https://docs.scrapy.org/en/2.0/news.html#deprecations)
- [x] `scrapy.utils.python.retry_on_eintr` deprecated on [2020-08-04](https://docs.scrapy.org/en/2.4/news.html#id2)
- [x] `scrapy.utils.python.WeakKeyCache` deprecated on [2020-10-11](https://docs.scrapy.org/en/2.4/news.html#deprecations)