### PR TITLE
Fixed Docs Makefile to open build/html/index.html in browser(#5878)

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -87,7 +87,7 @@ coverage: build
 
 htmlview: html
 	 $(PYTHON) -c "import webbrowser; from pathlib import Path; \
-	 webbrowser.open('file://' + Path('build/html/index.html').resolve())"
+	 webbrowser.open(Path('build/html/index.html').resolve().as_uri())"
 
 clean:
 	-rm -rf build/*


### PR DESCRIPTION
PR for modifying Makefile to open build/html/index.html
Path.resolve() was returning the PosixPath class so it was not possible to concatenate it with a string.
as_uri() converts the PosixPath to a string and makes it possible to concatenate it to a string which opens "build/html/index.html" in the browser.
