### PR TITLE
Deprecate direct invocation of `setup.py`

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,8 +24,8 @@ jobs:
     - name: Publish to PyPI
       if: steps.check-release-tag.outputs.release_tag == 'true'
       run: |
-        pip install --upgrade setuptools wheel twine
-        python setup.py sdist bdist_wheel
+        pip install --upgrade build twine
+        python -m build
         export TWINE_USERNAME=__token__
         export TWINE_PASSWORD=${{ secrets.PYPI_TOKEN }}
         twine upload dist/*

--- a/tox.ini
+++ b/tox.ini
@@ -75,8 +75,9 @@ commands =
 basepython = python3
 deps =
     twine==4.0.1
+    build==0.9.0
 commands =
-    python setup.py sdist
+    python -m build --sdist
     twine check dist/*
 
 [pinned]


### PR DESCRIPTION
Closes #5774

We don't need to install `setuptools` and `wheel` packages anymore in publish workflow because build create a virtual environment in order to build the package. We don't need to pass any argument to `build` command because the default behaviour already create a wheel/source distribution 