### PR TITLE
Rename Spider.max_concurrent_requests

### DIFF
--- a/extras/qpsclient.py
+++ b/extras/qpsclient.py
@@ -17,7 +17,7 @@ class QPSSpider(Spider):
     benchurl = 'http://localhost:8880/'
 
     # Max concurrency is limited by global CONCURRENT_REQUESTS setting
-    max_concurrent_requests = 8
+    slot_concurrent_requests = 8
     # Requests per second goal
     qps = None # same as: 1 / download_delay
     download_delay = None

--- a/scrapy/core/downloader/__init__.py
+++ b/scrapy/core/downloader/__init__.py
@@ -60,8 +60,8 @@ def _get_concurrency_delay(concurrency, spider, settings):
     if hasattr(spider, 'download_delay'):
         delay = spider.download_delay
 
-    if hasattr(spider, 'max_concurrent_requests'):
-        concurrency = spider.max_concurrent_requests
+    if hasattr(spider, 'slot_concurrent_requests'):
+        concurrency = spider.slot_concurrent_requests
 
     return concurrency, delay
 


### PR DESCRIPTION
This resolves https://github.com/scrapy/scrapy/issues/5584. I agree with the naming suggested in the issue and this PR performs that renaming.