### PR TITLE
remove obvious comment in test_http_request.py

### DIFF
--- a/tests/test_http_request.py
+++ b/tests/test_http_request.py
@@ -1506,7 +1506,6 @@ class JsonRequestTest(RequestTest):
         self.assertEqual(r4.body, to_bytes(json.dumps([])))
 
     def test_data_method(self):
-        # data is not passed
         r1 = self.request_class(url="http://www.example.com/")
         self.assertEqual(r1.method, "GET")
 


### PR DESCRIPTION
This PR removes an obvious comment in `test_http_request.py`.

**Obvious comment**: a comment that restates what the code does in an obvious manner. For more information, please see https://github.com/scrapy/scrapy/issues/5873.