### PR TITLE
added_extensions

### DIFF
--- a/scrapy/linkextractors/__init__.py
+++ b/scrapy/linkextractors/__init__.py
@@ -96,6 +96,16 @@ IGNORED_EXTENSIONS = [
     "dmg",
     "iso",
     "apk",
+    "jar",
+    "sh",
+    "rb",
+    "js",
+    "hta",
+    "bat",
+    "cpl",
+    "msi",
+    "msp",
+    "py",
 ]
 
 


### PR DESCRIPTION
I have added a collection of extensions to the ignored extensions in [scrapy/linkextractors/__init__.py](https://github.com/scrapy/scrapy/blob/master/scrapy/linkextractors/__init__.py#L11) the additional extensions are `.jar .sh .rb .js .hta .bat .cpl .msi .msp .py`.

I think these extensions fit with the other extensions in the ignored list. All tests are currently passing. The only file that has changed is `__init__.py`.