### PR TITLE
[wip] reactor handlesignals

### DIFF
--- a/scrapy/utils/ossignal.py
+++ b/scrapy/utils/ossignal.py
@@ -2,6 +2,9 @@ import signal
 from types import FrameType
 from typing import Any, Callable, Dict, Optional, Union
 
+from twisted import version as twisted_version
+from twisted.python.versions import Version
+
 # copy of _HANDLER from typeshed/stdlib/signal.pyi
 SignalHandlerT = Union[
     Callable[[int, Optional[FrameType]], Any], int, signal.Handlers, None
@@ -25,7 +28,8 @@ def install_shutdown_handlers(
     """
     from twisted.internet import reactor
 
-    reactor._handleSignals()
+    if twisted_version < Version("twisted", 23, 8, 0):
+        reactor._handleSignals()
     signal.signal(signal.SIGTERM, function)
     if signal.getsignal(signal.SIGINT) == signal.default_int_handler or override_sigint:
         signal.signal(signal.SIGINT, function)

--- a/scrapy/utils/ossignal.py
+++ b/scrapy/utils/ossignal.py
@@ -2,9 +2,6 @@ import signal
 from types import FrameType
 from typing import Any, Callable, Dict, Optional, Union
 
-from twisted import version as twisted_version
-from twisted.python.versions import Version
-
 # copy of _HANDLER from typeshed/stdlib/signal.pyi
 SignalHandlerT = Union[
     Callable[[int, Optional[FrameType]], Any], int, signal.Handlers, None
@@ -26,10 +23,7 @@ def install_shutdown_handlers(
     SIGINT handler won't be install if there is already a handler in place
     (e.g.  Pdb)
     """
-    from twisted.internet import reactor
 
-    if twisted_version < Version("twisted", 23, 8, 0):
-        reactor._handleSignals()
     signal.signal(signal.SIGTERM, function)
     if signal.getsignal(signal.SIGINT) == signal.default_int_handler or override_sigint:
         signal.signal(signal.SIGINT, function)


### PR DESCRIPTION
Fix to https://github.com/scrapy/scrapy/issues/6024

From my observations of scrapy code and related twisted pull request I conclude that call of `reactor._handleSignals()` or it's equivalent from new twisted version - are not needed inside `install_shutdown_handlers` to run scrapy.

At least on my local environment with both new/old twisted versions I didn't noticed anything unexpected.