### PR TITLE
resolve issue 5932

### DIFF
--- a/scrapy/extensions/feedexport.py
+++ b/scrapy/extensions/feedexport.py
@@ -269,6 +269,7 @@ class GCSFeedStorage(BlockingFeedStorage):
         bucket = client.get_bucket(self.bucket_name)
         blob = bucket.blob(self.blob_name)
         blob.upload_from_file(file, predefined_acl=self.acl)
+        self.file.close()
 
 
 class FTPFeedStorage(BlockingFeedStorage):
@@ -310,6 +311,7 @@ class FTPFeedStorage(BlockingFeedStorage):
             use_active_mode=self.use_active_mode,
             overwrite=self.overwrite,
         )
+        self.file.close()
 
 
 class FeedSlot:

--- a/scrapy/extensions/postprocessing.py
+++ b/scrapy/extensions/postprocessing.py
@@ -42,7 +42,6 @@ class GzipPlugin:
 
     def close(self) -> None:
         self.gzipfile.close()
-        self.file.close()
 
 
 class Bz2Plugin:
@@ -69,7 +68,6 @@ class Bz2Plugin:
 
     def close(self) -> None:
         self.bz2file.close()
-        self.file.close()
 
 
 class LZMAPlugin:
@@ -111,10 +109,8 @@ class LZMAPlugin:
 
     def close(self) -> None:
         self.lzmafile.close()
-        self.file.close()
 
-
-# io.IOBase is subclassed here, so that exporters can use the PostProcessingManager
+        
 # instance as a file like writable object. This could be needed by some exporters
 # such as CsvItemExporter which wraps the feed storage with io.TextIOWrapper.
 class PostProcessingManager(IOBase):


### PR DESCRIPTION
Fixes #5932 

Removed the lines closing the temporary file in GzipPlugin, Bz2Plugin, and LMZAPlugin in postprocessing.py.

Placed file closes in GCSFeedExporter, FTPFeedStorage, and S3FeedStorage in feedexport.py.