### PR TITLE
Cleanup settings._DictProxy and scrapy.telnet

### DIFF
--- a/scrapy/settings/__init__.py
+++ b/scrapy/settings/__init__.py
@@ -435,30 +435,6 @@ class BaseSettings(MutableMapping):
             p.text(pformat(self.copy_to_dict()))
 
 
-class _DictProxy(MutableMapping):
-
-    def __init__(self, settings, priority):
-        self.o = {}
-        self.settings = settings
-        self.priority = priority
-
-    def __len__(self):
-        return len(self.o)
-
-    def __getitem__(self, k):
-        return self.o[k]
-
-    def __setitem__(self, k, v):
-        self.settings.set(k, v, priority=self.priority)
-        self.o[k] = v
-
-    def __delitem__(self, k):
-        del self.o[k]
-
-    def __iter__(self, k, v):
-        return iter(self.o)
-
-
 class Settings(BaseSettings):
     """
     This object stores Scrapy settings for the configuration of internal

--- a/scrapy/utils/deprecate.py
+++ b/scrapy/utils/deprecate.py
@@ -126,9 +126,7 @@ def _clspath(cls, forced=None):
     return f'{cls.__module__}.{cls.__name__}'
 
 
-DEPRECATION_RULES = [
-    ('scrapy.telnet.', 'scrapy.extensions.telnet.'),
-]
+DEPRECATION_RULES = []
 
 
 def update_classpath(path):

--- a/scrapy/utils/deprecate.py
+++ b/scrapy/utils/deprecate.py
@@ -2,6 +2,7 @@
 
 import warnings
 import inspect
+from typing import List, Tuple
 from scrapy.exceptions import ScrapyDeprecationWarning
 
 
@@ -126,7 +127,7 @@ def _clspath(cls, forced=None):
     return f'{cls.__module__}.{cls.__name__}'
 
 
-DEPRECATION_RULES = []
+DEPRECATION_RULES: List[Tuple[str, str]] = []
 
 
 def update_classpath(path):


### PR DESCRIPTION
This change removes the `_DictProxy` class from `scrapy/settings/__init__.py` since it is no longer used. It also removes `scrapy.telnet` from the `DEPRECATION_RULES` as part of the cleanup. It resolves https://github.com/scrapy/scrapy/issues/5729, resolves https://github.com/scrapy/scrapy/issues/5725.