### PR TITLE
Add a template for question/help issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,0 +1,13 @@
+---
+name: Question / Help
+about: Ask a question about Scrapy or ask for help with your Scrapy code.
+---
+
+Thanks for taking an interest in Scrapy!
+
+The Scrapy GitHub issue tracker is not meant for questions or help. Please ask
+for help in the [Scrapy community resources](https://scrapy.org/community/)
+instead.
+
+The GitHub issue tracker's purpose is to deal with bug reports and feature
+requests for the project itself.


### PR DESCRIPTION
Maybe a specific entry for questions/help when opening an issue, and a shorter text to read, can minimize the chance of issues like https://github.com/scrapy/scrapy/issues/6065 further. Maybe.