### PR TITLE
remove obvious comment in httperror.py

### DIFF
--- a/scrapy/spidermiddlewares/httperror.py
+++ b/scrapy/spidermiddlewares/httperror.py
@@ -28,7 +28,7 @@ class HttpErrorMiddleware:
         self.handle_httpstatus_list = settings.getlist("HTTPERROR_ALLOWED_CODES")
 
     def process_spider_input(self, response, spider):
-        if 200 <= response.status < 300:  # common case
+        if 200 <= response.status < 300:
             return
         meta = response.meta
         if meta.get("handle_httpstatus_all", False):


### PR DESCRIPTION
This PR removes an obvious comment in `httperror.py`.

**Obvious comment**: a comment that restates what the code does in an obvious manner. For more information, please see https://github.com/scrapy/scrapy/issues/5873.