### PR TITLE
periodic-log-dump-stats: feature added

### DIFF
--- a/scrapy/extensions/logstats.py
+++ b/scrapy/extensions/logstats.py
@@ -1,5 +1,5 @@
-from datetime import datetime
 import logging
+from datetime import datetime
 
 from twisted.internet import task
 
@@ -13,7 +13,9 @@ logger = logging.getLogger(__name__)
 class LogStats:
     """Log basic scraping stats periodically"""
 
-    def __init__(self, stats, interval=60.0, extended=False, ext_include=None, ext_exclude=None):
+    def __init__(
+            self, stats, interval=60.0, extended=False, ext_include=None, ext_exclude=None
+    ):
         self.stats = stats
         self.interval = interval
         self.multiplier = 60.0 / self.interval
@@ -54,9 +56,7 @@ class LogStats:
             data.update(self.log_timing())
             data.update(self.log_delta())
             data.update(self.log_crawler_stats())
-            logger.info(
-                self.encoder.encode(data)
-            )
+            logger.info(self.encoder.encode(data))
         else:
             items = self.stats.get_value("item_scraped_count", 0)
             pages = self.stats.get_value("response_received_count", 0)
@@ -78,7 +78,8 @@ class LogStats:
 
     def log_delta(self):
         num_stats = {
-            k: v for k, v in self.stats._stats.items()
+            k: v
+            for k, v in self.stats._stats.items()
             if isinstance(v, (int, float)) and self.delta_param_allowed(k)
         }
         delta = {k: v - self.delta_prev.get(k, 0) for k, v in num_stats.items()}
@@ -92,13 +93,15 @@ class LogStats:
             "start_time": self.stats._stats["start_time"],
             "utcnow": now,
             "log_interval_real": (now - self.time_prev).total_seconds(),
-            "elapsed": (now - self.stats._stats["start_time"]).total_seconds()}
+            "elapsed": (now - self.stats._stats["start_time"]).total_seconds(),
+        }
         self.time_prev = now
         return {"time": time}
 
     def log_time(self):
         num_stats = {
-            k: v for k, v in self.stats._stats.items()
+            k: v
+            for k, v in self.stats._stats.items()
             if isinstance(v, (int, float)) and self.delta_param_allowed(k)
         }
         delta = {k: v - self.stats_prev.get(k, 0) for k, v in num_stats.items()}
@@ -126,8 +129,6 @@ class LogStats:
             data.update(self.log_timing())
             data.update(self.log_delta())
             data.update(self.log_crawler_stats())
-            logger.info(
-                self.encoder.encode(data)
-            )
+            logger.info(self.encoder.encode(data))
         if self.task and self.task.running:
             self.task.stop()

--- a/scrapy/extensions/logstats.py
+++ b/scrapy/extensions/logstats.py
@@ -53,6 +53,7 @@ class LogStats:
             data = {}
             data.update(self.log_timing())
             data.update(self.log_delta())
+            data.update(self.log_crawler_stats())
             logger.info(
                 self.encoder.encode(data)
             )
@@ -104,6 +105,9 @@ class LogStats:
         self.stats_prev = num_stats
         return {"delta": delta}
 
+    def log_crawler_stats(self):
+        return {"stats": self.stats.get_stats()}
+
     def delta_param_allowed(self, stat_name):
         for p in self.ext_exclude:
             if p in stat_name:
@@ -121,6 +125,7 @@ class LogStats:
             data = {}
             data.update(self.log_timing())
             data.update(self.log_delta())
+            data.update(self.log_crawler_stats())
             logger.info(
                 self.encoder.encode(data)
             )

--- a/scrapy/extensions/logstats.py
+++ b/scrapy/extensions/logstats.py
@@ -117,5 +117,12 @@ class LogStats:
             return True
 
     def spider_closed(self, spider, reason):
+        if self.extended:
+            data = {}
+            data.update(self.log_timing())
+            data.update(self.log_delta())
+            logger.info(
+                self.encoder.encode(data)
+            )
         if self.task and self.task.running:
             self.task.stop()


### PR DESCRIPTION
Aimed to solve https://github.com/scrapy/scrapy/issues/2173

The main idea of this approach is to.. get  **all**  `int` and `float` values of `crawler.stats` (and key names of course) and log.. it's changes (delta) on periodic basis.
on default log interval (60 seconds) it will log numeric stats changes for last minute.

<details><summary>script.py (books to scrape LOG_LEVEL -> INFO)</summary>

```python
import scrapy
from scrapy.crawler import CrawlerProcess

class BooksToScrapeSpider(scrapy.Spider):
    name = "books"
    custom_settings = {
        "DOWNLOAD_DELAY": 0.3,
        "LOG_LEVEL": 'INFO'
    }
    def start_requests(self):
        yield scrapy.Request(url='https://books.toscrape.com/', callback=self.parse)

    def parse(self, response):
        for book_page_link in response.css('.product_pod a::attr(href)').getall():
            yield scrapy.Request(response.urljoin(book_page_link), self.parse_book)
        if next_page := response.css("li.next a::attr(href)").get():
            yield scrapy.Request(url=response.urljoin(next_page), callback=self.parse)

    def parse_book(self, response):
        yield {'response.url': response.url}

if __name__ == "__main__":
    process = CrawlerProcess()
    process.crawl(BooksToScrapeSpider)
    process.start()
```
</details>

<details><summary>log output</summary>

```
2023-02-09 01:27:23 [scrapy.utils.log] INFO: Scrapy 2.8.0 started (bot: scrapybot)
2023-02-09 01:27:23 [scrapy.utils.log] INFO: Versions: lxml 4.9.1.0, libxml2 2.9.14, cssselect 1.1.0, parsel 1.6.0, w3lib 1.21.0, Twisted 22.2.0, Python 3.10.8 | packaged by conda-forge | (main, Nov 24 2022, 14:07:00) [MSC v.1916 64 bit (AMD64)], pyOpenSSL 22.0.0 (OpenSSL 1.1.1s  1 Nov 2022), cryptography 37.0.4, Platform Windows-10-10.0.22621-SP0
2023-02-09 01:27:23 [scrapy.crawler] INFO: Overridden settings:
{'DOWNLOAD_DELAY': 0.3, 'LOG_LEVEL': 'INFO'}
2023-02-09 01:27:23 [py.warnings] WARNING: <redacted> ScrapyDeprecationWarning: '2.6' is a deprecated value for the 'REQUEST_FINGERPRINTER_IMPLEMENTATION' setting.

It is also the default value. In other words, it is normal to get this warning if you have not defined a value for the 'REQUEST_FINGERPRINTER_IMPLEMENTATION' setting. This is so for backward compatibility reasons, but it will change in a future version of Scrapy.

See the documentation of the 'REQUEST_FINGERPRINTER_IMPLEMENTATION' setting for information on how to handle this deprecation.
  return cls(crawler)

2023-02-09 01:27:23 [scrapy.extensions.telnet] INFO: Telnet Password: d8fd4beeb7768b38
2023-02-09 01:27:23 [scrapy.middleware] INFO: Enabled extensions:
['scrapy.extensions.corestats.CoreStats',
 'scrapy.extensions.telnet.TelnetConsole',
 'scrapy.extensions.logstats.LogStats']
2023-02-09 01:27:23 [scrapy.middleware] INFO: Enabled downloader middlewares:
['scrapy.downloadermiddlewares.httpauth.HttpAuthMiddleware',
 'scrapy.downloadermiddlewares.downloadtimeout.DownloadTimeoutMiddleware',
 'scrapy.downloadermiddlewares.defaultheaders.DefaultHeadersMiddleware',
 'scrapy.downloadermiddlewares.useragent.UserAgentMiddleware',
 'scrapy.downloadermiddlewares.retry.RetryMiddleware',
 'scrapy.downloadermiddlewares.redirect.MetaRefreshMiddleware',
 'scrapy.downloadermiddlewares.httpcompression.HttpCompressionMiddleware',
 'scrapy.downloadermiddlewares.redirect.RedirectMiddleware',
 'scrapy.downloadermiddlewares.cookies.CookiesMiddleware',
 'scrapy.downloadermiddlewares.httpproxy.HttpProxyMiddleware',
 'scrapy.downloadermiddlewares.stats.DownloaderStats']
2023-02-09 01:27:23 [scrapy.middleware] INFO: Enabled spider middlewares:
['scrapy.spidermiddlewares.httperror.HttpErrorMiddleware',
 'scrapy.spidermiddlewares.offsite.OffsiteMiddleware',
 'scrapy.spidermiddlewares.referer.RefererMiddleware',
 'scrapy.spidermiddlewares.urllength.UrlLengthMiddleware',
 'scrapy.spidermiddlewares.depth.DepthMiddleware']
2023-02-09 01:27:23 [scrapy.middleware] INFO: Enabled item pipelines:
[]
2023-02-09 01:27:23 [scrapy.core.engine] INFO: Spider opened
2023-02-09 01:27:24 [scrapy.extensions.logstats] INFO: Crawled 0 pages (at 0 pages/min), scraped 0 items (at 0 items/min)
2023-02-09 01:27:24 [scrapy.extensions.logstats] INFO: Dumping periodic (60.0 seconds) Scrapy stats (0):
{'log_count/INFO': 8, 'log_count/WARNING': 1}
2023-02-09 01:27:24 [scrapy.extensions.telnet] INFO: Telnet console listening on 127.0.0.1:6024
2023-02-09 01:28:24 [scrapy.extensions.logstats] INFO: Crawled 161 pages (at 161 pages/min), scraped 151 items (at 151 items/min)
2023-02-09 01:28:24 [scrapy.extensions.logstats] INFO: Dumping periodic (60.0 seconds) Scrapy stats (1):
{'downloader/request_bytes': 60517,
 'downloader/request_count': 177,
 'downloader/request_method_count/GET': 177,
 'downloader/response_bytes': 640456,
 'downloader/response_count': 161,
 'downloader/response_status_count/200': 161,
 'dupefilter/filtered': 200,
 'httpcompression/response_bytes': 3430779,
 'httpcompression/response_count': 161,
 'item_scraped_count': 151,
 'log_count/INFO': 3,
 'log_count/WARNING': 0,
 'request_depth_max': 10,
 'response_received_count': 161,
 'scheduler/dequeued': 177,
 'scheduler/dequeued/memory': 177,
 'scheduler/enqueued': 211,
 'scheduler/enqueued/memory': 211}
2023-02-09 01:29:24 [scrapy.extensions.logstats] INFO: Crawled 324 pages (at 163 pages/min), scraped 303 items (at 152 items/min)
2023-02-09 01:29:24 [scrapy.extensions.logstats] INFO: Dumping periodic (60.0 seconds) Scrapy stats (2):
{'downloader/request_bytes': 55640,
 'downloader/request_count': 163,
 'downloader/request_method_count/GET': 163,
 'downloader/response_bytes': 645464,
 'downloader/response_count': 163,
 'downloader/response_status_count/200': 163,
 'dupefilter/filtered': 200,
 'httpcompression/response_bytes': 3479739,
 'httpcompression/response_count': 163,
 'item_scraped_count': 152,
 'log_count/INFO': 2,
 'log_count/WARNING': 0,
 'request_depth_max': 10,
 'response_received_count': 163,
 'scheduler/dequeued': 163,
 'scheduler/dequeued/memory': 163,
 'scheduler/enqueued': 210,
 'scheduler/enqueued/memory': 210}
2023-02-09 01:30:24 [scrapy.extensions.logstats] INFO: Crawled 487 pages (at 163 pages/min), scraped 457 items (at 154 items/min)
2023-02-09 01:30:24 [scrapy.extensions.logstats] INFO: Dumping periodic (60.0 seconds) Scrapy stats (3):
{'downloader/request_bytes': 56059,
 'downloader/request_count': 163,
 'downloader/request_method_count/GET': 163,
 'downloader/response_bytes': 660927,
 'downloader/response_count': 163,
 'downloader/response_status_count/200': 163,
 'dupefilter/filtered': 200,
 'httpcompression/response_bytes': 3536010,
 'httpcompression/response_count': 163,
 'item_scraped_count': 154,
 'log_count/INFO': 2,
 'log_count/WARNING': 0,
 'request_depth_max': 10,
 'response_received_count': 163,
 'scheduler/dequeued': 163,
 'scheduler/dequeued/memory': 163,
 'scheduler/enqueued': 210,
 'scheduler/enqueued/memory': 210}
2023-02-09 01:31:24 [scrapy.extensions.logstats] INFO: Crawled 650 pages (at 163 pages/min), scraped 611 items (at 154 items/min)
2023-02-09 01:31:24 [scrapy.extensions.logstats] INFO: Dumping periodic (60.0 seconds) Scrapy stats (4):
{'downloader/request_bytes': 55443,
 'downloader/request_count': 163,
 'downloader/request_method_count/GET': 163,
 'downloader/response_bytes': 636596,
 'downloader/response_count': 163,
 'downloader/response_status_count/200': 163,
 'dupefilter/filtered': 180,
 'httpcompression/response_bytes': 3426316,
 'httpcompression/response_count': 163,
 'item_scraped_count': 154,
 'log_count/INFO': 2,
 'log_count/WARNING': 0,
 'request_depth_max': 9,
 'response_received_count': 163,
 'scheduler/dequeued': 163,
 'scheduler/dequeued/memory': 163,
 'scheduler/enqueued': 189,
 'scheduler/enqueued/memory': 189}
2023-02-09 01:32:24 [scrapy.extensions.logstats] INFO: Crawled 810 pages (at 160 pages/min), scraped 762 items (at 151 items/min)
2023-02-09 01:32:24 [scrapy.extensions.logstats] INFO: Dumping periodic (60.0 seconds) Scrapy stats (5):
{'downloader/request_bytes': 53771,
 'downloader/request_count': 160,
 'downloader/request_method_count/GET': 160,
 'downloader/response_bytes': 620190,
 'downloader/response_count': 160,
 'downloader/response_status_count/200': 160,
 'dupefilter/filtered': 180,
 'httpcompression/response_bytes': 3345432,
 'httpcompression/response_count': 160,
 'item_scraped_count': 151,
 'log_count/INFO': 2,
 'log_count/WARNING': 0,
 'request_depth_max': 9,
 'response_received_count': 160,
 'scheduler/dequeued': 160,
 'scheduler/dequeued/memory': 160,
 'scheduler/enqueued': 189,
 'scheduler/enqueued/memory': 189}
2023-02-09 01:33:24 [scrapy.extensions.logstats] INFO: Crawled 972 pages (at 162 pages/min), scraped 921 items (at 159 items/min)
2023-02-09 01:33:24 [scrapy.extensions.logstats] INFO: Dumping periodic (60.0 seconds) Scrapy stats (6):
{'downloader/request_bytes': 55483,
 'downloader/request_count': 162,
 'downloader/request_method_count/GET': 162,
 'downloader/response_bytes': 618267,
 'downloader/response_count': 162,
 'downloader/response_status_count/200': 162,
 'dupefilter/filtered': 40,
 'httpcompression/response_bytes': 3170892,
 'httpcompression/response_count': 162,
 'item_scraped_count': 159,
 'log_count/INFO': 2,
 'log_count/WARNING': 0,
 'request_depth_max': 2,
 'response_received_count': 162,
 'scheduler/dequeued': 162,
 'scheduler/dequeued/memory': 162,
 'scheduler/enqueued': 41,
 'scheduler/enqueued/memory': 41}
2023-02-09 01:33:54 [scrapy.core.engine] INFO: Closing spider (finished)
2023-02-09 01:33:54 [scrapy.statscollectors] INFO: Dumping Scrapy stats:
{'downloader/request_bytes': 358595,
 'downloader/request_count': 1050,
 'downloader/request_method_count/GET': 1050,
 'downloader/response_bytes': 4126715,
 'downloader/response_count': 1050,
 'downloader/response_status_count/200': 1050,
 'dupefilter/filtered': 1000,
 'elapsed_time_seconds': 390.017596,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2023, 2, 8, 23, 33, 54, 128634),
 'httpcompression/response_bytes': 21921006,
 'httpcompression/response_count': 1050,
 'item_scraped_count': 1000,
 'log_count/INFO': 23,
 'log_count/WARNING': 1,
 'request_depth_max': 50,
 'response_received_count': 1050,
 'scheduler/dequeued': 1050,
 'scheduler/dequeued/memory': 1050,
 'scheduler/enqueued': 1050,
 'scheduler/enqueued/memory': 1050,
 'start_time': datetime.datetime(2023, 2, 8, 23, 27, 24, 111038)}
2023-02-09 01:33:54 [scrapy.core.engine] INFO: Spider closed (finished)

Process finished with exit code 0


```
</details>