### PR TITLE
remove task comment in test_utils_python.py

### DIFF
--- a/tests/test_utils_python.py
+++ b/tests/test_utils_python.py
@@ -237,7 +237,6 @@ class UtilsPythonTestCase(unittest.TestCase):
         self.assertEqual(get_func_args(object), [])
 
         if platform.python_implementation() == "CPython":
-            # TODO: how do we fix this to return the actual argument names?
             self.assertEqual(get_func_args(str.split), [])
             self.assertEqual(get_func_args(" ".join), [])
             self.assertEqual(get_func_args(operator.itemgetter(2)), [])


### PR DESCRIPTION
This PR removes a task comment in `test_utils_python.py`. Instead, an issue was created here https://github.com/scrapy/scrapy/issues/5872

**Task comment**: a comment referring to a work that could/should be done in the future or was already done. For more information, please see https://github.com/scrapy/scrapy/issues/5873.