### PR TITLE
Finish exporting for each start exporting

### DIFF
--- a/scrapy/extensions/feedexport.py
+++ b/scrapy/extensions/feedexport.py
@@ -350,11 +350,11 @@ class FeedExporter:
         return defer.DeferredList(deferred_list) if deferred_list else None
 
     def _close_slot(self, slot, spider):
+        slot.finish_exporting()
         if not slot.itemcount and not slot.store_empty:
             # We need to call slot.storage.store nonetheless to get the file
             # properly closed.
             return defer.maybeDeferred(slot.storage.store, slot.file)
-        slot.finish_exporting()
         logmsg = f"{slot.format} feed ({slot.itemcount} items) in: {slot.uri}"
         d = defer.maybeDeferred(slot.storage.store, slot.file)
 

--- a/tests/test_feedexport.py
+++ b/tests/test_feedexport.py
@@ -680,20 +680,22 @@ class FeedExportTestBase(ABC, unittest.TestCase):
                     break
         return result
 
+
 class InstrumentedFeedSlot(_FeedSlot):
     """Instrumented _FeedSlot subclass for keeping track of calls to
     start_exporting and finish_exporting."""
     def start_exporting(self):
         self.update_listener('start')
         super().start_exporting()
-    
+
     def finish_exporting(self):
         self.update_listener('finish')
         super().start_exporting()
-    
+
     @classmethod
     def subscribe__listener(cls, listener):
         cls.update_listener = listener.update
+
 
 class IsExportingListener:
     """When subscribed to InstrumentedFeedSlot, keeps track of when

--- a/tests/test_feedexport.py
+++ b/tests/test_feedexport.py
@@ -690,7 +690,7 @@ class InstrumentedFeedSlot(_FeedSlot):
 
     def finish_exporting(self):
         self.update_listener('finish')
-        super().start_exporting()
+        super().finish_exporting()
 
     @classmethod
     def subscribe__listener(cls, listener):

--- a/tests/test_feedexport.py
+++ b/tests/test_feedexport.py
@@ -700,7 +700,7 @@ class InstrumentedFeedSlot(_FeedSlot):
 class IsExportingListener:
     """When subscribed to InstrumentedFeedSlot, keeps track of when
     a call to start_exporting has been made without a closing call to
-    finish_exporting and when a call to finis_exporting has been made
+    finish_exporting and when a call to finish_exporting has been made
     before a call to start_exporting."""
     def __init__(self):
         self.start_without_finish = False


### PR DESCRIPTION
Figured I'd take a crack at #5537 since it's been stale for a while.

This patch moves the call to `slot.finish_exporting()` up to before the conditional that checks if `slot.item_count > 0` so that if an exception occurs when an exporter's `export_item()` method is called, `slot.finish_exporting()` will still be called (as discussed in the issue).

I've included 4 new tests to that each check that:
1. if `slot.start_exporting()` was called that there is a call to `slot.finish_exporting()` after
2. `slot.finish_exporting()` is not called before a call to `slot.start_exporting()`. I.e. they assert that `slot.finish_exporting()` isn't called twice in a row without a call to `slot.start_exporting()` in between and that `slot.finish_exporting()` isn't called before an initial call to `slot.start_exporting`.

`test_start_finish_exporting_items_exception` fails before the patch and passes after the patch. The other 3 tests pass before and after.

Fixes https://github.com/scrapy/scrapy/issues/5537