### PR TITLE
Remove support for override settings with `SCRAPY_` environment variables

### DIFF
--- a/scrapy/utils/project.py
+++ b/scrapy/utils/project.py
@@ -6,7 +6,7 @@ from os.path import join, dirname, abspath, isabs, exists
 
 from scrapy.utils.conf import closest_scrapy_cfg, get_config, init_env
 from scrapy.settings import Settings
-from scrapy.exceptions import NotConfigured, ScrapyDeprecationWarning
+from scrapy.exceptions import NotConfigured
 
 
 ENVVAR = 'SCRAPY_SETTINGS_MODULE'
@@ -67,23 +67,16 @@ def get_project_settings():
     if settings_module_path:
         settings.setmodule(settings_module_path, priority='project')
 
-    scrapy_envvars = {k[7:]: v for k, v in os.environ.items() if
-                      k.startswith('SCRAPY_')}
     valid_envvars = {
         'CHECK',
         'PROJECT',
         'PYTHON_SHELL',
         'SETTINGS_MODULE',
     }
-    setting_envvars = {k for k in scrapy_envvars if k not in valid_envvars}
-    if setting_envvars:
-        setting_envvar_list = ', '.join(sorted(setting_envvars))
-        warnings.warn(
-            'Use of environment variables prefixed with SCRAPY_ to override '
-            'settings is deprecated. The following environment variables are '
-            f'currently defined: {setting_envvar_list}',
-            ScrapyDeprecationWarning
-        )
+
+    scrapy_envvars = {k[7:]: v for k, v in os.environ.items() if
+                      k.startswith('SCRAPY_') and k.replace('SCRAPY_', '') in valid_envvars}
+
     settings.setdict(scrapy_envvars, priority='project')
 
     return settings

--- a/tests/test_cmdline/__init__.py
+++ b/tests/test_cmdline/__init__.py
@@ -31,10 +31,6 @@ class CmdlineTest(unittest.TestCase):
         self.assertEqual(self._execute('settings', '--get', 'TEST1', '-s',
                                        'TEST1=override'), 'override')
 
-    def test_override_settings_using_envvar(self):
-        self.env['SCRAPY_TEST1'] = 'override'
-        self.assertEqual(self._execute('settings', '--get', 'TEST1'), 'override')
-
     def test_profiling(self):
         path = tempfile.mkdtemp()
         filename = os.path.join(path, 'res.prof')

--- a/tests/test_utils_project.py
+++ b/tests/test_utils_project.py
@@ -5,9 +5,6 @@ import shutil
 import contextlib
 import warnings
 
-from pytest import warns
-
-from scrapy.exceptions import ScrapyDeprecationWarning
 from scrapy.utils.project import data_path, get_project_settings
 
 
@@ -80,10 +77,10 @@ class GetProjectSettingsTestCase(unittest.TestCase):
         envvars = {
             'SCRAPY_FOO': 'bar',
         }
-        with warns(ScrapyDeprecationWarning, match=': FOO') as record:
-            with set_env(**envvars):
-                get_project_settings()
-        assert len(record) == 1
+        with set_env(**envvars):
+            settings = get_project_settings()
+
+        assert settings.get("SCRAPY_FOO") is None
 
     def test_valid_and_invalid_envvars(self):
         value = 'tests.test_cmdline.settings'
@@ -91,8 +88,7 @@ class GetProjectSettingsTestCase(unittest.TestCase):
             'SCRAPY_FOO': 'bar',
             'SCRAPY_SETTINGS_MODULE': value,
         }
-        with warns(ScrapyDeprecationWarning, match=': FOO') as record:
-            with set_env(**envvars):
-                settings = get_project_settings()
-        assert len(record) == 1
+        with set_env(**envvars):
+            settings = get_project_settings()
         assert settings.get('SETTINGS_MODULE') == value
+        assert settings.get('SCRAPY_FOO') is None


### PR DESCRIPTION
Another cleanup. 🧹 (Last one this week i promise 🤞🏻 )

- [x] Deprecated on [Scrapy 2.0.0 (2020-03-03)](https://docs.scrapy.org/en/latest/news.html#id47)

We could change the `valid_envvars` and append `SCRAPY_` prefix, but i choose to leave the dictionary intact and just add another condition to if statement, changed tests accordingly.
