### PR TITLE
Fix: Remove docs for other projects from the Scrapy docs

### DIFF
--- a/docs/topics/items.rst
+++ b/docs/topics/items.rst
@@ -399,12 +399,7 @@ In code that receives an item, such as methods of :ref:`item pipelines
 <topics-spider-middleware>`, it is a good practice to use the
 :class:`~itemadapter.ItemAdapter` class and the
 :func:`~itemadapter.is_item` function to write code that works for
-any :ref:`supported item type <item-types>`:
-
-.. autoclass:: itemadapter.ItemAdapter
-
-.. autofunction:: itemadapter.is_item
-
+any supported item type.
 
 Other classes related to items
 ==============================

--- a/docs/topics/selectors.rst
+++ b/docs/topics/selectors.rst
@@ -1032,11 +1032,6 @@ whereas the CSS lookup is translated into XPath and thus runs more efficiently,
 so performance-wise its uses are limited to situations that are not easily
 described with CSS selectors.
 
-Parsel also simplifies adding your own XPath extensions.
-
-.. autofunction:: parsel.xpathfuncs.set_xpathfunc
-
-
 .. _topics-selectors-ref:
 
 Built-in Selectors reference

--- a/docs/topics/selectors.rst
+++ b/docs/topics/selectors.rst
@@ -1032,6 +1032,9 @@ whereas the CSS lookup is translated into XPath and thus runs more efficiently,
 so performance-wise its uses are limited to situations that are not easily
 described with CSS selectors.
 
+Parsel also simplifies adding your own XPath extensions with 
+:func:`~parsel.xpathfuncs.set_xpathfunc`.
+
 .. _topics-selectors-ref:
 
 Built-in Selectors reference


### PR DESCRIPTION
Removed `auto[function|class]` declarations from external projects

Resolves https://github.com/scrapy/scrapy/issues/5920, closes https://github.com/scrapy/scrapy/pull/6043, closes https://github.com/scrapy/scrapy/pull/6131.