### PR TITLE
Make FTPFilesStore compatible with pathlib.Path

### DIFF
--- a/scrapy/pipelines/files.py
+++ b/scrapy/pipelines/files.py
@@ -265,10 +265,12 @@ class FTPFilesStore:
     FTP_PASSWORD = None
     USE_ACTIVE_MODE = None
 
-    def __init__(self, uri):
-        if not uri.startswith("ftp://"):
-            raise ValueError(f"Incorrect URI scheme in {uri}, expected 'ftp'")
+    def __init__(self, uri: str):
         u = urlparse(uri)
+        if u.scheme != "ftp":
+            raise ValueError(f"Incorrect URI scheme in {uri}, expected 'ftp'")
+        if not uri.startswith("ftp://"):
+            u = urlparse(uri.replace("ftp:/", "ftp://"))
         self.port = u.port
         self.host = u.hostname
         self.port = int(u.port or 21)

--- a/tests/test_pipeline_files.py
+++ b/tests/test_pipeline_files.py
@@ -502,6 +502,18 @@ class FilesPipelineTestCaseCustomSettings(unittest.TestCase):
         request = Request("http://example.com/image01.jpg")
         self.assertEqual(pipeline.file_path(request), Path("subdir/image01.jpg"))
 
+    def test_ftp_pipeline_using_pathlike_objects(self):
+        pipeline = FilesPipeline.from_settings(
+            Settings({"FILES_STORE": Path("ftp://username:password@address:21/path")})
+        )
+        fs = pipeline.store
+        assert isinstance(fs, FTPFilesStore)
+        assert fs.host == "address"
+        assert fs.port == 21
+        assert fs.username == "username"
+        assert fs.password == "password"
+        assert fs.basedir == "/path"
+
     def test_files_store_constructor_with_pathlike_object(self):
         path = Path("./FileDir")
         fs_store = FSFilesStore(path)


### PR DESCRIPTION
Related https://github.com/scrapy/scrapy/issues/5739

Per the [docs](https://docs.scrapy.org/en/latest/topics/media-pipeline.html?highlight=FTP#ftp-server-storage), `FILES_STORE` and `IMAGES_STORE` can point to an FTP server.

However, `pathlib` removes a slash from the URI when converted to a string. This is [expected behaviour](https://bugs.python.org/issue44842).
```
from pathlib import Path
p = Path("ftp://username:password@address:21/path")
str(p)
>>> 'ftp:/username:password@address:21/path'
```

As a result, `urllib.parse.urlparse` cannot parse the string-ified path correctly. 
from [docs](https://docs.python.org/3/library/urllib.parse.html#urllib.parse.urlparse):
> Following the syntax specifications in [RFC 1808](https://datatracker.ietf.org/doc/html/rfc1808.html), urlparse recognizes a netloc only if it is properly introduced by ‘//’. Otherwise the input is presumed to be a relative URL and thus to start with a path component.
```
from urllib.parse import urlparse
p = "ftp://username:password@address:21/path"
urlparse(str(Path(p)))
>>> ParseResult(scheme='ftp', netloc='', path='/username:password@address:21/path', params='', query='', fragment='')

urlparse(p)
>>> ParseResult(scheme='ftp', netloc='username:password@address:21', path='/path', params='', query='', fragment='')
```

Added a test and an ugly fix for this. Am open to other suggestions on how to best fix this.