### PR TITLE
remove beautification comment in test_spidermiddleware_referer.py

### DIFF
--- a/tests/test_spidermiddleware_referer.py
+++ b/tests/test_spidermiddleware_referer.py
@@ -624,7 +624,7 @@ class TestRefererMiddlewareDefault(MixinDefault, TestRefererMiddleware):
     pass
 
 
-# --- Tests using settings to set policy using class path
+# Tests using settings to set policy using class path
 class TestSettingsNoReferrer(MixinNoReferrer, TestRefererMiddleware):
     settings = {"REFERRER_POLICY": "scrapy.spidermiddlewares.referer.NoReferrerPolicy"}
 


### PR DESCRIPTION
This PR removes a beautification comment in `test_spidermiddleware_referer.py`.

**Beautification comment**: a comment that includes an array of special characters for beautification. For more information, please see https://github.com/scrapy/scrapy/issues/5873.