### PR TITLE
fix: make CloseSpider exception's traceback display error message

### DIFF
--- a/scrapy/exceptions.py
+++ b/scrapy/exceptions.py
@@ -41,7 +41,7 @@ class CloseSpider(Exception):
     """Raise this from callbacks to request the spider to be closed"""
 
     def __init__(self, reason: str = "cancelled"):
-        super().__init__()
+        super().__init__(reason)
         self.reason = reason
 
 


### PR DESCRIPTION
make CloseSpider exception put its reason to traceback instead of ignoring it