### PR TITLE
Add type hints to FilesPipeline and ImagesPipeline

### DIFF
--- a/scrapy/pipelines/files.py
+++ b/scrapy/pipelines/files.py
@@ -340,7 +340,9 @@ class FilesPipeline(MediaPipeline):
     DEFAULT_FILES_URLS_FIELD = "file_urls"
     DEFAULT_FILES_RESULT_FIELD = "files"
 
-    def __init__(self, store_uri, download_func=None, settings=None):
+    def __init__(
+        self, store_uri: Union[str, PathLike], download_func=None, settings=None
+    ):
         store_uri = _to_string(store_uri)
         if not store_uri:
             raise NotConfigured

--- a/scrapy/pipelines/images.py
+++ b/scrapy/pipelines/images.py
@@ -8,7 +8,8 @@ import hashlib
 import warnings
 from contextlib import suppress
 from io import BytesIO
-from typing import Dict, Tuple
+from os import PathLike
+from typing import Dict, Tuple, Union
 
 from itemadapter import ItemAdapter
 
@@ -53,7 +54,9 @@ class ImagesPipeline(FilesPipeline):
     DEFAULT_IMAGES_URLS_FIELD = "image_urls"
     DEFAULT_IMAGES_RESULT_FIELD = "images"
 
-    def __init__(self, store_uri, download_func=None, settings=None):
+    def __init__(
+        self, store_uri: Union[str, PathLike], download_func=None, settings=None
+    ):
         try:
             from PIL import Image
 


### PR DESCRIPTION
Related https://github.com/scrapy/scrapy/issues/5739
Follow-up to https://github.com/scrapy/scrapy/pull/5801, where compatibility with `Path` was added but type hints were not updated.