### PR TITLE
Apply sitemap_filter only if sitemap type is urlset

### DIFF
--- a/scrapy/spiders/sitemap.py
+++ b/scrapy/spiders/sitemap.py
@@ -51,13 +51,13 @@ class SitemapSpider(Spider):
                 return
 
             s = Sitemap(body)
-            it = self.sitemap_filter(s)
 
             if s.type == "sitemapindex":
-                for loc in iterloc(it, self.sitemap_alternate_links):
+                for loc in iterloc(s, self.sitemap_alternate_links):
                     if any(x.search(loc) for x in self._follow):
                         yield Request(loc, callback=self._parse_sitemap)
             elif s.type == "urlset":
+                it = self.sitemap_filter(s)
                 for loc in iterloc(it, self.sitemap_alternate_links):
                     for r, c in self._cbs:
                         if r.search(loc):


### PR DESCRIPTION
Here's [sitemap_filter](https://docs.scrapy.org/en/latest/topics/spiders.html#scrapy.spiders.SitemapSpider.sitemap_filter) documentation:

> This is a filter function that could be overridden to select sitemap entries based on their attributes.

I wanted to create a sitemap_filter to limit requests made, but this takes into account urls from sitemap index files.

I believe this contradicts with documentation of sitemap_filter and this function should be applied on sitemaps of type `urlset`.

I fixed the issue and made a pull request, hope it helps.