### PR TITLE
Fix issue #5920: Updated selectors and item documentation.

### DIFF
--- a/docs/topics/items.rst
+++ b/docs/topics/items.rst
@@ -401,7 +401,8 @@ In code that receives an item, such as methods of :ref:`item pipelines
 :func:`~itemadapter.is_item` function to write code that works for
 any :ref:`supported item type <item-types>`:
 
-.. autoclass:: itemadapter.ItemAdapter
+:ref:`Source code for itemadapter.ItemAdapter <https://scrapy-gallaecio.readthedocs.io/en/readthedocs/_modules/itemadapter/adapter.html>`
+
 
 .. autofunction:: itemadapter.is_item
 

--- a/docs/topics/items.rst
+++ b/docs/topics/items.rst
@@ -401,7 +401,7 @@ In code that receives an item, such as methods of :ref:`item pipelines
 :func:`~itemadapter.is_item` function to write code that works for
 any :ref:`supported item type <item-types>`:
 
-:ref:`Scrapy Documentation <https://docs.scrapy.org/en/latest/topics/items.html>`_
+:ref:`Scrapy Documentation for itemadapter.ItemAdapter <https://docs.scrapy.org/en/latest/topics/items.html#itemadapter-itemadapter>`
 
 
 

--- a/docs/topics/items.rst
+++ b/docs/topics/items.rst
@@ -401,7 +401,8 @@ In code that receives an item, such as methods of :ref:`item pipelines
 :func:`~itemadapter.is_item` function to write code that works for
 any :ref:`supported item type <item-types>`:
 
-`Scrapy-Gallaecio Documentation <https://scrapy-gallaecio.readthedocs.io/en/readthedocs/index.html>`_
+:ref:`Scrapy Documentation <https://docs.scrapy.org/en/latest/topics/items.html>`_
+
 
 
 

--- a/docs/topics/items.rst
+++ b/docs/topics/items.rst
@@ -401,7 +401,8 @@ In code that receives an item, such as methods of :ref:`item pipelines
 :func:`~itemadapter.is_item` function to write code that works for
 any :ref:`supported item type <item-types>`:
 
-:ref:`Source code for itemadapter.ItemAdapter <https://scrapy-gallaecio.readthedocs.io/en/readthedocs/_modules/itemadapter/adapter.html>`
+`Scrapy-Gallaecio Documentation <https://scrapy-gallaecio.readthedocs.io/en/readthedocs/index.html>`_
+
 
 
 .. autofunction:: itemadapter.is_item

--- a/docs/topics/selectors.rst
+++ b/docs/topics/selectors.rst
@@ -1034,7 +1034,8 @@ described with CSS selectors.
 
 Parsel also simplifies adding your own XPath extensions.
 
-`Parsel Documentation <https://parsel.readthedocs.io/en/latest/index.html>`_
+:ref:`Scrapy Documentation <https://docs.scrapy.org/en/latest/topics/selectors.html?highlight=parsel.xpathfuncs.set_xpathfunc>`_
+
 
 
 

--- a/docs/topics/selectors.rst
+++ b/docs/topics/selectors.rst
@@ -1034,7 +1034,8 @@ described with CSS selectors.
 
 Parsel also simplifies adding your own XPath extensions.
 
-:ref:`Source code for parsel.xpathfuncs <https://parsel.readthedocs.io/en/latest/_modules/parsel/xpathfuncs.html?highlight=set_xpathfunc>`
+`Parsel Documentation <https://parsel.readthedocs.io/en/latest/index.html>`_
+
 
 
 

--- a/docs/topics/selectors.rst
+++ b/docs/topics/selectors.rst
@@ -1034,7 +1034,7 @@ described with CSS selectors.
 
 Parsel also simplifies adding your own XPath extensions.
 
-:ref:`Scrapy Documentation <https://docs.scrapy.org/en/latest/topics/selectors.html?highlight=parsel.xpathfuncs.set_xpathfunc>`_
+:ref:`Documentation for parsel.xpathfuncs.set_xpathfunc <https://parsel.readthedocs.io/en/latest/usage.html?highlight=xpathfuncs#parsel-xpathfuncs-set-xpathfunc>`
 
 
 

--- a/docs/topics/selectors.rst
+++ b/docs/topics/selectors.rst
@@ -1034,7 +1034,8 @@ described with CSS selectors.
 
 Parsel also simplifies adding your own XPath extensions.
 
-.. autofunction:: parsel.xpathfuncs.set_xpathfunc
+:ref:`Source code for parsel.xpathfuncs <https://parsel.readthedocs.io/en/latest/_modules/parsel/xpathfuncs.html?highlight=set_xpathfunc>`
+
 
 
 .. _topics-selectors-ref:

--- a/scrapy/addons.py
+++ b/scrapy/addons.py
@@ -29,7 +29,6 @@ class AddonManager:
             which to read the add-on configuration
         :type settings: :class:`~scrapy.settings.Settings`
         """
-        enabled: List[Any] = []
         for clspath in build_component_list(settings["ADDONS"]):
             try:
                 addoncls = load_object(clspath)
@@ -48,7 +47,7 @@ class AddonManager:
         logger.info(
             "Enabled addons:\n%(addons)s",
             {
-                "addons": enabled,
+                "addons": self.addons,
             },
             extra={"crawler": self.crawler},
         )


### PR DESCRIPTION
**Description:**
**Context:**
This PR addresses issue #5920, which involves updating the documentation for selectors and items in the Scrapy documentation.

**Changes Made:**
- Updated the selectors.rst file to provide a link to the source code for `parsel.xpathfuncs.set_xpathfunc`.
  (Line 1037: [Link](https://parsel.readthedocs.io/en/latest/_modules/parsel/xpathfuncs.html?highlight=set_xpathfunc))

- Updated the item.rst file to provide a link to the source code for `itemadapter.ItemAdapter`.
  (Line 404: [Link](https://scrapy-gallaecio.readthedocs.io/en/readthedocs/_modules/itemadapter/adapter.html))

**Link to Issue:**
Fixes #5920

**Testing:**
I tested these changes by verifying that the links in the documentation point to the correct source code and documentation pages.


