### PR TITLE
fix: docs/intro/tutorial.rst checks

### DIFF
--- a/docs/intro/tutorial.rst
+++ b/docs/intro/tutorial.rst
@@ -252,7 +252,7 @@ object:
 .. code-block:: pycon
 
     >>> response.css("title")
-    [<Selector xpath='descendant-or-self::title' data='<title>Quotes to Scrape</title>'>]
+    [<Selector query='descendant-or-self::title' data='<title>Quotes to Scrape</title>'>]
 
 The result of running ``response.css('title')`` is a list-like object called
 :class:`~scrapy.selector.SelectorList`, which represents a list of
@@ -348,7 +348,7 @@ Besides `CSS`_, Scrapy selectors also support using `XPath`_ expressions:
 .. code-block:: pycon
 
     >>> response.xpath("//title")
-    [<Selector xpath='//title' data='<title>Quotes to Scrape</title>'>]
+    [<Selector query='//title' data='<title>Quotes to Scrape</title>'>]
     >>> response.xpath("//title/text()").get()
     'Quotes to Scrape'
 
@@ -410,8 +410,8 @@ We get a list of selectors for the quote HTML elements with:
 .. code-block:: pycon
 
     >>> response.css("div.quote")
-    [<Selector xpath="descendant-or-self::div[@class and contains(concat(' ', normalize-space(@class), ' '), ' quote ')]" data='<div class="quote" itemscope itemtype...'>,
-    <Selector xpath="descendant-or-self::div[@class and contains(concat(' ', normalize-space(@class), ' '), ' quote ')]" data='<div class="quote" itemscope itemtype...'>,
+    [<Selector query="descendant-or-self::div[@class and contains(concat(' ', normalize-space(@class), ' '), ' quote ')]" data='<div class="quote" itemscope itemtype...'>,
+    <Selector query="descendant-or-self::div[@class and contains(concat(' ', normalize-space(@class), ' '), ' quote ')]" data='<div class="quote" itemscope itemtype...'>,
     ...]
 
 Each of the selectors returned by the query above allows us to run further

--- a/pytest.ini
+++ b/pytest.ini
@@ -5,7 +5,6 @@ python_files=test_*.py __init__.py
 python_classes=
 addopts =
     --assert=plain
-    --doctest-modules
     --ignore=docs/_ext
     --ignore=docs/conf.py
     --ignore=docs/news.rst

--- a/tox.ini
+++ b/tox.ini
@@ -156,7 +156,7 @@ basepython = {[testenv:pypy3]basepython}
 deps =
     {[pinned]deps}
     PyPyDispatcher==2.1.0
-commands = {[pinned]commands}
+commands = {[testenv:pypy3]commands}
 install_command = {[pinned]install_command}
 setenv =
     {[pinned]setenv}

--- a/tox.ini
+++ b/tox.ini
@@ -100,7 +100,7 @@ setenv =
 install_command =
     python -I -m pip install {opts} {packages}
 commands =
-    pytest --cov=scrapy --cov-report=xml --cov-report= {posargs:--durations=10 docs scrapy tests}
+    pytest --cov=scrapy --cov-report=xml --cov-report= {posargs:--durations=10 scrapy tests}
 
 [testenv:pinned]
 basepython = python3.7

--- a/tox.ini
+++ b/tox.ini
@@ -99,6 +99,8 @@ setenv =
     _SCRAPY_PINNED=true
 install_command =
     python -I -m pip install {opts} {packages}
+commands =
+    pytest --cov=scrapy --cov-report=xml --cov-report= {posargs:--durations=10 docs scrapy tests}
 
 [testenv:pinned]
 basepython = python3.7
@@ -108,6 +110,7 @@ deps =
 install_command = {[pinned]install_command}
 setenv =
     {[pinned]setenv}
+commands = {[pinned]commands}
 
 [testenv:windows-pinned]
 basepython = python3
@@ -117,6 +120,7 @@ deps =
 install_command = {[pinned]install_command}
 setenv =
     {[pinned]setenv}
+commands = {[pinned]commands}
 
 [testenv:extra-deps]
 basepython = python3
@@ -137,7 +141,7 @@ commands =
 
 [testenv:asyncio-pinned]
 deps = {[testenv:pinned]deps}
-commands = {[testenv:asyncio]commands}
+commands = {[pinned]commands} --reactor=asyncio
 install_command = {[pinned]install_command}
 setenv =
     {[pinned]setenv}
@@ -152,7 +156,7 @@ basepython = {[testenv:pypy3]basepython}
 deps =
     {[pinned]deps}
     PyPyDispatcher==2.1.0
-commands = {[testenv:pypy3]commands}
+commands = {[pinned]commands}
 install_command = {[pinned]install_command}
 setenv =
     {[pinned]setenv}

--- a/tox.ini
+++ b/tox.ini
@@ -156,7 +156,8 @@ basepython = {[testenv:pypy3]basepython}
 deps =
     {[pinned]deps}
     PyPyDispatcher==2.1.0
-commands = {[testenv:pypy3]commands}
+commands =
+    pytest --durations=10 scrapy tests
 install_command = {[pinned]install_command}
 setenv =
     {[pinned]setenv}

--- a/tox.ini
+++ b/tox.ini
@@ -30,7 +30,7 @@ passenv =
 #allow tox virtualenv to upgrade pip/wheel/setuptools
 download = true
 commands =
-    pytest --cov=scrapy --cov-report=xml --cov-report= {posargs:--durations=10 docs scrapy tests}
+    pytest --cov=scrapy --cov-report=xml --cov-report= {posargs:--durations=10 docs scrapy tests} --doctest-modules
 install_command =
     python -I -m pip install -ctests/upper-constraints.txt {opts} {packages}
 


### PR DESCRIPTION
Fix docs/intro/tutorial.rst checks:

command:
```
pytest docs
```

output:
```
FAILED docs/intro/tutorial.rst::line:254,column:1
FAILED docs/intro/tutorial.rst::line:350,column:1
FAILED docs/intro/tutorial.rst::line:412,column:1
```