### PR TITLE
set asyncio event loop at start of new thread

### DIFF
--- a/scrapy/shell.py
+++ b/scrapy/shell.py
@@ -21,6 +21,7 @@ from scrapy.utils.console import DEFAULT_PYTHON_SHELLS, start_python_console
 from scrapy.utils.datatypes import SequenceExclude
 from scrapy.utils.misc import load_object
 from scrapy.utils.response import open_in_browser
+from scrapy.utils.reactor import is_asyncio_reactor_installed, set_asyncio_event_loop
 
 
 class Shell:
@@ -76,6 +77,10 @@ class Shell:
                                  banner=self.vars.pop('banner', ''))
 
     def _schedule(self, request, spider):
+        if is_asyncio_reactor_installed():
+            # set the asyncio event loop for the current thread
+            event_loop_path = self.crawler.settings['ASYNCIO_EVENT_LOOP']
+            set_asyncio_event_loop(event_loop_path)
         spider = self._open_spider(request, spider)
         d = _request_deferred(request)
         d.addCallback(lambda x: (x, spider))

--- a/scrapy/utils/reactor.py
+++ b/scrapy/utils/reactor.py
@@ -80,6 +80,7 @@ def install_reactor(reactor_path, event_loop_path=None):
         with suppress(error.ReactorAlreadyInstalledError):
             installer()
 
+
 def set_asyncio_event_loop(event_loop_path):
     """Sets and returns the event loop with specified import path."""
     policy = get_asyncio_event_loop_policy()

--- a/tests/test_command_shell.py
+++ b/tests/test_command_shell.py
@@ -115,3 +115,14 @@ class ShellTest(ProcessTest, SiteTest, unittest.TestCase):
         errcode, out, err = yield self.execute([url, '-c', 'item'], check_code=False)
         self.assertEqual(errcode, 1, out or err)
         self.assertIn(b'DNS lookup failed', err)
+
+    @defer.inlineCallbacks
+    def test_shell_fetch_async(self):
+        reactor_path = "twisted.internet.asyncioreactor.AsyncioSelectorReactor"
+        url = self.url('/html')
+        code = f"fetch('{url}')"
+        args = ["-c", code, "--set", f"TWISTED_REACTOR={reactor_path}"]
+        _, _, err = yield self.execute(args, check_code=True)
+        self.assertNotIn(
+            b"RuntimeError: There is no current event loop in thread", err
+        )


### PR DESCRIPTION
This is an alternative to PR https://github.com/scrapy/scrapy/pull/5748 which addresses the issues https://github.com/scrapy/scrapy/issues/5740 and https://github.com/scrapy/scrapy/issues/5742

The alternative approach used in this PR is to explicitly set the event loop in the new thread created by the scrapy shell when using the fetch command.

The main benefit to this strategy is the ability to honor the `ASYNCIO_EVENT_LOOP` setting.

Closes #5748, fixes #5740.