### PR TITLE
Added `setdefault` to `BaseSettings`

### DIFF
--- a/scrapy/settings/__init__.py
+++ b/scrapy/settings/__init__.py
@@ -293,6 +293,13 @@ class BaseSettings(MutableMapping):
         else:
             self.attributes[name].set(value, priority)
 
+    def setdefault(self, name, default=None, priority="project"):
+        if name not in self:
+            self.set(name, default, priority)
+            return default
+
+        return self.attributes[name].value
+
     def setdict(self, values, priority="project"):
         self.update(values, priority)
 

--- a/tests/test_settings/__init__.py
+++ b/tests/test_settings/__init__.py
@@ -65,6 +65,12 @@ class BaseSettingsTest(unittest.TestCase):
     def setUp(self):
         self.settings = BaseSettings()
 
+    def test_setdefault(self):
+        settings = BaseSettings()
+        value = settings.setdefault("TEST_OPTION", "value")
+        self.assertEqual(value, "value")
+        self.assertIsNotNone(value)
+
     def test_set_new_attribute(self):
         self.settings.set("TEST_OPTION", "value", 0)
         self.assertIn("TEST_OPTION", self.settings.attributes)

--- a/tests/test_settings/__init__.py
+++ b/tests/test_settings/__init__.py
@@ -65,12 +65,18 @@ class BaseSettingsTest(unittest.TestCase):
     def setUp(self):
         self.settings = BaseSettings()
 
-    def test_setdefault(self):
+    def test_setdefault_not_existing_value(self):
         settings = BaseSettings()
         value = settings.setdefault("TEST_OPTION", "value")
         self.assertEqual(settings["TEST_OPTION"], "value")
         self.assertEqual(value, "value")
         self.assertIsNotNone(value)
+
+    def test_setdefault_existing_value(self):
+        settings = BaseSettings({"TEST_OPTION": "value"})
+        value = settings.setdefault("TEST_OPTION", None)
+        self.assertEqual(settings["TEST_OPTION"], "value")
+        self.assertEqual(value, "value")
 
     def test_set_new_attribute(self):
         self.settings.set("TEST_OPTION", "value", 0)

--- a/tests/test_settings/__init__.py
+++ b/tests/test_settings/__init__.py
@@ -68,6 +68,7 @@ class BaseSettingsTest(unittest.TestCase):
     def test_setdefault(self):
         settings = BaseSettings()
         value = settings.setdefault("TEST_OPTION", "value")
+        self.assertEqual(settings["TEST_OPTION"], "value")
         self.assertEqual(value, "value")
         self.assertIsNotNone(value)
 


### PR DESCRIPTION
Added the `setdefault` method to the `BaseSettings` class.

Now `setdefault` works as expected, if the _key_ does not exist in `BaseSettings` then this _key_ will be added and _default value_ will be assigned to it and this _value_ will be returned. For example:

```python
from scrapy.settings import BaseSettings

settings = BaseSettings()
# 'some_key' does not exist in BaseSettings, so it returns 'default_value'
print(settings.setdefault("some_key", "default_value"))

# 'some_key' now gets 'default_value'
print(settings.get("some_key"))
```

Closes https://github.com/scrapy/scrapy/issues/5811