### PR TITLE
remove obvious comment in agent.py

### DIFF
--- a/scrapy/core/http2/agent.py
+++ b/scrapy/core/http2/agent.py
@@ -47,7 +47,6 @@ class H2ConnectionPool:
         # Check if we already have a connection to the remote
         conn = self._connections.get(key, None)
         if conn:
-            # Return this connection instance wrapped inside a deferred
             return defer.succeed(conn)
 
         # No connection is established for the given URI


### PR DESCRIPTION
This PR removes an obvious comment in `agent.py`.

**Obvious comment**: a comment that restates what the code does in an obvious manner. For more information, please see https://github.com/scrapy/scrapy/issues/5873.