### PR TITLE
Fix the problem about _handleSignals 

### DIFF
--- a/scrapy/utils/ossignal.py
+++ b/scrapy/utils/ossignal.py
@@ -25,7 +25,10 @@ def install_shutdown_handlers(
     """
     from twisted.internet import reactor
 
-    reactor._handleSignals()
+    if hasattr(reactor, "_signalsFactory"):
+        reactor._signalsFactory()
+    else:
+        reactor._handleSignals()
     signal.signal(signal.SIGTERM, function)
     if signal.getsignal(signal.SIGINT) == signal.default_int_handler or override_sigint:
         signal.signal(signal.SIGINT, function)


### PR DESCRIPTION
Fix the problem that Twisted 23.8.0 and above remove the _handleSignals method and cause an error