### PR TITLE
httpcompression middleware: warn of unexpected and prevent manual unupported encodings

### DIFF
--- a/scrapy/downloadermiddlewares/httpcompression.py
+++ b/scrapy/downloadermiddlewares/httpcompression.py
@@ -123,7 +123,7 @@ class HttpCompressionMiddleware:
             if b"br" in ACCEPTED_ENCODINGS:
                 body = brotli.decompress(body)
             else:
-                body = ""
+                body = bytes()
                 logger.warning(
                     "Brotli encoding received. "
                     "Cannot decompress the body as Brotli is not installed."


### PR DESCRIPTION
This change is made for solving issue [#4697](https://github.com/scrapy/scrapy/issues/4697).

PR [#4697](https://github.com/scrapy/scrapy/pull/5480) is used in terms of fast understanding where the code base must be changed. Please, inform me if this PR must be to that branch first and not directly to master of scrapy/scrapy.

Please, not that in initial version of this PR, the body becomes empty bytes in case of b"br" is used in response but not supported by executing machine. Please, inform me if it's not correct approach.

Will be happy to get review. 



