### PR TITLE
set asyncio event loop upon launching new thread

### DIFF
--- a/scrapy/shell.py
+++ b/scrapy/shell.py
@@ -21,6 +21,7 @@ from scrapy.utils.console import DEFAULT_PYTHON_SHELLS, start_python_console
 from scrapy.utils.datatypes import SequenceExclude
 from scrapy.utils.misc import load_object
 from scrapy.utils.response import open_in_browser
+from scrapy.utils.reactor import is_asyncio_reactor_installed, set_asyncio_event_loop
 
 
 class Shell:
@@ -76,6 +77,10 @@ class Shell:
                                  banner=self.vars.pop('banner', ''))
 
     def _schedule(self, request, spider):
+        if is_asyncio_reactor_installed():
+            # set the asyncio event loop for the current thread
+            loop_path = self.crawler.settings['ASYNCIO_EVENT_LOOP']
+            set_asyncio_event_loop(loop_path)
         spider = self._open_spider(request, spider)
         d = _request_deferred(request)
         d.addCallback(lambda x: (x, spider))

--- a/scrapy/utils/reactor.py
+++ b/scrapy/utils/reactor.py
@@ -71,14 +71,7 @@ def install_reactor(reactor_path, event_loop_path=None):
     reactor_class = load_object(reactor_path)
     if reactor_class is asyncioreactor.AsyncioSelectorReactor:
         with suppress(error.ReactorAlreadyInstalledError):
-            policy = get_asyncio_event_loop_policy()
-            if event_loop_path is not None:
-                event_loop_class = load_object(event_loop_path)
-                event_loop = event_loop_class()
-                asyncio.set_event_loop(event_loop)
-            else:
-                event_loop = policy.get_event_loop()
-
+            event_loop = set_asyncio_event_loop(event_loop_path)
             asyncioreactor.install(eventloop=event_loop)
     else:
         *module, _ = reactor_path.split(".")
@@ -86,6 +79,25 @@ def install_reactor(reactor_path, event_loop_path=None):
         installer = load_object(".".join(installer_path))
         with suppress(error.ReactorAlreadyInstalledError):
             installer()
+
+
+def set_asyncio_event_loop(event_loop_path):
+    """Sets and returns the asyncio event loop with the specified import path."""
+    policy = get_asyncio_event_loop_policy()
+    if event_loop_path is not None:
+        event_loop_class = load_object(event_loop_path)
+        event_loop = event_loop_class()
+        asyncio.set_event_loop(event_loop)
+    else:
+        try:
+            event_loop = policy.get_event_loop()
+        except RuntimeError:
+            # `get_event_loop` is expected to fail when called in a thread
+            # with no active event loop, such as when used with `scrapy shell`.
+            event_loop = policy.new_event_loop()
+            asyncio.set_event_loop(event_loop)
+
+    return event_loop
 
 
 def verify_installed_reactor(reactor_path):

--- a/test.py
+++ b/test.py
@@ -1,0 +1,6 @@
+from scrapy.cmdline import execute
+import sys
+
+sys.argv = ['scrapy', 'shell', '--set', 'TWISTED_REACTOR=twisted.internet.asyncioreactor.AsyncioSelectorReactor']
+
+execute()


### PR DESCRIPTION
This is an alternative to PR #5748 which addresses the issues #5740 and #5742 

The alternative approach used in this PR is to explicitly set the event loop in the new thread created by the `scrapy shell` when using the `fetch` command.

The main benefit to this approach is if the user has specified a non-standard event loop by setting the `ASYNCIO_EVENT_LOOP` setting, this approach is able to honor that setting.

It also passes all tests when run locally on windows and linux.
