### PR TITLE
scrapy.utils.data_path type hint change

### DIFF
--- a/scrapy/utils/project.py
+++ b/scrapy/utils/project.py
@@ -1,9 +1,9 @@
 import os
 import warnings
 from importlib import import_module
+from os import PathLike
 from pathlib import Path
 from typing import Union
-from os import PathLike
 
 from scrapy.exceptions import NotConfigured
 from scrapy.settings import Settings

--- a/scrapy/utils/project.py
+++ b/scrapy/utils/project.py
@@ -2,6 +2,8 @@ import os
 import warnings
 from importlib import import_module
 from pathlib import Path
+from typing import Union
+from os import PathLike
 
 from scrapy.exceptions import NotConfigured
 from scrapy.settings import Settings
@@ -44,7 +46,7 @@ def project_data_dir(project: str = "default") -> str:
     return str(d)
 
 
-def data_path(path: str, createdir: bool = False) -> str:
+def data_path(path: Union[str, PathLike, Path], createdir: bool = False) -> str:
     """
     Return the given path joined with the .scrapy data directory.
     If given an absolute path, return it unmodified.

--- a/scrapy/utils/project.py
+++ b/scrapy/utils/project.py
@@ -3,6 +3,7 @@ import warnings
 from importlib import import_module
 from pathlib import Path
 from typing import Union
+from os import PathLike
 
 from scrapy.exceptions import NotConfigured
 from scrapy.settings import Settings
@@ -45,7 +46,7 @@ def project_data_dir(project: str = "default") -> str:
     return str(d)
 
 
-def data_path(path: Union[str, Path], createdir: bool = False) -> str:
+def data_path(path: Union[str, PathLike], createdir: bool = False) -> str:
     """
     Return the given path joined with the .scrapy data directory.
     If given an absolute path, return it unmodified.

--- a/scrapy/utils/project.py
+++ b/scrapy/utils/project.py
@@ -3,7 +3,6 @@ import warnings
 from importlib import import_module
 from pathlib import Path
 from typing import Union
-from os import PathLike
 
 from scrapy.exceptions import NotConfigured
 from scrapy.settings import Settings
@@ -46,7 +45,7 @@ def project_data_dir(project: str = "default") -> str:
     return str(d)
 
 
-def data_path(path: Union[str, PathLike, Path], createdir: bool = False) -> str:
+def data_path(path: Union[str, Path], createdir: bool = False) -> str:
     """
     Return the given path joined with the .scrapy data directory.
     If given an absolute path, return it unmodified.


### PR DESCRIPTION
Updating type hint for `scrapy.utils.project.data_path`. 

This is a small change which brings a part of solution of the issue [#5739](https://github.com/scrapy/scrapy/issues/5739).

The type hint change was suggested [here](https://github.com/scrapy/scrapy/issues/5739#issuecomment-1789203848).