### PR TITLE
Improved Documentation Fixing Issue #6057

### DIFF
--- a/docs/topics/spiders.rst
+++ b/docs/topics/spiders.rst
@@ -144,6 +144,33 @@ scrapy.Spider
            as they can be modified later by e.g. :ref:`add-ons
            <topics-addons>`. The final settings are available in the
            :meth:`start_requests` method and later.
+      .. _spider-from-crawler:
+           Spider.from_crawler()
+           When you create a spider using the :meth:`Spider.from_crawler()` 
+           class method, it's important to note that the spider doesn't have all 
+           its components fully initialized at that point. Some components, such 
+           as the downloader middleware, are not yet set up.
+
+           To work with a fully initialized spider, consider using the 
+          `engine_started` signal handler as described in :ref:`engine-started- 
+           signal-handler`. This ensures that your spider has access to all its 
+           components.
+
+           .. code-block:: python
+
+              class MySpider(scrapy.Spider):
+
+                  name = 'my_spider'
+
+                  @classmethod
+                  def from_crawler(cls, crawler, *args, **kwargs):
+                      spider = super(MySpider, cls).from_crawler(crawler, *args, **kwargs)
+
+                      # Initialize additional components here if needed.
+
+                      return spider
+
+
 
        :param crawler: crawler to which the spider will be bound
        :type crawler: :class:`~scrapy.crawler.Crawler` instance

--- a/docs/topics/spiders.rst
+++ b/docs/topics/spiders.rst
@@ -169,6 +169,36 @@ scrapy.Spider
                       # Initialize additional components here if needed.
 
                       return spider
+     .. _spider-from-crawler:
+
+     Spider.from_crawler()
+
+
+    When you create a spider using the :meth:`Spider.from_crawler()` class 
+    method, it's important to note that the spider doesn't have all its 
+    components fully initialized at that point. Some components, such as the 
+    downloader middleware, are not yet set up.
+
+    To work with a fully initialized spider, consider using the 
+    `engine_started` signal handler as described in :ref:`engine-started- 
+    signal-handler`. This ensures that your spider has access to all its 
+    components.
+
+    .. code-block:: python
+
+       class MySpider(scrapy.Spider):
+
+           name = 'my_spider'
+
+           @classmethod
+           def from_crawler(cls, crawler, *args, **kwargs):
+               spider = super(MySpider, cls).from_crawler(crawler, *args, **kwargs)
+
+               # Initialize additional components here if needed.
+
+               return spider
+
+
 
 
 


### PR DESCRIPTION
This PR updates the documentation for spider.from_crawler() initialization and engine_started signal handler.

The change was adding the code snippet and comments on initialization and using the engine_started handler for fully initialized spiders.

Fixes #6057 

![image](https://github.com/scrapy/scrapy/assets/93534905/1a5e1073-b670-4a81-8dde-3a07ead8b199)
