### PR TITLE
Fixes issue with calling fetch in scrapy shell.

### DIFF
--- a/docs/topics/settings.rst
+++ b/docs/topics/settings.rst
@@ -279,6 +279,8 @@ class to be used.
 
 Note that the event loop class must inherit from :class:`asyncio.AbstractEventLoop`.
 
+This setting is not compatible with scrapy shell.
+
 .. caution:: Please be aware that, when using a non-default event loop
     (either defined via :setting:`ASYNCIO_EVENT_LOOP` or installed with
     :func:`~scrapy.utils.reactor.install_reactor`), Scrapy will call

--- a/docs/topics/settings.rst
+++ b/docs/topics/settings.rst
@@ -279,7 +279,7 @@ class to be used.
 
 Note that the event loop class must inherit from :class:`asyncio.AbstractEventLoop`.
 
-This setting is not compatible with scrapy shell.
+This setting is not compatible with `scrapy shell`.
 
 .. caution:: Please be aware that, when using a non-default event loop
     (either defined via :setting:`ASYNCIO_EVENT_LOOP` or installed with

--- a/tests/test_command_shell.py
+++ b/tests/test_command_shell.py
@@ -115,3 +115,14 @@ class ShellTest(ProcessTest, SiteTest, unittest.TestCase):
         errcode, out, err = yield self.execute([url, '-c', 'item'], check_code=False)
         self.assertEqual(errcode, 1, out or err)
         self.assertIn(b'DNS lookup failed', err)
+
+    @defer.inlineCallbacks
+    def test_shell_fetch_async(self):
+        reactor_path = "twisted.internet.asyncioreactor.AsyncioSelectorReactor"
+        url = self.url('/html')
+        code = f"fetch('{url}')"
+        args = ["-c", code, "--set", f"TWISTED_REACTOR={reactor_path}"]
+        _, _, err = yield self.execute(args, check_code=True)
+        self.assertNotIn(
+            b"RuntimeError: There is no current event loop in thread", err
+        )


### PR DESCRIPTION
Reference Issue Fixes #5740 ,  #5742

You can recreate the issue with the following script.

```
import asyncio
import threading
from twisted.internet import asyncioreactor
from scrapy.utils.defer import deferred_from_coro
from scrapy.utils.reactor import get_asyncio_event_loop_policy

async def test_coro():
    pass

def test_deferred_from_coro():
    return deferred_from_coro(test_coro())

def trigger_warning_message():
    event_loop = get_asyncio_event_loop_policy().new_event_loop()
    asyncio.set_event_loop(event_loop)
    asyncioreactor.install()
    thread = threading.Thread(target=test_deferred_from_coro)
    thread.start()
    thread.join()

trigger_warning_message()
```

I was able to recreate this issue using `scrapy shell` and `fetch` on both windows and linux.  However it only occurs inside of a project with the `TWISTED_REACTOR` setting set to AsyncioSelectorReactor. 

What causes the issue is when `get_asyncio_event_loop_policy().get_event_loop()` is called, there is no event loop in the thread that the function is called from. Which raises an exception.  