### PR TITLE
fix(typo): correct `successfully`

### DIFF
--- a/tests/test_extension_periodic_log.py
+++ b/tests/test_extension_periodic_log.py
@@ -67,7 +67,7 @@ def extension(settings=None):
 
 class TestPeriodicLog(unittest.TestCase):
     def test_extension_enabled(self):
-        # Expected that settings for this extension loaded succesfully
+        # Expected that settings for this extension loaded successfully
         # And on certain conditions - extension raising NotConfigured
 
         # "PERIODIC_LOG_STATS": True -> set to {"enabled": True}


### PR DESCRIPTION
Just tiny comment fix.