### PR TITLE
Set `FEED_EXPORT_ENCODING='utf-8'` in the default template

### DIFF
--- a/docs/topics/feed-exports.rst
+++ b/docs/topics/feed-exports.rst
@@ -517,8 +517,7 @@ Use ``utf-8`` if you want UTF-8 for JSON too.
 
 .. versionchanged:: 2.8
    The :command:`startproject` command now sets this setting to
-   ``utf-8`` in the generated
-   ``settings.py`` file.
+   ``utf-8`` in the generated ``settings.py`` file.
 
 .. setting:: FEED_EXPORT_FIELDS
 

--- a/docs/topics/feed-exports.rst
+++ b/docs/topics/feed-exports.rst
@@ -515,6 +515,11 @@ which uses safe numeric encoding (``\uXXXX`` sequences) for historic reasons.
 
 Use ``utf-8`` if you want UTF-8 for JSON too.
 
+.. versionchanged:: 2.8
+   The :command:`startproject` command now sets this setting to
+   ``utf-8`` in the generated
+   ``settings.py`` file.
+
 .. setting:: FEED_EXPORT_FIELDS
 
 FEED_EXPORT_FIELDS

--- a/docs/topics/feed-exports.rst
+++ b/docs/topics/feed-exports.rst
@@ -515,7 +515,7 @@ which uses safe numeric encoding (``\uXXXX`` sequences) for historic reasons.
 
 Use ``utf-8`` if you want UTF-8 for JSON too.
 
-.. versionchanged:: 2.8
+.. versionchanged:: VERSION
    The :command:`startproject` command now sets this setting to
    ``utf-8`` in the generated ``settings.py`` file.
 

--- a/scrapy/templates/project/module/settings.py.tmpl
+++ b/scrapy/templates/project/module/settings.py.tmpl
@@ -90,3 +90,4 @@ ROBOTSTXT_OBEY = True
 # Set settings whose default value is deprecated to a future-proof value
 REQUEST_FINGERPRINTER_IMPLEMENTATION = '2.7'
 TWISTED_REACTOR = 'twisted.internet.asyncioreactor.AsyncioSelectorReactor'
+FEED_EXPORT_ENCODING = 'utf-8'


### PR DESCRIPTION
Resolves #5797