### PR TITLE
302-s responses do not filtered on redirection to.. itself

### DIFF
--- a/scrapy/downloadermiddlewares/redirect.py
+++ b/scrapy/downloadermiddlewares/redirect.py
@@ -38,6 +38,7 @@ class BaseRedirectMiddleware:
 
     @classmethod
     def from_crawler(cls, crawler):
+        cls.fp = crawler.request_fingerprinter.fingerprint
         return cls(crawler.settings)
 
     def _redirect(self, redirected, request, spider, reason):

--- a/scrapy/downloadermiddlewares/redirect.py
+++ b/scrapy/downloadermiddlewares/redirect.py
@@ -50,7 +50,7 @@ class BaseRedirectMiddleware:
             redirected.meta['redirect_ttl'] = ttl - 1
             redirected.meta['redirect_urls'] = request.meta.get('redirect_urls', []) + [request.url]
             redirected.meta['redirect_reasons'] = request.meta.get('redirect_reasons', []) + [reason]
-            redirected.dont_filter = request.dont_filter
+            redirected.dont_filter = request.dont_filter or self.fp(request) == self.fp(redirected)
             redirected.priority = request.priority + self.priority_adjust
             logger.debug("Redirecting (%(reason)s) to %(redirected)s from %(request)s",
                          {'reason': reason, 'redirected': redirected, 'request': request},


### PR DESCRIPTION
Fixes https://github.com/scrapy/scrapy/issues/1225, closes #4314, closes #7754.

In case if fingerprint of initial request equals to fingerprint of new redirected request -> `dont_filter=True` set to new redirected request.

Redirected requests loop to the same(in terms of.. the same fingerprint) request will be limited by existing `REDIRECT_MAX_TIMES` setting (by default - 20)

Code samples:
redirect_server.py (based on https://github.com/scrapy/scrapy/issues/1225#issuecomment-265388573 code) - running in background.
test_script.py 

<details> <summary>redirect_server.py</summary>

```python
from http import server
from http.server import SimpleHTTPRequestHandler


class RequestHandler(SimpleHTTPRequestHandler):
    protocol_version = "HTTP/1.1"

    def do_GET(self):
        if self.path == '/?foo=bar&qux=quux' or self.path == '/?qux=quux&foo=bar':
            self.send_response(302)
            self.send_header('Location', '/?foo=bar&qux=quux')
            self.send_header('Content-Length', 0)
            self.end_headers()
            return b''

        msg = b'Hello world'
        self.send_response(200)
        self.send_header('Content-Length', len(msg))
        self.end_headers()
        self.wfile.write(msg)
        self.finish()
        return msg


if __name__ == '__main__':
    httpd = server.HTTPServer(('127.0.0.1', 8000), RequestHandler)
    sa = httpd.socket.getsockname()
    print("Serving HTTP on", sa[0], "port", sa[1], "...")
    httpd.serve_forever()
```
</details>
<details> <summary>test_script.py</summary>

```python
import scrapy
from scrapy.crawler import CrawlerProcess

class ExampleSpider(scrapy.Spider):
    name = "example"; custom_settings = {'DOWNLOAD_DELAY':0.5}

    def start_requests(self):
        yield scrapy.Request(
            'http://localhost:8000/?foo=bar&qux=quux',
            callback=self.parse)

    def parse(self, response): pass

if __name__ == "__main__":
    process = CrawlerProcess()
    process.crawl(ExampleSpider)
    process.start()

```
</details>

<details><summary>log output</summary>

```
2023-01-16 00:13:40 [scrapy.utils.log] INFO: Scrapy 2.7.1 started (bot: scrapybot)
2023-01-16 00:13:40 [scrapy.utils.log] INFO: Versions: lxml 4.9.1.0, libxml2 2.9.14, cssselect 1.1.0, parsel 1.6.0, w3lib 1.21.0, Twisted 22.2.0, Python 3.10.8 | packaged by conda-forge | (main, Nov 24 2022, 14:07:00) [MSC v.1916 64 bit (AMD64)], pyOpenSSL 22.0.0 (OpenSSL 1.1.1s  1 Nov 2022), cryptography 37.0.4, Platform Windows-10-10.0.22621-SP0
2023-01-16 00:13:40 [scrapy.crawler] INFO: Overridden settings:
{'DOWNLOAD_DELAY': 0.5}
2023-01-16 00:13:40 [py.warnings] WARNING: C:\Users\user\PycharmProjects\scrapy\scrapy\utils\request.py:231: ScrapyDeprecationWarning: '2.6' is a deprecated value for the 'REQUEST_FINGERPRINTER_IMPLEMENTATION' setting.

It is also the default value. In other words, it is normal to get this warning if you have not defined a value for the 'REQUEST_FINGERPRINTER_IMPLEMENTATION' setting. This is so for backward compatibility reasons, but it will change in a future version of Scrapy.

See the documentation of the 'REQUEST_FINGERPRINTER_IMPLEMENTATION' setting for information on how to handle this deprecation.
  return cls(crawler)

2023-01-16 00:13:40 [scrapy.utils.log] DEBUG: Using reactor: twisted.internet.selectreactor.SelectReactor
2023-01-16 00:13:40 [scrapy.extensions.telnet] INFO: Telnet Password: 7cc8ea6120feaca1
2023-01-16 00:13:40 [scrapy.middleware] INFO: Enabled extensions:
['scrapy.extensions.corestats.CoreStats',
 'scrapy.extensions.telnet.TelnetConsole',
 'scrapy.extensions.logstats.LogStats']
2023-01-16 00:13:40 [scrapy.middleware] INFO: Enabled downloader middlewares:
['scrapy.downloadermiddlewares.httpauth.HttpAuthMiddleware',
 'scrapy.downloadermiddlewares.downloadtimeout.DownloadTimeoutMiddleware',
 'scrapy.downloadermiddlewares.defaultheaders.DefaultHeadersMiddleware',
 'scrapy.downloadermiddlewares.useragent.UserAgentMiddleware',
 'scrapy.downloadermiddlewares.retry.RetryMiddleware',
 'scrapy.downloadermiddlewares.redirect.MetaRefreshMiddleware',
 'scrapy.downloadermiddlewares.httpcompression.HttpCompressionMiddleware',
 'scrapy.downloadermiddlewares.redirect.RedirectMiddleware',
 'scrapy.downloadermiddlewares.cookies.CookiesMiddleware',
 'scrapy.downloadermiddlewares.httpproxy.HttpProxyMiddleware',
 'scrapy.downloadermiddlewares.stats.DownloaderStats']
2023-01-16 00:13:40 [scrapy.middleware] INFO: Enabled spider middlewares:
['scrapy.spidermiddlewares.httperror.HttpErrorMiddleware',
 'scrapy.spidermiddlewares.offsite.OffsiteMiddleware',
 'scrapy.spidermiddlewares.referer.RefererMiddleware',
 'scrapy.spidermiddlewares.urllength.UrlLengthMiddleware',
 'scrapy.spidermiddlewares.depth.DepthMiddleware']
2023-01-16 00:13:40 [scrapy.middleware] INFO: Enabled item pipelines:
[]
2023-01-16 00:13:40 [scrapy.core.engine] INFO: Spider opened
2023-01-16 00:13:40 [scrapy.extensions.logstats] INFO: Crawled 0 pages (at 0 pages/min), scraped 0 items (at 0 items/min)
2023-01-16 00:13:40 [scrapy.extensions.telnet] INFO: Telnet console listening on 127.0.0.1:6023
2023-01-16 00:13:40 [scrapy.downloadermiddlewares.redirect] DEBUG: Redirecting (302) to <GET http://localhost:8000/?foo=bar&qux=quux> from <GET http://localhost:8000/?foo=bar&qux=quux>
2023-01-16 00:13:41 [scrapy.downloadermiddlewares.redirect] DEBUG: Redirecting (302) to <GET http://localhost:8000/?foo=bar&qux=quux> from <GET http://localhost:8000/?foo=bar&qux=quux>
2023-01-16 00:13:41 [scrapy.downloadermiddlewares.redirect] DEBUG: Redirecting (302) to <GET http://localhost:8000/?foo=bar&qux=quux> from <GET http://localhost:8000/?foo=bar&qux=quux>
2023-01-16 00:13:42 [scrapy.downloadermiddlewares.redirect] DEBUG: Redirecting (302) to <GET http://localhost:8000/?foo=bar&qux=quux> from <GET http://localhost:8000/?foo=bar&qux=quux>
2023-01-16 00:13:43 [scrapy.downloadermiddlewares.redirect] DEBUG: Redirecting (302) to <GET http://localhost:8000/?foo=bar&qux=quux> from <GET http://localhost:8000/?foo=bar&qux=quux>
2023-01-16 00:13:43 [scrapy.downloadermiddlewares.redirect] DEBUG: Redirecting (302) to <GET http://localhost:8000/?foo=bar&qux=quux> from <GET http://localhost:8000/?foo=bar&qux=quux>
2023-01-16 00:13:44 [scrapy.downloadermiddlewares.redirect] DEBUG: Redirecting (302) to <GET http://localhost:8000/?foo=bar&qux=quux> from <GET http://localhost:8000/?foo=bar&qux=quux>
2023-01-16 00:13:45 [scrapy.downloadermiddlewares.redirect] DEBUG: Redirecting (302) to <GET http://localhost:8000/?foo=bar&qux=quux> from <GET http://localhost:8000/?foo=bar&qux=quux>
2023-01-16 00:13:45 [scrapy.downloadermiddlewares.redirect] DEBUG: Redirecting (302) to <GET http://localhost:8000/?foo=bar&qux=quux> from <GET http://localhost:8000/?foo=bar&qux=quux>
2023-01-16 00:13:46 [scrapy.downloadermiddlewares.redirect] DEBUG: Redirecting (302) to <GET http://localhost:8000/?foo=bar&qux=quux> from <GET http://localhost:8000/?foo=bar&qux=quux>
2023-01-16 00:13:47 [scrapy.downloadermiddlewares.redirect] DEBUG: Redirecting (302) to <GET http://localhost:8000/?foo=bar&qux=quux> from <GET http://localhost:8000/?foo=bar&qux=quux>
2023-01-16 00:13:47 [scrapy.downloadermiddlewares.redirect] DEBUG: Redirecting (302) to <GET http://localhost:8000/?foo=bar&qux=quux> from <GET http://localhost:8000/?foo=bar&qux=quux>
2023-01-16 00:13:48 [scrapy.downloadermiddlewares.redirect] DEBUG: Redirecting (302) to <GET http://localhost:8000/?foo=bar&qux=quux> from <GET http://localhost:8000/?foo=bar&qux=quux>
2023-01-16 00:13:48 [scrapy.downloadermiddlewares.redirect] DEBUG: Redirecting (302) to <GET http://localhost:8000/?foo=bar&qux=quux> from <GET http://localhost:8000/?foo=bar&qux=quux>
2023-01-16 00:13:49 [scrapy.downloadermiddlewares.redirect] DEBUG: Redirecting (302) to <GET http://localhost:8000/?foo=bar&qux=quux> from <GET http://localhost:8000/?foo=bar&qux=quux>
2023-01-16 00:13:50 [scrapy.downloadermiddlewares.redirect] DEBUG: Redirecting (302) to <GET http://localhost:8000/?foo=bar&qux=quux> from <GET http://localhost:8000/?foo=bar&qux=quux>
2023-01-16 00:13:51 [scrapy.downloadermiddlewares.redirect] DEBUG: Redirecting (302) to <GET http://localhost:8000/?foo=bar&qux=quux> from <GET http://localhost:8000/?foo=bar&qux=quux>
2023-01-16 00:13:51 [scrapy.downloadermiddlewares.redirect] DEBUG: Redirecting (302) to <GET http://localhost:8000/?foo=bar&qux=quux> from <GET http://localhost:8000/?foo=bar&qux=quux>
2023-01-16 00:13:52 [scrapy.downloadermiddlewares.redirect] DEBUG: Redirecting (302) to <GET http://localhost:8000/?foo=bar&qux=quux> from <GET http://localhost:8000/?foo=bar&qux=quux>
2023-01-16 00:13:53 [scrapy.downloadermiddlewares.redirect] DEBUG: Redirecting (302) to <GET http://localhost:8000/?foo=bar&qux=quux> from <GET http://localhost:8000/?foo=bar&qux=quux>
2023-01-16 00:13:53 [scrapy.downloadermiddlewares.redirect] DEBUG: Discarding <GET http://localhost:8000/?foo=bar&qux=quux>: max redirections reached
2023-01-16 00:13:53 [scrapy.core.engine] INFO: Closing spider (finished)
2023-01-16 00:13:53 [scrapy.statscollectors] INFO: Dumping Scrapy stats:
{'downloader/request_bytes': 4830,
 'downloader/request_count': 21,
 'downloader/request_method_count/GET': 21,
 'downloader/response_bytes': 3066,
 'downloader/response_count': 21,
 'downloader/response_status_count/302': 21,
 'elapsed_time_seconds': 13.011227,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2023, 1, 15, 22, 13, 53, 949405),
 'log_count/DEBUG': 22,
 'log_count/INFO': 10,
 'log_count/WARNING': 1,
 'scheduler/dequeued': 21,
 'scheduler/dequeued/memory': 21,
 'scheduler/enqueued': 21,
 'scheduler/enqueued/memory': 21,
 'start_time': datetime.datetime(2023, 1, 15, 22, 13, 40, 938178)}
2023-01-16 00:13:53 [scrapy.core.engine] INFO: Spider closed (finished)

Process finished with exit code 0

```
</details>

<details><summary>log_output ( 'REQUEST_FINGERPRINTER_IMPLEMENTATION': '2.7' added to custom settings)</summary>

```
2023-01-16 01:00:31 [scrapy.utils.log] INFO: Scrapy 2.7.1 started (bot: scrapybot)
2023-01-16 01:00:31 [scrapy.utils.log] INFO: Versions: lxml 4.9.1.0, libxml2 2.9.14, cssselect 1.1.0, parsel 1.6.0, w3lib 1.21.0, Twisted 22.2.0, Python 3.10.8 | packaged by conda-forge | (main, Nov 24 2022, 14:07:00) [MSC v.1916 64 bit (AMD64)], pyOpenSSL 22.0.0 (OpenSSL 1.1.1s  1 Nov 2022), cryptography 37.0.4, Platform Windows-10-10.0.22621-SP0
2023-01-16 01:00:31 [scrapy.crawler] INFO: Overridden settings:
{'DOWNLOAD_DELAY': 0.5, 'REQUEST_FINGERPRINTER_IMPLEMENTATION': '2.7'}
2023-01-16 01:00:31 [scrapy.utils.log] DEBUG: Using reactor: twisted.internet.selectreactor.SelectReactor
2023-01-16 01:00:31 [scrapy.extensions.telnet] INFO: Telnet Password: 77fc5dcc4b9b8691
2023-01-16 01:00:31 [scrapy.middleware] INFO: Enabled extensions:
['scrapy.extensions.corestats.CoreStats',
 'scrapy.extensions.telnet.TelnetConsole',
 'scrapy.extensions.logstats.LogStats']
2023-01-16 01:00:31 [scrapy.middleware] INFO: Enabled downloader middlewares:
['scrapy.downloadermiddlewares.httpauth.HttpAuthMiddleware',
 'scrapy.downloadermiddlewares.downloadtimeout.DownloadTimeoutMiddleware',
 'scrapy.downloadermiddlewares.defaultheaders.DefaultHeadersMiddleware',
 'scrapy.downloadermiddlewares.useragent.UserAgentMiddleware',
 'scrapy.downloadermiddlewares.retry.RetryMiddleware',
 'scrapy.downloadermiddlewares.redirect.MetaRefreshMiddleware',
 'scrapy.downloadermiddlewares.httpcompression.HttpCompressionMiddleware',
 'scrapy.downloadermiddlewares.redirect.RedirectMiddleware',
 'scrapy.downloadermiddlewares.cookies.CookiesMiddleware',
 'scrapy.downloadermiddlewares.httpproxy.HttpProxyMiddleware',
 'scrapy.downloadermiddlewares.stats.DownloaderStats']
2023-01-16 01:00:31 [scrapy.middleware] INFO: Enabled spider middlewares:
['scrapy.spidermiddlewares.httperror.HttpErrorMiddleware',
 'scrapy.spidermiddlewares.offsite.OffsiteMiddleware',
 'scrapy.spidermiddlewares.referer.RefererMiddleware',
 'scrapy.spidermiddlewares.urllength.UrlLengthMiddleware',
 'scrapy.spidermiddlewares.depth.DepthMiddleware']
2023-01-16 01:00:31 [scrapy.middleware] INFO: Enabled item pipelines:
[]
2023-01-16 01:00:31 [scrapy.core.engine] INFO: Spider opened
2023-01-16 01:00:32 [scrapy.extensions.logstats] INFO: Crawled 0 pages (at 0 pages/min), scraped 0 items (at 0 items/min)
2023-01-16 01:00:32 [scrapy.extensions.telnet] INFO: Telnet console listening on 127.0.0.1:6023
2023-01-16 01:00:32 [scrapy.downloadermiddlewares.redirect] DEBUG: Redirecting (302) to <GET http://localhost:8000/?foo=bar&qux=quux> from <GET http://localhost:8000/?foo=bar&qux=quux>
2023-01-16 01:00:32 [scrapy.downloadermiddlewares.redirect] DEBUG: Redirecting (302) to <GET http://localhost:8000/?foo=bar&qux=quux> from <GET http://localhost:8000/?foo=bar&qux=quux>
2023-01-16 01:00:32 [scrapy.downloadermiddlewares.redirect] DEBUG: Redirecting (302) to <GET http://localhost:8000/?foo=bar&qux=quux> from <GET http://localhost:8000/?foo=bar&qux=quux>
2023-01-16 01:00:33 [scrapy.downloadermiddlewares.redirect] DEBUG: Redirecting (302) to <GET http://localhost:8000/?foo=bar&qux=quux> from <GET http://localhost:8000/?foo=bar&qux=quux>
2023-01-16 01:00:33 [scrapy.downloadermiddlewares.redirect] DEBUG: Redirecting (302) to <GET http://localhost:8000/?foo=bar&qux=quux> from <GET http://localhost:8000/?foo=bar&qux=quux>
2023-01-16 01:00:34 [scrapy.downloadermiddlewares.redirect] DEBUG: Redirecting (302) to <GET http://localhost:8000/?foo=bar&qux=quux> from <GET http://localhost:8000/?foo=bar&qux=quux>
2023-01-16 01:00:35 [scrapy.downloadermiddlewares.redirect] DEBUG: Redirecting (302) to <GET http://localhost:8000/?foo=bar&qux=quux> from <GET http://localhost:8000/?foo=bar&qux=quux>
2023-01-16 01:00:35 [scrapy.downloadermiddlewares.redirect] DEBUG: Redirecting (302) to <GET http://localhost:8000/?foo=bar&qux=quux> from <GET http://localhost:8000/?foo=bar&qux=quux>
2023-01-16 01:00:36 [scrapy.downloadermiddlewares.redirect] DEBUG: Redirecting (302) to <GET http://localhost:8000/?foo=bar&qux=quux> from <GET http://localhost:8000/?foo=bar&qux=quux>
2023-01-16 01:00:36 [scrapy.downloadermiddlewares.redirect] DEBUG: Redirecting (302) to <GET http://localhost:8000/?foo=bar&qux=quux> from <GET http://localhost:8000/?foo=bar&qux=quux>
2023-01-16 01:00:37 [scrapy.downloadermiddlewares.redirect] DEBUG: Redirecting (302) to <GET http://localhost:8000/?foo=bar&qux=quux> from <GET http://localhost:8000/?foo=bar&qux=quux>
2023-01-16 01:00:37 [scrapy.downloadermiddlewares.redirect] DEBUG: Redirecting (302) to <GET http://localhost:8000/?foo=bar&qux=quux> from <GET http://localhost:8000/?foo=bar&qux=quux>
2023-01-16 01:00:38 [scrapy.downloadermiddlewares.redirect] DEBUG: Redirecting (302) to <GET http://localhost:8000/?foo=bar&qux=quux> from <GET http://localhost:8000/?foo=bar&qux=quux>
2023-01-16 01:00:39 [scrapy.downloadermiddlewares.redirect] DEBUG: Redirecting (302) to <GET http://localhost:8000/?foo=bar&qux=quux> from <GET http://localhost:8000/?foo=bar&qux=quux>
2023-01-16 01:00:39 [scrapy.downloadermiddlewares.redirect] DEBUG: Redirecting (302) to <GET http://localhost:8000/?foo=bar&qux=quux> from <GET http://localhost:8000/?foo=bar&qux=quux>
2023-01-16 01:00:40 [scrapy.downloadermiddlewares.redirect] DEBUG: Redirecting (302) to <GET http://localhost:8000/?foo=bar&qux=quux> from <GET http://localhost:8000/?foo=bar&qux=quux>
2023-01-16 01:00:41 [scrapy.downloadermiddlewares.redirect] DEBUG: Redirecting (302) to <GET http://localhost:8000/?foo=bar&qux=quux> from <GET http://localhost:8000/?foo=bar&qux=quux>
2023-01-16 01:00:41 [scrapy.downloadermiddlewares.redirect] DEBUG: Redirecting (302) to <GET http://localhost:8000/?foo=bar&qux=quux> from <GET http://localhost:8000/?foo=bar&qux=quux>
2023-01-16 01:00:42 [scrapy.downloadermiddlewares.redirect] DEBUG: Redirecting (302) to <GET http://localhost:8000/?foo=bar&qux=quux> from <GET http://localhost:8000/?foo=bar&qux=quux>
2023-01-16 01:00:42 [scrapy.downloadermiddlewares.redirect] DEBUG: Redirecting (302) to <GET http://localhost:8000/?foo=bar&qux=quux> from <GET http://localhost:8000/?foo=bar&qux=quux>
2023-01-16 01:00:43 [scrapy.downloadermiddlewares.redirect] DEBUG: Discarding <GET http://localhost:8000/?foo=bar&qux=quux>: max redirections reached
2023-01-16 01:00:43 [scrapy.core.engine] INFO: Closing spider (finished)
2023-01-16 01:00:43 [scrapy.statscollectors] INFO: Dumping Scrapy stats:
{'downloader/request_bytes': 4830,
 'downloader/request_count': 21,
 'downloader/request_method_count/GET': 21,
 'downloader/response_bytes': 3066,
 'downloader/response_count': 21,
 'downloader/response_status_count/302': 21,
 'elapsed_time_seconds': 11.439783,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2023, 1, 15, 23, 0, 43, 531342),
 'log_count/DEBUG': 22,
 'log_count/INFO': 10,
 'scheduler/dequeued': 21,
 'scheduler/dequeued/memory': 21,
 'scheduler/enqueued': 21,
 'scheduler/enqueued/memory': 21,
 'start_time': datetime.datetime(2023, 1, 15, 23, 0, 32, 91559)}
2023-01-16 01:00:43 [scrapy.core.engine] INFO: Spider closed (finished)

Process finished with exit code 0
```
</details>

Differences comparing to existing opened https://github.com/scrapy/scrapy/pull/4314 :
1. Changes don't affect actual dupefilter code in any way.
2. Solution based on usage of relatively recently added as result of https://github.com/scrapy/scrapy/pull/4524 centralized  `crawler.request_fingerprinter`. - it will use the same fingerprinter as on dupefilter and httpcache - it can be safely used with other compatible fingerprinting implementations(log output for both "old" 2.6 and "bytes" 2.7 provided)   while current implementation https://github.com/scrapy/scrapy/pull/4314  limited by single fingerprinting algorithm implemented in  `scrapy.utils.request.request_fingerprint`