### PR TITLE
remove obvious comment in linkfix.py

### DIFF
--- a/docs/utils/linkfix.py
+++ b/docs/utils/linkfix.py
@@ -60,7 +60,6 @@ def main():
 
                 _contents = _contents.replace(match.group(3), match.group(4))
         else:
-            # We don't understand what the current line means!
             print("Not Understood: " + line)
 
 


### PR DESCRIPTION
This PR removes an obvious comment in `linkfix.py`.

**Obvious comment**: a comment that restates what the code does in an obvious manner. For more information, please see https://github.com/scrapy/scrapy/issues/5873.