### PR TITLE
remove vague comment in engine.py

### DIFF
--- a/scrapy/core/engine.py
+++ b/scrapy/core/engine.py
@@ -153,7 +153,7 @@ class ExecutionEngine:
         if self.slot is None:
             return
 
-        assert self.spider is not None  # typing
+        assert self.spider is not None
 
         if self.paused:
             return None


### PR DESCRIPTION
This PR removes a vague comment in `engine.py`.

**Vague comment**: a comment that is not clearly understood. For more information, please see https://github.com/scrapy/scrapy/issues/5873.