### PR TITLE
Fix for issue 6136

### DIFF
--- a/docs/news.rst
+++ b/docs/news.rst
@@ -5676,7 +5676,7 @@ Scrapy 0.16.1 (released 2012-10-26)
 
 - fixed LogStats extension, which got broken after a wrong merge before the 0.16 release (:commit:`8c780fd`)
 - better backward compatibility for scrapy.conf.settings (:commit:`3403089`)
-- extended documentation on how to access crawler stats from extensions (:commit:`c4da0b5`)
+- extended documentation on how to access crawler.stats from extensions (:commit:`c4da0b5`)
 - removed .hgtags (no longer needed now that Scrapy uses git) (:commit:`d52c188`)
 - fix dashes under rst headers (:commit:`fa4f7f9`)
 - set release date for 0.16.0 in news (:commit:`e292246`)
@@ -5693,7 +5693,7 @@ Scrapy changes:
 - major Stats Collection refactoring: removed separation of global/per-spider stats, removed stats-related signals (``stats_spider_opened``, etc). Stats are much simpler now, backward compatibility is kept on the Stats Collector API and signals.
 - added :meth:`~scrapy.spidermiddlewares.SpiderMiddleware.process_start_requests` method to spider middlewares
 - dropped Signals singleton. Signals should now be accessed through the Crawler.signals attribute. See the signals documentation for more info.
-- dropped Stats Collector singleton. Stats can now be accessed through the Crawler.stats attribute. See the stats collection documentation for more info.
+- dropped Stats Collector singleton. Stats can now be accessed through the crawler.stats attribute. See the stats collection documentation for more info.
 - documented :ref:`topics-api`
 - ``lxml`` is now the default selectors backend instead of ``libxml2``
 - ported FormRequest.from_response() to use `lxml`_ instead of `ClientForm`_

--- a/docs/topics/stats.rst
+++ b/docs/topics/stats.rst
@@ -6,7 +6,7 @@ Stats Collection
 
 Scrapy provides a convenient facility for collecting stats in the form of
 key/values, where values are often counters. The facility is called the Stats
-Collector, and can be accessed through the :attr:`~scrapy.crawler.Crawler.stats`
+Collector, and can be accessed through the :attr:`~scrapy.crawler.crawler.stats`
 attribute of the :ref:`topics-api-crawler`, as illustrated by the examples in
 the :ref:`topics-stats-usecases` section below.
 
@@ -29,7 +29,7 @@ opened when the spider is opened, and closed when the spider is closed.
 Common Stats Collector uses
 ===========================
 
-Access the stats collector through the :attr:`~scrapy.crawler.Crawler.stats`
+Access the stats collector through the :attr:`~scrapy.crawler.stats`
 attribute. Here is an example of an extension that access stats:
 
 .. code-block:: python

--- a/docs/topics/telnetconsole.rst
+++ b/docs/topics/telnetconsole.rst
@@ -81,7 +81,7 @@ convenience:
 +----------------+-------------------------------------------------------------------+
 | ``extensions`` | the Extension Manager (Crawler.extensions attribute)              |
 +----------------+-------------------------------------------------------------------+
-| ``stats``      | the Stats Collector (Crawler.stats attribute)                     |
+| ``stats``      | the Stats Collector (crawler.stats attribute)                     |
 +----------------+-------------------------------------------------------------------+
 | ``settings``   | the Scrapy settings object (Crawler.settings attribute)           |
 +----------------+-------------------------------------------------------------------+

--- a/scrapy/core/engine.py
+++ b/scrapy/core/engine.py
@@ -369,8 +369,7 @@ class ExecutionEngine:
         if hasattr(scheduler, "open"):
             yield scheduler.open(spider)
         yield self.scraper.open_spider(spider)
-        assert self.crawler.stats
-        self.crawler.stats.open_spider(spider)
+        self.crawler.retrieve_stats().open_spider(spider)
         yield self.signals.send_catch_log_deferred(signals.spider_opened, spider=spider)
         self.slot.nextcall.schedule()
         self.slot.heartbeat.start(5)
@@ -442,8 +441,7 @@ class ExecutionEngine:
         dfd.addErrback(log_failure("Error while sending spider_close signal"))
 
         def close_stats(_: Any) -> None:
-            assert self.crawler.stats
-            self.crawler.stats.close_spider(spider, reason=reason)
+            self.crawler.retrieve_stats().close_spider(spider, reason=reason)
 
         dfd.addBoth(close_stats)
         dfd.addErrback(log_failure("Stats close failure"))

--- a/scrapy/core/scraper.py
+++ b/scrapy/core/scraper.py
@@ -246,8 +246,7 @@ class Scraper:
             response=response,
             spider=spider,
         )
-        assert self.crawler.stats
-        self.crawler.stats.inc_value(
+        self.crawler.retrieve_stats().inc_value(
             f"spider_exceptions/{_failure.value.__class__.__name__}", spider=spider
         )
 

--- a/scrapy/crawler.py
+++ b/scrapy/crawler.py
@@ -87,6 +87,11 @@ class Crawler:
         self.spider: Optional[Spider] = None
         self.engine: Optional[ExecutionEngine] = None
 
+    def retrieve_stats(self):
+        assert self.stats is not None, "Stats not initialized"
+        return self.stats
+    
+    
     def _update_root_log_handler(self) -> None:
         if get_scrapy_root_handler() is not None:
             # scrapy root handler already installed: update it with new settings

--- a/scrapy/downloadermiddlewares/httpcache.py
+++ b/scrapy/downloadermiddlewares/httpcache.py
@@ -54,8 +54,7 @@ class HttpCacheMiddleware:
 
     @classmethod
     def from_crawler(cls, crawler: Crawler) -> Self:
-        assert crawler.stats
-        o = cls(crawler.settings, crawler.stats)
+        o = cls(crawler.settings, crawler.retrieve_stats())
         crawler.signals.connect(o.spider_opened, signal=signals.spider_opened)
         crawler.signals.connect(o.spider_closed, signal=signals.spider_closed)
         return o

--- a/scrapy/downloadermiddlewares/retry.py
+++ b/scrapy/downloadermiddlewares/retry.py
@@ -104,8 +104,7 @@ def get_retry_request(
     retry-related job stats
     """
     settings = spider.crawler.settings
-    assert spider.crawler.stats
-    stats = spider.crawler.stats
+    stats = spider.crawler.retrieve_stats()
     retry_times = request.meta.get("retry_times", 0) + 1
     if max_retry_times is None:
         max_retry_times = request.meta.get("max_retry_times")

--- a/scrapy/downloadermiddlewares/robotstxt.py
+++ b/scrapy/downloadermiddlewares/robotstxt.py
@@ -78,8 +78,7 @@ class RobotsTxtMiddleware:
                 {"request": request},
                 extra={"spider": spider},
             )
-            assert self.crawler.stats
-            self.crawler.stats.inc_value("robotstxt/forbidden")
+            self.crawler.retrieve_stats().inc_value("robotstxt/forbidden")
             raise IgnoreRequest("Forbidden by robots.txt")
 
     def robot_parser(
@@ -98,12 +97,11 @@ class RobotsTxtMiddleware:
                 callback=NO_CALLBACK,
             )
             assert self.crawler.engine
-            assert self.crawler.stats
             dfd = self.crawler.engine.download(robotsreq)
             dfd.addCallback(self._parse_robots, netloc, spider)
             dfd.addErrback(self._logerror, robotsreq, spider)
             dfd.addErrback(self._robots_error, netloc)
-            self.crawler.stats.inc_value("robotstxt/request_count")
+            self.crawler.retrieve_stats().inc_value("robotstxt/request_count")
 
         parser = self._parsers[netloc]
         if isinstance(parser, Deferred):
@@ -128,8 +126,7 @@ class RobotsTxtMiddleware:
         return failure
 
     def _parse_robots(self, response: Response, netloc: str, spider: Spider) -> None:
-        assert self.crawler.stats
-        self.crawler.stats.inc_value("robotstxt/response_count")
+        self.crawler.retrieve_stats().inc_value("robotstxt/response_count")
         self.crawler.stats.inc_value(
             f"robotstxt/response_status_count/{response.status}"
         )
@@ -142,8 +139,7 @@ class RobotsTxtMiddleware:
     def _robots_error(self, failure: Failure, netloc: str) -> None:
         if failure.type is not IgnoreRequest:
             key = f"robotstxt/exception_count/{failure.type}"
-            assert self.crawler.stats
-            self.crawler.stats.inc_value(key)
+            self.crawler.retrieve_stats().inc_value(key)
         rp_dfd = self._parsers[netloc]
         assert isinstance(rp_dfd, Deferred)
         self._parsers[netloc] = None

--- a/scrapy/downloadermiddlewares/stats.py
+++ b/scrapy/downloadermiddlewares/stats.py
@@ -39,8 +39,7 @@ class DownloaderStats:
     def from_crawler(cls, crawler: Crawler) -> Self:
         if not crawler.settings.getbool("DOWNLOADER_STATS"):
             raise NotConfigured
-        assert crawler.stats
-        return cls(crawler.stats)
+        return cls(crawler.retrieve_stats())
 
     def process_request(
         self, request: Request, spider: Spider

--- a/scrapy/dupefilters.py
+++ b/scrapy/dupefilters.py
@@ -113,5 +113,4 @@ class RFPDupeFilter(BaseDupeFilter):
             self.logger.debug(msg, {"request": request}, extra={"spider": spider})
             self.logdupes = False
 
-        assert spider.crawler.stats
-        spider.crawler.stats.inc_value("dupefilter/filtered", spider=spider)
+        spider.crawler.retrieve_stats().inc_value("dupefilter/filtered", spider=spider)

--- a/scrapy/extensions/corestats.py
+++ b/scrapy/extensions/corestats.py
@@ -13,7 +13,7 @@ class CoreStats:
 
     @classmethod
     def from_crawler(cls, crawler):
-        o = cls(crawler.stats)
+        o = cls(crawler.retrieve_stats())
         crawler.signals.connect(o.spider_opened, signal=signals.spider_opened)
         crawler.signals.connect(o.spider_closed, signal=signals.spider_closed)
         crawler.signals.connect(o.item_scraped, signal=signals.item_scraped)

--- a/scrapy/extensions/feedexport.py
+++ b/scrapy/extensions/feedexport.py
@@ -516,11 +516,11 @@ class FeedExporter:
             exc_info=failure_to_exc_info(f),
             extra={"spider": spider},
         )
-        self.crawler.stats.inc_value(f"feedexport/failed_count/{slot_type}")
+        self.crawler.retrieve_stats().inc_value(f"feedexport/failed_count/{slot_type}")
 
     def _handle_store_success(self, f, logmsg, spider, slot_type):
         logger.info("Stored %s", logmsg, extra={"spider": spider})
-        self.crawler.stats.inc_value(f"feedexport/success_count/{slot_type}")
+        self.crawler.retrieve_stats().inc_value(f"feedexport/success_count/{slot_type}")
 
     def _start_new_batch(self, batch_id, uri, feed_options, spider, uri_template):
         """

--- a/scrapy/extensions/logstats.py
+++ b/scrapy/extensions/logstats.py
@@ -22,7 +22,7 @@ class LogStats:
         interval = crawler.settings.getfloat("LOGSTATS_INTERVAL")
         if not interval:
             raise NotConfigured
-        o = cls(crawler.stats, interval)
+        o = cls(crawler.retrieve_stats(), interval)
         crawler.signals.connect(o.spider_opened, signal=signals.spider_opened)
         crawler.signals.connect(o.spider_closed, signal=signals.spider_closed)
         return o

--- a/scrapy/extensions/memdebug.py
+++ b/scrapy/extensions/memdebug.py
@@ -19,7 +19,7 @@ class MemoryDebugger:
     def from_crawler(cls, crawler):
         if not crawler.settings.getbool("MEMDEBUG_ENABLED"):
             raise NotConfigured
-        o = cls(crawler.stats)
+        o = cls(crawler.retrieve_stats())
         crawler.signals.connect(o.spider_closed, signal=signals.spider_closed)
         return o
 

--- a/scrapy/spidermiddlewares/depth.py
+++ b/scrapy/spidermiddlewares/depth.py
@@ -40,8 +40,8 @@ class DepthMiddleware:
         maxdepth = settings.getint("DEPTH_LIMIT")
         verbose = settings.getbool("DEPTH_STATS_VERBOSE")
         prio = settings.getint("DEPTH_PRIORITY")
-        assert crawler.stats
-        return cls(maxdepth, crawler.stats, verbose, prio)
+        assert crawler.retrieve_stats()
+        return cls(maxdepth, crawler.retrieve_stats(), verbose, prio)
 
     def process_spider_output(
         self, response: Response, result: Iterable[Any], spider: Spider

--- a/scrapy/spidermiddlewares/httperror.py
+++ b/scrapy/spidermiddlewares/httperror.py
@@ -62,8 +62,7 @@ class HttpErrorMiddleware:
         self, response: Response, exception: Exception, spider: Spider
     ) -> Optional[Iterable[Any]]:
         if isinstance(exception, HttpError):
-            assert spider.crawler.stats
-            spider.crawler.stats.inc_value("httperror/response_ignored_count")
+            spider.crawler.retrieve_stats().inc_value("httperror/response_ignored_count")
             spider.crawler.stats.inc_value(
                 f"httperror/response_ignored_status_count/{response.status}"
             )

--- a/scrapy/spidermiddlewares/offsite.py
+++ b/scrapy/spidermiddlewares/offsite.py
@@ -30,8 +30,7 @@ class OffsiteMiddleware:
 
     @classmethod
     def from_crawler(cls, crawler: Crawler) -> Self:
-        assert crawler.stats
-        o = cls(crawler.stats)
+        o = cls(crawler.retrieve_stats())
         crawler.signals.connect(o.spider_opened, signal=signals.spider_opened)
         return o
 

--- a/scrapy/spidermiddlewares/urllength.py
+++ b/scrapy/spidermiddlewares/urllength.py
@@ -51,8 +51,7 @@ class UrlLengthMiddleware:
                 {"maxlength": self.maxlength, "url": request.url},
                 extra={"spider": spider},
             )
-            assert spider.crawler.stats
-            spider.crawler.stats.inc_value(
+            spider.crawler.retrieve_stats().inc_value(
                 "urllength/request_ignored_count", spider=spider
             )
             return False

--- a/scrapy/utils/log.py
+++ b/scrapy/utils/log.py
@@ -212,7 +212,7 @@ class StreamLogger:
 
 
 class LogCounterHandler(logging.Handler):
-    """Record log levels count into a crawler stats"""
+    """Record log levels count into a crawler.stats"""
 
     def __init__(self, crawler: Crawler, *args: Any, **kwargs: Any):
         super().__init__(*args, **kwargs)
@@ -220,8 +220,7 @@ class LogCounterHandler(logging.Handler):
 
     def emit(self, record: logging.LogRecord) -> None:
         sname = f"log_count/{record.levelname}"
-        assert self.crawler.stats
-        self.crawler.stats.inc_value(sname)
+        self.crawler.retrieve_stats().inc_value(sname)
 
 
 def logformatter_adapter(logkws: dict) -> Tuple[int, str, dict]:

--- a/scrapy/utils/misc.py
+++ b/scrapy/utils/misc.py
@@ -47,19 +47,6 @@ def arg_to_iter(arg: Any) -> Iterable[Any]:
         return cast(Iterable[Any], arg)
     return [arg]
 
-def build_from_crawler(objcls, crawler, none, *args, **kwargs):
-    if crawler 
-        if hasattr(objcls, "from_crawler"):
-            instance = objcls.from_crawler(crawler, *args, **kwargs)
-            method_name = "from_crawler"
-        if instance is None: 
-            raise TypeError(f"{objcls.__qualname__}.{method_name} returned None)
-    else: 
-        instance = objcls(*args, **kwargs)
-        method_name = "__new__"
-
-    return instance
-
 def load_object(path: Union[str, Callable]) -> Any:
     """Load an object given its absolute object path, and return it.
 

--- a/scrapy/utils/misc.py
+++ b/scrapy/utils/misc.py
@@ -47,6 +47,18 @@ def arg_to_iter(arg: Any) -> Iterable[Any]:
         return cast(Iterable[Any], arg)
     return [arg]
 
+def build_from_crawler(objcls, crawler, none, *args, **kwargs):
+    if crawler 
+        if hasattr(objcls, "from_crawler"):
+            instance = objcls.from_crawler(crawler, *args, **kwargs)
+            method_name = "from_crawler"
+        if instance is None: 
+            raise TypeError(f"{objcls.__qualname__}.{method_name} returned None)
+    else: 
+        instance = objcls(*args, **kwargs)
+        method_name = "__new__"
+
+    return instance
 
 def load_object(path: Union[str, Callable]) -> Any:
     """Load an object given its absolute object path, and return it.

--- a/tests/test_closespider.py
+++ b/tests/test_closespider.py
@@ -21,7 +21,7 @@ class TestCloseSpider(TestCase):
         yield crawler.crawl(mockserver=self.mockserver)
         reason = crawler.spider.meta["close_reason"]
         self.assertEqual(reason, "closespider_itemcount")
-        itemcount = crawler.stats.get_value("item_scraped_count")
+        itemcount = crawler.retrieve_stats().get_value("item_scraped_count")
         self.assertTrue(itemcount >= close_on)
 
     @defer.inlineCallbacks
@@ -31,7 +31,7 @@ class TestCloseSpider(TestCase):
         yield crawler.crawl(mockserver=self.mockserver)
         reason = crawler.spider.meta["close_reason"]
         self.assertEqual(reason, "closespider_pagecount")
-        pagecount = crawler.stats.get_value("response_received_count")
+        pagecount = crawler.retrieve_stats().get_value("response_received_count")
         self.assertTrue(pagecount >= close_on)
 
     @defer.inlineCallbacks
@@ -42,7 +42,7 @@ class TestCloseSpider(TestCase):
         reason = crawler.spider.meta["close_reason"]
         self.assertEqual(reason, "closespider_errorcount")
         key = f"spider_exceptions/{crawler.spider.exception_cls.__name__}"
-        errorcount = crawler.stats.get_value(key)
+        errorcount = crawler.retrieve_stats().get_value(key)
         self.assertTrue(errorcount >= close_on)
 
     @defer.inlineCallbacks
@@ -52,7 +52,7 @@ class TestCloseSpider(TestCase):
         yield crawler.crawl(total=1000000, mockserver=self.mockserver)
         reason = crawler.spider.meta["close_reason"]
         self.assertEqual(reason, "closespider_timeout")
-        total_seconds = crawler.stats.get_value("elapsed_time_seconds")
+        total_seconds = crawler.retrieve_stats().get_value("elapsed_time_seconds")
         self.assertTrue(total_seconds >= close_on)
 
     @defer.inlineCallbacks
@@ -62,5 +62,5 @@ class TestCloseSpider(TestCase):
         yield crawler.crawl(n=3, mockserver=self.mockserver)
         reason = crawler.spider.meta["close_reason"]
         self.assertEqual(reason, "closespider_timeout_no_item")
-        total_seconds = crawler.stats.get_value("elapsed_time_seconds")
+        total_seconds = crawler.retrieve_stats().get_value("elapsed_time_seconds")
         self.assertTrue(total_seconds >= timeout)

--- a/tests/test_crawl.py
+++ b/tests/test_crawl.py
@@ -432,7 +432,7 @@ class CrawlSpiderTestCase(TestCase):
             yield crawler.crawl(
                 self.mockserver.url("/status?n=200"), mockserver=self.mockserver
             )
-        return log, items, crawler.stats
+        return log, items, crawler.retrieve_stats()
 
     @defer.inlineCallbacks
     def test_crawlspider_with_parse(self):

--- a/tests/test_crawler.py
+++ b/tests/test_crawler.py
@@ -123,7 +123,7 @@ class CrawlerLoggingTestCase(unittest.TestCase):
         self.assertEqual(get_scrapy_root_handler().level, logging.DEBUG)
         crawler = get_crawler(MySpider)
         self.assertEqual(get_scrapy_root_handler().level, logging.INFO)
-        info_count = crawler.stats.get_value("log_count/INFO")
+        info_count = crawler.retrieve_stats().get_value("log_count/INFO")
         logging.debug("debug message")
         logging.info("info message")
         logging.warning("warning message")
@@ -136,10 +136,10 @@ class CrawlerLoggingTestCase(unittest.TestCase):
         self.assertIn("info message", logged)
         self.assertIn("warning message", logged)
         self.assertIn("error message", logged)
-        self.assertEqual(crawler.stats.get_value("log_count/ERROR"), 1)
-        self.assertEqual(crawler.stats.get_value("log_count/WARNING"), 1)
-        self.assertEqual(crawler.stats.get_value("log_count/INFO") - info_count, 1)
-        self.assertEqual(crawler.stats.get_value("log_count/DEBUG", 0), 0)
+        self.assertEqual(crawler.retrieve_stats().get_value("log_count/ERROR"), 1)
+        self.assertEqual(crawler.retrieve_stats().get_value("log_count/WARNING"), 1)
+        self.assertEqual(crawler.retrieve_stats().get_value("log_count/INFO") - info_count, 1)
+        self.assertEqual(crawler.retrieve_stats().get_value("log_count/DEBUG", 0), 0)
 
     def test_spider_custom_settings_log_append(self):
         log_file = Path(self.mktemp())

--- a/tests/test_downloadermiddleware.py
+++ b/tests/test_downloadermiddleware.py
@@ -23,11 +23,11 @@ class ManagerTestCase(TestCase):
         self.spider = self.crawler._create_spider("foo")
         self.mwman = DownloaderMiddlewareManager.from_crawler(self.crawler)
         # some mw depends on stats collector
-        self.crawler.stats.open_spider(self.spider)
+        self.crawler.retrieve_stats().open_spider(self.spider)
         return self.mwman.open_spider(self.spider)
 
     def tearDown(self):
-        self.crawler.stats.close_spider(self.spider, "")
+        self.crawler.retrieve_stats().close_spider(self.spider, "")
         return self.mwman.close_spider(self.spider)
 
     def _download(self, request, response=None):

--- a/tests/test_downloadermiddleware_httpcache.py
+++ b/tests/test_downloadermiddleware_httpcache.py
@@ -31,10 +31,10 @@ class _BaseTest(unittest.TestCase):
             body=b"test body",
             status=202,
         )
-        self.crawler.stats.open_spider(self.spider)
+        self.crawler.retrieve_stats().open_spider(self.spider)
 
     def tearDown(self):
-        self.crawler.stats.close_spider(self.spider, "")
+        self.crawler.retrieve_stats().close_spider(self.spider, "")
         shutil.rmtree(self.tmpdir)
 
     def _get_settings(self, **new_settings):
@@ -62,7 +62,7 @@ class _BaseTest(unittest.TestCase):
     @contextmanager
     def _middleware(self, **new_settings):
         settings = self._get_settings(**new_settings)
-        mw = HttpCacheMiddleware(settings, self.crawler.stats)
+        mw = HttpCacheMiddleware(settings, self.crawler.retrieve_stats())
         mw.spider_opened(self.spider)
         try:
             yield mw

--- a/tests/test_downloadermiddleware_httpcompression.py
+++ b/tests/test_downloadermiddleware_httpcompression.py
@@ -42,7 +42,7 @@ class HttpCompressionTest(TestCase):
         self.crawler = get_crawler(Spider)
         self.spider = self.crawler._create_spider("scrapytest.org")
         self.mw = HttpCompressionMiddleware.from_crawler(self.crawler)
-        self.crawler.stats.open_spider(self.spider)
+        self.crawler.retrieve_stats().open_spider(self.spider)
 
     def _getresponse(self, coding):
         if coding not in FORMAT:
@@ -68,9 +68,9 @@ class HttpCompressionTest(TestCase):
 
     def assertStatsEqual(self, key, value):
         self.assertEqual(
-            self.crawler.stats.get_value(key, spider=self.spider),
+            self.crawler.retrieve_stats().get_value(key, spider=self.spider),
             value,
-            str(self.crawler.stats.get_stats(self.spider)),
+            str(self.crawler.retrieve_stats().get_stats(self.spider)),
         )
 
     def test_setting_false_compression_enabled(self):

--- a/tests/test_downloadermiddleware_retry.py
+++ b/tests/test_downloadermiddleware_retry.py
@@ -80,12 +80,12 @@ class RetryTest(unittest.TestCase):
         # discard it
         assert self.mw.process_response(req, rsp, self.spider) is rsp
 
-        assert self.crawler.stats.get_value("retry/max_reached") == 1
+        assert self.crawler.retrieve_stats().get_value("retry/max_reached") == 1
         assert (
-            self.crawler.stats.get_value("retry/reason_count/503 Service Unavailable")
+            self.crawler.retrieve_stats().get_value("retry/reason_count/503 Service Unavailable")
             == 2
         )
-        assert self.crawler.stats.get_value("retry/count") == 2
+        assert self.crawler.retrieve_stats().get_value("retry/count") == 2
 
     def test_twistederrors(self):
         exceptions = [
@@ -104,7 +104,7 @@ class RetryTest(unittest.TestCase):
             req = Request(f"http://www.scrapytest.org/{exc.__name__}")
             self._test_retry_exception(req, exc("foo"))
 
-        stats = self.crawler.stats
+        stats = self.crawler.retrieve_stats()
         assert stats.get_value("retry/max_reached") == len(exceptions)
         assert stats.get_value("retry/count") == len(exceptions) * 2
         assert (
@@ -327,7 +327,7 @@ class GetRetryRequestTest(unittest.TestCase):
         self.assertEqual(new_request.priority, -1)
         expected_reason = "unspecified"
         for stat in ("retry/count", f"retry/reason_count/{expected_reason}"):
-            self.assertEqual(spider.crawler.stats.get_value(stat), 1)
+            self.assertEqual(spider.crawler.retrieve_stats().get_value(stat), 1)
         log.check_present(
             (
                 "scrapy.downloadermiddlewares.retry",
@@ -348,7 +348,7 @@ class GetRetryRequestTest(unittest.TestCase):
                 max_retry_times=max_retry_times,
             )
         self.assertEqual(new_request, None)
-        self.assertEqual(spider.crawler.stats.get_value("retry/max_reached"), 1)
+        self.assertEqual(spider.crawler.retrieve_stats().get_value("retry/max_reached"), 1)
         failure_count = max_retry_times + 1
         expected_reason = "unspecified"
         log.check_present(
@@ -377,7 +377,7 @@ class GetRetryRequestTest(unittest.TestCase):
         self.assertEqual(new_request.priority, -1)
         expected_reason = "unspecified"
         for stat in ("retry/count", f"retry/reason_count/{expected_reason}"):
-            self.assertEqual(spider.crawler.stats.get_value(stat), 1)
+            self.assertEqual(spider.crawler.retrieve_stats().get_value(stat), 1)
         log.check_present(
             (
                 "scrapy.downloadermiddlewares.retry",
@@ -407,7 +407,7 @@ class GetRetryRequestTest(unittest.TestCase):
             self.assertEqual(new_request.priority, -expected_retry_times)
             expected_reason = "unspecified"
             for stat in ("retry/count", f"retry/reason_count/{expected_reason}"):
-                value = spider.crawler.stats.get_value(stat)
+                value = spider.crawler.retrieve_stats().get_value(stat)
                 self.assertEqual(value, expected_retry_times)
             log.check_present(
                 (
@@ -425,7 +425,7 @@ class GetRetryRequestTest(unittest.TestCase):
                 max_retry_times=max_retry_times,
             )
         self.assertEqual(new_request, None)
-        self.assertEqual(spider.crawler.stats.get_value("retry/max_reached"), 1)
+        self.assertEqual(spider.crawler.retrieve_stats().get_value("retry/max_reached"), 1)
         failure_count = max_retry_times + 1
         expected_reason = "unspecified"
         log.check_present(
@@ -529,7 +529,7 @@ class GetRetryRequestTest(unittest.TestCase):
             )
         expected_retry_times = 1
         for stat in ("retry/count", f"retry/reason_count/{expected_reason}"):
-            self.assertEqual(spider.crawler.stats.get_value(stat), 1)
+            self.assertEqual(spider.crawler.retrieve_stats().get_value(stat), 1)
         log.check_present(
             (
                 "scrapy.downloadermiddlewares.retry",
@@ -551,7 +551,7 @@ class GetRetryRequestTest(unittest.TestCase):
                 reason=expected_reason,
             )
         expected_retry_times = 1
-        stat = spider.crawler.stats.get_value(
+        stat = spider.crawler.retrieve_stats().get_value(
             f"retry/reason_count/{expected_reason_string}"
         )
         self.assertEqual(stat, 1)
@@ -576,7 +576,7 @@ class GetRetryRequestTest(unittest.TestCase):
                 reason=expected_reason,
             )
         expected_retry_times = 1
-        stat = spider.crawler.stats.get_value(
+        stat = spider.crawler.retrieve_stats().get_value(
             f"retry/reason_count/{expected_reason_string}"
         )
         self.assertEqual(stat, 1)
@@ -601,7 +601,7 @@ class GetRetryRequestTest(unittest.TestCase):
                 reason=expected_reason,
             )
         expected_retry_times = 1
-        stat = spider.crawler.stats.get_value(
+        stat = spider.crawler.retrieve_stats().get_value(
             f"retry/reason_count/{expected_reason_string}"
         )
         self.assertEqual(stat, 1)
@@ -626,7 +626,7 @@ class GetRetryRequestTest(unittest.TestCase):
                 reason=expected_reason,
             )
         expected_retry_times = 1
-        stat = spider.crawler.stats.get_value(
+        stat = spider.crawler.retrieve_stats().get_value(
             f"retry/reason_count/{expected_reason_string}"
         )
         self.assertEqual(stat, 1)
@@ -674,7 +674,7 @@ class GetRetryRequestTest(unittest.TestCase):
             f"{stats_key}/count",
             f"{stats_key}/reason_count/{expected_reason}",
         ):
-            self.assertEqual(spider.crawler.stats.get_value(stat), 1)
+            self.assertEqual(spider.crawler.retrieve_stats().get_value(stat), 1)
 
 
 if __name__ == "__main__":

--- a/tests/test_downloadermiddleware_stats.py
+++ b/tests/test_downloadermiddleware_stats.py
@@ -14,18 +14,18 @@ class TestDownloaderStats(TestCase):
     def setUp(self):
         self.crawler = get_crawler(Spider)
         self.spider = self.crawler._create_spider("scrapytest.org")
-        self.mw = DownloaderStats(self.crawler.stats)
+        self.mw = DownloaderStats(self.crawler.retrieve_stats())
 
-        self.crawler.stats.open_spider(self.spider)
+        self.crawler.retrieve_stats().open_spider(self.spider)
 
         self.req = Request("http://scrapytest.org")
         self.res = Response("scrapytest.org", status=400)
 
     def assertStatsEqual(self, key, value):
         self.assertEqual(
-            self.crawler.stats.get_value(key, spider=self.spider),
+            self.crawler.retrieve_stats().get_value(key, spider=self.spider),
             value,
-            str(self.crawler.stats.get_stats(self.spider)),
+            str(self.crawler.retrieve_stats().get_stats(self.spider)),
         )
 
     def test_process_request(self):
@@ -45,4 +45,4 @@ class TestDownloaderStats(TestCase):
         )
 
     def tearDown(self):
-        self.crawler.stats.close_spider(self.spider, "")
+        self.crawler.retrieve_stats().close_spider(self.spider, "")

--- a/tests/test_dupefilters.py
+++ b/tests/test_dupefilters.py
@@ -188,7 +188,7 @@ class RFPDupeFilterTest(unittest.TestCase):
             dupefilter.log(r1, spider)
             dupefilter.log(r2, spider)
 
-            assert crawler.stats.get_value("dupefilter/filtered") == 2
+            assert crawler.retrieve_stats().get_value("dupefilter/filtered") == 2
             log.check_present(
                 (
                     "scrapy.dupefilters",
@@ -220,7 +220,7 @@ class RFPDupeFilterTest(unittest.TestCase):
             dupefilter.log(r1, spider)
             dupefilter.log(r2, spider)
 
-            assert crawler.stats.get_value("dupefilter/filtered") == 2
+            assert crawler.retrieve_stats().get_value("dupefilter/filtered") == 2
             log.check_present(
                 (
                     "scrapy.dupefilters",
@@ -258,7 +258,7 @@ class RFPDupeFilterTest(unittest.TestCase):
             dupefilter.log(r1, spider)
             dupefilter.log(r2, spider)
 
-            assert crawler.stats.get_value("dupefilter/filtered") == 2
+            assert crawler.retrieve_stats().get_value("dupefilter/filtered") == 2
             log.check_present(
                 (
                     "scrapy.dupefilters",

--- a/tests/test_extension_periodic_log.py
+++ b/tests/test_extension_periodic_log.py
@@ -145,9 +145,9 @@ class TestPeriodicLog(unittest.TestCase):
             ext = extension(settings)
             ext.spider_opened(spider)
             ext.set_a()
-            a = ext.log_crawler_stats()
+            a = ext.log_crawler.retrieve_stats()()
             ext.set_a()
-            b = ext.log_crawler_stats()
+            b = ext.log_crawler.retrieve_stats()()
             ext.spider_closed(spider, reason="finished")
             return ext, a, b
 

--- a/tests/test_feedexport.py
+++ b/tests/test_feedexport.py
@@ -912,10 +912,10 @@ class FeedExportTest(FeedExportTestBase):
         with MockServer() as mockserver:
             yield crawler.crawl(mockserver=mockserver)
         self.assertIn(
-            "feedexport/success_count/FileFeedStorage", crawler.stats.get_stats()
+            "feedexport/success_count/FileFeedStorage", crawler.retrieve_stats().get_stats()
         )
         self.assertEqual(
-            crawler.stats.get_value("feedexport/success_count/FileFeedStorage"), 1
+            crawler.retrieve_stats().get_value("feedexport/success_count/FileFeedStorage"), 1
         )
 
     @defer.inlineCallbacks
@@ -938,10 +938,10 @@ class FeedExportTest(FeedExportTestBase):
             )
             yield crawler.crawl(mockserver=mockserver)
         self.assertIn(
-            "feedexport/failed_count/FileFeedStorage", crawler.stats.get_stats()
+            "feedexport/failed_count/FileFeedStorage", crawler.retrieve_stats().get_stats()
         )
         self.assertEqual(
-            crawler.stats.get_value("feedexport/failed_count/FileFeedStorage"), 1
+            crawler.retrieve_stats().get_value("feedexport/failed_count/FileFeedStorage"), 1
         )
 
     @defer.inlineCallbacks
@@ -960,16 +960,16 @@ class FeedExportTest(FeedExportTestBase):
         with MockServer() as mockserver, mock.patch.object(S3FeedStorage, "store"):
             yield crawler.crawl(mockserver=mockserver)
         self.assertIn(
-            "feedexport/success_count/FileFeedStorage", crawler.stats.get_stats()
+            "feedexport/success_count/FileFeedStorage", crawler.retrieve_stats().get_stats()
         )
         self.assertIn(
-            "feedexport/success_count/StdoutFeedStorage", crawler.stats.get_stats()
+            "feedexport/success_count/StdoutFeedStorage", crawler.retrieve_stats().get_stats()
         )
         self.assertEqual(
-            crawler.stats.get_value("feedexport/success_count/FileFeedStorage"), 1
+            crawler.retrieve_stats().get_value("feedexport/success_count/FileFeedStorage"), 1
         )
         self.assertEqual(
-            crawler.stats.get_value("feedexport/success_count/StdoutFeedStorage"), 1
+            crawler.retrieve_stats().get_value("feedexport/success_count/StdoutFeedStorage"), 1
         )
 
     @defer.inlineCallbacks
@@ -2636,10 +2636,10 @@ class BatchDeliveriesTest(FeedExportTestBase):
         with MockServer() as mockserver:
             yield crawler.crawl(total=2, mockserver=mockserver)
         self.assertIn(
-            "feedexport/success_count/FileFeedStorage", crawler.stats.get_stats()
+            "feedexport/success_count/FileFeedStorage", crawler.retrieve_stats().get_stats()
         )
         self.assertEqual(
-            crawler.stats.get_value("feedexport/success_count/FileFeedStorage"), 12
+            crawler.retrieve_stats().get_value("feedexport/success_count/FileFeedStorage"), 12
         )
 
     @defer.inlineCallbacks

--- a/tests/test_pipeline_crawl.py
+++ b/tests/test_pipeline_crawl.py
@@ -124,14 +124,14 @@ class FileDownloadCrawlTestCase(TestCase):
 
         # check that there was 1 successful fetch and 3 other responses with non-200 code
         self.assertEqual(
-            crawler.stats.get_value("downloader/request_method_count/GET"), 4
+            crawler.retrieve_stats().get_value("downloader/request_method_count/GET"), 4
         )
-        self.assertEqual(crawler.stats.get_value("downloader/response_count"), 4)
+        self.assertEqual(crawler.retrieve_stats().get_value("downloader/response_count"), 4)
         self.assertEqual(
-            crawler.stats.get_value("downloader/response_status_count/200"), 1
+            crawler.retrieve_stats().get_value("downloader/response_status_count/200"), 1
         )
         self.assertEqual(
-            crawler.stats.get_value(f"downloader/response_status_count/{code}"), 3
+            crawler.retrieve_stats().get_value(f"downloader/response_status_count/{code}"), 3
         )
 
         # check that logs do show the failure on the file downloads
@@ -190,7 +190,7 @@ class FileDownloadCrawlTestCase(TestCase):
             )
         self._assert_files_downloaded(self.items, str(log))
         self.assertEqual(
-            crawler.stats.get_value("downloader/response_status_count/302"), 3
+            crawler.retrieve_stats().get_value("downloader/response_status_count/302"), 3
         )
 
 

--- a/tests/test_request_cb_kwargs.py
+++ b/tests/test_request_cb_kwargs.py
@@ -89,7 +89,7 @@ class KeywordArgumentsSpider(MockServerSpider):
     def parse_first(self, response, key, number):
         self.checks.append(key == "value")
         self.checks.append(number == 123)
-        self.crawler.stats.inc_value("boolean_checks", 2)
+        self.crawler.retrieve_stats().inc_value("boolean_checks", 2)
         yield response.follow(
             self.mockserver.url("/two"),
             self.parse_second,
@@ -98,30 +98,30 @@ class KeywordArgumentsSpider(MockServerSpider):
 
     def parse_second(self, response, new_key):
         self.checks.append(new_key == "new_value")
-        self.crawler.stats.inc_value("boolean_checks")
+        self.crawler.retrieve_stats().inc_value("boolean_checks")
 
     def parse_general(self, response, **kwargs):
         if response.url.endswith("/general_with"):
             self.checks.append(kwargs["key"] == "value")
             self.checks.append(kwargs["number"] == 123)
             self.checks.append(kwargs["callback"] == "some_callback")
-            self.crawler.stats.inc_value("boolean_checks", 3)
+            self.crawler.retrieve_stats().inc_value("boolean_checks", 3)
         elif response.url.endswith("/general_without"):
             self.checks.append(
                 kwargs == {}  # pylint: disable=use-implicit-booleaness-not-comparison
             )
-            self.crawler.stats.inc_value("boolean_checks")
+            self.crawler.retrieve_stats().inc_value("boolean_checks")
 
     def parse_no_kwargs(self, response):
         self.checks.append(response.url.endswith("/no_kwargs"))
-        self.crawler.stats.inc_value("boolean_checks")
+        self.crawler.retrieve_stats().inc_value("boolean_checks")
 
     def parse_default(self, response, key, number=None, default=99):
         self.checks.append(response.url.endswith("/default"))
         self.checks.append(key == "value")
         self.checks.append(number == 123)
         self.checks.append(default == 99)
-        self.crawler.stats.inc_value("boolean_checks", 4)
+        self.crawler.retrieve_stats().inc_value("boolean_checks", 4)
 
     def parse_takes_less(self, response, key, callback):
         """
@@ -140,19 +140,19 @@ class KeywordArgumentsSpider(MockServerSpider):
     ):
         self.checks.append(bool(from_process_request))
         self.checks.append(bool(from_process_response))
-        self.crawler.stats.inc_value("boolean_checks", 2)
+        self.crawler.retrieve_stats().inc_value("boolean_checks", 2)
 
     def parse_spider_mw(
         self, response, from_process_spider_input, from_process_start_requests
     ):
         self.checks.append(bool(from_process_spider_input))
         self.checks.append(bool(from_process_start_requests))
-        self.crawler.stats.inc_value("boolean_checks", 2)
+        self.crawler.retrieve_stats().inc_value("boolean_checks", 2)
         return Request(self.mockserver.url("/spider_mw_2"), self.parse_spider_mw_2)
 
     def parse_spider_mw_2(self, response, from_process_spider_output):
         self.checks.append(bool(from_process_spider_output))
-        self.crawler.stats.inc_value("boolean_checks", 1)
+        self.crawler.retrieve_stats().inc_value("boolean_checks", 1)
 
 
 class CallbackKeywordArgumentsTestCase(TestCase):
@@ -172,7 +172,7 @@ class CallbackKeywordArgumentsTestCase(TestCase):
             yield crawler.crawl(mockserver=self.mockserver)
         self.assertTrue(all(crawler.spider.checks))
         self.assertEqual(
-            len(crawler.spider.checks), crawler.stats.get_value("boolean_checks")
+            len(crawler.spider.checks), crawler.retrieve_stats().get_value("boolean_checks")
         )
         # check exceptions for argument mismatch
         exceptions = {}

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -331,7 +331,7 @@ class TestIntegrationWithDownloaderAwareInMemory(TestCase):
             start_urls = [url] * 6
             yield self.crawler.crawl(start_urls)
             self.assertEqual(
-                self.crawler.stats.get_value("downloader/response_count"),
+                self.crawler.retrieve_stats().get_value("downloader/response_count"),
                 len(start_urls),
             )
 

--- a/tests/test_spidermiddleware_httperror.py
+++ b/tests/test_spidermiddleware_httperror.py
@@ -188,7 +188,7 @@ class TestHttpErrorMiddlewareIntegrational(TrialTestCase):
         self.assertEqual(crawler.spider.parsed, {"200"})
         self.assertEqual(crawler.spider.failed, {"404", "402", "500"})
 
-        get_value = crawler.stats.get_value
+        get_value = crawler.retrieve_stats().get_value
         self.assertEqual(get_value("httperror/response_ignored_count"), 3)
         self.assertEqual(get_value("httperror/response_ignored_status_count/404"), 1)
         self.assertEqual(get_value("httperror/response_ignored_status_count/402"), 1)

--- a/tests/test_spidermiddleware_urllength.py
+++ b/tests/test_spidermiddleware_urllength.py
@@ -16,7 +16,7 @@ class TestUrlLengthMiddleware(TestCase):
 
         crawler = get_crawler(Spider)
         self.spider = crawler._create_spider("foo")
-        self.stats = crawler.stats
+        self.stats = crawler.retrieve_stats()
         self.mw = UrlLengthMiddleware.from_settings(settings)
 
         self.response = Response("http://scrapytest.org")

--- a/tests/test_utils_log.py
+++ b/tests/test_utils_log.py
@@ -77,19 +77,19 @@ class LogCounterHandlerTest(unittest.TestCase):
         self.logger.removeHandler(self.handler)
 
     def test_init(self):
-        self.assertIsNone(self.crawler.stats.get_value("log_count/DEBUG"))
-        self.assertIsNone(self.crawler.stats.get_value("log_count/INFO"))
-        self.assertIsNone(self.crawler.stats.get_value("log_count/WARNING"))
-        self.assertIsNone(self.crawler.stats.get_value("log_count/ERROR"))
-        self.assertIsNone(self.crawler.stats.get_value("log_count/CRITICAL"))
+        self.assertIsNone(self.crawler.retrieve_stats().get_value("log_count/DEBUG"))
+        self.assertIsNone(self.crawler.retrieve_stats().get_value("log_count/INFO"))
+        self.assertIsNone(self.crawler.retrieve_stats().get_value("log_count/WARNING"))
+        self.assertIsNone(self.crawler.retrieve_stats().get_value("log_count/ERROR"))
+        self.assertIsNone(self.crawler.retrieve_stats().get_value("log_count/CRITICAL"))
 
     def test_accepted_level(self):
         self.logger.error("test log msg")
-        self.assertEqual(self.crawler.stats.get_value("log_count/ERROR"), 1)
+        self.assertEqual(self.crawler.retrieve_stats().get_value("log_count/ERROR"), 1)
 
     def test_filtered_out_level(self):
         self.logger.debug("test log msg")
-        self.assertIsNone(self.crawler.stats.get_value("log_count/INFO"))
+        self.assertIsNone(self.crawler.retrieve_stats().get_value("log_count/INFO"))
 
 
 class StreamLoggerTest(unittest.TestCase):


### PR DESCRIPTION
Resolve issue #6136. 

Added a method for the crawler class called retrieve_stats() that performs the necessary assertion to check if the stat field is not none and then returns crawler.stats. This removes the need to add an assert statement every time crawler.stats needs to be accessed. Additionally, most instances of crawler.stats has been replaced with crawler.retrieve_stats() so that the assertion is performed automatically. 