### PR TITLE
Remove extra spider parameter in item pipeline docs

### DIFF
--- a/docs/topics/item-pipeline.rst
+++ b/docs/topics/item-pipeline.rst
@@ -215,7 +215,7 @@ item.
             screenshot_url = self.SPLASH_URL.format(encoded_item_url)
             request = scrapy.Request(screenshot_url, callback=NO_CALLBACK)
             response = await maybe_deferred_to_future(
-                spider.crawler.engine.download(request, spider)
+                spider.crawler.engine.download(request)
             )
 
             if response.status != 200:


### PR DESCRIPTION
Fixes #6008 

I looked in other files and this is the only place where we still have an example of passing an extra spider parameter.