### PR TITLE
Add missing slash in selecting dynamically-loaded content documentation

### DIFF
--- a/docs/topics/dynamic-content.rst
+++ b/docs/topics/dynamic-content.rst
@@ -263,7 +263,7 @@ The following is a simple snippet to illustrate its usage within a Scrapy spider
             async with async_playwright() as pw:
                 browser = await pw.chromium.launch()
                 page = await browser.new_page()
-                await page.goto("https:/example.org")
+                await page.goto("https://example.org")
                 title = await page.title()
                 return {"title": title}
 


### PR DESCRIPTION
I've been reading scrapy documentation and I've realized that a slash is missing in one of the examples. This PR adds the missing slash in the "selecting dynamically-loaded content" documentation.