### PR TITLE
Converting create_instance to 2 separate functions

### DIFF
--- a/scrapy/addons.py
+++ b/scrapy/addons.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING, Any, List
 from scrapy.exceptions import NotConfigured
 from scrapy.settings import Settings
 from scrapy.utils.conf import build_component_list
-from scrapy.utils.misc import create_instance, load_object
+from scrapy.utils.misc import build_from_settings, load_object
 
 if TYPE_CHECKING:
     from scrapy.crawler import Crawler
@@ -32,8 +32,9 @@ class AddonManager:
         for clspath in build_component_list(settings["ADDONS"]):
             try:
                 addoncls = load_object(clspath)
-                addon = create_instance(
-                    addoncls, settings=settings, crawler=self.crawler
+                # changes create_instance call to build_from_settings
+                addon = build_from_settings(
+                    addoncls, settings=settings
                 )
                 addon.update_settings(settings)
                 self.addons.append(addon)

--- a/scrapy/addons.py
+++ b/scrapy/addons.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING, Any, List
 from scrapy.exceptions import NotConfigured
 from scrapy.settings import Settings
 from scrapy.utils.conf import build_component_list
-from scrapy.utils.misc import build_from_crawler, build_from_settings, load_object
+from scrapy.utils.misc import build_from_crawler, load_object
 
 if TYPE_CHECKING:
     from scrapy.crawler import Crawler
@@ -32,11 +32,7 @@ class AddonManager:
         for clspath in build_component_list(settings["ADDONS"]):
             try:
                 addoncls = load_object(clspath)
-                # changes create_instance call to build_from_settings
-                if self.crawler is not None:
-                    addon = build_from_crawler(addoncls, self.crawler)
-                else:
-                    addon = build_from_settings(addoncls, settings)
+                addon = build_from_crawler(addoncls, self.crawler)
                 addon.update_settings(settings)
                 self.addons.append(addon)
             except NotConfigured as e:

--- a/scrapy/addons.py
+++ b/scrapy/addons.py
@@ -33,9 +33,7 @@ class AddonManager:
             try:
                 addoncls = load_object(clspath)
                 # changes create_instance call to build_from_settings
-                addon = build_from_settings(
-                    addoncls, settings=settings
-                )
+                addon = build_from_settings(addoncls, settings=settings)
                 addon.update_settings(settings)
                 self.addons.append(addon)
             except NotConfigured as e:

--- a/scrapy/addons.py
+++ b/scrapy/addons.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING, Any, List
 from scrapy.exceptions import NotConfigured
 from scrapy.settings import Settings
 from scrapy.utils.conf import build_component_list
-from scrapy.utils.misc import build_from_settings, load_object
+from scrapy.utils.misc import build_from_crawler, build_from_settings, load_object
 
 if TYPE_CHECKING:
     from scrapy.crawler import Crawler
@@ -33,7 +33,10 @@ class AddonManager:
             try:
                 addoncls = load_object(clspath)
                 # changes create_instance call to build_from_settings
-                addon = build_from_settings(addoncls, settings=settings)
+                if self.crawler is not None:
+                    addon = build_from_crawler(addoncls, self.crawler)
+                else:
+                    addon = build_from_settings(addoncls, settings)
                 addon.update_settings(settings)
                 self.addons.append(addon)
             except NotConfigured as e:

--- a/scrapy/core/downloader/contextfactory.py
+++ b/scrapy/core/downloader/contextfactory.py
@@ -20,7 +20,7 @@ from scrapy.core.downloader.tls import (
     openssl_methods,
 )
 from scrapy.settings import BaseSettings
-from scrapy.utils.misc import create_instance, load_object
+from scrapy.utils.misc import build_from_settings, load_object
 
 if TYPE_CHECKING:
     from twisted.internet._sslverify import ClientTLSOptions
@@ -165,19 +165,27 @@ def load_context_factory_from_settings(settings, crawler):
     context_factory_cls = load_object(settings["DOWNLOADER_CLIENTCONTEXTFACTORY"])
     # try method-aware context factory
     try:
-        context_factory = create_instance(
-            objcls=context_factory_cls,
-            settings=settings,
-            crawler=crawler,
-            method=ssl_method,
+        # changes create_instance call to build_from_settings
+        context_factory = build_from_settings(
+            context_factory_cls, settings=settings, method=ssl_method
         )
+        # context_factory = create_instance(
+        #     objcls=context_factory_cls,
+        #     settings=settings,
+        #     crawler=crawler,
+        #     method=ssl_method,
+        # )
     except TypeError:
         # use context factory defaults
-        context_factory = create_instance(
-            objcls=context_factory_cls,
-            settings=settings,
-            crawler=crawler,
+        # changes create_instance call to build_from_settings
+        context_factory = build_from_settings(
+            context_factory_cls, settings = settings
         )
+        # context_factory = create_instance(
+        #     objcls=context_factory_cls,
+        #     settings=settings,
+        #     crawler=crawler,
+        # )
         msg = (
             f"{settings['DOWNLOADER_CLIENTCONTEXTFACTORY']} does not accept "
             "a `method` argument (type OpenSSL.SSL method, e.g. "

--- a/scrapy/core/downloader/contextfactory.py
+++ b/scrapy/core/downloader/contextfactory.py
@@ -178,9 +178,7 @@ def load_context_factory_from_settings(settings, crawler):
     except TypeError:
         # use context factory defaults
         # changes create_instance call to build_from_settings
-        context_factory = build_from_settings(
-            context_factory_cls, settings = settings
-        )
+        context_factory = build_from_settings(context_factory_cls, settings=settings)
         # context_factory = create_instance(
         #     objcls=context_factory_cls,
         #     settings=settings,

--- a/scrapy/core/downloader/contextfactory.py
+++ b/scrapy/core/downloader/contextfactory.py
@@ -20,7 +20,7 @@ from scrapy.core.downloader.tls import (
     openssl_methods,
 )
 from scrapy.settings import BaseSettings
-from scrapy.utils.misc import build_from_crawler, build_from_settings, load_object
+from scrapy.utils.misc import build_from_crawler, load_object
 
 if TYPE_CHECKING:
     from twisted.internet._sslverify import ClientTLSOptions
@@ -165,29 +165,16 @@ def load_context_factory_from_settings(settings, crawler):
     context_factory_cls = load_object(settings["DOWNLOADER_CLIENTCONTEXTFACTORY"])
     # try method-aware context factory
     try:
-        if crawler is not None:
-            context_factory = build_from_crawler(
-                objcls=context_factory_cls,
-                crawler=crawler,
-                method=ssl_method,
-            )
-        else:
-            context_factory = build_from_settings(
-                objcls=context_factory_cls,
-                settings=settings,
-                method=ssl_method,
-            )
+        context_factory = build_from_crawler(
+            objcls=context_factory_cls,
+            crawler=crawler,
+            method=ssl_method,
+        )
     except TypeError:
-        if crawler is not None:
-            context_factory = build_from_crawler(
-                objcls=context_factory_cls,
-                crawler=crawler,
-            )
-        else:
-            context_factory = build_from_settings(
-                objcls=context_factory_cls,
-                settings=settings,
-            )
+        context_factory = build_from_crawler(
+            objcls=context_factory_cls,
+            crawler=crawler,
+        )
         msg = (
             f"{settings['DOWNLOADER_CLIENTCONTEXTFACTORY']} does not accept "
             "a `method` argument (type OpenSSL.SSL method, e.g. "

--- a/scrapy/core/downloader/contextfactory.py
+++ b/scrapy/core/downloader/contextfactory.py
@@ -166,14 +166,14 @@ def load_context_factory_from_settings(settings, crawler):
     # try method-aware context factory
     try:
         context_factory = build_from_crawler(
-            objcls=context_factory_cls,
-            crawler=crawler,
+            context_factory_cls,
+            crawler,
             method=ssl_method,
         )
     except TypeError:
         context_factory = build_from_crawler(
-            objcls=context_factory_cls,
-            crawler=crawler,
+            context_factory_cls,
+            crawler,
         )
         msg = (
             f"{settings['DOWNLOADER_CLIENTCONTEXTFACTORY']} does not accept "

--- a/scrapy/core/downloader/contextfactory.py
+++ b/scrapy/core/downloader/contextfactory.py
@@ -171,6 +171,7 @@ def load_context_factory_from_settings(settings, crawler):
             method=ssl_method,
         )
     except TypeError:
+        # use context factory defaults
         context_factory = build_from_crawler(
             context_factory_cls,
             crawler,

--- a/scrapy/core/downloader/handlers/__init__.py
+++ b/scrapy/core/downloader/handlers/__init__.py
@@ -56,9 +56,7 @@ class DownloadHandlers:
             if skip_lazy and getattr(dhcls, "lazy", True):
                 return None
             # change create_instance call to build_from_settings
-            dh = build_from_settings(
-                dhcls, settings=self._crawler.settings
-            )
+            dh = build_from_settings(dhcls, settings=self._crawler.settings)
             # dh = create_instance(
             #     objcls=dhcls,
             #     settings=self._crawler.settings,

--- a/scrapy/core/downloader/handlers/__init__.py
+++ b/scrapy/core/downloader/handlers/__init__.py
@@ -9,7 +9,7 @@ from twisted.internet.defer import Deferred
 from scrapy import Request, Spider, signals
 from scrapy.exceptions import NotConfigured, NotSupported
 from scrapy.utils.httpobj import urlparse_cached
-from scrapy.utils.misc import build_from_settings, load_object
+from scrapy.utils.misc import build_from_crawler, build_from_settings, load_object
 from scrapy.utils.python import without_none_values
 
 if TYPE_CHECKING:
@@ -56,12 +56,16 @@ class DownloadHandlers:
             if skip_lazy and getattr(dhcls, "lazy", True):
                 return None
             # change create_instance call to build_from_settings
-            dh = build_from_settings(dhcls, settings=self._crawler.settings)
-            # dh = create_instance(
-            #     objcls=dhcls,
-            #     settings=self._crawler.settings,
-            #     crawler=self._crawler,
-            # )
+            if self._crawler is not None:
+                dh = build_from_crawler(
+                    objcls=dhcls,
+                    crawler=self._crawler,
+                )
+            else:
+                dh = build_from_settings(
+                    objcls=dhcls,
+                    settings=self._crawler.settings,
+                )
         except NotConfigured as ex:
             self._notconfigured[scheme] = str(ex)
             return None

--- a/scrapy/core/downloader/handlers/__init__.py
+++ b/scrapy/core/downloader/handlers/__init__.py
@@ -9,7 +9,7 @@ from twisted.internet.defer import Deferred
 from scrapy import Request, Spider, signals
 from scrapy.exceptions import NotConfigured, NotSupported
 from scrapy.utils.httpobj import urlparse_cached
-from scrapy.utils.misc import build_from_crawler, build_from_settings, load_object
+from scrapy.utils.misc import build_from_crawler, load_object
 from scrapy.utils.python import without_none_values
 
 if TYPE_CHECKING:
@@ -56,16 +56,10 @@ class DownloadHandlers:
             if skip_lazy and getattr(dhcls, "lazy", True):
                 return None
             # change create_instance call to build_from_settings
-            if self._crawler is not None:
-                dh = build_from_crawler(
-                    objcls=dhcls,
-                    crawler=self._crawler,
-                )
-            else:
-                dh = build_from_settings(
-                    objcls=dhcls,
-                    settings=self._crawler.settings,
-                )
+            dh = build_from_crawler(
+                objcls=dhcls,
+                crawler=self._crawler,
+            )
         except NotConfigured as ex:
             self._notconfigured[scheme] = str(ex)
             return None

--- a/scrapy/core/downloader/handlers/__init__.py
+++ b/scrapy/core/downloader/handlers/__init__.py
@@ -9,7 +9,7 @@ from twisted.internet.defer import Deferred
 from scrapy import Request, Spider, signals
 from scrapy.exceptions import NotConfigured, NotSupported
 from scrapy.utils.httpobj import urlparse_cached
-from scrapy.utils.misc import create_instance, load_object
+from scrapy.utils.misc import build_from_crawler, build_from_settings, load_object
 from scrapy.utils.python import without_none_values
 
 if TYPE_CHECKING:
@@ -55,11 +55,15 @@ class DownloadHandlers:
             dhcls = load_object(path)
             if skip_lazy and getattr(dhcls, "lazy", True):
                 return None
-            dh = create_instance(
-                objcls=dhcls,
-                settings=self._crawler.settings,
-                crawler=self._crawler,
+            # change create_instance call to build_from_settings
+            dh = build_from_settings(
+                dhcls, settings=self._crawler.settings
             )
+            # dh = create_instance(
+            #     objcls=dhcls,
+            #     settings=self._crawler.settings,
+            #     crawler=self._crawler,
+            # )
         except NotConfigured as ex:
             self._notconfigured[scheme] = str(ex)
             return None

--- a/scrapy/core/downloader/handlers/__init__.py
+++ b/scrapy/core/downloader/handlers/__init__.py
@@ -9,7 +9,7 @@ from twisted.internet.defer import Deferred
 from scrapy import Request, Spider, signals
 from scrapy.exceptions import NotConfigured, NotSupported
 from scrapy.utils.httpobj import urlparse_cached
-from scrapy.utils.misc import build_from_crawler, build_from_settings, load_object
+from scrapy.utils.misc import build_from_settings, load_object
 from scrapy.utils.python import without_none_values
 
 if TYPE_CHECKING:

--- a/scrapy/core/downloader/handlers/__init__.py
+++ b/scrapy/core/downloader/handlers/__init__.py
@@ -56,8 +56,8 @@ class DownloadHandlers:
             if skip_lazy and getattr(dhcls, "lazy", True):
                 return None
             dh = build_from_crawler(
-                objcls=dhcls,
-                crawler=self._crawler,
+                dhcls,
+                self._crawler,
             )
         except NotConfigured as ex:
             self._notconfigured[scheme] = str(ex)

--- a/scrapy/core/downloader/handlers/__init__.py
+++ b/scrapy/core/downloader/handlers/__init__.py
@@ -55,7 +55,6 @@ class DownloadHandlers:
             dhcls = load_object(path)
             if skip_lazy and getattr(dhcls, "lazy", True):
                 return None
-            # change create_instance call to build_from_settings
             dh = build_from_crawler(
                 objcls=dhcls,
                 crawler=self._crawler,

--- a/scrapy/core/downloader/handlers/http10.py
+++ b/scrapy/core/downloader/handlers/http10.py
@@ -1,6 +1,6 @@
 """Download handlers for http and https schemes
 """
-from scrapy.utils.misc import build_from_settings, build_from_crawler, load_object
+from scrapy.utils.misc import build_from_crawler, build_from_settings, load_object
 from scrapy.utils.python import to_unicode
 
 

--- a/scrapy/core/downloader/handlers/http10.py
+++ b/scrapy/core/downloader/handlers/http10.py
@@ -1,6 +1,6 @@
 """Download handlers for http and https schemes
 """
-from scrapy.utils.misc import build_from_crawler, build_from_settings, load_object
+from scrapy.utils.misc import build_from_crawler, load_object
 from scrapy.utils.python import to_unicode
 
 
@@ -30,15 +30,9 @@ class HTTP10DownloadHandler:
 
         host, port = to_unicode(factory.host), factory.port
         if factory.scheme == b"https":
-            if self._crawler is not None:
-                client_context_factory = build_from_crawler(
-                    objcls=self.ClientContextFactory,
-                    crawler=self._crawler,
-                )
-            else:
-                client_context_factory = build_from_settings(
-                    objcls=self.ClientContextFactory,
-                    settings=self._settings,
-                )
+            client_context_factory = build_from_crawler(
+                objcls=self.ClientContextFactory,
+                crawler=self._crawler,
+            )
             return reactor.connectSSL(host, port, factory, client_context_factory)
         return reactor.connectTCP(host, port, factory)

--- a/scrapy/core/downloader/handlers/http10.py
+++ b/scrapy/core/downloader/handlers/http10.py
@@ -30,7 +30,7 @@ class HTTP10DownloadHandler:
 
         host, port = to_unicode(factory.host), factory.port
         if factory.scheme == b"https":
-            if self._settings is None:
+            if self._crawler is not None:
                 client_context_factory = build_from_crawler(
                     objcls=self.ClientContextFactory,
                     crawler=self._crawler,

--- a/scrapy/core/downloader/handlers/http10.py
+++ b/scrapy/core/downloader/handlers/http10.py
@@ -1,6 +1,6 @@
 """Download handlers for http and https schemes
 """
-from scrapy.utils.misc import create_instance, load_object
+from scrapy.utils.misc import build_from_settings, build_from_crawler, load_object
 from scrapy.utils.python import to_unicode
 
 
@@ -30,10 +30,15 @@ class HTTP10DownloadHandler:
 
         host, port = to_unicode(factory.host), factory.port
         if factory.scheme == b"https":
-            client_context_factory = create_instance(
-                objcls=self.ClientContextFactory,
-                settings=self._settings,
-                crawler=self._crawler,
-            )
+            if self._settings is None:
+                client_context_factory = build_from_crawler(
+                    objcls=self.ClientContextFactory,
+                    crawler=self._crawler,
+                )
+            else:
+                client_context_factory = build_from_settings(
+                    objcls=self.ClientContextFactory,
+                    settings=self._settings,
+                )
             return reactor.connectSSL(host, port, factory, client_context_factory)
         return reactor.connectTCP(host, port, factory)

--- a/scrapy/core/downloader/handlers/http10.py
+++ b/scrapy/core/downloader/handlers/http10.py
@@ -31,8 +31,8 @@ class HTTP10DownloadHandler:
         host, port = to_unicode(factory.host), factory.port
         if factory.scheme == b"https":
             client_context_factory = build_from_crawler(
-                objcls=self.ClientContextFactory,
-                crawler=self._crawler,
+                self.ClientContextFactory,
+                self._crawler,
             )
             return reactor.connectSSL(host, port, factory, client_context_factory)
         return reactor.connectTCP(host, port, factory)

--- a/scrapy/core/downloader/handlers/s3.py
+++ b/scrapy/core/downloader/handlers/s3.py
@@ -50,7 +50,7 @@ class S3DownloadHandler:
                 )
             )
 
-        if settings is None:
+        if crawler is not None:
             _http_handler = build_from_crawler(
                 objcls=httpdownloadhandler,
                 crawler=crawler,

--- a/scrapy/core/downloader/handlers/s3.py
+++ b/scrapy/core/downloader/handlers/s3.py
@@ -2,7 +2,7 @@ from scrapy.core.downloader.handlers.http import HTTPDownloadHandler
 from scrapy.exceptions import NotConfigured
 from scrapy.utils.boto import is_botocore_available
 from scrapy.utils.httpobj import urlparse_cached
-from scrapy.utils.misc import create_instance
+from scrapy.utils.misc import build_from_crawler, build_from_settings
 
 
 class S3DownloadHandler:
@@ -50,11 +50,16 @@ class S3DownloadHandler:
                 )
             )
 
-        _http_handler = create_instance(
-            objcls=httpdownloadhandler,
-            settings=settings,
-            crawler=crawler,
-        )
+        if settings is None:
+            _http_handler = build_from_crawler(
+                objcls=httpdownloadhandler,
+                crawler=crawler,
+            )
+        else:
+            _http_handler = build_from_settings(
+                objcls=httpdownloadhandler,
+                settings=settings,
+            )
         self._download_http = _http_handler.download_request
 
     @classmethod

--- a/scrapy/core/downloader/handlers/s3.py
+++ b/scrapy/core/downloader/handlers/s3.py
@@ -2,7 +2,7 @@ from scrapy.core.downloader.handlers.http import HTTPDownloadHandler
 from scrapy.exceptions import NotConfigured
 from scrapy.utils.boto import is_botocore_available
 from scrapy.utils.httpobj import urlparse_cached
-from scrapy.utils.misc import build_from_crawler, build_from_settings
+from scrapy.utils.misc import build_from_crawler
 
 
 class S3DownloadHandler:
@@ -50,16 +50,10 @@ class S3DownloadHandler:
                 )
             )
 
-        if crawler is not None:
-            _http_handler = build_from_crawler(
-                objcls=httpdownloadhandler,
-                crawler=crawler,
-            )
-        else:
-            _http_handler = build_from_settings(
-                objcls=httpdownloadhandler,
-                settings=settings,
-            )
+        _http_handler = build_from_crawler(
+            objcls=httpdownloadhandler,
+            crawler=crawler,
+        )
         self._download_http = _http_handler.download_request
 
     @classmethod

--- a/scrapy/core/downloader/handlers/s3.py
+++ b/scrapy/core/downloader/handlers/s3.py
@@ -51,8 +51,8 @@ class S3DownloadHandler:
             )
 
         _http_handler = build_from_crawler(
-            objcls=httpdownloadhandler,
-            crawler=crawler,
+            httpdownloadhandler,
+            crawler,
         )
         self._download_http = _http_handler.download_request
 

--- a/scrapy/core/engine.py
+++ b/scrapy/core/engine.py
@@ -358,7 +358,7 @@ class ExecutionEngine:
             raise RuntimeError(f"No free spider slot when opening {spider.name!r}")
         logger.info("Spider opened", extra={"spider": spider})
         nextcall = CallLaterOnce(self._next_request)
-        scheduler = build_from_crawler(self.scheduler_cls, crawler=self.crawler)
+        scheduler = build_from_crawler(self.scheduler_cls, self.crawler)
         start_requests = yield self.scraper.spidermw.process_start_requests(
             start_requests, spider
         )

--- a/scrapy/core/engine.py
+++ b/scrapy/core/engine.py
@@ -34,7 +34,7 @@ from scrapy.settings import BaseSettings, Settings
 from scrapy.signalmanager import SignalManager
 from scrapy.spiders import Spider
 from scrapy.utils.log import failure_to_exc_info, logformatter_adapter
-from scrapy.utils.misc import create_instance, load_object
+from scrapy.utils.misc import build_from_crawler, load_object
 from scrapy.utils.reactor import CallLaterOnce
 
 if TYPE_CHECKING:
@@ -358,8 +358,8 @@ class ExecutionEngine:
             raise RuntimeError(f"No free spider slot when opening {spider.name!r}")
         logger.info("Spider opened", extra={"spider": spider})
         nextcall = CallLaterOnce(self._next_request)
-        scheduler = create_instance(
-            self.scheduler_cls, settings=None, crawler=self.crawler
+        scheduler = build_from_crawler(
+            self.scheduler_cls, crawler=self.crawler
         )
         start_requests = yield self.scraper.spidermw.process_start_requests(
             start_requests, spider

--- a/scrapy/core/engine.py
+++ b/scrapy/core/engine.py
@@ -358,9 +358,7 @@ class ExecutionEngine:
             raise RuntimeError(f"No free spider slot when opening {spider.name!r}")
         logger.info("Spider opened", extra={"spider": spider})
         nextcall = CallLaterOnce(self._next_request)
-        scheduler = build_from_crawler(
-            self.scheduler_cls, crawler=self.crawler
-        )
+        scheduler = build_from_crawler(self.scheduler_cls, crawler=self.crawler)
         start_requests = yield self.scraper.spidermw.process_start_requests(
             start_requests, spider
         )

--- a/scrapy/core/scheduler.py
+++ b/scrapy/core/scheduler.py
@@ -14,7 +14,7 @@ from scrapy.http.request import Request
 from scrapy.spiders import Spider
 from scrapy.statscollectors import StatsCollector
 from scrapy.utils.job import job_dir
-from scrapy.utils.misc import build_from_crawler, build_from_settings, load_object
+from scrapy.utils.misc import build_from_crawler, load_object
 
 if TYPE_CHECKING:
     # typing.Self requires Python 3.11
@@ -201,12 +201,8 @@ class Scheduler(BaseScheduler):
         Factory method, initializes the scheduler with arguments taken from the crawl settings
         """
         dupefilter_cls = load_object(crawler.settings["DUPEFILTER_CLASS"])
-        if crawler is not None:
-            dupefilter = build_from_crawler(dupefilter_cls, crawler)
-        else:
-            dupefilter = build_from_settings(dupefilter_cls, crawler.settings)
         return cls(
-            dupefilter=dupefilter,
+            dupefilter=build_from_crawler(dupefilter_cls, crawler),
             jobdir=job_dir(crawler.settings),
             dqclass=load_object(crawler.settings["SCHEDULER_DISK_QUEUE"]),
             mqclass=load_object(crawler.settings["SCHEDULER_MEMORY_QUEUE"]),

--- a/scrapy/core/scheduler.py
+++ b/scrapy/core/scheduler.py
@@ -14,7 +14,7 @@ from scrapy.http.request import Request
 from scrapy.spiders import Spider
 from scrapy.statscollectors import StatsCollector
 from scrapy.utils.job import job_dir
-from scrapy.utils.misc import create_instance, load_object
+from scrapy.utils.misc import build_from_crawler, load_object
 
 if TYPE_CHECKING:
     # typing.Self requires Python 3.11
@@ -202,7 +202,7 @@ class Scheduler(BaseScheduler):
         """
         dupefilter_cls = load_object(crawler.settings["DUPEFILTER_CLASS"])
         return cls(
-            dupefilter=create_instance(dupefilter_cls, crawler.settings, crawler),
+            dupefilter=build_from_crawler(dupefilter_cls, crawler),
             jobdir=job_dir(crawler.settings),
             dqclass=load_object(crawler.settings["SCHEDULER_DISK_QUEUE"]),
             mqclass=load_object(crawler.settings["SCHEDULER_MEMORY_QUEUE"]),
@@ -322,9 +322,8 @@ class Scheduler(BaseScheduler):
 
     def _mq(self):
         """Create a new priority queue instance, with in-memory storage"""
-        return create_instance(
+        return build_from_crawler(
             self.pqclass,
-            settings=None,
             crawler=self.crawler,
             downstream_queue_cls=self.mqclass,
             key="",
@@ -334,9 +333,8 @@ class Scheduler(BaseScheduler):
         """Create a new priority queue instance, with disk storage"""
         assert self.dqdir
         state = self._read_dqs_state(self.dqdir)
-        q = create_instance(
+        q = build_from_crawler(
             self.pqclass,
-            settings=None,
             crawler=self.crawler,
             downstream_queue_cls=self.dqclass,
             key=self.dqdir,

--- a/scrapy/core/scheduler.py
+++ b/scrapy/core/scheduler.py
@@ -14,7 +14,7 @@ from scrapy.http.request import Request
 from scrapy.spiders import Spider
 from scrapy.statscollectors import StatsCollector
 from scrapy.utils.job import job_dir
-from scrapy.utils.misc import build_from_crawler, load_object
+from scrapy.utils.misc import build_from_crawler, build_from_settings, load_object
 
 if TYPE_CHECKING:
     # typing.Self requires Python 3.11
@@ -201,8 +201,12 @@ class Scheduler(BaseScheduler):
         Factory method, initializes the scheduler with arguments taken from the crawl settings
         """
         dupefilter_cls = load_object(crawler.settings["DUPEFILTER_CLASS"])
+        if crawler is not None:
+            dupefilter = build_from_crawler(dupefilter_cls, crawler)
+        else:
+            dupefilter = build_from_settings(dupefilter_cls, crawler.settings)
         return cls(
-            dupefilter=build_from_crawler(dupefilter_cls, crawler),
+            dupefilter=dupefilter,
             jobdir=job_dir(crawler.settings),
             dqclass=load_object(crawler.settings["SCHEDULER_DISK_QUEUE"]),
             mqclass=load_object(crawler.settings["SCHEDULER_MEMORY_QUEUE"]),

--- a/scrapy/core/scheduler.py
+++ b/scrapy/core/scheduler.py
@@ -324,7 +324,7 @@ class Scheduler(BaseScheduler):
         """Create a new priority queue instance, with in-memory storage"""
         return build_from_crawler(
             self.pqclass,
-            crawler=self.crawler,
+            self.crawler,
             downstream_queue_cls=self.mqclass,
             key="",
         )
@@ -335,7 +335,7 @@ class Scheduler(BaseScheduler):
         state = self._read_dqs_state(self.dqdir)
         q = build_from_crawler(
             self.pqclass,
-            crawler=self.crawler,
+            self.crawler,
             downstream_queue_cls=self.dqclass,
             key=self.dqdir,
             startprios=state,

--- a/scrapy/crawler.py
+++ b/scrapy/crawler.py
@@ -109,7 +109,6 @@ class Crawler:
         lf_cls: Type[LogFormatter] = load_object(self.settings["LOG_FORMATTER"])
         self.logformatter = lf_cls.from_crawler(self)
 
-        # changes create_instance call to build_from_crawler
         self.request_fingerprinter = build_from_crawler(
             load_object(self.settings["REQUEST_FINGERPRINTER_CLASS"]),
             crawler=self,
@@ -404,7 +403,6 @@ class CrawlerProcess(CrawlerRunner):
             d.addBoth(self._stop_reactor)
 
         resolver_class = load_object(self.settings["DNS_RESOLVER"])
-        # changes create_instance call to build_from_crawler/settings
         resolver = build_from_crawler(resolver_class, self, reactor=reactor)
         resolver.install_on_reactor()
         tp = reactor.getThreadPool()

--- a/scrapy/crawler.py
+++ b/scrapy/crawler.py
@@ -111,7 +111,7 @@ class Crawler:
 
         self.request_fingerprinter = build_from_crawler(
             load_object(self.settings["REQUEST_FINGERPRINTER_CLASS"]),
-            crawler=self,
+            self,
         )
 
         reactor_class: str = self.settings["TWISTED_REACTOR"]

--- a/scrapy/crawler.py
+++ b/scrapy/crawler.py
@@ -39,7 +39,7 @@ from scrapy.utils.log import (
     log_reactor_info,
     log_scrapy_info,
 )
-from scrapy.utils.misc import build_from_crawler, build_from_settings, load_object
+from scrapy.utils.misc import build_from_crawler, load_object
 from scrapy.utils.ossignal import install_shutdown_handlers, signal_names
 from scrapy.utils.reactor import (
     install_reactor,
@@ -109,17 +109,11 @@ class Crawler:
         lf_cls: Type[LogFormatter] = load_object(self.settings["LOG_FORMATTER"])
         self.logformatter = lf_cls.from_crawler(self)
 
-        # changes create_instance call to build_from_crawler/settings
-        if self is not None:
-            self.request_fingerprinter = build_from_crawler(
-                load_object(self.settings["REQUEST_FINGERPRINTER_CLASS"]),
-                crawler=self,
-            )
-        else:
-            self.request_fingerprinter = build_from_settings(
-                load_object(self.settings["REQUEST_FINGERPRINTER_CLASS"]),
-                settings=self.settings,
-            )
+        # changes create_instance call to build_from_crawler
+        self.request_fingerprinter = build_from_crawler(
+            load_object(self.settings["REQUEST_FINGERPRINTER_CLASS"]),
+            crawler=self,
+        )
 
         reactor_class: str = self.settings["TWISTED_REACTOR"]
         event_loop: str = self.settings["ASYNCIO_EVENT_LOOP"]
@@ -411,12 +405,7 @@ class CrawlerProcess(CrawlerRunner):
 
         resolver_class = load_object(self.settings["DNS_RESOLVER"])
         # changes create_instance call to build_from_crawler/settings
-        if self is not None:
-            resolver = build_from_crawler(resolver_class, self, reactor=reactor)
-        else:
-            resolver = build_from_settings(
-                resolver_class, self.settings, reactor=reactor
-            )
+        resolver = build_from_crawler(resolver_class, self, reactor=reactor)
         resolver.install_on_reactor()
         tp = reactor.getThreadPool()
         tp.adjustPoolsize(maxthreads=self.settings.getint("REACTOR_THREADPOOL_MAXSIZE"))

--- a/scrapy/crawler.py
+++ b/scrapy/crawler.py
@@ -39,7 +39,7 @@ from scrapy.utils.log import (
     log_reactor_info,
     log_scrapy_info,
 )
-from scrapy.utils.misc import create_instance, load_object
+from scrapy.utils.misc import build_from_settings, load_object
 from scrapy.utils.ossignal import install_shutdown_handlers, signal_names
 from scrapy.utils.reactor import (
     install_reactor,
@@ -109,11 +109,16 @@ class Crawler:
         lf_cls: Type[LogFormatter] = load_object(self.settings["LOG_FORMATTER"])
         self.logformatter = lf_cls.from_crawler(self)
 
-        self.request_fingerprinter = create_instance(
-            load_object(self.settings["REQUEST_FINGERPRINTER_CLASS"]),
-            settings=self.settings,
-            crawler=self,
+        # changes create_instance call to build_from_settings
+        self.request_fingerprinter = build_from_settings(
+            load_object(self.settings["REQUEST_FINGERPRINTER_CLASS"]), settings=self.settings
         )
+
+        # self.request_fingerprinter = create_instance(
+        #     load_object(self.settings["REQUEST_FINGERPRINTER_CLASS"]),
+        #     settings=self.settings,
+        #     crawler=self,
+        # )
 
         reactor_class: str = self.settings["TWISTED_REACTOR"]
         event_loop: str = self.settings["ASYNCIO_EVENT_LOOP"]
@@ -404,7 +409,9 @@ class CrawlerProcess(CrawlerRunner):
             d.addBoth(self._stop_reactor)
 
         resolver_class = load_object(self.settings["DNS_RESOLVER"])
-        resolver = create_instance(resolver_class, self.settings, self, reactor=reactor)
+        # changes create_instance call to build_from_settings
+        resolver = build_from_settings(resolver_class, self.settings, reactor=reactor)
+        # resolver = create_instance(resolver_class, self.settings, self, reactor=reactor)
         resolver.install_on_reactor()
         tp = reactor.getThreadPool()
         tp.adjustPoolsize(maxthreads=self.settings.getint("REACTOR_THREADPOOL_MAXSIZE"))

--- a/scrapy/crawler.py
+++ b/scrapy/crawler.py
@@ -111,7 +111,8 @@ class Crawler:
 
         # changes create_instance call to build_from_settings
         self.request_fingerprinter = build_from_settings(
-            load_object(self.settings["REQUEST_FINGERPRINTER_CLASS"]), settings=self.settings
+            load_object(self.settings["REQUEST_FINGERPRINTER_CLASS"]),
+            settings=self.settings,
         )
 
         # self.request_fingerprinter = create_instance(

--- a/scrapy/extensions/feedexport.py
+++ b/scrapy/extensions/feedexport.py
@@ -28,7 +28,7 @@ from scrapy.utils.defer import maybe_deferred_to_future
 from scrapy.utils.deprecate import create_deprecated_class
 from scrapy.utils.ftp import ftp_store_file
 from scrapy.utils.log import failure_to_exc_info
-from scrapy.utils.misc import create_instance, load_object
+from scrapy.utils.misc import build_from_settings, build_from_crawler, load_object
 from scrapy.utils.python import without_none_values
 
 logger = logging.getLogger(__name__)
@@ -371,7 +371,10 @@ class FeedSlot:
             self._exporting = True
 
     def _get_instance(self, objcls, *args, **kwargs):
-        return create_instance(objcls, self.settings, self.crawler, *args, **kwargs)
+        if self.settings is None:
+            return build_from_crawler(objcls, self.crawler, *args, **kwargs)
+        else:
+            return build_from_settings(objcls, self.settings, *args, **kwargs)
 
     def _get_exporter(self, file, format, *args, **kwargs):
         return self._get_instance(self.exporters[format], file, *args, **kwargs)

--- a/scrapy/extensions/feedexport.py
+++ b/scrapy/extensions/feedexport.py
@@ -371,7 +371,7 @@ class FeedSlot:
             self._exporting = True
 
     def _get_instance(self, objcls, *args, **kwargs):
-        if self.settings is None:
+        if self.crawler is not None:
             return build_from_crawler(objcls, self.crawler, *args, **kwargs)
         else:
             return build_from_settings(objcls, self.settings, *args, **kwargs)

--- a/scrapy/extensions/feedexport.py
+++ b/scrapy/extensions/feedexport.py
@@ -28,7 +28,7 @@ from scrapy.utils.defer import maybe_deferred_to_future
 from scrapy.utils.deprecate import create_deprecated_class
 from scrapy.utils.ftp import ftp_store_file
 from scrapy.utils.log import failure_to_exc_info
-from scrapy.utils.misc import build_from_settings, build_from_crawler, load_object
+from scrapy.utils.misc import build_from_crawler, build_from_settings, load_object
 from scrapy.utils.python import without_none_values
 
 logger = logging.getLogger(__name__)

--- a/scrapy/extensions/feedexport.py
+++ b/scrapy/extensions/feedexport.py
@@ -28,7 +28,7 @@ from scrapy.utils.defer import maybe_deferred_to_future
 from scrapy.utils.deprecate import create_deprecated_class
 from scrapy.utils.ftp import ftp_store_file
 from scrapy.utils.log import failure_to_exc_info
-from scrapy.utils.misc import build_from_crawler, build_from_settings, load_object
+from scrapy.utils.misc import build_from_crawler, load_object
 from scrapy.utils.python import without_none_values
 
 logger = logging.getLogger(__name__)
@@ -371,10 +371,7 @@ class FeedSlot:
             self._exporting = True
 
     def _get_instance(self, objcls, *args, **kwargs):
-        if self.crawler is not None:
-            return build_from_crawler(objcls, self.crawler, *args, **kwargs)
-        else:
-            return build_from_settings(objcls, self.settings, *args, **kwargs)
+        return build_from_crawler(objcls, self.crawler, *args, **kwargs)
 
     def _get_exporter(self, file, format, *args, **kwargs):
         return self._get_instance(self.exporters[format], file, *args, **kwargs)

--- a/scrapy/middleware.py
+++ b/scrapy/middleware.py
@@ -23,7 +23,7 @@ from scrapy import Spider
 from scrapy.exceptions import NotConfigured
 from scrapy.settings import Settings
 from scrapy.utils.defer import process_chain, process_parallel
-from scrapy.utils.misc import build_from_settings, load_object
+from scrapy.utils.misc import build_from_crawler, build_from_settings, load_object
 
 if TYPE_CHECKING:
     # typing.Self requires Python 3.11
@@ -64,7 +64,10 @@ class MiddlewareManager:
         for clspath in mwlist:
             try:
                 mwcls = load_object(clspath)
-                mw = build_from_settings(mwcls, settings)
+                if crawler is not None:
+                    mw = build_from_crawler(mwcls, crawler)
+                else:
+                    mw = build_from_settings(mwcls, settings)
                 middlewares.append(mw)
                 enabled.append(clspath)
             except NotConfigured as e:

--- a/scrapy/middleware.py
+++ b/scrapy/middleware.py
@@ -23,7 +23,7 @@ from scrapy import Spider
 from scrapy.exceptions import NotConfigured
 from scrapy.settings import Settings
 from scrapy.utils.defer import process_chain, process_parallel
-from scrapy.utils.misc import create_instance, load_object
+from scrapy.utils.misc import build_from_settings, load_object
 
 if TYPE_CHECKING:
     # typing.Self requires Python 3.11
@@ -64,7 +64,7 @@ class MiddlewareManager:
         for clspath in mwlist:
             try:
                 mwcls = load_object(clspath)
-                mw = create_instance(mwcls, settings, crawler)
+                mw = build_from_settings(mwcls, settings)
                 middlewares.append(mw)
                 enabled.append(clspath)
             except NotConfigured as e:

--- a/scrapy/pqueues.py
+++ b/scrapy/pqueues.py
@@ -1,7 +1,7 @@
 import hashlib
 import logging
 
-from scrapy.utils.misc import create_instance
+from scrapy.utils.misc import build_from_crawler
 
 logger = logging.getLogger(__name__)
 
@@ -72,9 +72,8 @@ class ScrapyPriorityQueue:
         self.curprio = min(startprios)
 
     def qfactory(self, key):
-        return create_instance(
+        return build_from_crawler(
             self.downstream_queue_cls,
-            None,
             self.crawler,
             self.key + "/" + str(key),
         )

--- a/scrapy/utils/misc.py
+++ b/scrapy/utils/misc.py
@@ -25,6 +25,7 @@ from typing import (
     cast,
 )
 
+from scrapy.exceptions import ScrapyDeprecationWarning
 from scrapy.item import Item
 from scrapy.utils.datatypes import LocalWeakReferencedCache
 
@@ -142,6 +143,13 @@ def create_instance(objcls, settings, crawler, *args, **kwargs):
        Raises ``TypeError`` if the resulting instance is ``None`` (e.g. if an
        extension has not been implemented correctly).
     """
+    warnings.warn(
+        "The create_instance() function is deprecated. "
+        "Please use build_from_crawler() or build_from_settings() instead.",
+        category=ScrapyDeprecationWarning,
+        stacklevel=2,
+    )
+
     if settings is None:
         if crawler is None:
             raise ValueError("Specify at least one of settings and crawler.")

--- a/scrapy/utils/misc.py
+++ b/scrapy/utils/misc.py
@@ -47,18 +47,18 @@ def arg_to_iter(arg: Any) -> Iterable[Any]:
         return cast(Iterable[Any], arg)
     return [arg]
 
-def build_from_crawler(objcls, crawler, none, *args, **kwargs):
-    if crawler 
-        if hasattr(objcls, "from_crawler"):
-            instance = objcls.from_crawler(crawler, *args, **kwargs)
-            method_name = "from_crawler"
-        if instance is None: 
-            raise TypeError(f"{objcls.__qualname__}.{method_name} returned None)
-    else: 
-        instance = objcls(*args, **kwargs)
-        method_name = "__new__"
+# def build_from_crawler(objcls, crawler, none, *args, **kwargs):
+#     if crawler 
+#         if hasattr(objcls, "from_crawler"):
+#             instance = objcls.from_crawler(crawler, *args, **kwargs)
+#             method_name = "from_crawler"
+#         if instance is None: 
+#             raise TypeError(f"{objcls.__qualname__}.{method_name} returned None)
+#     else: 
+#         instance = objcls(*args, **kwargs)
+#         method_name = "__new__"
 
-    return instance
+#     return instance
 
 def load_object(path: Union[str, Callable]) -> Any:
     """Load an object given its absolute object path, and return it.

--- a/scrapy/utils/misc.py
+++ b/scrapy/utils/misc.py
@@ -161,8 +161,7 @@ def create_instance(objcls, settings, crawler, *args, **kwargs):
 
 
 def build_from_crawler(objcls, crawler, /, *args, **kwargs):
-    """
-    Constructs a class instance using ``from_crawler`` constructor
+    """Construct a class instance using its ``from_crawler`` constructor.
 
     ``*args`` and ``**kwargs`` are forwarded to the constructors.
 

--- a/scrapy/utils/misc.py
+++ b/scrapy/utils/misc.py
@@ -47,18 +47,20 @@ def arg_to_iter(arg: Any) -> Iterable[Any]:
         return cast(Iterable[Any], arg)
     return [arg]
 
+
 # def build_from_crawler(objcls, crawler, none, *args, **kwargs):
-#     if crawler 
+#     if crawler
 #         if hasattr(objcls, "from_crawler"):
 #             instance = objcls.from_crawler(crawler, *args, **kwargs)
 #             method_name = "from_crawler"
-#         if instance is None: 
+#         if instance is None:
 #             raise TypeError(f"{objcls.__qualname__}.{method_name} returned None)
-#     else: 
+#     else:
 #         instance = objcls(*args, **kwargs)
 #         method_name = "__new__"
 
 #     return instance
+
 
 def load_object(path: Union[str, Callable]) -> Any:
     """Load an object given its absolute object path, and return it.
@@ -176,8 +178,8 @@ def rel_has_nofollow(rel: Optional[str]) -> bool:
 # Raises ``ValueError`` if``crawler`` is``None``.
 #  Raises typeError is instance is None
 # Creates a class instance using 'from_crawler' constructor
-def build_from_crawler(objcls, crawler, /, *args, **kwargs):
-    if crawler is None: 
+def build_from_crawler(objcls, crawler, *args, **kwargs):
+    if crawler is None:
         raise ValueError("Specify crawler.")
     if crawler and hasattr(objcls, "from_crawler"):
         instance = objcls.from_crawler(crawler, *args, **kwargs)
@@ -188,14 +190,14 @@ def build_from_crawler(objcls, crawler, /, *args, **kwargs):
     if instance is None:
         raise TypeError(f"{objcls.__qualname__}.{method_name} returned None")
     return instance
-            
 
-#``*args`` and ``**kwargs`` are forwarded to the constructors.
+
+# ``*args`` and ``**kwargs`` are forwarded to the constructors.
 # Raises ``ValueError`` if``settings`` is``None``.
 #  Raises typeError is instance is None
 # Creates a class instance using 'from_settings' constructor
-def build_from_settings(objcls, settings, /, *args, **kwargs):
-    if settings is None: 
+def build_from_settings(objcls, settings, *args, **kwargs):
+    if settings is None:
         raise ValueError("Specify settings.")
     if settings and hasattr(objcls, "from_settings"):
         instance = objcls.from_settings(settings, *args, **kwargs)
@@ -206,8 +208,6 @@ def build_from_settings(objcls, settings, /, *args, **kwargs):
     if instance is None:
         raise TypeError(f"{objcls.__qualname__}.{method_name} returned None")
     return instance
-
-
 
 
 @contextmanager

--- a/scrapy/utils/misc.py
+++ b/scrapy/utils/misc.py
@@ -182,7 +182,7 @@ def build_from_crawler(objcls, crawler, /, *args, **kwargs):
 
 
 def build_from_settings(objcls, settings, /, *args, **kwargs):
-    """Constructs a class instance using its ``from_settings`` constructor.
+    """Construct a class instance using its ``from_settings`` constructor.
 
     ``*args`` and ``**kwargs`` are forwarded to the constructor.
 

--- a/scrapy/utils/misc.py
+++ b/scrapy/utils/misc.py
@@ -163,10 +163,9 @@ def create_instance(objcls, settings, crawler, *args, **kwargs):
 def build_from_crawler(objcls, crawler, /, *args, **kwargs):
     """Construct a class instance using its ``from_crawler`` constructor.
 
-    ``*args`` and ``**kwargs`` are forwarded to the constructors.
+    ``*args`` and ``**kwargs`` are forwarded to the constructor.
 
-    Raises ``ValueError`` if``crawler`` is``None``.
-    Raises typeError is instance is None
+    Raises ``TypeError`` if the resulting instance is ``None``.
     """
     settings = crawler.settings
     if crawler and hasattr(objcls, "from_crawler"):
@@ -184,13 +183,11 @@ def build_from_crawler(objcls, crawler, /, *args, **kwargs):
 
 
 def build_from_settings(objcls, settings, /, *args, **kwargs):
-    """
-    Constructs a class instance using ``from_settings`` constructor
+    """Constructs a class instance using its ``from_settings`` constructor
 
     ``*args`` and ``**kwargs`` are forwarded to the constructors.
 
-    Raises ``ValueError`` if``settings`` is``None``.
-    Raises typeError is instance is None
+    Raises ``TypeError`` if the resulting instance is ``None``.
     """
     if settings and hasattr(objcls, "from_settings"):
         instance = objcls.from_settings(settings, *args, **kwargs)

--- a/scrapy/utils/misc.py
+++ b/scrapy/utils/misc.py
@@ -167,12 +167,11 @@ def build_from_crawler(objcls, crawler, /, *args, **kwargs):
 
     Raises ``TypeError`` if the resulting instance is ``None``.
     """
-    settings = crawler.settings
-    if crawler and hasattr(objcls, "from_crawler"):
+    if hasattr(objcls, "from_crawler"):
         instance = objcls.from_crawler(crawler, *args, **kwargs)
         method_name = "from_crawler"
     elif hasattr(objcls, "from_settings"):
-        instance = objcls.from_settings(settings, *args, **kwargs)
+        instance = objcls.from_settings(crawler.settings, *args, **kwargs)
         method_name = "from_settings"
     else:
         instance = objcls(*args, **kwargs)
@@ -183,13 +182,13 @@ def build_from_crawler(objcls, crawler, /, *args, **kwargs):
 
 
 def build_from_settings(objcls, settings, /, *args, **kwargs):
-    """Constructs a class instance using its ``from_settings`` constructor
+    """Constructs a class instance using its ``from_settings`` constructor.
 
-    ``*args`` and ``**kwargs`` are forwarded to the constructors.
+    ``*args`` and ``**kwargs`` are forwarded to the constructor.
 
     Raises ``TypeError`` if the resulting instance is ``None``.
     """
-    if settings and hasattr(objcls, "from_settings"):
+    if hasattr(objcls, "from_settings"):
         instance = objcls.from_settings(settings, *args, **kwargs)
         method_name = "from_settings"
     else:

--- a/scrapy/utils/misc.py
+++ b/scrapy/utils/misc.py
@@ -47,6 +47,18 @@ def arg_to_iter(arg: Any) -> Iterable[Any]:
         return cast(Iterable[Any], arg)
     return [arg]
 
+def build_from_crawler(objcls, crawler, none, *args, **kwargs):
+    if crawler 
+        if hasattr(objcls, "from_crawler"):
+            instance = objcls.from_crawler(crawler, *args, **kwargs)
+            method_name = "from_crawler"
+        if instance is None: 
+            raise TypeError(f"{objcls.__qualname__}.{method_name} returned None)
+    else: 
+        instance = objcls(*args, **kwargs)
+        method_name = "__new__"
+
+    return instance
 
 def load_object(path: Union[str, Callable]) -> Any:
     """Load an object given its absolute object path, and return it.

--- a/scrapy/utils/misc.py
+++ b/scrapy/utils/misc.py
@@ -184,7 +184,7 @@ def build_from_crawler(objcls, crawler, /, *args, **kwargs):
     return instance
 
 
-def build_from_settings(objcls, settings, *args, **kwargs):
+def build_from_settings(objcls, settings, /, *args, **kwargs):
     """
     Constructs a class instance using ``from_settings`` constructor
 

--- a/scrapy/utils/misc.py
+++ b/scrapy/utils/misc.py
@@ -48,20 +48,6 @@ def arg_to_iter(arg: Any) -> Iterable[Any]:
     return [arg]
 
 
-# def build_from_crawler(objcls, crawler, none, *args, **kwargs):
-#     if crawler
-#         if hasattr(objcls, "from_crawler"):
-#             instance = objcls.from_crawler(crawler, *args, **kwargs)
-#             method_name = "from_crawler"
-#         if instance is None:
-#             raise TypeError(f"{objcls.__qualname__}.{method_name} returned None)
-#     else:
-#         instance = objcls(*args, **kwargs)
-#         method_name = "__new__"
-
-#     return instance
-
-
 def load_object(path: Union[str, Callable]) -> Any:
     """Load an object given its absolute object path, and return it.
 
@@ -139,41 +125,6 @@ def rel_has_nofollow(rel: Optional[str]) -> bool:
     return rel is not None and "nofollow" in rel.replace(",", " ").split()
 
 
-# def create_instance(objcls, settings, crawler, *args, **kwargs):
-#     """Construct a class instance using its ``from_crawler`` or
-#     ``from_settings`` constructors, if available.
-
-#     At least one of ``settings`` and ``crawler`` needs to be different from
-#     ``None``. If ``settings `` is ``None``, ``crawler.settings`` will be used.
-#     If ``crawler`` is ``None``, only the ``from_settings`` constructor will be
-#     tried.
-
-#     ``*args`` and ``**kwargs`` are forwarded to the constructors.
-
-#     Raises ``ValueError`` if both ``settings`` and ``crawler`` are ``None``.
-
-#     .. versionchanged:: 2.2
-#        Raises ``TypeError`` if the resulting instance is ``None`` (e.g. if an
-#        extension has not been implemented correctly).
-#     """
-#     if settings is None:
-#         if crawler is None:
-#             raise ValueError("Specify at least one of settings and crawler.")
-#         settings = crawler.settings
-#     if crawler and hasattr(objcls, "from_crawler"):
-#         instance = objcls.from_crawler(crawler, *args, **kwargs)
-#         method_name = "from_crawler"
-#     elif hasattr(objcls, "from_settings"):
-#         instance = objcls.from_settings(settings, *args, **kwargs)
-#         method_name = "from_settings"
-#     else:
-#         instance = objcls(*args, **kwargs)
-#         method_name = "__new__"
-#     if instance is None:
-#         raise TypeError(f"{objcls.__qualname__}.{method_name} returned None")
-#     return instance
-
-
 # ``*args`` and ``**kwargs`` are forwarded to the constructors.
 # Raises ``ValueError`` if``crawler`` is``None``.
 #  Raises typeError is instance is None
@@ -181,9 +132,13 @@ def rel_has_nofollow(rel: Optional[str]) -> bool:
 def build_from_crawler(objcls, crawler, *args, **kwargs):
     if crawler is None:
         raise ValueError("Specify crawler.")
+    settings = crawler.settings
     if crawler and hasattr(objcls, "from_crawler"):
         instance = objcls.from_crawler(crawler, *args, **kwargs)
         method_name = "from_crawler"
+    elif hasattr(objcls, "from_settings"):
+        instance = objcls.from_settings(settings, *args, **kwargs)
+        method_name = "from_settings"
     else:
         instance = objcls(*args, **kwargs)
         method_name = "__new__"

--- a/scrapy/utils/misc.py
+++ b/scrapy/utils/misc.py
@@ -125,11 +125,48 @@ def rel_has_nofollow(rel: Optional[str]) -> bool:
     return rel is not None and "nofollow" in rel.replace(",", " ").split()
 
 
-# ``*args`` and ``**kwargs`` are forwarded to the constructors.
-# Raises ``ValueError`` if``crawler`` is``None``.
-#  Raises typeError is instance is None
-# Creates a class instance using 'from_crawler' constructor
+def create_instance(objcls, settings, crawler, *args, **kwargs):
+    """Construct a class instance using its ``from_crawler`` or
+    ``from_settings`` constructors, if available.
+
+    At least one of ``settings`` and ``crawler`` needs to be different from
+    ``None``. If ``settings `` is ``None``, ``crawler.settings`` will be used.
+    If ``crawler`` is ``None``, only the ``from_settings`` constructor will be
+    tried.
+
+    ``*args`` and ``**kwargs`` are forwarded to the constructors.
+
+    Raises ``ValueError`` if both ``settings`` and ``crawler`` are ``None``.
+
+    .. versionchanged:: 2.2
+       Raises ``TypeError`` if the resulting instance is ``None`` (e.g. if an
+       extension has not been implemented correctly).
+    """
+    if settings is None:
+        if crawler is None:
+            raise ValueError("Specify at least one of settings and crawler.")
+        settings = crawler.settings
+    if crawler and hasattr(objcls, "from_crawler"):
+        instance = objcls.from_crawler(crawler, *args, **kwargs)
+        method_name = "from_crawler"
+    elif hasattr(objcls, "from_settings"):
+        instance = objcls.from_settings(settings, *args, **kwargs)
+        method_name = "from_settings"
+    else:
+        instance = objcls(*args, **kwargs)
+        method_name = "__new__"
+    if instance is None:
+        raise TypeError(f"{objcls.__qualname__}.{method_name} returned None")
+    return instance
+
+
 def build_from_crawler(objcls, crawler, *args, **kwargs):
+    """
+    ``*args`` and ``**kwargs`` are forwarded to the constructors.
+    Raises ``ValueError`` if``crawler`` is``None``.
+    Raises typeError is instance is None
+    Creates a class instance using 'from_crawler' constructor
+    """
     if crawler is None:
         raise ValueError("Specify crawler.")
     settings = crawler.settings
@@ -147,11 +184,13 @@ def build_from_crawler(objcls, crawler, *args, **kwargs):
     return instance
 
 
-# ``*args`` and ``**kwargs`` are forwarded to the constructors.
-# Raises ``ValueError`` if``settings`` is``None``.
-#  Raises typeError is instance is None
-# Creates a class instance using 'from_settings' constructor
 def build_from_settings(objcls, settings, *args, **kwargs):
+    """
+    ``*args`` and ``**kwargs`` are forwarded to the constructors.
+    Raises ``ValueError`` if``settings`` is``None``.
+    Raises typeError is instance is None
+    Creates a class instance using 'from_settings' constructor
+    """
     if settings is None:
         raise ValueError("Specify settings.")
     if settings and hasattr(objcls, "from_settings"):

--- a/scrapy/utils/misc.py
+++ b/scrapy/utils/misc.py
@@ -160,7 +160,7 @@ def create_instance(objcls, settings, crawler, *args, **kwargs):
     return instance
 
 
-def build_from_crawler(objcls, crawler, *args, **kwargs):
+def build_from_crawler(objcls, crawler, /, *args, **kwargs):
     """
     Constructs a class instance using ``from_crawler`` constructor
 

--- a/scrapy/utils/misc.py
+++ b/scrapy/utils/misc.py
@@ -137,31 +137,67 @@ def rel_has_nofollow(rel: Optional[str]) -> bool:
     return rel is not None and "nofollow" in rel.replace(",", " ").split()
 
 
-def create_instance(objcls, settings, crawler, *args, **kwargs):
-    """Construct a class instance using its ``from_crawler`` or
-    ``from_settings`` constructors, if available.
+# def create_instance(objcls, settings, crawler, *args, **kwargs):
+#     """Construct a class instance using its ``from_crawler`` or
+#     ``from_settings`` constructors, if available.
 
-    At least one of ``settings`` and ``crawler`` needs to be different from
-    ``None``. If ``settings `` is ``None``, ``crawler.settings`` will be used.
-    If ``crawler`` is ``None``, only the ``from_settings`` constructor will be
-    tried.
+#     At least one of ``settings`` and ``crawler`` needs to be different from
+#     ``None``. If ``settings `` is ``None``, ``crawler.settings`` will be used.
+#     If ``crawler`` is ``None``, only the ``from_settings`` constructor will be
+#     tried.
 
-    ``*args`` and ``**kwargs`` are forwarded to the constructors.
+#     ``*args`` and ``**kwargs`` are forwarded to the constructors.
 
-    Raises ``ValueError`` if both ``settings`` and ``crawler`` are ``None``.
+#     Raises ``ValueError`` if both ``settings`` and ``crawler`` are ``None``.
 
-    .. versionchanged:: 2.2
-       Raises ``TypeError`` if the resulting instance is ``None`` (e.g. if an
-       extension has not been implemented correctly).
-    """
-    if settings is None:
-        if crawler is None:
-            raise ValueError("Specify at least one of settings and crawler.")
-        settings = crawler.settings
+#     .. versionchanged:: 2.2
+#        Raises ``TypeError`` if the resulting instance is ``None`` (e.g. if an
+#        extension has not been implemented correctly).
+#     """
+#     if settings is None:
+#         if crawler is None:
+#             raise ValueError("Specify at least one of settings and crawler.")
+#         settings = crawler.settings
+#     if crawler and hasattr(objcls, "from_crawler"):
+#         instance = objcls.from_crawler(crawler, *args, **kwargs)
+#         method_name = "from_crawler"
+#     elif hasattr(objcls, "from_settings"):
+#         instance = objcls.from_settings(settings, *args, **kwargs)
+#         method_name = "from_settings"
+#     else:
+#         instance = objcls(*args, **kwargs)
+#         method_name = "__new__"
+#     if instance is None:
+#         raise TypeError(f"{objcls.__qualname__}.{method_name} returned None")
+#     return instance
+
+
+# ``*args`` and ``**kwargs`` are forwarded to the constructors.
+# Raises ``ValueError`` if``crawler`` is``None``.
+#  Raises typeError is instance is None
+# Creates a class instance using 'from_crawler' constructor
+def build_from_crawler(objcls, crawler, /, *args, **kwargs):
+    if crawler is None: 
+        raise ValueError("Specify crawler.")
     if crawler and hasattr(objcls, "from_crawler"):
         instance = objcls.from_crawler(crawler, *args, **kwargs)
         method_name = "from_crawler"
-    elif hasattr(objcls, "from_settings"):
+    else:
+        instance = objcls(*args, **kwargs)
+        method_name = "__new__"
+    if instance is None:
+        raise TypeError(f"{objcls.__qualname__}.{method_name} returned None")
+    return instance
+            
+
+#``*args`` and ``**kwargs`` are forwarded to the constructors.
+# Raises ``ValueError`` if``settings`` is``None``.
+#  Raises typeError is instance is None
+# Creates a class instance using 'from_settings' constructor
+def build_from_settings(objcls, settings, /, *args, **kwargs):
+    if settings is None: 
+        raise ValueError("Specify settings.")
+    if settings and hasattr(objcls, "from_settings"):
         instance = objcls.from_settings(settings, *args, **kwargs)
         method_name = "from_settings"
     else:
@@ -170,6 +206,8 @@ def create_instance(objcls, settings, crawler, *args, **kwargs):
     if instance is None:
         raise TypeError(f"{objcls.__qualname__}.{method_name} returned None")
     return instance
+
+
 
 
 @contextmanager

--- a/scrapy/utils/misc.py
+++ b/scrapy/utils/misc.py
@@ -162,13 +162,13 @@ def create_instance(objcls, settings, crawler, *args, **kwargs):
 
 def build_from_crawler(objcls, crawler, *args, **kwargs):
     """
+    Constructs a class instance using ``from_crawler`` constructor
+
     ``*args`` and ``**kwargs`` are forwarded to the constructors.
+
     Raises ``ValueError`` if``crawler`` is``None``.
     Raises typeError is instance is None
-    Creates a class instance using 'from_crawler' constructor
     """
-    if crawler is None:
-        raise ValueError("Specify crawler.")
     settings = crawler.settings
     if crawler and hasattr(objcls, "from_crawler"):
         instance = objcls.from_crawler(crawler, *args, **kwargs)
@@ -186,13 +186,13 @@ def build_from_crawler(objcls, crawler, *args, **kwargs):
 
 def build_from_settings(objcls, settings, *args, **kwargs):
     """
+    Constructs a class instance using ``from_settings`` constructor
+
     ``*args`` and ``**kwargs`` are forwarded to the constructors.
+
     Raises ``ValueError`` if``settings`` is``None``.
     Raises typeError is instance is None
-    Creates a class instance using 'from_settings' constructor
     """
-    if settings is None:
-        raise ValueError("Specify settings.")
     if settings and hasattr(objcls, "from_settings"):
         instance = objcls.from_settings(settings, *args, **kwargs)
         method_name = "from_settings"

--- a/tests/test_addons.py
+++ b/tests/test_addons.py
@@ -109,7 +109,7 @@ class AddonManagerTest(unittest.TestCase):
         self.assertIsInstance(manager.addons[0], CreateInstanceAddon)
         self.assertEqual(crawler.settings.get("MYADDON_KEY"), "val")
 
-     def test_build_from_crawler(self):
+    def test_build_from_crawler(self):
         settings_dict = {
             "ADDONS": {"tests.test_addons.CreateInstanceAddon": 0},
             "MYADDON": {"MYADDON_KEY": "val"},

--- a/tests/test_addons.py
+++ b/tests/test_addons.py
@@ -89,7 +89,27 @@ class AddonManagerTest(unittest.TestCase):
             self.assertEqual([a.number for a in manager.addons], expected_order)
             self.assertEqual(crawler.settings.getint("KEY1"), expected_order[-1])
 
-    def test_create_instance(self):
+    # def test_create_instance(self):
+    #     settings_dict = {
+    #         "ADDONS": {"tests.test_addons.CreateInstanceAddon": 0},
+    #         "MYADDON": {"MYADDON_KEY": "val"},
+    #     }
+    #     crawler = get_crawler(settings_dict=settings_dict)
+    #     manager = crawler.addons
+    #     self.assertIsInstance(manager.addons[0], CreateInstanceAddon)
+    #     self.assertEqual(crawler.settings.get("MYADDON_KEY"), "val")
+
+    def test_build_from_settings(self):
+        settings_dict = {
+            "ADDONS": {"tests.test_addons.CreateInstanceAddon": 0},
+            "MYADDON": {"MYADDON_KEY": "val"},
+        }
+        crawler = get_crawler(settings_dict=settings_dict)
+        manager = crawler.addons
+        self.assertIsInstance(manager.addons[0], CreateInstanceAddon)
+        self.assertEqual(crawler.settings.get("MYADDON_KEY"), "val")
+
+     def test_build_from_crawler(self):
         settings_dict = {
             "ADDONS": {"tests.test_addons.CreateInstanceAddon": 0},
             "MYADDON": {"MYADDON_KEY": "val"},

--- a/tests/test_addons.py
+++ b/tests/test_addons.py
@@ -89,26 +89,6 @@ class AddonManagerTest(unittest.TestCase):
             self.assertEqual([a.number for a in manager.addons], expected_order)
             self.assertEqual(crawler.settings.getint("KEY1"), expected_order[-1])
 
-    # def test_create_instance(self):
-    #     settings_dict = {
-    #         "ADDONS": {"tests.test_addons.CreateInstanceAddon": 0},
-    #         "MYADDON": {"MYADDON_KEY": "val"},
-    #     }
-    #     crawler = get_crawler(settings_dict=settings_dict)
-    #     manager = crawler.addons
-    #     self.assertIsInstance(manager.addons[0], CreateInstanceAddon)
-    #     self.assertEqual(crawler.settings.get("MYADDON_KEY"), "val")
-
-    def test_build_from_settings(self):
-        settings_dict = {
-            "ADDONS": {"tests.test_addons.CreateInstanceAddon": 0},
-            "MYADDON": {"MYADDON_KEY": "val"},
-        }
-        crawler = get_crawler(settings_dict=settings_dict)
-        manager = crawler.addons
-        self.assertIsInstance(manager.addons[0], CreateInstanceAddon)
-        self.assertEqual(crawler.settings.get("MYADDON_KEY"), "val")
-
     def test_build_from_crawler(self):
         settings_dict = {
             "ADDONS": {"tests.test_addons.CreateInstanceAddon": 0},
@@ -187,12 +167,12 @@ class AddonManagerTest(unittest.TestCase):
                 pass
 
         with patch("scrapy.addons.logger") as logger_mock:
-            with patch("scrapy.addons.create_instance") as create_instance_mock:
+            with patch("scrapy.addons.build_from_crawler") as build_from_crawler_mock:
                 settings_dict = {
                     "ADDONS": {LoggedAddon: 1},
                 }
                 addon = LoggedAddon()
-                create_instance_mock.return_value = addon
+                build_from_crawler_mock.return_value = addon
                 crawler = get_crawler(settings_dict=settings_dict)
                 logger_mock.info.assert_called_once_with(
                     "Enabled addons:\n%(addons)s",

--- a/tests/test_downloader_handlers.py
+++ b/tests/test_downloader_handlers.py
@@ -669,9 +669,7 @@ class Https11CustomCiphers(unittest.TestCase):
         crawler = get_crawler(
             settings_dict={"DOWNLOADER_CLIENT_TLS_CIPHERS": "CAMELLIA256-SHA"}
         )
-        self.download_handler = build_from_crawler(
-            self.download_handler_cls, crawler
-        )
+        self.download_handler = build_from_crawler(self.download_handler_cls, crawler)
         self.download_request = self.download_handler.download_request
 
     @defer.inlineCallbacks
@@ -1036,9 +1034,7 @@ class BaseFTPTestCase(unittest.TestCase):
         self.port = reactor.listenTCP(0, self.factory, interface="127.0.0.1")
         self.portNum = self.port.getHost().port
         crawler = get_crawler()
-        self.download_handler = build_from_crawler(
-            FTPDownloadHandler, crawler
-        )
+        self.download_handler = build_from_crawler(FTPDownloadHandler, crawler)
         self.addCleanup(self.port.stopListening)
 
     def tearDown(self):
@@ -1182,9 +1178,7 @@ class AnonymousFTPTestCase(BaseFTPTestCase):
         self.port = reactor.listenTCP(0, self.factory, interface="127.0.0.1")
         self.portNum = self.port.getHost().port
         crawler = get_crawler()
-        self.download_handler = build_from_crawler(
-            FTPDownloadHandler, crawler
-        )
+        self.download_handler = build_from_crawler(FTPDownloadHandler, crawler)
         self.addCleanup(self.port.stopListening)
 
     def tearDown(self):
@@ -1194,9 +1188,7 @@ class AnonymousFTPTestCase(BaseFTPTestCase):
 class DataURITestCase(unittest.TestCase):
     def setUp(self):
         crawler = get_crawler()
-        self.download_handler = build_from_crawler(
-            DataURIDownloadHandler, crawler
-        )
+        self.download_handler = build_from_crawler(DataURIDownloadHandler, crawler)
         self.download_request = self.download_handler.download_request
         self.spider = Spider("foo")
 

--- a/tests/test_downloader_handlers.py
+++ b/tests/test_downloader_handlers.py
@@ -29,7 +29,7 @@ from scrapy.http import Headers, HtmlResponse, Request
 from scrapy.http.response.text import TextResponse
 from scrapy.responsetypes import responsetypes
 from scrapy.spiders import Spider
-from scrapy.utils.misc import build_from_crawler
+from scrapy.utils.misc import build_from_crawler, build_from_settings
 from scrapy.utils.python import to_bytes
 from scrapy.utils.test import get_crawler, skip_if_no_boto
 from tests import NON_EXISTING_RESOLVABLE
@@ -1034,7 +1034,12 @@ class BaseFTPTestCase(unittest.TestCase):
         self.port = reactor.listenTCP(0, self.factory, interface="127.0.0.1")
         self.portNum = self.port.getHost().port
         crawler = get_crawler()
-        self.download_handler = build_from_crawler(FTPDownloadHandler, crawler)
+        if crawler is not None:
+            self.download_handler = build_from_crawler(FTPDownloadHandler, crawler)
+        else:
+            self.download_handler = build_from_settings(
+                FTPDownloadHandler, crawler.settings
+            )
         self.addCleanup(self.port.stopListening)
 
     def tearDown(self):
@@ -1178,7 +1183,12 @@ class AnonymousFTPTestCase(BaseFTPTestCase):
         self.port = reactor.listenTCP(0, self.factory, interface="127.0.0.1")
         self.portNum = self.port.getHost().port
         crawler = get_crawler()
-        self.download_handler = build_from_crawler(FTPDownloadHandler, crawler)
+        if crawler is not None:
+            self.download_handler = build_from_crawler(FTPDownloadHandler, crawler)
+        else:
+            self.download_handler = build_from_settings(
+                FTPDownloadHandler, crawler.settings
+            )
         self.addCleanup(self.port.stopListening)
 
     def tearDown(self):
@@ -1188,7 +1198,12 @@ class AnonymousFTPTestCase(BaseFTPTestCase):
 class DataURITestCase(unittest.TestCase):
     def setUp(self):
         crawler = get_crawler()
-        self.download_handler = build_from_crawler(DataURIDownloadHandler, crawler)
+        if crawler is not None:
+            self.download_handler = build_from_crawler(DataURIDownloadHandler, crawler)
+        else:
+            self.download_handler = build_from_settings(
+                DataURIDownloadHandler, crawler.settings
+            )
         self.download_request = self.download_handler.download_request
         self.spider = Spider("foo")
 

--- a/tests/test_downloader_handlers.py
+++ b/tests/test_downloader_handlers.py
@@ -29,7 +29,7 @@ from scrapy.http import Headers, HtmlResponse, Request
 from scrapy.http.response.text import TextResponse
 from scrapy.responsetypes import responsetypes
 from scrapy.spiders import Spider
-from scrapy.utils.misc import create_instance
+from scrapy.utils.misc import build_from_crawler
 from scrapy.utils.python import to_bytes
 from scrapy.utils.test import get_crawler, skip_if_no_boto
 from tests import NON_EXISTING_RESOLVABLE
@@ -109,7 +109,7 @@ class FileTestCase(unittest.TestCase):
         # add a special char to check that they are handled correctly
         self.tmpname = Path(self.mktemp() + "^")
         Path(self.tmpname).write_text("0123456789", encoding="utf-8")
-        handler = create_instance(FileDownloadHandler, None, get_crawler())
+        handler = build_from_crawler(FileDownloadHandler, get_crawler())
         self.download_request = handler.download_request
 
     def tearDown(self):
@@ -257,8 +257,8 @@ class HttpTestCase(unittest.TestCase):
         else:
             self.port = reactor.listenTCP(0, self.wrapper, interface=self.host)
         self.portno = self.port.getHost().port
-        self.download_handler = create_instance(
-            self.download_handler_cls, None, get_crawler()
+        self.download_handler = build_from_crawler(
+            self.download_handler_cls, get_crawler()
         )
         self.download_request = self.download_handler.download_request
 
@@ -557,7 +557,7 @@ class Http11TestCase(HttpTestCase):
 
     def test_download_broken_content_allow_data_loss_via_setting(self, url="broken"):
         crawler = get_crawler(settings_dict={"DOWNLOAD_FAIL_ON_DATALOSS": False})
-        download_handler = create_instance(self.download_handler_cls, None, crawler)
+        download_handler = build_from_crawler(self.download_handler_cls, crawler)
         request = Request(self.getURL(url))
         d = download_handler.download_request(request, Spider("foo"))
         d.addCallback(lambda r: r.flags)
@@ -590,7 +590,7 @@ class Https11TestCase(Http11TestCase):
         crawler = get_crawler(
             settings_dict={"DOWNLOADER_CLIENT_TLS_VERBOSE_LOGGING": True}
         )
-        download_handler = create_instance(self.download_handler_cls, None, crawler)
+        download_handler = build_from_crawler(self.download_handler_cls, crawler)
         try:
             with LogCapture() as log_capture:
                 request = Request(self.getURL("file"))
@@ -669,8 +669,8 @@ class Https11CustomCiphers(unittest.TestCase):
         crawler = get_crawler(
             settings_dict={"DOWNLOADER_CLIENT_TLS_CIPHERS": "CAMELLIA256-SHA"}
         )
-        self.download_handler = create_instance(
-            self.download_handler_cls, None, crawler
+        self.download_handler = build_from_crawler(
+            self.download_handler_cls, crawler
         )
         self.download_request = self.download_handler.download_request
 
@@ -751,8 +751,8 @@ class HttpProxyTestCase(unittest.TestCase):
         wrapper = WrappingFactory(site)
         self.port = reactor.listenTCP(0, wrapper, interface="127.0.0.1")
         self.portno = self.port.getHost().port
-        self.download_handler = create_instance(
-            self.download_handler_cls, None, get_crawler()
+        self.download_handler = build_from_crawler(
+            self.download_handler_cls, get_crawler()
         )
         self.download_request = self.download_handler.download_request
 
@@ -830,9 +830,8 @@ class S3AnonTestCase(unittest.TestCase):
     def setUp(self):
         skip_if_no_boto()
         crawler = get_crawler()
-        self.s3reqh = create_instance(
+        self.s3reqh = build_from_crawler(
             objcls=S3DownloadHandler,
-            settings=None,
             crawler=crawler,
             httpdownloadhandler=HttpDownloadHandlerMock,
             # anon=True, # implicit
@@ -861,9 +860,8 @@ class S3TestCase(unittest.TestCase):
     def setUp(self):
         skip_if_no_boto()
         crawler = get_crawler()
-        s3reqh = create_instance(
+        s3reqh = build_from_crawler(
             objcls=S3DownloadHandler,
-            settings=None,
             crawler=crawler,
             aws_access_key_id=self.AWS_ACCESS_KEY_ID,
             aws_secret_access_key=self.AWS_SECRET_ACCESS_KEY,
@@ -889,9 +887,8 @@ class S3TestCase(unittest.TestCase):
     def test_extra_kw(self):
         try:
             crawler = get_crawler()
-            create_instance(
+            build_from_crawler(
                 objcls=S3DownloadHandler,
-                settings=None,
                 crawler=crawler,
                 extra_kw=True,
             )
@@ -1039,8 +1036,8 @@ class BaseFTPTestCase(unittest.TestCase):
         self.port = reactor.listenTCP(0, self.factory, interface="127.0.0.1")
         self.portNum = self.port.getHost().port
         crawler = get_crawler()
-        self.download_handler = create_instance(
-            FTPDownloadHandler, crawler.settings, crawler
+        self.download_handler = build_from_crawler(
+            FTPDownloadHandler, crawler
         )
         self.addCleanup(self.port.stopListening)
 
@@ -1185,8 +1182,8 @@ class AnonymousFTPTestCase(BaseFTPTestCase):
         self.port = reactor.listenTCP(0, self.factory, interface="127.0.0.1")
         self.portNum = self.port.getHost().port
         crawler = get_crawler()
-        self.download_handler = create_instance(
-            FTPDownloadHandler, crawler.settings, crawler
+        self.download_handler = build_from_crawler(
+            FTPDownloadHandler, crawler
         )
         self.addCleanup(self.port.stopListening)
 
@@ -1197,8 +1194,8 @@ class AnonymousFTPTestCase(BaseFTPTestCase):
 class DataURITestCase(unittest.TestCase):
     def setUp(self):
         crawler = get_crawler()
-        self.download_handler = create_instance(
-            DataURIDownloadHandler, crawler.settings, crawler
+        self.download_handler = build_from_crawler(
+            DataURIDownloadHandler, crawler
         )
         self.download_request = self.download_handler.download_request
         self.spider = Spider("foo")

--- a/tests/test_downloader_handlers.py
+++ b/tests/test_downloader_handlers.py
@@ -29,7 +29,7 @@ from scrapy.http import Headers, HtmlResponse, Request
 from scrapy.http.response.text import TextResponse
 from scrapy.responsetypes import responsetypes
 from scrapy.spiders import Spider
-from scrapy.utils.misc import build_from_crawler, build_from_settings
+from scrapy.utils.misc import build_from_crawler
 from scrapy.utils.python import to_bytes
 from scrapy.utils.test import get_crawler, skip_if_no_boto
 from tests import NON_EXISTING_RESOLVABLE
@@ -1034,12 +1034,7 @@ class BaseFTPTestCase(unittest.TestCase):
         self.port = reactor.listenTCP(0, self.factory, interface="127.0.0.1")
         self.portNum = self.port.getHost().port
         crawler = get_crawler()
-        if crawler is not None:
-            self.download_handler = build_from_crawler(FTPDownloadHandler, crawler)
-        else:
-            self.download_handler = build_from_settings(
-                FTPDownloadHandler, crawler.settings
-            )
+        self.download_handler = build_from_crawler(FTPDownloadHandler, crawler)
         self.addCleanup(self.port.stopListening)
 
     def tearDown(self):
@@ -1183,12 +1178,7 @@ class AnonymousFTPTestCase(BaseFTPTestCase):
         self.port = reactor.listenTCP(0, self.factory, interface="127.0.0.1")
         self.portNum = self.port.getHost().port
         crawler = get_crawler()
-        if crawler is not None:
-            self.download_handler = build_from_crawler(FTPDownloadHandler, crawler)
-        else:
-            self.download_handler = build_from_settings(
-                FTPDownloadHandler, crawler.settings
-            )
+        self.download_handler = build_from_crawler(FTPDownloadHandler, crawler)
         self.addCleanup(self.port.stopListening)
 
     def tearDown(self):
@@ -1198,12 +1188,7 @@ class AnonymousFTPTestCase(BaseFTPTestCase):
 class DataURITestCase(unittest.TestCase):
     def setUp(self):
         crawler = get_crawler()
-        if crawler is not None:
-            self.download_handler = build_from_crawler(DataURIDownloadHandler, crawler)
-        else:
-            self.download_handler = build_from_settings(
-                DataURIDownloadHandler, crawler.settings
-            )
+        self.download_handler = build_from_crawler(DataURIDownloadHandler, crawler)
         self.download_request = self.download_handler.download_request
         self.spider = Spider("foo")
 

--- a/tests/test_downloader_handlers.py
+++ b/tests/test_downloader_handlers.py
@@ -829,8 +829,8 @@ class S3AnonTestCase(unittest.TestCase):
         skip_if_no_boto()
         crawler = get_crawler()
         self.s3reqh = build_from_crawler(
-            objcls=S3DownloadHandler,
-            crawler=crawler,
+            S3DownloadHandler,
+            crawler,
             httpdownloadhandler=HttpDownloadHandlerMock,
             # anon=True, # implicit
         )
@@ -859,8 +859,8 @@ class S3TestCase(unittest.TestCase):
         skip_if_no_boto()
         crawler = get_crawler()
         s3reqh = build_from_crawler(
-            objcls=S3DownloadHandler,
-            crawler=crawler,
+            S3DownloadHandler,
+            crawler,
             aws_access_key_id=self.AWS_ACCESS_KEY_ID,
             aws_secret_access_key=self.AWS_SECRET_ACCESS_KEY,
             httpdownloadhandler=HttpDownloadHandlerMock,
@@ -886,8 +886,8 @@ class S3TestCase(unittest.TestCase):
         try:
             crawler = get_crawler()
             build_from_crawler(
-                objcls=S3DownloadHandler,
-                crawler=crawler,
+                S3DownloadHandler,
+                crawler,
                 extra_kw=True,
             )
         except Exception as e:

--- a/tests/test_downloader_handlers_http2.py
+++ b/tests/test_downloader_handlers_http2.py
@@ -11,7 +11,7 @@ from twisted.web.http import H2_ENABLED
 
 from scrapy.http import Request
 from scrapy.spiders import Spider
-from scrapy.utils.misc import create_instance
+from scrapy.utils.misc import build_from_crawler
 from scrapy.utils.test import get_crawler
 from tests.mockserver import ssl_context_factory
 from tests.test_downloader_handlers import (
@@ -240,8 +240,8 @@ class Https2ProxyTestCase(Http11ProxyTestCase):
             interface=self.host,
         )
         self.portno = self.port.getHost().port
-        self.download_handler = create_instance(
-            self.download_handler_cls, None, get_crawler()
+        self.download_handler = build_from_crawler(
+            self.download_handler_cls, get_crawler()
         )
         self.download_request = self.download_handler.download_request
 

--- a/tests/test_settings/__init__.py
+++ b/tests/test_settings/__init__.py
@@ -440,7 +440,7 @@ class SettingsTest(unittest.TestCase):
 
     def test_passing_objects_as_values(self):
         from scrapy.core.downloader.handlers.file import FileDownloadHandler
-        from scrapy.utils.misc import create_instance
+        from scrapy.utils.misc import build_from_crawler
         from scrapy.utils.test import get_crawler
 
         class TestPipeline:
@@ -468,7 +468,7 @@ class SettingsTest(unittest.TestCase):
 
         myhandler = settings.getdict("DOWNLOAD_HANDLERS").pop("ftp")
         self.assertEqual(myhandler, FileDownloadHandler)
-        myhandler_instance = create_instance(myhandler, None, get_crawler())
+        myhandler_instance = build_from_crawler(myhandler, get_crawler())
         self.assertIsInstance(myhandler_instance, FileDownloadHandler)
         self.assertTrue(hasattr(myhandler_instance, "download_request"))
 

--- a/tests/test_utils_misc/__init__.py
+++ b/tests/test_utils_misc/__init__.py
@@ -7,7 +7,8 @@ from unittest import mock
 from scrapy.item import Field, Item
 from scrapy.utils.misc import (
     arg_to_iter,
-    create_instance,
+    build_from_crawler,
+    build_from_settings,
     load_object,
     rel_has_nofollow,
     set_environ,
@@ -94,25 +95,13 @@ class UtilsMiscTestCase(unittest.TestCase):
         self.assertEqual(
             list(arg_to_iter(TestItem(name="john"))), [TestItem(name="john")]
         )
-
-    def test_create_instance(self):
-        settings = mock.MagicMock()
+    def test_build_from_crawler(self):
         crawler = mock.MagicMock(spec_set=["settings"])
         args = (True, 100.0)
         kwargs = {"key": "val"}
 
-        def _test_with_settings(mock, settings):
-            create_instance(mock, settings, None, *args, **kwargs)
-            if hasattr(mock, "from_crawler"):
-                self.assertEqual(mock.from_crawler.call_count, 0)
-            if hasattr(mock, "from_settings"):
-                mock.from_settings.assert_called_once_with(settings, *args, **kwargs)
-                self.assertEqual(mock.call_count, 0)
-            else:
-                mock.assert_called_once_with(*args, **kwargs)
-
         def _test_with_crawler(mock, settings, crawler):
-            create_instance(mock, settings, crawler, *args, **kwargs)
+            build_from_crawler(mock, crawler, *args, **kwargs)
             if hasattr(mock, "from_crawler"):
                 mock.from_crawler.assert_called_once_with(crawler, *args, **kwargs)
                 if hasattr(mock, "from_settings"):
@@ -124,34 +113,56 @@ class UtilsMiscTestCase(unittest.TestCase):
             else:
                 mock.assert_called_once_with(*args, **kwargs)
 
-        # Check usage of correct constructor using four mocks:
+        # Check usage of correct constructor using two mocks:
+        #   1. with no alternative constructors
+        #   2. with from_crawler() constructor
+        spec_sets = (
+            ["__qualname__"],
+            ["__qualname__", "from_crawler"],
+        )
+        for specs in spec_sets:
+            m = mock.MagicMock(spec_set=specs)
+            _test_with_crawler(m, settings, crawler)
+            m.reset_mock()
+
+        # Check adoption of crawler
+        m = mock.MagicMock(spec_set=["__qualname__", "from_crawler"])
+        m.from_crawler.return_value = None
+        with self.assertRaises(TypeError):
+            build_from_crawler(m, crawler, *args, **kwargs)
+    
+    def test_build_from_settings(self):
+        settings = mock.MagicMock()
+        args = (True, 100.0)
+        kwargs = {"key": "val"}
+
+        def _test_with_settings(mock, settings):
+            build_from_settings(mock, settings, *args, **kwargs)
+            if hasattr(mock, "from_crawler"):
+                self.assertEqual(mock.from_crawler.call_count, 0)
+            if hasattr(mock, "from_settings"):
+                mock.from_settings.assert_called_once_with(settings, *args, **kwargs)
+                self.assertEqual(mock.call_count, 0)
+            else:
+                mock.assert_called_once_with(*args, **kwargs)
+
+        # Check usage of correct constructor using two mocks:
         #   1. with no alternative constructors
         #   2. with from_settings() constructor
-        #   3. with from_crawler() constructor
-        #   4. with from_settings() and from_crawler() constructor
         spec_sets = (
             ["__qualname__"],
             ["__qualname__", "from_settings"],
-            ["__qualname__", "from_crawler"],
-            ["__qualname__", "from_settings", "from_crawler"],
         )
         for specs in spec_sets:
             m = mock.MagicMock(spec_set=specs)
             _test_with_settings(m, settings)
             m.reset_mock()
-            _test_with_crawler(m, settings, crawler)
 
         # Check adoption of crawler settings
         m = mock.MagicMock(spec_set=["__qualname__", "from_settings"])
-        create_instance(m, None, crawler, *args, **kwargs)
-        m.from_settings.assert_called_once_with(crawler.settings, *args, **kwargs)
-
-        with self.assertRaises(ValueError):
-            create_instance(m, None, None)
-
         m.from_settings.return_value = None
         with self.assertRaises(TypeError):
-            create_instance(m, settings, None)
+            build_from_settings(m, settings, *args, **kwargs)
 
     def test_set_environ(self):
         assert os.environ.get("some_test_environ") is None

--- a/tests/test_utils_misc/__init__.py
+++ b/tests/test_utils_misc/__init__.py
@@ -101,18 +101,13 @@ class UtilsMiscTestCase(unittest.TestCase):
         args = (True, 100.0)
         kwargs = {"key": "val"}
 
-        def _test_with_crawler(mock, settings, crawler):
-            build_from_crawler(mock, crawler, *args, **kwargs)
-            if hasattr(mock, "from_crawler"):
-                mock.from_crawler.assert_called_once_with(crawler, *args, **kwargs)
-                if hasattr(mock, "from_settings"):
-                    self.assertEqual(mock.from_settings.call_count, 0)
-                self.assertEqual(mock.call_count, 0)
-            elif hasattr(mock, "from_settings"):
-                mock.from_settings.assert_called_once_with(settings, *args, **kwargs)
-                self.assertEqual(mock.call_count, 0)
+        def _test_with_crawler(m, crawler):
+            build_from_crawler(m, crawler, *args, **kwargs)
+            if hasattr(m, "from_crawler"):
+                m.from_crawler.assert_called_once_with(crawler, *args, **kwargs)
+                self.assertEqual(m.call_count, 0)
             else:
-                mock.assert_called_once_with(*args, **kwargs)
+                m.assert_called_once_with(*args, **kwargs)
 
         # Check usage of correct constructor using two mocks:
         #   1. with no alternative constructors

--- a/tests/test_utils_misc/__init__.py
+++ b/tests/test_utils_misc/__init__.py
@@ -95,6 +95,7 @@ class UtilsMiscTestCase(unittest.TestCase):
         self.assertEqual(
             list(arg_to_iter(TestItem(name="john"))), [TestItem(name="john")]
         )
+
     def test_build_from_crawler(self):
         crawler = mock.MagicMock(spec_set=["settings"])
         args = (True, 100.0)
@@ -122,7 +123,7 @@ class UtilsMiscTestCase(unittest.TestCase):
         )
         for specs in spec_sets:
             m = mock.MagicMock(spec_set=specs)
-            _test_with_crawler(m, settings, crawler)
+            _test_with_crawler(m, crawler)
             m.reset_mock()
 
         # Check adoption of crawler
@@ -130,7 +131,7 @@ class UtilsMiscTestCase(unittest.TestCase):
         m.from_crawler.return_value = None
         with self.assertRaises(TypeError):
             build_from_crawler(m, crawler, *args, **kwargs)
-    
+
     def test_build_from_settings(self):
         settings = mock.MagicMock()
         args = (True, 100.0)

--- a/tests/test_webclient.py
+++ b/tests/test_webclient.py
@@ -24,7 +24,7 @@ from scrapy.core.downloader import webclient as client
 from scrapy.core.downloader.contextfactory import ScrapyClientContextFactory
 from scrapy.http import Headers, Request
 from scrapy.settings import Settings
-from scrapy.utils.misc import create_instance
+from scrapy.utils.misc import build_from_settings
 from scrapy.utils.python import to_bytes, to_unicode
 from tests.mockserver import (
     BrokenDownloadResource,
@@ -470,8 +470,8 @@ class WebClientCustomCiphersSSLTestCase(WebClientSSLTestCase):
     def testPayload(self):
         s = "0123456789" * 10
         settings = Settings({"DOWNLOADER_CLIENT_TLS_CIPHERS": self.custom_ciphers})
-        client_context_factory = create_instance(
-            ScrapyClientContextFactory, settings=settings, crawler=None
+        client_context_factory = build_from_settings(
+            ScrapyClientContextFactory, settings=settings
         )
         return getPage(
             self.getURL("payload"), body=s, contextFactory=client_context_factory
@@ -482,8 +482,8 @@ class WebClientCustomCiphersSSLTestCase(WebClientSSLTestCase):
         settings = Settings(
             {"DOWNLOADER_CLIENT_TLS_CIPHERS": "ECDHE-RSA-AES256-GCM-SHA384"}
         )
-        client_context_factory = create_instance(
-            ScrapyClientContextFactory, settings=settings, crawler=None
+        client_context_factory = build_from_settings(
+            ScrapyClientContextFactory, settings=settings
         )
         d = getPage(
             self.getURL("payload"), body=s, contextFactory=client_context_factory

--- a/tests/test_webclient.py
+++ b/tests/test_webclient.py
@@ -471,7 +471,7 @@ class WebClientCustomCiphersSSLTestCase(WebClientSSLTestCase):
         s = "0123456789" * 10
         settings = Settings({"DOWNLOADER_CLIENT_TLS_CIPHERS": self.custom_ciphers})
         client_context_factory = build_from_settings(
-            ScrapyClientContextFactory, settings=settings
+            ScrapyClientContextFactory, settings
         )
         return getPage(
             self.getURL("payload"), body=s, contextFactory=client_context_factory
@@ -483,7 +483,7 @@ class WebClientCustomCiphersSSLTestCase(WebClientSSLTestCase):
             {"DOWNLOADER_CLIENT_TLS_CIPHERS": "ECDHE-RSA-AES256-GCM-SHA384"}
         )
         client_context_factory = build_from_settings(
-            ScrapyClientContextFactory, settings=settings
+            ScrapyClientContextFactory, settings
         )
         d = getPage(
             self.getURL("payload"), body=s, contextFactory=client_context_factory


### PR DESCRIPTION
Converted `create_instance` to 2 separate functions (`build_from_crawler` and `build_from_settings`).
Changed other calls to `create_instance` in other files.
Added tests for the new functions.

Fixes #5523, closes #5884, closes #6162.
