### PR TITLE
Fix: Request.from_curl() with $-prefixed string literals

### DIFF
--- a/scrapy/utils/curl.py
+++ b/scrapy/utils/curl.py
@@ -11,8 +11,7 @@ from w3lib.http import basic_auth_header
 class DataAction(argparse.Action):
     def __call__(self, parser, namespace, values, option_string=None):
         value = str(values).encode("utf-8").decode("utf-8")
-        items = re.findall(r"\$(.+)", value)
-        value = items[0] if items else value
+        value = value[1::] if re.match(r"^\$(.+)", value) else value
         setattr(namespace, self.dest, value)
 
 

--- a/scrapy/utils/curl.py
+++ b/scrapy/utils/curl.py
@@ -10,8 +10,9 @@ from w3lib.http import basic_auth_header
 
 class DataAction(argparse.Action):
     def __call__(self, parser, namespace, values, option_string=None):
-        value = str(values).encode("utf-8").decode("utf-8")
-        value = value[1::] if re.match(r"^\$(.+)", value) else value
+        value = str(values)
+        if value.startswith("$"):
+            value = value[1:]
         setattr(namespace, self.dest, value)
 
 

--- a/scrapy/utils/curl.py
+++ b/scrapy/utils/curl.py
@@ -1,10 +1,20 @@
 import argparse
+import re
 import warnings
 from http.cookies import SimpleCookie
 from shlex import split
 from urllib.parse import urlparse
 
 from w3lib.http import basic_auth_header
+
+
+class DataAction(argparse.Action):
+    def __call__(self, parser, namespace, values, option_string=None):
+        value = str(values).encode("utf-8").decode("utf-8")
+        if items := re.findall(r"{.+}", value):
+            value = items[0]
+
+        setattr(namespace, self.dest, value)
 
 
 class CurlParser(argparse.ArgumentParser):
@@ -17,7 +27,7 @@ curl_parser = CurlParser()
 curl_parser.add_argument("url")
 curl_parser.add_argument("-H", "--header", dest="headers", action="append")
 curl_parser.add_argument("-X", "--request", dest="method")
-curl_parser.add_argument("-d", "--data", "--data-raw", dest="data")
+curl_parser.add_argument("-d", "--data", "--data-raw", dest="data", action=DataAction)
 curl_parser.add_argument("-u", "--user", dest="auth")
 
 

--- a/scrapy/utils/curl.py
+++ b/scrapy/utils/curl.py
@@ -11,7 +11,7 @@ from w3lib.http import basic_auth_header
 class DataAction(argparse.Action):
     def __call__(self, parser, namespace, values, option_string=None):
         value = str(values).encode("utf-8").decode("utf-8")
-        if items := re.findall(r"{.+}", value):
+        if items := re.findall(r"\$(.+)", value):
             value = items[0]
 
         setattr(namespace, self.dest, value)

--- a/scrapy/utils/curl.py
+++ b/scrapy/utils/curl.py
@@ -11,9 +11,8 @@ from w3lib.http import basic_auth_header
 class DataAction(argparse.Action):
     def __call__(self, parser, namespace, values, option_string=None):
         value = str(values).encode("utf-8").decode("utf-8")
-        if items := re.findall(r"\$(.+)", value):
-            value = items[0]
-
+        items = re.findall(r"\$(.+)", value)
+        value = items[0] if items else value
         setattr(namespace, self.dest, value)
 
 

--- a/scrapy/utils/curl.py
+++ b/scrapy/utils/curl.py
@@ -1,5 +1,4 @@
 import argparse
-import re
 import warnings
 from http.cookies import SimpleCookie
 from shlex import split

--- a/tests/test_utils_curl.py
+++ b/tests/test_utils_curl.py
@@ -154,6 +154,15 @@ class CurlToRequestKwargsTest(unittest.TestCase):
         }
         self._test_command(curl_command, expected_result)
 
+    def test_post_data_raw_with_string_prefix(self):
+        curl_command = "curl 'https://www.example.org/' --data-raw $'{\"$filters\":\"Filter\u0021\"}'"
+        expected_result = {
+            "method": "POST",
+            "url": "https://www.example.org/",
+            "body": '{"$filters":"Filter!"}',
+        }
+        self._test_command(curl_command, expected_result)
+
     def test_explicit_get_with_data(self):
         curl_command = "curl httpbin.org/anything -X GET --data asdf"
         expected_result = {


### PR DESCRIPTION
Hi @wRAR 

I added an [`action`](https://docs.python.org/3/library/argparse.html#action) for the `--data` argument that removes the _string prefix_ and decodes the string. Although `Request.from_curl()` now works correctly with requests like the one you shared in the issue, I don't know if this is the best way to approach this.


```python
curl_command = "curl 'https://www.example.org/' --data-raw $'{\"$filters\":\"Filter\u0021\"}'"
curl_to_request_kwargs(curl_command)

# output: {'method': 'POST', 'url': 'https://www.example.org/', 'body': '{"$filters":"Filter!"}'}
```


Closes https://github.com/scrapy/scrapy/issues/5899