### PR TITLE
chore(docs): update `sphinx` dependencies

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,4 @@
-sphinx==5.0.2
-sphinx-hoverxref==1.1.1
-sphinx-notfound-page==0.8
-sphinx-rtd-theme==1.0.0
+sphinx==6.2.1
+sphinx-hoverxref==1.3.0
+sphinx-notfound-page==1.0.0
+sphinx-rtd-theme==2.0.0


### PR DESCRIPTION
## Change

Update `sphinx` dependencies to latest version.

## Restriction

Currently do not use sphinx v7 a lot is being reworked and often breaks.

## Reference

#6177