### PR TITLE
Handling CloseSpider exception if it has been raised in start_requests()

### DIFF
--- a/scrapy/core/engine.py
+++ b/scrapy/core/engine.py
@@ -400,10 +400,11 @@ class ExecutionEngine:
             assert isinstance(ex, CloseSpider)  # typing
             self.close_spider(self.spider, reason=ex.reason)
 
-    def close_spider_on_start(self, spider: Spider, reason: str = "cancelled"):
+    def close_spider_before_start(self, spider: Spider, reason: str = "cancelled"):
         if self.slot is not None:
             raise RuntimeError("Engine slot is already assigned. Use self.close_spider")
 
+        self.start()
         nextcall_none = CallLaterOnce(lambda: None)
         scheduler = create_instance(
             self.scheduler_cls, settings=None, crawler=self.crawler

--- a/scrapy/core/engine.py
+++ b/scrapy/core/engine.py
@@ -410,7 +410,7 @@ class ExecutionEngine:
             self.scheduler_cls, settings=None, crawler=self.crawler
         )
         self.slot = Slot((), True, nextcall_none, scheduler)
-        self.close_spider(spider, reason)
+        return self.close_spider(spider, reason)
 
     def close_spider(self, spider: Spider, reason: str = "cancelled") -> Deferred:
         """Close (cancel) spider and clear all its outstanding requests"""

--- a/scrapy/core/engine.py
+++ b/scrapy/core/engine.py
@@ -141,7 +141,7 @@ class ExecutionEngine:
         )
         return dfd.addBoth(_finish_stopping_engine)
 
-    def close(self, close_spider_reason: str = None) -> Deferred:
+    def close(self) -> Deferred:
         """
         Gracefully close the execution engine.
         If it has already been started, stop it. In all cases, close the spider and the downloader.
@@ -150,7 +150,7 @@ class ExecutionEngine:
             return self.stop()  # will also close spider and downloader
         if self.spider is not None:
             return self.close_spider(
-                self.spider, reason=close_spider_reason or "shutdown"
+                self.spider, reason="shutdown"
             )  # will also close downloader
         self.downloader.close()
         return succeed(None)

--- a/scrapy/crawler.py
+++ b/scrapy/crawler.py
@@ -160,8 +160,9 @@ class Crawler:
                 yield self.engine.open_spider(self.spider, start_requests)
                 yield maybeDeferred(self.engine.start)
             except CloseSpider as e:
-                self.engine.close_spider_before_start(self.spider, reason=e.reason)
-                return None
+                yield self.engine.close_spider_before_start(
+                    self.spider, reason=e.reason
+                )
         except Exception:
             self.crawling = False
             if self.engine is not None:

--- a/scrapy/crawler.py
+++ b/scrapy/crawler.py
@@ -155,17 +155,18 @@ class Crawler:
             self._apply_settings()
             self._update_root_log_handler()
             self.engine = self._create_engine()
-            start_requests = iter(self.spider.start_requests())
-            yield self.engine.open_spider(self.spider, start_requests)
-            yield maybeDeferred(self.engine.start)
-        except Exception as e:
-            self.crawling = False
-            if isinstance(e, CloseSpider):
+            try:
+                start_requests = iter(self.spider.start_requests())
+                yield self.engine.open_spider(self.spider, start_requests)
+                yield maybeDeferred(self.engine.start)
+            except CloseSpider as e:
                 self.engine.close_spider_on_start(self.spider, reason=e.reason)
                 return None
+        except Exception:
+            self.crawling = False
             if self.engine is not None:
                 yield self.engine.close()
-            raise e
+            raise
 
     def _create_spider(self, *args: Any, **kwargs: Any) -> Spider:
         return self.spidercls.from_crawler(self, *args, **kwargs)

--- a/scrapy/crawler.py
+++ b/scrapy/crawler.py
@@ -160,7 +160,7 @@ class Crawler:
                 yield self.engine.open_spider(self.spider, start_requests)
                 yield maybeDeferred(self.engine.start)
             except CloseSpider as e:
-                self.engine.close_spider_on_start(self.spider, reason=e.reason)
+                self.engine.close_spider_before_start(self.spider, reason=e.reason)
                 return None
         except Exception:
             self.crawling = False

--- a/tests/spiders.py
+++ b/tests/spiders.py
@@ -278,12 +278,11 @@ class ErrorSpider(FollowAllSpider):
 
 
 class CloseExceptionSpider(FollowAllSpider):
-    _expected_message: str = None
+    _expected_message: str = "Error"
 
     def __init__(self, *args, **kwargs):
-        self._expected_message = (
-            kwargs["expected_message"] if "expected_message" in kwargs else "Error"
-        )
+        if "expected_message" in kwargs:
+            self._expected_message = kwargs["expected_message"]
         super().__init__(*args, **kwargs)
 
 


### PR DESCRIPTION
Fixes #3463

I assume it's not the cleanest approach, so I'm opened for change requests after review.

I was trying to modify the `ExecutionEngine.open_spider` in a way that the `start_requests`'s exception would be called inside it. But it looked that it would take too much changes, so a lot of stuff can be broken.

Still, I'm opened to any ideas of how to make this change better.