### PR TITLE
introduce CLOSESPIDER_TIMEOUT_NO_ITEM in CloseSpider

### DIFF
--- a/docs/topics/extensions.rst
+++ b/docs/topics/extensions.rst
@@ -258,6 +258,7 @@ The conditions for closing a spider can be configured through the following
 settings:
 
 * :setting:`CLOSESPIDER_TIMEOUT`
+* :setting:`CLOSESPIDER_TIMEOUT_NO_ITEM`
 * :setting:`CLOSESPIDER_ITEMCOUNT`
 * :setting:`CLOSESPIDER_PAGECOUNT`
 * :setting:`CLOSESPIDER_ERRORCOUNT`
@@ -279,6 +280,18 @@ An integer which specifies a number of seconds. If the spider remains open for
 more than that number of second, it will be automatically closed with the
 reason ``closespider_timeout``. If zero (or non set), spiders won't be closed by
 timeout.
+
+.. setting:: CLOSESPIDER_TIMEOUT_NO_ITEM
+
+CLOSESPIDER_TIMEOUT_NO_ITEM
+"""""""""""""""""""""""""""
+
+Default: ``0``
+
+An integer which specifies a number of seconds. If the spider has not produced
+any items in the last number of seconds, it will be closed with the reason
+``closespider_timeout_no_item``. If zero (or non set), spiders won't be closed
+regardless if it hasn't produced any items.
 
 .. setting:: CLOSESPIDER_ITEMCOUNT
 

--- a/scrapy/extensions/closespider.py
+++ b/scrapy/extensions/closespider.py
@@ -84,7 +84,7 @@ class CloseSpider:
             task.cancel()
 
         task_no_item = getattr(self, "task_no_item", False)
-        if task_no_item.running:
+        if task_no_item and task_no_item.running:
             task_no_item.stop()
 
     def spider_opened_no_item(self, spider):

--- a/tests/spiders.py
+++ b/tests/spiders.py
@@ -77,6 +77,22 @@ class DelaySpider(MetaSpider):
         self.t2_err = time.time()
 
 
+class SlowSpider(DelaySpider):
+    name = "slow"
+
+    def start_requests(self):
+        # 1st response is fast
+        url = self.mockserver.url("/delay?n=0&b=0")
+        yield Request(url, callback=self.parse, errback=self.errback)
+
+        # 2nd response is slow
+        url = self.mockserver.url(f"/delay?n={self.n}&b={self.b}")
+        yield Request(url, callback=self.parse, errback=self.errback)
+
+    def parse(self, response):
+        yield Item()
+
+
 class SimpleSpider(MetaSpider):
     name = "simple"
 

--- a/tests/test_closespider.py
+++ b/tests/test_closespider.py
@@ -3,7 +3,7 @@ from twisted.trial.unittest import TestCase
 
 from scrapy.utils.test import get_crawler
 from tests.mockserver import MockServer
-from tests.spiders import DelaySpider, ErrorSpider, FollowAllSpider, ItemSpider
+from tests.spiders import ErrorSpider, FollowAllSpider, ItemSpider, SlowSpider
 
 
 class TestCloseSpider(TestCase):
@@ -58,8 +58,8 @@ class TestCloseSpider(TestCase):
     @defer.inlineCallbacks
     def test_closespider_timeout_no_item(self):
         timeout = 1
-        crawler = get_crawler(DelaySpider, {"CLOSESPIDER_TIMEOUT_NO_ITEM": timeout})
-        yield crawler.crawl(n=3, total=10, mockserver=self.mockserver)
+        crawler = get_crawler(SlowSpider, {"CLOSESPIDER_TIMEOUT_NO_ITEM": timeout})
+        yield crawler.crawl(n=3, mockserver=self.mockserver)
         reason = crawler.spider.meta["close_reason"]
         self.assertEqual(reason, "closespider_timeout_no_item")
         total_seconds = crawler.stats.get_value("elapsed_time_seconds")

--- a/tests/test_closespider.py
+++ b/tests/test_closespider.py
@@ -3,7 +3,7 @@ from twisted.trial.unittest import TestCase
 
 from scrapy.utils.test import get_crawler
 from tests.mockserver import MockServer
-from tests.spiders import ErrorSpider, FollowAllSpider, ItemSpider
+from tests.spiders import DelaySpider, ErrorSpider, FollowAllSpider, ItemSpider
 
 
 class TestCloseSpider(TestCase):
@@ -54,3 +54,13 @@ class TestCloseSpider(TestCase):
         self.assertEqual(reason, "closespider_timeout")
         total_seconds = crawler.stats.get_value("elapsed_time_seconds")
         self.assertTrue(total_seconds >= close_on)
+
+    @defer.inlineCallbacks
+    def test_closespider_timeout_no_item(self):
+        timeout = 1
+        crawler = get_crawler(DelaySpider, {"CLOSESPIDER_TIMEOUT_NO_ITEM": timeout})
+        yield crawler.crawl(n=3, total=10, mockserver=self.mockserver)
+        reason = crawler.spider.meta["close_reason"]
+        self.assertEqual(reason, "closespider_timeout_no_item")
+        total_seconds = crawler.stats.get_value("elapsed_time_seconds")
+        self.assertTrue(total_seconds >= timeout)


### PR DESCRIPTION
**Motivation:** Sometimes spiders still keep running without producing any items. This could be due to a variety of reasons like poor dupe URL filtration, bad crawling strategy, etc.

**Proposal:** Auto-close the spider if it hasn't produced any items in the past number of seconds.