### PR TITLE
scrapy parse: fix the signature of callbacks from the CLI

### DIFF
--- a/tests/test_command_check.py
+++ b/tests/test_command_check.py
@@ -16,11 +16,11 @@ import scrapy
 
 class CheckSpider(scrapy.Spider):
     name = '{self.spider_name}'
-    start_urls = ['http://toscrape.com']
+    start_urls = ['data:,']
 
     def parse(self, response, **cb_kwargs):
         \"\"\"
-        @url http://toscrape.com
+        @url data:,
         {contracts}
         \"\"\"
         {parse_def}


### PR DESCRIPTION
Fixes https://github.com/scrapinghub/scrapy-poet/issues/39.

It feels kind of hacky, specially the fact that it will not work for “rules”, but I see no way about it given rules depend on the response.