### PR TITLE
remove obvious comment in agent.py

### DIFF
--- a/scrapy/core/http2/agent.py
+++ b/scrapy/core/http2/agent.py
@@ -50,7 +50,6 @@ class H2ConnectionPool:
             # Return this connection instance wrapped inside a deferred
             return defer.succeed(conn)
 
-        # No connection is established for the given URI
         return self._new_connection(key, uri, endpoint)
 
     def _new_connection(


### PR DESCRIPTION
This PR removes an obvious comment in `agent.py`.

**Obvious comment**: a comment that restates what the code does in an obvious manner. For more information, please see https://github.com/scrapy/scrapy/issues/5873.