### PR TITLE
Replace the raw checksum with b64 decoded checksum for GCS

### DIFF
--- a/scrapy/pipelines/files.py
+++ b/scrapy/pipelines/files.py
@@ -3,6 +3,7 @@ Files Pipeline
 
 See documentation in topics/media-pipeline.rst
 """
+import base64
 import functools
 import hashlib
 import logging
@@ -228,7 +229,7 @@ class GCSFilesStore:
     def stat_file(self, path, info):
         def _onsuccess(blob):
             if blob:
-                checksum = blob.md5_hash
+                checksum = base64.b64decode(blob.md5_hash).hex()
                 last_modified = time.mktime(blob.updated.timetuple())
                 return {"checksum": checksum, "last_modified": last_modified}
             return {}

--- a/tests/test_pipeline_files.py
+++ b/tests/test_pipeline_files.py
@@ -601,7 +601,7 @@ class TestGCSFilesStore(unittest.TestCase):
         s = yield store.stat_file(path, info=None)
         self.assertIn("last_modified", s)
         self.assertIn("checksum", s)
-        self.assertEqual(s["checksum"], "zc2oVgXkbQr2EQdSdw3OPA==")
+        self.assertEqual(s["checksum"], "cdcda85605e46d0af6110752770dce3c")
         u = urlparse(uri)
         content, acl, blob = get_gcs_content_and_delete(u.hostname, u.path[1:] + path)
         self.assertEqual(content, data)


### PR DESCRIPTION
Fixes #5874 

Replace the raw checksum with b64 decoded checksum for GCS