### PR TITLE
Set spider name in the stats logs.

### DIFF
--- a/scrapy/extensions/logstats.py
+++ b/scrapy/extensions/logstats.py
@@ -42,10 +42,11 @@ class LogStats:
         self.pagesprev, self.itemsprev = pages, items
 
         msg = (
-            "Crawled %(pages)d pages (at %(pagerate)d pages/min), "
+            "Spider %(name)s: Crawled %(pages)d pages (at %(pagerate)d pages/min), "
             "scraped %(items)d items (at %(itemrate)d items/min)"
         )
         log_args = {
+            "name": spider.name,
             "pages": pages,
             "pagerate": prate,
             "items": items,


### PR DESCRIPTION
When the multiple crawlers are run through CrawlerProcess, logstats are not clear as which spider these stats are for. Adding a spider name in the log.