### PR TITLE
docs: change DOWNLOAD_DELAY description format

### DIFF
--- a/docs/topics/settings.rst
+++ b/docs/topics/settings.rst
@@ -652,10 +652,9 @@ per ip address instead of per domain.
 
 .. _spider-download_delay-attribute:
 
-Note
+.. note::
 
-This delay can be set per spider using :attr:`download_delay` spider attribute.
-
+    This delay can be set per spider using :attr:`download_delay` spider attribute.
 
 .. setting:: DOWNLOAD_HANDLERS
 

--- a/docs/topics/settings.rst
+++ b/docs/topics/settings.rst
@@ -652,8 +652,10 @@ per ip address instead of per domain.
 
 .. _spider-download_delay-attribute:
 
-You can also change this setting per spider by setting ``download_delay``
-spider attribute.
+Note
+
+This delay can be set per spider using :attr:`download_delay` spider attribute.
+
 
 .. setting:: DOWNLOAD_HANDLERS
 


### PR DESCRIPTION
To be consistent with the other settings' descriptions