### PR TITLE
Use concurrency groups to limit duplicate jobs

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -1,6 +1,10 @@
 name: Checks
 on: [push, pull_request]
 
+concurrency:
+  group: ${{github.workflow}}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   checks:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,6 +4,10 @@ on:
     tags:
       - '[0-9]+.[0-9]+.[0-9]+'
 
+concurrency:
+  group: ${{github.workflow}}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   publish:
     runs-on: ubuntu-latest

--- a/.github/workflows/tests-macos.yml
+++ b/.github/workflows/tests-macos.yml
@@ -1,6 +1,10 @@
 name: macOS
 on: [push, pull_request]
 
+concurrency:
+  group: ${{github.workflow}}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   tests:
     runs-on: macos-11

--- a/.github/workflows/tests-ubuntu.yml
+++ b/.github/workflows/tests-ubuntu.yml
@@ -1,6 +1,10 @@
 name: Ubuntu
 on: [push, pull_request]
 
+concurrency:
+  group: ${{github.workflow}}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/tests-windows.yml
+++ b/.github/workflows/tests-windows.yml
@@ -1,6 +1,10 @@
 name: Windows
 on: [push, pull_request]
 
+concurrency:
+  group: ${{github.workflow}}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   tests:
     runs-on: windows-latest


### PR DESCRIPTION
Leverage concurrency groups along with cancel-in-progress to favor running the most recent job.

Closes #5997 

Concurrency groups are on a per workflow, per branch/tag basis. So, pushing newer updates to a branch, e.g. as part of a PR, should cancel any in progress runs of workflows that have been retriggered.

Note that I've added these to all workflows, since I couldn't think of a case where it wouldn't make sense to favor the more recently added jobs. Let me know if I've missed something, or that should be done differently.

Note as well that the documentation lists a caveat about order not being guaranteed. In practice I've never had issues with the ordering, though that was for smaller repos with less chance of parallel collaboration.

See:
- https://docs.github.com/en/enterprise-cloud@latest/actions/using-workflows/workflow-syntax-for-github-actions#concurrency
- https://docs.github.com/en/enterprise-cloud@latest/actions/learn-github-actions/contexts#github-context

## Validation

Separate from the workflows running for the main Scrapy repo (which will need to be approved), I validated: 
- Syntax, via the fact that the workflows run as normal in my fork. 
- The cancellation behavior, via a test branch based off of the branch with these changes (also available on my [fork as a PR](https://github.com/AndrewADev/scrapy/pull/2)) Note that the test changes were simple comment changes in violation of the linting rules, which caused a linting failure. They were just to test the cancellation logic. They are not included here. 

Cancellation in action: 
![image](https://github.com/scrapy/scrapy/assets/2937540/9a3edd9e-b096-4778-b777-5d88a66a805e)
[Run link](https://github.com/AndrewADev/scrapy/actions/runs/6369866027?pr=2) (will eventually expire).