### PR TITLE
Adding support for windows absolute pathlib.Path objects in FeedExporter

### DIFF
--- a/docs/topics/feed-exports.rst
+++ b/docs/topics/feed-exports.rst
@@ -156,8 +156,7 @@ The feeds are stored in the local filesystem.
 -   Required external libraries: none
 
 Note that for the local filesystem storage (only) you can omit the scheme, and
-use an absolute or relative filesystem path (or a :class:`pathlib.Path`
-object) instead.
+use an absolute filesystem path (or a :class:`pathlib.Path` object) instead.
 
 .. _topics-feed-storage-ftp:
 

--- a/docs/topics/feed-exports.rst
+++ b/docs/topics/feed-exports.rst
@@ -156,7 +156,8 @@ The feeds are stored in the local filesystem.
 -   Required external libraries: none
 
 Note that for the local filesystem storage (only) you can omit the scheme, and
-use an absolute filesystem path (or a :class:`pathlib.Path` object) instead.
+use an absolute filesystem path (unix only) or a :class:`pathlib.Path` object
+instead.
 
 .. _topics-feed-storage-ftp:
 

--- a/docs/topics/feed-exports.rst
+++ b/docs/topics/feed-exports.rst
@@ -155,9 +155,9 @@ The feeds are stored in the local filesystem.
 -   Example URI: ``file:///tmp/export.csv``
 -   Required external libraries: none
 
-Note that for the local filesystem storage (only) you can omit the scheme if
-you specify an absolute path like ``/tmp/export.csv``. This only works on Unix
-systems though.
+Note that for the local filesystem storage (only) you can omit the scheme, and
+use an absolute or relative filesystem path (or a :class:`pathlib.Path`
+object) instead.
 
 .. _topics-feed-storage-ftp:
 
@@ -175,7 +175,7 @@ FTP supports two different connection modes: `active or passive
 mode by default. To use the active connection mode instead, set the
 :setting:`FEED_STORAGE_FTP_ACTIVE` setting to ``True``.
 
-The default value for the ``overwrite`` key in the :setting:`FEEDS` for this 
+The default value for the ``overwrite`` key in the :setting:`FEEDS` for this
 storage backend is: ``True``.
 
 .. caution:: The value ``True`` in ``overwrite`` will cause you to lose the
@@ -215,7 +215,7 @@ You can also define a custom ACL and custom endpoint for exported feeds using th
 -   :setting:`FEED_STORAGE_S3_ACL`
 -   :setting:`AWS_ENDPOINT_URL`
 
-The default value for the ``overwrite`` key in the :setting:`FEEDS` for this 
+The default value for the ``overwrite`` key in the :setting:`FEEDS` for this
 storage backend is: ``True``.
 
 .. caution:: The value ``True`` in ``overwrite`` will cause you to lose the
@@ -248,7 +248,7 @@ You can set a *Project ID* and *Access Control List (ACL)* through the following
 -   :setting:`FEED_STORAGE_GCS_ACL`
 -   :setting:`GCS_PROJECT_ID`
 
-The default value for the ``overwrite`` key in the :setting:`FEEDS` for this 
+The default value for the ``overwrite`` key in the :setting:`FEEDS` for this
 storage backend is: ``True``.
 
 .. caution:: The value ``True`` in ``overwrite`` will cause you to lose the

--- a/docs/topics/feed-exports.rst
+++ b/docs/topics/feed-exports.rst
@@ -155,9 +155,9 @@ The feeds are stored in the local filesystem.
 -   Example URI: ``file:///tmp/export.csv``
 -   Required external libraries: none
 
-Note that for the local filesystem storage (only) you can omit the scheme, and
-use an absolute filesystem path (unix only) or a :class:`pathlib.Path` object
-instead.
+Note that for the local filesystem storage (only) you can omit the scheme if
+you specify an absolute path like ``/tmp/export.csv`` (Unix systems only).
+Alternatively you can also use a :class:`pathlib.Path` object.
 
 .. _topics-feed-storage-ftp:
 
@@ -175,7 +175,7 @@ FTP supports two different connection modes: `active or passive
 mode by default. To use the active connection mode instead, set the
 :setting:`FEED_STORAGE_FTP_ACTIVE` setting to ``True``.
 
-The default value for the ``overwrite`` key in the :setting:`FEEDS` for this
+The default value for the ``overwrite`` key in the :setting:`FEEDS` for this 
 storage backend is: ``True``.
 
 .. caution:: The value ``True`` in ``overwrite`` will cause you to lose the
@@ -215,7 +215,7 @@ You can also define a custom ACL and custom endpoint for exported feeds using th
 -   :setting:`FEED_STORAGE_S3_ACL`
 -   :setting:`AWS_ENDPOINT_URL`
 
-The default value for the ``overwrite`` key in the :setting:`FEEDS` for this
+The default value for the ``overwrite`` key in the :setting:`FEEDS` for this 
 storage backend is: ``True``.
 
 .. caution:: The value ``True`` in ``overwrite`` will cause you to lose the
@@ -248,7 +248,7 @@ You can set a *Project ID* and *Access Control List (ACL)* through the following
 -   :setting:`FEED_STORAGE_GCS_ACL`
 -   :setting:`GCS_PROJECT_ID`
 
-The default value for the ``overwrite`` key in the :setting:`FEEDS` for this
+The default value for the ``overwrite`` key in the :setting:`FEEDS` for this 
 storage backend is: ``True``.
 
 .. caution:: The value ``True`` in ``overwrite`` will cause you to lose the

--- a/scrapy/extensions/feedexport.py
+++ b/scrapy/extensions/feedexport.py
@@ -358,7 +358,8 @@ class FeedExporter:
                 stacklevel=2,
             )
             uri = self.settings["FEED_URI"]
-            uri = _check_local_path(str(uri))  # handle pathlib.Path objects
+            # handle pathlib.Path objects
+            uri = str(uri) if not isinstance(uri, Path) else uri.resolve().as_uri()
             feed_options = {"format": self.settings.get("FEED_FORMAT", "jsonlines")}
             self.feeds[uri] = feed_complete_default_values_from_settings(
                 feed_options, self.settings
@@ -368,7 +369,8 @@ class FeedExporter:
 
         # 'FEEDS' setting takes precedence over 'FEED_URI'
         for uri, feed_options in self.settings.getdict("FEEDS").items():
-            uri = _check_local_path(str(uri))  # handle pathlib.Path objects
+            # handle pathlib.Path objects
+            uri = str(uri) if not isinstance(uri, Path) else uri.resolve().as_uri()
             self.feeds[uri] = feed_complete_default_values_from_settings(
                 feed_options, self.settings
             )

--- a/scrapy/extensions/feedexport.py
+++ b/scrapy/extensions/feedexport.py
@@ -347,7 +347,9 @@ class FeedExporter:
                 category=ScrapyDeprecationWarning,
                 stacklevel=2,
             )
-            uri = str(self.settings["FEED_URI"])  # handle pathlib.Path objects
+            uri = self.settings["FEED_URI"]
+            if isinstance(uri, Path):  # handle pathlib.Path objects
+                uri = uri.as_uri()
             feed_options = {"format": self.settings.get("FEED_FORMAT", "jsonlines")}
             self.feeds[uri] = feed_complete_default_values_from_settings(
                 feed_options, self.settings
@@ -357,7 +359,8 @@ class FeedExporter:
 
         # 'FEEDS' setting takes precedence over 'FEED_URI'
         for uri, feed_options in self.settings.getdict("FEEDS").items():
-            uri = str(uri)  # handle pathlib.Path objects
+            if isinstance(uri, Path):  # handle pathlib.Path objects
+                uri = uri.as_uri()
             self.feeds[uri] = feed_complete_default_values_from_settings(
                 feed_options, self.settings
             )

--- a/scrapy/extensions/feedexport.py
+++ b/scrapy/extensions/feedexport.py
@@ -348,8 +348,8 @@ class FeedExporter:
                 stacklevel=2,
             )
             uri = self.settings["FEED_URI"]
-            if isinstance(uri, Path):  # handle pathlib.Path objects
-                uri = uri.as_uri()
+            # handle pathlib.Path objects
+            uri = str(uri) if not isinstance(uri, Path) else uri.as_uri()
             feed_options = {"format": self.settings.get("FEED_FORMAT", "jsonlines")}
             self.feeds[uri] = feed_complete_default_values_from_settings(
                 feed_options, self.settings
@@ -359,8 +359,8 @@ class FeedExporter:
 
         # 'FEEDS' setting takes precedence over 'FEED_URI'
         for uri, feed_options in self.settings.getdict("FEEDS").items():
-            if isinstance(uri, Path):  # handle pathlib.Path objects
-                uri = uri.as_uri()
+            # handle pathlib.Path objects
+            uri = str(uri) if not isinstance(uri, Path) else uri.as_uri()
             self.feeds[uri] = feed_complete_default_values_from_settings(
                 feed_options, self.settings
             )

--- a/scrapy/extensions/feedexport.py
+++ b/scrapy/extensions/feedexport.py
@@ -318,16 +318,6 @@ _FeedSlot = create_deprecated_class(
 )
 
 
-def _check_local_path(uri: str):
-    """
-    Checks if uri is a local filesystem path
-    or Path object and converts it to a uri.
-    """
-    if Path(uri).parent.exists() and re.match(r"\w+:/*?$", uri) is None:
-        return Path(uri).resolve().as_uri()
-    return uri
-
-
 class FeedExporter:
     _pending_deferreds: List[defer.Deferred] = []
 

--- a/scrapy/extensions/feedexport.py
+++ b/scrapy/extensions/feedexport.py
@@ -359,7 +359,7 @@ class FeedExporter:
             )
             uri = self.settings["FEED_URI"]
             # handle pathlib.Path objects
-            uri = str(uri) if not isinstance(uri, Path) else uri.resolve().as_uri()
+            uri = str(uri) if not isinstance(uri, Path) else uri.absolute().as_uri()
             feed_options = {"format": self.settings.get("FEED_FORMAT", "jsonlines")}
             self.feeds[uri] = feed_complete_default_values_from_settings(
                 feed_options, self.settings
@@ -370,7 +370,7 @@ class FeedExporter:
         # 'FEEDS' setting takes precedence over 'FEED_URI'
         for uri, feed_options in self.settings.getdict("FEEDS").items():
             # handle pathlib.Path objects
-            uri = str(uri) if not isinstance(uri, Path) else uri.resolve().as_uri()
+            uri = str(uri) if not isinstance(uri, Path) else uri.absolute().as_uri()
             self.feeds[uri] = feed_complete_default_values_from_settings(
                 feed_options, self.settings
             )

--- a/tests/test_feedexport.py
+++ b/tests/test_feedexport.py
@@ -2765,18 +2765,17 @@ class FeedExportInitTest(unittest.TestCase):
             exporter = FeedExporter.from_crawler(crawler)
             self.assertIsInstance(exporter, FeedExporter)
 
-    def test_absolute_str_path_as_uri(self):
-        with tempfile.NamedTemporaryFile(suffix="json") as tmp:
-            settings = {
-                "FEEDS": {
-                    tmp.name: {
-                        "format": "json",
-                    },
+    def test_relative_pathlib_as_uri(self):
+        settings = {
+            "FEEDS": {
+                Path("./items.json"): {
+                    "format": "json",
                 },
-            }
-            crawler = get_crawler(settings_dict=settings)
-            exporter = FeedExporter.from_crawler(crawler)
-            self.assertIsInstance(exporter, FeedExporter)
+            },
+        }
+        crawler = get_crawler(settings_dict=settings)
+        exporter = FeedExporter.from_crawler(crawler)
+        self.assertIsInstance(exporter, FeedExporter)
 
 
 class StdoutFeedStorageWithoutFeedOptions(StdoutFeedStorage):

--- a/tests/test_feedexport.py
+++ b/tests/test_feedexport.py
@@ -2765,6 +2765,25 @@ class FeedExportInitTest(unittest.TestCase):
             exporter = FeedExporter.from_crawler(crawler)
             self.assertIsInstance(exporter, FeedExporter)
 
+    def test_absolute_str_path_as_uri(self):
+        with tempfile.NamedTemporaryFile(suffix="json") as tmp:
+            settings = {"FEEDS": {tmp.name: {"format": "json"}}}
+            crawler = get_crawler(settings_dict=settings)
+            exporter = FeedExporter.from_crawler(crawler)
+            self.assertIsInstance(exporter, FeedExporter)
+
+    def test_relative_str_path_as_uri(self):
+        settings = {"FEEDS": {"./relative_path.json": {"format": "json"}}}
+        crawler = get_crawler(settings_dict=settings)
+        exporter = FeedExporter.from_crawler(crawler)
+        self.assertIsInstance(exporter, FeedExporter)
+
+    def test_relative_pathlib_path_as_uri(self):
+        settings = {"FEEDS": {Path("./relative_path.json"): {"format": "json"}}}
+        crawler = get_crawler(settings_dict=settings)
+        exporter = FeedExporter.from_crawler(crawler)
+        self.assertIsInstance(exporter, FeedExporter)
+
 
 class StdoutFeedStorageWithoutFeedOptions(StdoutFeedStorage):
     def __init__(self, uri):

--- a/tests/test_feedexport.py
+++ b/tests/test_feedexport.py
@@ -2752,6 +2752,19 @@ class FeedExportInitTest(unittest.TestCase):
         with self.assertRaises(NotConfigured):
             FeedExporter.from_crawler(crawler)
 
+    def test_absolute_pathlib_as_uri(self):
+        with tempfile.NamedTemporaryFile(suffix="json") as tmp:
+            settings = {
+                "FEEDS": {
+                    Path(tmp.name).resolve(): {
+                        "format": "json",
+                    },
+                },
+            }
+            crawler = get_crawler(settings_dict=settings)
+            exporter = FeedExporter.from_crawler(crawler)
+            self.assertIsInstance(exporter, FeedExporter)
+
 
 class StdoutFeedStorageWithoutFeedOptions(StdoutFeedStorage):
     def __init__(self, uri):

--- a/tests/test_feedexport.py
+++ b/tests/test_feedexport.py
@@ -2767,22 +2767,16 @@ class FeedExportInitTest(unittest.TestCase):
 
     def test_absolute_str_path_as_uri(self):
         with tempfile.NamedTemporaryFile(suffix="json") as tmp:
-            settings = {"FEEDS": {tmp.name: {"format": "json"}}}
+            settings = {
+                "FEEDS": {
+                    tmp.name: {
+                        "format": "json",
+                    },
+                },
+            }
             crawler = get_crawler(settings_dict=settings)
             exporter = FeedExporter.from_crawler(crawler)
             self.assertIsInstance(exporter, FeedExporter)
-
-    def test_relative_str_path_as_uri(self):
-        settings = {"FEEDS": {"./relative_path.json": {"format": "json"}}}
-        crawler = get_crawler(settings_dict=settings)
-        exporter = FeedExporter.from_crawler(crawler)
-        self.assertIsInstance(exporter, FeedExporter)
-
-    def test_relative_pathlib_path_as_uri(self):
-        settings = {"FEEDS": {Path("./relative_path.json"): {"format": "json"}}}
-        crawler = get_crawler(settings_dict=settings)
-        exporter = FeedExporter.from_crawler(crawler)
-        self.assertIsInstance(exporter, FeedExporter)
 
 
 class StdoutFeedStorageWithoutFeedOptions(StdoutFeedStorage):


### PR DESCRIPTION
This PR is related to #5739  as well as some conflicting information in the docs.

On the [Feed Exports](https://docs.scrapy.org/en/latest/topics/feed-exports.html#topics-feed-storage-fs) page, in the [FEEDS](https://docs.scrapy.org/en/latest/topics/feed-exports.html#feeds) subsection it mentions that you can use a URI or a `pathlib.Path` object as the target.

https://github.com/scrapy/scrapy/blob/33b418dc846c8a0de21bef7a71c7ed259e24b269/docs/topics/feed-exports.rst?plain=1#L412-L423


Earlier on the same page however under the [Storage Backends](https://docs.scrapy.org/en/latest/topics/feed-exports.html#local-filesystem) section it mentions that you can use a standard string path as long as its an absolute path, but only on Unix systems.

https://github.com/scrapy/scrapy/blob/33b418dc846c8a0de21bef7a71c7ed259e24b269/docs/topics/feed-exports.rst?plain=1#L149-L161

Both of these statements are accurate however, if one were to miss the second statement and only read the first you might think, as I did, that using an absolute `pathlib.Path` object on windows would work fine, when in fact it doesn't.  For example using a `Path(__file__).parent / "items.json"` fails when used on windows OS.  

My proposed solution to this, which is implemented in this PR is to simply get rid of the "only on Unix" caveat and make it work for windows as well.  I achieved this by adding a conditional statement in the `FeedExporter.__init__` method that tests if the uri used in the settings is a `Path` object, and if it is then to convert it to a filesystem uri. 

I also included an accompanying unit test that would fail prior to the changes.