### PR TITLE
Deprecate ReppyRobotParser.

### DIFF
--- a/docs/topics/downloader-middleware.rst
+++ b/docs/topics/downloader-middleware.rst
@@ -1039,8 +1039,8 @@ RobotsTxtMiddleware
 
     * :ref:`Protego <protego-parser>` (default)
     * :ref:`RobotFileParser <python-robotfileparser>`
-    * :ref:`Reppy <reppy-parser>`
     * :ref:`Robotexclusionrulesparser <rerp-parser>`
+    * :ref:`Reppy <reppy-parser>` (deprecated)
 
     You can change the robots.txt_ parser with the :setting:`ROBOTSTXT_PARSER`
     setting. Or you can also :ref:`implement support for a new parser <support-for-new-robots-parser>`.
@@ -1133,6 +1133,7 @@ In order to use this parser:
 
     .. warning:: `Upstream issue #122
         <https://github.com/seomoz/reppy/issues/122>`_ prevents reppy usage in Python 3.9+.
+        Because of this the Reppy parser is deprecated.
 
 * Set :setting:`ROBOTSTXT_PARSER` setting to
   ``scrapy.robotstxt.ReppyRobotParser``

--- a/scrapy/robotstxt.py
+++ b/scrapy/robotstxt.py
@@ -1,6 +1,7 @@
 import logging
 import sys
 from abc import ABCMeta, abstractmethod
+from warnings import warn
 
 from scrapy.exceptions import ScrapyDeprecationWarning
 from scrapy.utils.python import to_unicode
@@ -80,9 +81,7 @@ class PythonRobotParser(RobotParser):
 
 class ReppyRobotParser(RobotParser):
     def __init__(self, robotstxt_body, spider):
-        logger.warning(
-            "ReppyRobotParser is deprecated", ScrapyDeprecationWarning, stacklevel=2
-        )
+        warn("ReppyRobotParser is deprecated.", ScrapyDeprecationWarning, stacklevel=2)
         from reppy.robots import Robots
 
         self.spider = spider

--- a/scrapy/robotstxt.py
+++ b/scrapy/robotstxt.py
@@ -2,6 +2,7 @@ import logging
 import sys
 from abc import ABCMeta, abstractmethod
 
+from scrapy.exceptions import ScrapyDeprecationWarning
 from scrapy.utils.python import to_unicode
 
 logger = logging.getLogger(__name__)
@@ -79,6 +80,9 @@ class PythonRobotParser(RobotParser):
 
 class ReppyRobotParser(RobotParser):
     def __init__(self, robotstxt_body, spider):
+        logger.warning(
+            "ReppyRobotParser is deprecated", ScrapyDeprecationWarning, stacklevel=2
+        )
         from reppy.robots import Robots
 
         self.spider = spider


### PR DESCRIPTION
Closes #5230. Note that we don't run tests for reppy because of https://github.com/seomoz/reppy/issues/132