### PR TITLE
Add TerminalConsole test_without_start_listening

### DIFF
--- a/tests/test_extension_telnet.py
+++ b/tests/test_extension_telnet.py
@@ -72,5 +72,7 @@ class TestWithoutStartListening(unittest.TestCase):
         telnet_console = TelnetConsole(crawler=get_crawler())
         # The .start_listening() should be called but humans are imperfect.
         # telnet_console.start_listening()
-        with self.assertRaises(AttributeError, msg="'TelnetConsole' object has no attribute 'port'"):
+        with self.assertRaises(
+            AttributeError, msg="'TelnetConsole' object has no attribute 'port'"
+        ):
             telnet_console.stop_listening()

--- a/tests/test_extension_telnet.py
+++ b/tests/test_extension_telnet.py
@@ -67,10 +67,10 @@ class TestWithoutStartListening(unittest.TestCase):
         """
         Calls are made in an incorrect order so `self.port` is never initialized.
         Class variables should be initialized in the .__init__() method but .port
-        is not.  This raises a NameError as discussed in scrapy/scrapy#2702
+        is not.  This raises an AttributeError as discussed in scrapy/scrapy#2702
         """
         telnet_console = TelnetConsole(crawler=get_crawler())
-        # The .start_listening() should be called but humans are imperfect.
+        # .start_listening() method should be called but developers are imperfect
         # telnet_console.start_listening()
         with self.assertRaises(
             AttributeError, msg="'TelnetConsole' object has no attribute 'port'"

--- a/tests/test_extension_telnet.py
+++ b/tests/test_extension_telnet.py
@@ -72,5 +72,5 @@ class TestWithoutStartListening(unittest.TestCase):
         telnet_console = TelnetConsole(crawler=get_crawler())
         # The .start_listening() should be called but humans are imperfect.
         # telnet_console.start_listening()
-        with self.assertRaises(NameError):
+        with self.assertRaises(AttributeError, msg="'TelnetConsole' object has no attribute 'port'"):
             telnet_console.stop_listening()

--- a/tests/test_extension_telnet.py
+++ b/tests/test_extension_telnet.py
@@ -50,3 +50,27 @@ class TelnetExtensionTest(unittest.TestCase):
         d = portal.login(creds, None, ITelnetProtocol)
         yield d
         console.stop_listening()
+
+
+class TestWithStartListening(unittest.TestCase):
+    def test_with_start_Lintening(self):
+        """
+        Calls are made in the correct order so there should be no problems.
+        """
+        telnet_console = TelnetConsole(crawler=get_crawler())
+        telnet_console.start_listening()  # Called as expected.
+        telnet_console.stop_listening()
+
+
+class TestWithoutStartListening(unittest.TestCase):
+    def test_without_start_Lintening(self):
+        """
+        Calls are made in an incorrect order so `self.port` is never initialized.
+        Class variables should be initialized in the .__init__() method but .port
+        is not.  This raises a NameError as discussed in scrapy/scrapy#2702
+        """
+        telnet_console = TelnetConsole(crawler=get_crawler())
+        # The .start_listening() should be called but humans are imperfect.
+        # telnet_console.start_listening()
+        with assertRaises(NameError, msg=None):
+            telnet_console.stop_listening()

--- a/tests/test_extension_telnet.py
+++ b/tests/test_extension_telnet.py
@@ -72,5 +72,5 @@ class TestWithoutStartListening(unittest.TestCase):
         telnet_console = TelnetConsole(crawler=get_crawler())
         # The .start_listening() should be called but humans are imperfect.
         # telnet_console.start_listening()
-        with assertRaises(NameError, msg=None):
+        with self.assertRaises(NameError):
             telnet_console.stop_listening()


### PR DESCRIPTION
Class variables should always be initialized in the `.__init__()` method but `TerminalConsole.port` is not.  As discussed in:
* #2702
* #2892