### PR TITLE
Improve the docs about Crawler attributes and settings initialization.

### DIFF
--- a/docs/news.rst
+++ b/docs/news.rst
@@ -32,8 +32,10 @@ Backward-incompatible changes
     :meth:`scrapy.crawler.Crawler.__init__` and before the settings are
     finalized and frozen. This change was needed to allow changing the settings
     in :meth:`scrapy.Spider.from_crawler`. If you want to access the final
-    setting values in the spider code as early as possible you can do this in
-    :meth:`~scrapy.Spider.start_requests`. (:issue:`6038`)
+    setting values and the initialized :class:`~scrapy.crawler.Crawler`
+    attributes in the spider code as early as possible you can do this in
+    :meth:`~scrapy.Spider.start_requests` or in a handler of the
+    :signal:`engine_started` signal. (:issue:`6038`)
 
 -   The :meth:`TextResponse.json <scrapy.http.TextResponse.json>` method now
     requires the response to be in a valid JSON encoding (UTF-8, UTF-16, or

--- a/docs/topics/spiders.rst
+++ b/docs/topics/spiders.rst
@@ -142,8 +142,14 @@ scrapy.Spider
            method, which is handy if you want to modify them based on
            arguments. As a consequence, these settings aren't the final values
            as they can be modified later by e.g. :ref:`add-ons
-           <topics-addons>`. The final settings are available in the
-           :meth:`start_requests` method and later.
+           <topics-addons>`. For the same reason, most of the
+           :class:`~scrapy.crawler.Crawler` attributes aren't initialized at
+           this point.
+
+           The final settings and the initialized
+           :class:`~scrapy.crawler.Crawler` attributes are available in the
+           :meth:`start_requests` method, handlers of the
+           :signal:`engine_started` signal and later.
 
        :param crawler: crawler to which the spider will be bound
        :type crawler: :class:`~scrapy.crawler.Crawler` instance


### PR DESCRIPTION
Fixes #6057, closes #6076, closes #6080.

I decided not to modify the signal doc because I'm not sure anymore that it makes sense to put that there. 