### PR TITLE
fix test_follow_whitespace_* tests

### DIFF
--- a/tests/test_http_response.py
+++ b/tests/test_http_response.py
@@ -2,7 +2,8 @@ import codecs
 import unittest
 from unittest import mock
 
-from pkg_resources import parse_version
+from packaging.version import Version as parse_version
+from pytest import mark
 from w3lib import __version__ as w3lib_version
 from w3lib.encoding import resolve_encoding
 
@@ -181,19 +182,23 @@ class BaseResponseTest(unittest.TestCase):
         r = self.response_class("http://example.com")
         self.assertRaises(ValueError, r.follow, None)
 
+    @mark.xfail(
+        parse_version(w3lib_version) >= parse_version("2.1.1"),
+        reason="https://github.com/scrapy/w3lib/pull/207",
+        strict=True,
+    )
     def test_follow_whitespace_url(self):
-        target_url = 'http://example.com/foo'
-        if parse_version(w3lib_version) < parse_version("2.1.1"):
-            target_url += '%20'
         self._assert_followed_url('foo ',
-                                  target_url)
+                                  'http://example.com/foo%20')
 
+    @mark.xfail(
+        parse_version(w3lib_version) >= parse_version("2.1.1"),
+        reason="https://github.com/scrapy/w3lib/pull/207",
+        strict=True,
+    )
     def test_follow_whitespace_link(self):
-        target_url = 'http://example.com/foo'
-        if parse_version(w3lib_version) < parse_version("2.1.1"):
-            target_url += '%20'
         self._assert_followed_url(Link('http://example.com/foo '),
-                                  target_url)
+                                  'http://example.com/foo%20')
 
     def test_follow_flags(self):
         res = self.response_class('http://example.com/')

--- a/tests/test_http_response.py
+++ b/tests/test_http_response.py
@@ -183,22 +183,22 @@ class BaseResponseTest(unittest.TestCase):
         self.assertRaises(ValueError, r.follow, None)
 
     @mark.xfail(
-        parse_version(w3lib_version) >= parse_version("2.1.1"),
+        parse_version(w3lib_version) < parse_version("2.1.1"),
         reason="https://github.com/scrapy/w3lib/pull/207",
         strict=True,
     )
     def test_follow_whitespace_url(self):
         self._assert_followed_url('foo ',
-                                  'http://example.com/foo%20')
+                                  'http://example.com/foo')
 
     @mark.xfail(
-        parse_version(w3lib_version) >= parse_version("2.1.1"),
+        parse_version(w3lib_version) < parse_version("2.1.1"),
         reason="https://github.com/scrapy/w3lib/pull/207",
         strict=True,
     )
     def test_follow_whitespace_link(self):
         self._assert_followed_url(Link('http://example.com/foo '),
-                                  'http://example.com/foo%20')
+                                  'http://example.com/foo')
 
     def test_follow_flags(self):
         res = self.response_class('http://example.com/')

--- a/tests/test_http_response.py
+++ b/tests/test_http_response.py
@@ -2,14 +2,16 @@ import codecs
 import unittest
 from unittest import mock
 
+from pkg_resources import parse_version
+from w3lib import __version__ as w3lib_version
 from w3lib.encoding import resolve_encoding
 
-from scrapy.http import (Request, Response, TextResponse, HtmlResponse,
-                         XmlResponse, Headers)
+from scrapy.exceptions import NotSupported
+from scrapy.http import (Headers, HtmlResponse, Request, Response,
+                         TextResponse, XmlResponse)
+from scrapy.link import Link
 from scrapy.selector import Selector
 from scrapy.utils.python import to_unicode
-from scrapy.exceptions import NotSupported
-from scrapy.link import Link
 from tests import get_testdata
 
 
@@ -180,12 +182,18 @@ class BaseResponseTest(unittest.TestCase):
         self.assertRaises(ValueError, r.follow, None)
 
     def test_follow_whitespace_url(self):
+        target_url = 'http://example.com/foo'
+        if parse_version(w3lib_version) < parse_version("2.1.1"):
+            target_url += '%20'
         self._assert_followed_url('foo ',
-                                  'http://example.com/foo%20')
+                                  target_url)
 
     def test_follow_whitespace_link(self):
+        target_url = 'http://example.com/foo'
+        if parse_version(w3lib_version) < parse_version("2.1.1"):
+            target_url += '%20'
         self._assert_followed_url(Link('http://example.com/foo '),
-                                  'http://example.com/foo%20')
+                                  target_url)
 
     def test_follow_flags(self):
         res = self.response_class('http://example.com/')


### PR DESCRIPTION
The tests are failing because after release 2.1.1, w3lib is striping spaces from url, so i add a validation to append `%20` if the version that is running is minor than 2.1.1.

- https://github.com/scrapy/w3lib/pull/207

resolves #5750