### PR TITLE
Added base_url arg to http.Response's urljoin method

### DIFF
--- a/scrapy/http/response/__init__.py
+++ b/scrapy/http/response/__init__.py
@@ -114,10 +114,14 @@ class Response(object_ref):
         cls = kwargs.pop('cls', self.__class__)
         return cls(*args, **kwargs)
 
-    def urljoin(self, url):
+    def urljoin(self, url, base_url=None):
         """Join this Response's url with a possible relative url to form an
-        absolute interpretation of the latter."""
-        return urljoin(self.url, url)
+        absolute interpretation of the latter.
+        If base url is given, join this with a relative url.
+        """
+        if not base_url:
+            return urljoin(self.url, url)
+        return urljoin(base_url, url)
 
     @property
     def text(self):


### PR DESCRIPTION
↓Actual, difficult cases that I have encountered.

page_url: "~.com/list/2(pageNumber)"
href: "123(articleId)"

in this case. current urljoion returns "-.com/list/2/123" not reaced to anywhere.
valid joined url is "~.com/123". It is reacheable to desired website.