### PR TITLE
remove misleading comment in test_utils_python.py

### DIFF
--- a/tests/test_utils_python.py
+++ b/tests/test_utils_python.py
@@ -183,7 +183,6 @@ class UtilsPythonTestCase(unittest.TestCase):
         b.meta = {}
         self.assertTrue(equal_attributes(a, b, ["meta"]))
 
-        # compare ['meta']['a']
         a.meta["z"] = 1
         b.meta["z"] = 1
 


### PR DESCRIPTION
This PR removes a misleading comment in `test_utils_python.py`.

**Misleading comment**: a comment that does not accurately represent what the code does. For more information, please see https://github.com/scrapy/scrapy/issues/5873.