### PR TITLE
Fix minor typo in docs/intro/overview.rst 

### DIFF
--- a/docs/intro/overview.rst
+++ b/docs/intro/overview.rst
@@ -4,7 +4,7 @@
 Scrapy at a glance
 ==================
 
-Scrapy (/ˈskreɪpaɪ/) is an application framework for crawling web sites and extracting
+Scrapy (/ˈskreɪpaɪ/) is an application framework for crawling websites and extracting
 structured data which can be used for a wide range of useful applications, like
 data mining, information processing or historical archival.
 


### PR DESCRIPTION
Fixed a minor typo on line 7 of overview page to fall in line with the rest of Scrapy documentation. 