### PR TITLE
#6056 Issue: Updated news.rst

### DIFF
--- a/docs/news.rst
+++ b/docs/news.rst
@@ -476,6 +476,9 @@ Deprecations
 -   :exc:`scrapy.pipelines.images.NoimagesDrop` is now deprecated.
     (:issue:`5368`, :issue:`5489`)
 
+-   The ``scrapy.utils.boto.is_botocore()`` function is now deprecated.
+    (:issue:`5719`)
+
 -   :meth:`ImagesPipeline.convert_image
     <scrapy.pipelines.images.ImagesPipeline.convert_image>` must now accept a
     ``response_body`` parameter.

--- a/docs/news.rst
+++ b/docs/news.rst
@@ -469,7 +469,7 @@ Deprecation removals
     has now been removed.
     (:issue:`5719`)
 
--   The ``scrapy.utils.boto.is_botocore()`` function is now deprecated,
+-   The ``scrapy.utils.boto.is_botocore()`` function, deprecated in Scrapy 2.4,
     has now been removed.
     (:issue:`5719`)
 

--- a/docs/news.rst
+++ b/docs/news.rst
@@ -469,15 +469,16 @@ Deprecation removals
     has now been removed.
     (:issue:`5719`)
 
+-   The ``scrapy.utils.boto.is_botocore()`` function is now deprecated,
+    has now been removed.
+    (:issue:`5719`)
+
 
 Deprecations
 ~~~~~~~~~~~~
 
 -   :exc:`scrapy.pipelines.images.NoimagesDrop` is now deprecated.
     (:issue:`5368`, :issue:`5489`)
-
--   The ``scrapy.utils.boto.is_botocore()`` function is now deprecated.
-    (:issue:`5719`)
 
 -   :meth:`ImagesPipeline.convert_image
     <scrapy.pipelines.images.ImagesPipeline.convert_image>` must now accept a


### PR DESCRIPTION
Updated the docs with the ``scrapy.utils.boto.is_botocore()`` function is removed at 2.8.0 release note.

Fixes #6056 