### PR TITLE
exception is raised from using PathLike obj #5739

### DIFF
--- a/scrapy/pipelines/files.py
+++ b/scrapy/pipelines/files.py
@@ -14,7 +14,7 @@ from contextlib import suppress
 from ftplib import FTP
 from io import BytesIO
 from pathlib import Path
-from typing import DefaultDict, Optional, Set
+from typing import DefaultDict, Optional, Set, Union
 from urllib.parse import urlparse
 
 from itemadapter import ItemAdapter
@@ -41,7 +41,8 @@ class FileException(Exception):
 
 
 class FSFilesStore:
-    def __init__(self, basedir: str):
+    def __init__(self, basedir: Union[str, os.PathLike]):
+        basedir = str(basedir)  # convert PathLike obj to str
         if '://' in basedir:
             basedir = basedir.split('://', 1)[1]
         self.basedir = basedir
@@ -65,8 +66,8 @@ class FSFilesStore:
 
         return {'last_modified': last_modified, 'checksum': checksum}
 
-    def _get_filesystem_path(self, path: str) -> Path:
-        path_comps = path.split('/')
+    def _get_filesystem_path(self, path: Union[str, os.PathLike]) -> Path:
+        path_comps = str(path).split('/')
         return Path(self.basedir, *path_comps)
 
     def _mkdir(self, dirname: Path, domain: Optional[str] = None):
@@ -370,7 +371,7 @@ class FilesPipeline(MediaPipeline):
         ftp_store.FTP_PASSWORD = settings['FTP_PASSWORD']
         ftp_store.USE_ACTIVE_MODE = settings.getbool('FEED_STORAGE_FTP_ACTIVE')
 
-        store_uri = settings['FILES_STORE']
+        store_uri = str(settings['FILES_STORE'])  # convert PathLike to string
         return cls(store_uri, settings=settings)
 
     def _get_store(self, uri: str):

--- a/tests/test_pipeline_files.py
+++ b/tests/test_pipeline_files.py
@@ -405,6 +405,23 @@ class FilesPipelineTestCaseCustomSettings(unittest.TestCase):
             self.assertEqual(getattr(pipeline_cls, pipe_inst_attr),
                              expected_value)
 
+    def test_file_pipeline_using_pathlike_objects(self):
+
+        class CustomFilesPipelineWithPathLikeDir(FilesPipeline):
+            def file_path(self, request, response=None, info=None, *, item=None):
+                return Path('subdir') / Path(request.url).name
+
+        pipeline = CustomFilesPipelineWithPathLikeDir.from_settings(
+            Settings({'FILES_STORE': Path('./Temp')})
+        )
+        request = Request("http://example.com/image01.jpg")
+        self.assertEqual(pipeline.file_path(request), Path('subdir/image01.jpg'))
+
+    def test_files_store_constructor_with_pathlike_object(self):
+        path = Path('./FileDir')
+        fs_store = FSFilesStore(path)
+        self.assertEqual(fs_store.basedir, str(path))
+
 
 class TestS3FilesStore(unittest.TestCase):
 


### PR DESCRIPTION
Located a couple of places where using `Path` object raises an exception. Relates to Issue #5739.

The issue can be reproduced by using a `Path` object in the `"IMAGES_STORE"`  or `"FILES_STORE"` settings when configuring a file or image pipeline.

Code to reproduce:

```
from pathlib import Path
import scrapy

class MySpider(scrapy.Spider):
    name = 'myspider'
    custom_settings = {
        "IMAGES_URLS_FIELD": 'image_urls',
        "IMAGES_RESULT_FIELD": 'images',
        "IMAGES_STORE": Path.home() / 'Images',   # <-- here
        "ITEM_PIPELINES": {
            "scrapy.pipelines.images.ImagesPipeline": 1,
        }
    }
    ...
```

The unit tests I added will also trigger the error when tested without the changes.

And the exception that is raised:

```
2023-01-15 07:18:46 [twisted] CRITICAL:
Traceback (most recent call last):
  File "...\venv\lib\site-packages\twisted\internet\defer.py", line 1697, in _inlineCallbacks
    result = context.run(gen.send, result)
  File "...\spiders\venv\lib\site-packages\scrapy\crawler.py", line 116, in crawl
    self.engine = self._create_engine()
  File "...\venv\lib\site-packages\scrapy\crawler.py", line 130, in _create_engine
    return ExecutionEngine(self, lambda _: self.stop())
  File "...\venv\lib\site-packages\scrapy\core\engine.py", line 84, in __init__
    self.scraper = Scraper(crawler)
  File "...\venv\lib\site-packages\scrapy\core\scraper.py", line 82, in __init__
    self.itemproc = itemproc_cls.from_crawler(crawler)
  File "...\venv\lib\site-packages\scrapy\middleware.py", line 60, in from_crawler
    return cls.from_settings(crawler.settings, crawler)
  File "...\venv\lib\site-packages\scrapy\middleware.py", line 42, in from_settings
    mw = create_instance(mwcls, settings, crawler)
  File "...\venv\lib\site-packages\scrapy\utils\misc.py", line 167, in create_instance
    instance = objcls.from_crawler(crawler, *args, **kwargs)
  File "...\venv\lib\site-packages\scrapy\pipelines\media.py", line 75, in from_crawler
    pipe = cls.from_settings(crawler.settings)
  File "...\venv\lib\site-packages\scrapy\pipelines\images.py", line 112, in from_settings
    return cls(store_uri, settings=settings)
  File "...\spiders\venv\lib\site-packages\scrapy\pipelines\images.py", line 55, in __init__
    super().__init__(store_uri, settings=settings, download_func=download_func)
  File "...\venv\lib\site-packages\scrapy\pipelines\files.py", line 333, in __init__
    self.store = self._get_store(store_uri)
  File "...\venv\lib\site-packages\scrapy\pipelines\files.py", line 383, in _get_store
    return store_cls(uri)
  File "...\venv\lib\site-packages\scrapy\pipelines\files.py", line 43, in __init__
    if '://' in basedir:
TypeError: argument of type 'WindowsPath' is not iterable
```

I can make additional commits to this PR if I come across any others.