### PR TITLE
chore: Implement `pop` method on `BaseSettings` class

### DIFF
--- a/scrapy/settings/__init__.py
+++ b/scrapy/settings/__init__.py
@@ -456,7 +456,7 @@ class BaseSettings(MutableMapping):
 
             return SettingsAttribute(default, get_settings_priority("project"))
         else:
-            del self.attributes[name]
+            self.__delitem__(name)
             return value
 
 

--- a/scrapy/settings/__init__.py
+++ b/scrapy/settings/__init__.py
@@ -75,6 +75,8 @@ class BaseSettings(MutableMapping):
     highest priority will be retrieved.
     """
 
+    __default = object()
+
     def __init__(self, values=None, priority="project"):
         self.frozen = False
         self.attributes = {}
@@ -444,6 +446,18 @@ class BaseSettings(MutableMapping):
             p.text(repr(self))
         else:
             p.text(pformat(self.copy_to_dict()))
+
+    def pop(self, name, default=__default):
+        try:
+            value = self.attributes[name]
+        except KeyError:
+            if default is self.__default:
+                raise
+
+            return SettingsAttribute(default, get_settings_priority("project"))
+        else:
+            del self.attributes[name]
+            return value
 
 
 class Settings(BaseSettings):

--- a/tests/test_settings/__init__.py
+++ b/tests/test_settings/__init__.py
@@ -464,7 +464,7 @@ class SettingsTest(unittest.TestCase):
         )
         self.assertEqual(dummy_config.value, "dummy_value")
 
-    def test_pop_item_with_frozen_settings(self):
+    def test_pop_item_with_immutable_settings(self):
         settings = Settings(
             {"DUMMY_CONFIG": "dummy_value", "OTHER_DUMMY_CONFIG": "other_dummy_value"}
         )

--- a/tests/test_settings/__init__.py
+++ b/tests/test_settings/__init__.py
@@ -464,6 +464,22 @@ class SettingsTest(unittest.TestCase):
         )
         self.assertEqual(dummy_config.value, "dummy_value")
 
+    def test_pop_item_with_frozen_settings(self):
+        settings = Settings(
+            {"DUMMY_CONFIG": "dummy_value", "OTHER_DUMMY_CONFIG": "other_dummy_value"}
+        )
+
+        self.assertEqual(settings.pop("DUMMY_CONFIG").value, "dummy_value")
+
+        settings.freeze()
+
+        with self.assertRaises(TypeError) as error:
+            settings.pop("OTHER_DUMMY_CONFIG")
+
+        self.assertEqual(
+            str(error.exception), "Trying to modify an immutable Settings object"
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_settings/__init__.py
+++ b/tests/test_settings/__init__.py
@@ -451,6 +451,19 @@ class SettingsTest(unittest.TestCase):
         self.assertIsInstance(myhandler_instance, FileDownloadHandler)
         self.assertTrue(hasattr(myhandler_instance, "download_request"))
 
+    def test_pop_item_with_default_value(self):
+        settings = Settings()
+
+        with self.assertRaises(KeyError):
+            settings.pop("DUMMY_CONFIG")
+
+        dummy_config = settings.pop("DUMMY_CONFIG", "dummy_value")
+
+        self.assertEqual(
+            repr(dummy_config), "<SettingsAttribute value='dummy_value' priority=20>"
+        )
+        self.assertEqual(dummy_config.value, "dummy_value")
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
fixes: #5959