### PR TITLE
my solution for enhancement #issue5968

### DIFF
--- a/scrapy/http/response/text.py
+++ b/scrapy/http/response/text.py
@@ -71,15 +71,10 @@ class TextResponse(Response):
             or self._body_declared_encoding()
         )
 
-    def json(self):
-        """
-        .. versionadded:: 2.2
+    def json(self,response:Response):
+        json_data = json.loads(response.body)
+        return self.json_data
 
-        Deserialize a JSON document to a Python object.
-        """
-        if self._cached_decoded_json is _NONE:
-            self._cached_decoded_json = json.loads(self.text)
-        return self._cached_decoded_json
 
     @property
     def text(self):


### PR DESCRIPTION
we directly access response.body and use the json.loads() function from the json module to parse the JSON data into a Python object.

By using this approach, you avoid unnecessary memory usage and the need to store both the bytes and string representation of the response.