### PR TITLE
Add FAQ on making a blank request

### DIFF
--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -405,6 +405,25 @@ or :class:`~scrapy.signals.headers_received` signals and raising a
 :ref:`topics-stop-response-download` topic for additional information and examples.
 
 
+.. _faq-blank-request:
+
+How can I make a blank request?
+-------------------------------
+
+.. code-block:: python
+    
+    from scrapy import Request
+
+    yield Request(
+        url="data:,",
+        callback=self.your_call_back,
+    )
+
+In this case, the URL is set to a data URI scheme. Data URLs allow you to include data 
+in-line in web pages as if they were external resources. The "data:" scheme with an empty 
+content (",") essentially creates a request to a data URL without any specific content.
+
+
 Running ``runspider`` I get ``error: No spider found in file: <filename>``
 --------------------------------------------------------------------------
 

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -414,10 +414,11 @@ How can I make a blank request?
     
     from scrapy import Request
 
-    yield Request(
-        url="data:,",
-        callback=self.your_call_back,
-    )
+    def make_blank_request(your_call_back):
+        yield Request(
+            url="data:,",
+            callback=your_call_back,
+        )
 
 In this case, the URL is set to a data URI scheme. Data URLs allow you to include data 
 in-line in web pages as if they were external resources. The "data:" scheme with an empty 

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -414,11 +414,8 @@ How can I make a blank request?
     
     from scrapy import Request
 
-    def make_blank_request(your_call_back):
-        yield Request(
-            url="data:,",
-            callback=your_call_back,
-        )
+
+    blank_request = Request("data:,")
 
 In this case, the URL is set to a data URI scheme. Data URLs allow you to include data 
 in-line in web pages as if they were external resources. The "data:" scheme with an empty 


### PR DESCRIPTION
This PR addresses issue #6203, adding a FAQ entry on making a blank requests.

```python
yield Request(
    url="data:,", 
    callback=self.your_call_back
)
```
suggested by: @Gallaecio 
