### PR TITLE
Added documentation for Spider.update_settings

### DIFF
--- a/docs/topics/settings.rst
+++ b/docs/topics/settings.rst
@@ -66,8 +66,8 @@ Example::
 ----------------------
 
 Spiders (See the :ref:`topics-spiders` chapter for reference) can define their
-own settings that will take precedence and override the project ones. They can
-do so by setting their :attr:`~scrapy.Spider.custom_settings` attribute:
+own settings that will take precedence and override the project ones. One way
+to do so is by setting their :attr:`~scrapy.Spider.custom_settings` attribute:
 
 .. code-block:: python
 
@@ -80,6 +80,22 @@ do so by setting their :attr:`~scrapy.Spider.custom_settings` attribute:
         custom_settings = {
             "SOME_SETTING": "some value",
         }
+
+It's often better to provide a :meth:`~scrapy.Spider.update_settings` instead,
+and settings set there should use the "spider" priority explicitly:
+
+.. code-block:: python
+
+    import scrapy
+
+
+    class MySpider(scrapy.Spider):
+        name = "myspider"
+
+        @classmethod
+        def update_settings(cls, settings):
+            settings.set("SOME_SETTING", "some value", priority="spider")
+            super().update_settings(settings)
 
 3. Project settings module
 --------------------------

--- a/docs/topics/settings.rst
+++ b/docs/topics/settings.rst
@@ -81,7 +81,7 @@ to do so is by setting their :attr:`~scrapy.Spider.custom_settings` attribute:
             "SOME_SETTING": "some value",
         }
 
-It's often better to provide a :meth:`~scrapy.Spider.update_settings` instead,
+It's often better to implement :meth:`~scrapy.Spider.update_settings` instead,
 and settings set there should use the "spider" priority explicitly:
 
 .. code-block:: python
@@ -94,8 +94,8 @@ and settings set there should use the "spider" priority explicitly:
 
         @classmethod
         def update_settings(cls, settings):
-            settings.set("SOME_SETTING", "some value", priority="spider")
             super().update_settings(settings)
+            settings.set("SOME_SETTING", "some value", priority="spider")
 
 3. Project settings module
 --------------------------

--- a/docs/topics/spiders.rst
+++ b/docs/topics/spiders.rst
@@ -162,7 +162,7 @@ scrapy.Spider
        settings, spider attributes or other factors and use setting priorities
        other than ``'spider'``. Also, it's easy to extend ``update_settings()``
        in a subclass by overriding it, while doing the same with
-       :attr:`~scrapy.Spider.custom_settings` is hard or impossible.
+       :attr:`~scrapy.Spider.custom_settings` can be hard.
 
        For example, suppose a spider needs to modify :setting:`FEEDS`:
 
@@ -182,8 +182,8 @@ scrapy.Spider
 
                @classmethod
                def update_settings(cls, settings):
-                   settings.setdefault("FEEDS", {}).update(cls.custom_feed)
                    super().update_settings(settings)
+                   settings.setdefault("FEEDS", {}).update(cls.custom_feed)
 
    .. method:: start_requests()
 

--- a/docs/topics/spiders.rst
+++ b/docs/topics/spiders.rst
@@ -179,8 +179,6 @@ scrapy.Spider
                    settings.setdefault("FEEDS", {}).update(cls.custom_feed)
                    super().update_settings(settings)
 
-
-
    .. method:: start_requests()
 
        This method must return an iterable with the first Requests to crawl for

--- a/docs/topics/spiders.rst
+++ b/docs/topics/spiders.rst
@@ -151,7 +151,7 @@ scrapy.Spider
        and is called during initialization of a spider instance.
 
        It takes a :class:`~scrapy.settings.Settings` object as a parameter and
-       can add or updates the spider's configuration values. This method is a class method,
+       can add or update the spider's configuration values. This method is a class method,
        meaning that it is called on the :class:`~scrapy.Spider` class and allows all instances
        of the spider to share the same configuration.
 

--- a/docs/topics/spiders.rst
+++ b/docs/topics/spiders.rst
@@ -151,13 +151,18 @@ scrapy.Spider
        and is called during initialization of a spider instance.
 
        It takes a :class:`~scrapy.settings.Settings` object as a parameter and
-       can add or update the spider's configuration values. This method is a class method,
-       meaning that it is called on the :class:`~scrapy.Spider` class and allows all instances
-       of the spider to share the same configuration.
+       can add or update the spider's configuration values. This method is a
+       class method, meaning that it is called on the :class:`~scrapy.Spider`
+       class and allows all instances of the spider to share the same
+       configuration.
 
-       One of the main advantages of ``update_settings()`` is that it allows
-       you to dynamically add, remove or change settings based on other settings 
-       or other external factors.
+       While per-spider settings can be set in
+       :attr:`~scrapy.Spider.custom_settings`, using ``update_settings()``
+       allows you to dynamically add, remove or change settings based on other
+       settings, spider attributes or other factors and use setting priorities
+       other than ``'spider'``. Also, it's easy to extend ``update_settings()``
+       in a subclass by overriding it, while doing the same with
+       :attr:`~scrapy.Spider.custom_settings` is hard or impossible.
 
        For example, suppose a spider needs to modify :setting:`FEEDS`:
 

--- a/docs/topics/spiders.rst
+++ b/docs/topics/spiders.rst
@@ -159,7 +159,7 @@ scrapy.Spider
        you to dynamically add, remove or change settings based on spider arguments
        or other external factors.
 
-       For example, suppose a spider needs update :setting:`FEEDS`:
+       For example, suppose a spider needs to modify :setting:`FEEDS`:
 
        .. code-block:: python
 

--- a/docs/topics/spiders.rst
+++ b/docs/topics/spiders.rst
@@ -148,16 +148,16 @@ scrapy.Spider
    .. classmethod:: update_settings(settings)
 
        The ``update_settings()`` method is used to modify the spider's settings
-       and can be called during initialization of a spider instance.
+       and is called during initialization of a spider instance.
 
        It takes a :class:`~scrapy.settings.Settings` object as a parameter and
-       adds or updates the spider's configuration values. This method is a class method,
+       can add or updates the spider's configuration values. This method is a class method,
        meaning that it is called on the :class:`~scrapy.Spider` class and allows all instances
        of the spider to share the same configuration.
 
-       To create class hierarchies for spiders, it is recommended to use the :attr:`custom_settings`
-       attribute instead of ``update_settings()``, as it allows for default settings to be
-       defined and automatically inherited by subclasses.
+       One of the main advantages of ``update_settings()`` is that it allows
+       you to dynamically add, remove or change settings based on spider arguments
+       or other external factors.
 
        For example, suppose a spider needs update :setting:`FEEDS`:
 

--- a/docs/topics/spiders.rst
+++ b/docs/topics/spiders.rst
@@ -145,23 +145,24 @@ scrapy.Spider
        :param kwargs: keyword arguments passed to the :meth:`__init__` method
        :type kwargs: dict
 
-   .. method:: update_settings(cls, settings)
+   .. classmethod:: update_settings(settings)
 
        The ``update_settings()`` method is used to modify the spider's settings
        and can be called during initialization of a spider instance.
 
-       It takes a ``Settings`` object as a parameter and adds or updates the spider's
-       configuration values. This method is a class method, meaning that it is
-       called on the Spider class and allows all instances of the Spider to share
-       the same configuration.
+       It takes a :class:`~scrapy.settings.Settings` object as a parameter and
+       adds or updates the spider's configuration values. This method is a class method,
+       meaning that it is called on the :class:`~scrapy.Spider` class and allows all instances
+       of the spider to share the same configuration.
 
-       To create class hierarchies for spiders, it is recommended to use the ``custom_settings``
+       To create class hierarchies for spiders, it is recommended to use the :attr:`custom_settings`
        attribute instead of ``update_settings()``, as it allows for default settings to be
        defined and automatically inherited by subclasses.
 
-       For example, suppose a MySpider needs update FEEDS:
+       For example, suppose a spider needs update :setting:`FEEDS`:
 
        .. code-block:: python
+
            import scrapy
 
 

--- a/docs/topics/spiders.rst
+++ b/docs/topics/spiders.rst
@@ -145,6 +145,42 @@ scrapy.Spider
        :param kwargs: keyword arguments passed to the :meth:`__init__` method
        :type kwargs: dict
 
+   .. method:: update_settings(cls, settings)
+
+       The ``update_settings()`` method is used to modify the spider's settings
+       and can be called during initialization of a spider instance.
+
+       It takes a ``Settings`` object as a parameter and adds or updates the spider's
+       configuration values. This method is a class method, meaning that it is
+       called on the Spider class and allows all instances of the Spider to share
+       the same configuration.
+
+       To create class hierarchies for spiders, it is recommended to use the ``custom_settings``
+       attribute instead of ``update_settings()``, as it allows for default settings to be
+       defined and automatically inherited by subclasses.
+
+       For example, suppose a MySpider needs update FEEDS:
+
+       .. code-block:: python
+           import scrapy
+
+
+           class MySpider(scrapy.Spider):
+               name = "myspider"
+               custom_feed = {
+                   "/home/user/documents/items.json": {
+                       "format": "json",
+                       "indent": 4,
+                   }
+               }
+
+               @classmethod
+               def update_settings(cls, settings):
+                   settings.setdefault("FEEDS", {}).update(cls.custom_feed)
+                   super().update_settings(settings)
+
+
+
    .. method:: start_requests()
 
        This method must return an iterable with the first Requests to crawl for

--- a/docs/topics/spiders.rst
+++ b/docs/topics/spiders.rst
@@ -156,7 +156,7 @@ scrapy.Spider
        of the spider to share the same configuration.
 
        One of the main advantages of ``update_settings()`` is that it allows
-       you to dynamically add, remove or change settings based on spider arguments
+       you to dynamically add, remove or change settings based on other settings 
        or other external factors.
 
        For example, suppose a spider needs to modify :setting:`FEEDS`:


### PR DESCRIPTION
Added documentation for the `Spider.update_settings` class method.


Fixes #5745, closes #5757, closes #5784.