### PR TITLE
Fix overwriting repeated headers in HTTP2

### DIFF
--- a/scrapy/core/http2/stream.py
+++ b/scrapy/core/http2/stream.py
@@ -332,7 +332,7 @@ class Stream:
 
     def receive_headers(self, headers: List[HeaderTuple]) -> None:
         for name, value in headers:
-            self._response['headers'][name] = value
+            self._response['headers'].appendlist(name, value)
 
         # Check if we exceed the allowed max data size which can be received
         expected_size = int(self._response['headers'].get(b'Content-Length', -1))

--- a/tests/test_downloader_handlers.py
+++ b/tests/test_downloader_handlers.py
@@ -214,6 +214,12 @@ class LargeChunkedFileResource(resource.Resource):
         return server.NOT_DONE_YET
 
 
+class DuplicateHeaderResource(resource.Resource):
+    def render(self, request):
+        request.responseHeaders.setRawHeaders(b"Set-Cookie", [b"a=b", b"c=d"])
+        return b""
+
+
 class HttpTestCase(unittest.TestCase):
     scheme = 'http'
     download_handler_cls: Type = HTTPDownloadHandler
@@ -239,6 +245,7 @@ class HttpTestCase(unittest.TestCase):
         r.putChild(b"contentlength", ContentLengthHeaderResource())
         r.putChild(b"nocontenttype", EmptyContentTypeHeaderResource())
         r.putChild(b"largechunkedfile", LargeChunkedFileResource())
+        r.putChild(b"duplicate-header", DuplicateHeaderResource())
         r.putChild(b"echo", Echo())
         self.site = server.Site(r, timeout=None)
         self.wrapper = WrappingFactory(self.site)
@@ -406,6 +413,16 @@ class HttpTestCase(unittest.TestCase):
             b"<!DOCTYPE html>\n<title>.</title>",
             HtmlResponse,
         )
+
+    def test_get_duplicate_header(self):
+        def _test(response):
+            self.assertEqual(
+                response.headers.getlist(b'Set-Cookie'),
+                [b'a=b', b'c=d'],
+            )
+
+        request = Request(self.getURL('duplicate-header'))
+        return self.download_request(request, Spider('foo')).addCallback(_test)
 
 
 class Http10TestCase(HttpTestCase):


### PR DESCRIPTION
This commit fixes the overwriting bug of repeated header values using HTTP2

```py
raw_response = \
"""
HTTP 1.1 200 OK
Set-Cookie: first=1
Set-Cookie: second=2
"""

# Old logic
>>> response.headers.getlist(b'Set-Cookie')
[b'second=2']

# New logic
>>> response.headers.getlist(b'Set-Cookie')
[b'first=1', b'second=2']
```