### PR TITLE
Remove-docs-#5920

### DIFF
--- a/docs/topics/items.rst
+++ b/docs/topics/items.rst
@@ -401,7 +401,7 @@ In code that receives an item, such as methods of :ref:`item pipelines
 :func:`~itemadapter.is_item` function to write code that works for
 any :ref:`supported item type <item-types>`:
 
-.. autoclass:: itemadapter.ItemAdapter
+The itemadapter.ItemAdapter class is a wrapper for data container objects, providing a common interface to handle objects of different types in an uniform manner, regardless of their underlying implementation. see the: `itemadapter.ItemAdapter Documentation <https://github.com/scrapy/itemadapter>`_.
 
 .. autofunction:: itemadapter.is_item
 

--- a/docs/topics/selectors.rst
+++ b/docs/topics/selectors.rst
@@ -1034,7 +1034,7 @@ described with CSS selectors.
 
 Parsel also simplifies adding your own XPath extensions.
 
-.. autofunction:: parsel.xpathfuncs.set_xpathfunc
+For more details about the XPath extensions, see the `Parsel Documentation <https://parsel.readthedocs.io/en/latest/usage.html#parsel.xpathfuncs.set_xpathfunc>`_.
 
 
 .. _topics-selectors-ref:


### PR DESCRIPTION
Description:
This PR addresses issue #5920.

Changes:
Replaced direct code references with a brief explanation about itemadapter.
Added an external link directing readers to the official itemadapter documentation.
Did the same for XPath extensions, linking to the Parsel Documentation.

This is my first Open Source PR. If approved, I'm ready to proceed with replacing all the auto-linking. Feedback and guidance are appreciated!

Resolves #5920