### PR TITLE
Enable Python 3.11 on Windows CI

### DIFF
--- a/.github/workflows/tests-windows.yml
+++ b/.github/workflows/tests-windows.yml
@@ -20,13 +20,12 @@ jobs:
         - python-version: "3.10"
           env:
             TOXENV: asyncio
-# no binary package for lxml for 3.11 yet
-#        - python-version: "3.11"
-#          env:
-#            TOXENV: py
-#        - python-version: "3.11"
-#          env:
-#            TOXENV: asyncio
+        - python-version: "3.11"
+          env:
+            TOXENV: py
+        - python-version: "3.11"
+          env:
+            TOXENV: asyncio
 
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
Seems that now we have lxml available for 3.11 on Windows. 😄 

![image](https://github.com/scrapy/scrapy/assets/5853172/6722d6d6-7851-4e24-b167-ad6641be9883)
