### PR TITLE
Adds get_virtual_size to _check_limit Logging

### DIFF
--- a/scrapy/extensions/memusage.py
+++ b/scrapy/extensions/memusage.py
@@ -79,7 +79,7 @@ class MemoryUsage:
             self.crawler.stats.set_value('memusage/limit_reached', 1)
             mem = self.limit / 1024 / 1024
             logger.error("Memory usage exceeded %(memusage)dM. Shutting down Scrapy...",
-                         {'memusage': mem}, extra={'crawler': self.crawler})
+                         {'memusage': mem, 'virtualsize': self.get_virtual_size()}, extra={'crawler': self.crawler})
             if self.notify_mails:
                 subj = (
                     f"{self.crawler.settings['BOT_NAME']} terminated: "

--- a/scrapy/extensions/memusage.py
+++ b/scrapy/extensions/memusage.py
@@ -79,7 +79,7 @@ class MemoryUsage:
             self.crawler.stats.set_value('memusage/limit_reached', 1)
             mem = self.limit / 1024 / 1024
             logger.error("Memory usage exceeded %(memusage)dM. Shutting down Scrapy...",
-                         {'memusage': mem, 'virtualsize': self.get_virtual_size()}, extra={'crawler': self.crawler})
+                         {'memusage': mem}, extra={'crawler': self.crawler})
             if self.notify_mails:
                 subj = (
                     f"{self.crawler.settings['BOT_NAME']} terminated: "
@@ -92,6 +92,8 @@ class MemoryUsage:
                 self.crawler.engine.close_spider(self.crawler.engine.spider, 'memusage_exceeded')
             else:
                 self.crawler.stop()
+        else:
+            logger.info("Current memory usage is %(virtualsize)dM", {'virtualsize': self.get_virtual_size()})
 
     def _check_warning(self):
         if self.warned:  # warn only once

--- a/scrapy/extensions/memusage.py
+++ b/scrapy/extensions/memusage.py
@@ -75,7 +75,8 @@ class MemoryUsage:
         self.crawler.stats.max_value('memusage/max', self.get_virtual_size())
 
     def _check_limit(self):
-        if self.get_virtual_size() > self.limit:
+        current_mem_usage = self.get_virtual_size()
+        if current_mem_usage > self.limit:
             self.crawler.stats.set_value('memusage/limit_reached', 1)
             mem = self.limit / 1024 / 1024
             logger.error("Memory usage exceeded %(memusage)dM. Shutting down Scrapy...",
@@ -93,7 +94,7 @@ class MemoryUsage:
             else:
                 self.crawler.stop()
         else:
-            logger.info("Current memory usage is %(virtualsize)dM", {'virtualsize': self.get_virtual_size()})
+            logger.info("Current memory usage is %(virtualsize)dM", {'virtualsize': current_mem_usage / 1024 / 1024})
 
     def _check_warning(self):
         if self.warned:  # warn only once


### PR DESCRIPTION
Fixes #5717 

Request for additional memory logging when scrapy jobs with `MEMUSAGE_ENABLED : True` and `MEMUSAGE_LIMIT_MB` defined are stopped early. This should further assist with memory debugging by providing the size of the current process.