### PR TITLE
Remove unnecessary backwards compatibility comments

### DIFF
--- a/scrapy/utils/conf.py
+++ b/scrapy/utils/conf.py
@@ -44,14 +44,12 @@ def build_component_list(compdict, custom=None, convert=update_classpath):
                 raise ValueError(f'Invalid value {value} for component {name}, '
                                  'please provide a real number or None instead')
 
-    # BEGIN Backward compatibility for old (base, custom) call signature
     if isinstance(custom, (list, tuple)):
         _check_components(custom)
         return type(custom)(convert(c) for c in custom)
 
     if custom is not None:
         compdict.update(custom)
-    # END Backward compatibility
 
     _validate_values(compdict)
     compdict = without_none_values(_map_keys(compdict))


### PR DESCRIPTION
Related: https://github.com/scrapy/scrapy/issues/5726. The code seems to still be in use and is being invoked therefore, we can remove the backwards compatibility comment since it is part of the feature still. I didn't come across any code that would suggest this use-case will never be executed.