### PR TITLE
Replace OrderedDict to dict

### DIFF
--- a/scrapy/utils/console.py
+++ b/scrapy/utils/console.py
@@ -1,5 +1,4 @@
 from functools import wraps
-from collections import OrderedDict
 
 
 def _embed_ipython_shell(namespace={}, banner=''):
@@ -63,12 +62,12 @@ def _embed_standard_shell(namespace={}, banner=''):
     return wrapper
 
 
-DEFAULT_PYTHON_SHELLS = OrderedDict([
-    ('ptpython', _embed_ptpython_shell),
-    ('ipython', _embed_ipython_shell),
-    ('bpython', _embed_bpython_shell),
-    ('python', _embed_standard_shell),
-])
+DEFAULT_PYTHON_SHELLS = dict(
+    ptpython=_embed_ptpython_shell,
+    ipython=_embed_ipython_shell,
+    bpython=_embed_bpython_shell,
+    python=_embed_standard_shell,
+)
 
 
 def get_shell_embed_func(shells=None, known_shells=None):

--- a/scrapy/utils/console.py
+++ b/scrapy/utils/console.py
@@ -62,12 +62,12 @@ def _embed_standard_shell(namespace={}, banner=''):
     return wrapper
 
 
-DEFAULT_PYTHON_SHELLS = dict(
-    ptpython=_embed_ptpython_shell,
-    ipython=_embed_ipython_shell,
-    bpython=_embed_bpython_shell,
-    python=_embed_standard_shell,
-)
+DEFAULT_PYTHON_SHELLS = {
+    'ptpython': _embed_ptpython_shell,
+    'ipython': _embed_ipython_shell,
+    'bpython': _embed_bpython_shell,
+    'python': _embed_standard_shell,
+}
 
 
 def get_shell_embed_func(shells=None, known_shells=None):


### PR DESCRIPTION
Since version 3.7, it makes no sense to use OrderedDict because python keeps data in dictionaries in order. Ordinary dictionaries are fastest than OrderedDict