### PR TITLE
Updated README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -42,7 +42,7 @@ Scrapy
 Overview
 ========
 
-Scrapy is a fast high-level web crawling and web scraping framework, used to
+Scrapy is a BSD-licensed fast high-level web crawling and web scraping framework, used to
 crawl websites and extract structured data from their pages. It can be used for
 a wide range of purposes, from data mining to monitoring and automated testing.
 
@@ -96,7 +96,7 @@ Contributing
 See https://docs.scrapy.org/en/master/contributing.html for details.
 
 Code of Conduct
-===============
+---------------
 
 Please note that this project is released with a Contributor `Code of Conduct <https://github.com/scrapy/scrapy/blob/master/CODE_OF_CONDUCT.md>`_.
 
@@ -112,10 +112,3 @@ Commercial Support
 ==================
 
 See https://scrapy.org/support/ for details.
-
-License
-=======
-
-Scrapy is `BSD-3-Clause licensed`_.
-
-.. _BSD-3-Clause licensed: https://github.com/scrapy/scrapy/blob/master/LICENSE

--- a/README.rst
+++ b/README.rst
@@ -17,9 +17,10 @@ Scrapy
    :target: https://github.com/scrapy/scrapy/actions?query=workflow%3AUbuntu
    :alt: Ubuntu
 
-.. image:: https://github.com/scrapy/scrapy/workflows/macOS/badge.svg
-   :target: https://github.com/scrapy/scrapy/actions?query=workflow%3AmacOS
-   :alt: macOS
+.. .. image:: https://github.com/scrapy/scrapy/workflows/macOS/badge.svg
+   .. :target: https://github.com/scrapy/scrapy/actions?query=workflow%3AmacOS
+   .. :alt: macOS
+
 
 .. image:: https://github.com/scrapy/scrapy/workflows/Windows/badge.svg
    :target: https://github.com/scrapy/scrapy/actions?query=workflow%3AWindows
@@ -95,7 +96,7 @@ Contributing
 See https://docs.scrapy.org/en/master/contributing.html for details.
 
 Code of Conduct
----------------
+===============
 
 Please note that this project is released with a Contributor `Code of Conduct <https://github.com/scrapy/scrapy/blob/master/CODE_OF_CONDUCT.md>`_.
 
@@ -111,3 +112,10 @@ Commercial Support
 ==================
 
 See https://scrapy.org/support/ for details.
+
+License
+=======
+
+Scrapy is `BSD-3-Clause licensed`_.
+
+.. _BSD-3-Clause licensed: https://github.com/scrapy/scrapy/blob/master/LICENSE


### PR DESCRIPTION
- The macOS badge has been commented out because the associated workflow is currently disabled.
- Made Code of Conduct as Header 
- Added license