### PR TITLE
Add a comment about `tmpname + '^'`.

### DIFF
--- a/tests/test_downloader_handlers.py
+++ b/tests/test_downloader_handlers.py
@@ -109,6 +109,7 @@ class FileTestCase(unittest.TestCase):
 
     def setUp(self):
         self.tmpname = self.mktemp()
+        # add a special char to check that they are handled correctly
         with open(self.tmpname + '^', 'w') as f:
             f.write('0123456789')
         handler = create_instance(FileDownloadHandler, None, get_crawler())


### PR DESCRIPTION
I had no idea why is this needed and how should it be used (https://github.com/scrapy/scrapy/pull/5285/files#r844017508, https://github.com/scrapy/scrapy/pull/5682/files/726680c7125ab3a6622b12e25d45dbfedc5a39b3#r1027288466) so I tracked it down to 3012030b2faea43b00cb8ae233321c1f9eb8a579 and added this comment.