### PR TITLE
remove obvious comment in test_feedexport.py

### DIFF
--- a/tests/test_feedexport.py
+++ b/tests/test_feedexport.py
@@ -798,7 +798,7 @@ class FeedExportTest(FeedExportTestBase):
         )
         data = yield self.exported_data(items, settings)
         rows = [{k: v for k, v in row.items() if v} for row in rows]
-        # XML
+
         root = lxml.etree.fromstring(data["xml"])
         xml_rows = [{e.tag: e.text for e in it} for it in root.findall("item")]
         self.assertEqual(rows, xml_rows)


### PR DESCRIPTION
This PR removes an obvious comment in `test_feedexport.py`.

**Obvious comment**: a comment that restates what the code does in an obvious manner. For more information, please see https://github.com/scrapy/scrapy/issues/5873.