### PR TITLE
remove obvious comment in form.py

### DIFF
--- a/scrapy/http/request/form.py
+++ b/scrapy/http/request/form.py
@@ -231,7 +231,6 @@ def _get_clickable(
     if not clickables:
         return None
 
-    # If we don't have clickdata, we just use the first clickable element
     if clickdata is None:
         el = clickables[0]
         return (el.get("name"), el.get("value") or "")


### PR DESCRIPTION
This PR removes an obvious comment in `form.py`.

**Obvious comment**: a comment that restates what the code does in an obvious manner. For more information, please see https://github.com/scrapy/scrapy/issues/5873.