### PR TITLE
Simplifying create_instance function

### DIFF
--- a/scrapy/utils/misc.py
+++ b/scrapy/utils/misc.py
@@ -124,7 +124,9 @@ def rel_has_nofollow(rel: Optional[str]) -> bool:
     """Return True if link rel attribute has nofollow type"""
     return rel is not None and "nofollow" in rel.replace(",", " ").split()
 
-
+"""
+The new create_instance function provides default value (None) for both crawler and settings, to simplify the caller - only one of the two parameters will need a value at call.
+"""
 def create_instance(objcls, /, *args, crawler=None, settings=None, **kwargs): 
     """Construct a class instance using its ``from_crawler`` or
     ``from_settings`` constructors, if available.


### PR DESCRIPTION
fixes #5523 

Issue: the previous create_instance function has an unnecessarily verbose caller, with both "crawler" and "settings" as mandatory parameters where only one of them will be used.

Solution: added default None values for both crawler and settings to shorten the caller. We considered splitting the function into two (build_from_crawler & build_from_settings), but thought it was redundant for the purpose of simplifying the function.