### PR TITLE
Minimum cryptography: 3.3 → 3.4.6

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ def has_environment_marker_platform_impl_support():
 
 install_requires = [
     'Twisted>=18.9.0',
-    'cryptography>=3.3',
+    'cryptography>=3.4.6',
     'cssselect>=0.9.1',
     'itemloaders>=1.0.1',
     'parsel>=1.5.0',

--- a/tox.ini
+++ b/tox.ini
@@ -81,7 +81,7 @@ commands =
 
 [pinned]
 deps =
-    cryptography==3.3
+    cryptography==3.4.6
     cssselect==0.9.1
     h2==3.0
     itemadapter==0.1.0


### PR DESCRIPTION
Fixes #5785.

I am not sure exactly why CI started failing, I assume because the Docker image started using a newer OpenSSL. [3.4.6 recompiled wheels for OpenSSL 1.1.1j](https://cryptography.io/en/latest/changelog/#v3-4-6). I think increasing the minimum cryptography version is a small price to pay.