### PR TITLE
fix: Return value instead of `SettingsAttribute` object when using `pop` method

### DIFF
--- a/scrapy/settings/__init__.py
+++ b/scrapy/settings/__init__.py
@@ -449,12 +449,12 @@ class BaseSettings(MutableMapping):
 
     def pop(self, name, default=__default):
         try:
-            value = self.attributes[name]
+            value = self.attributes[name].value
         except KeyError:
             if default is self.__default:
                 raise
 
-            return SettingsAttribute(default, get_settings_priority("project"))
+            return default
         else:
             self.__delitem__(name)
             return value

--- a/tests/test_settings/__init__.py
+++ b/tests/test_settings/__init__.py
@@ -457,19 +457,15 @@ class SettingsTest(unittest.TestCase):
         with self.assertRaises(KeyError):
             settings.pop("DUMMY_CONFIG")
 
-        dummy_config = settings.pop("DUMMY_CONFIG", "dummy_value")
-
-        self.assertEqual(
-            repr(dummy_config), "<SettingsAttribute value='dummy_value' priority=20>"
-        )
-        self.assertEqual(dummy_config.value, "dummy_value")
+        dummy_config_value = settings.pop("DUMMY_CONFIG", "dummy_value")
+        self.assertEqual(dummy_config_value, "dummy_value")
 
     def test_pop_item_with_immutable_settings(self):
         settings = Settings(
             {"DUMMY_CONFIG": "dummy_value", "OTHER_DUMMY_CONFIG": "other_dummy_value"}
         )
 
-        self.assertEqual(settings.pop("DUMMY_CONFIG").value, "dummy_value")
+        self.assertEqual(settings.pop("DUMMY_CONFIG"), "dummy_value")
 
         settings.freeze()
 


### PR DESCRIPTION
As reported on https://github.com/scrapy/scrapy/issues/5959#issuecomment-1609832116, the implementation of `pop` method is returning `SettingsAttribute` object instead of the value itself which break interface. Mea culpa, sorry! 😅 