### PR TITLE
Fix extra-deps-pinned tests.

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -139,6 +139,7 @@ deps =
 install_command = {[pinned]install_command}
 setenv =
     {[pinned]setenv}
+commands = {[pinned]commands}
 
 [testenv:asyncio]
 commands =


### PR DESCRIPTION
This fixes the run command, skipping docs tests which are currently failing the test run (as old parsel breaks them).