### PR TITLE
Improved Image / File URL Handling | Handle Check if single Image / File URL needs to be Downloaded 

### DIFF
--- a/scrapy/pipelines/files.py
+++ b/scrapy/pipelines/files.py
@@ -525,6 +525,7 @@ class FilesPipeline(MediaPipeline):
     # Overridable Interface
     def get_media_requests(self, item, info):
         urls = ItemAdapter(item).get(self.files_urls_field, [])
+        urls = urls if isinstance(urls, list) else [urls]
         return [Request(u, callback=NO_CALLBACK) for u in urls]
 
     def file_downloaded(self, response, request, info, *, item=None):

--- a/scrapy/pipelines/images.py
+++ b/scrapy/pipelines/images.py
@@ -219,6 +219,7 @@ class ImagesPipeline(FilesPipeline):
 
     def get_media_requests(self, item, info):
         urls = ItemAdapter(item).get(self.images_urls_field, [])
+        urls = urls if isinstance(urls, list) else [urls]
         return [Request(u, callback=NO_CALLBACK) for u in urls]
 
     def item_completed(self, results, item, info):


### PR DESCRIPTION
- Previously, we need need to Download a Single Image / File URL, still, we need to make that URL a list i.e. `image_urls: [URL] or files_urls_field: [URL]`
- After this fix, we don't need to make it a list, `image_urls: URL` and `files_urls_field: URL`  will work.
- A better user experience.