### PR TITLE
Fix WindowsRunSpiderCommandTest skip outside Windows for older Twisted

### DIFF
--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -987,9 +987,13 @@ class MySpider(scrapy.Spider):
         self.assertIn("The value of FOO is 42", log)
 
 
-@skipIf(platform.system() != "Windows", "Windows required for .pyw files")
 class WindowsRunSpiderCommandTest(RunSpiderCommandTest):
     spider_filename = "myspider.pyw"
+
+    def setUp(self):
+        # https://github.com/scrapy/scrapy/issues/6286
+        if platform.system() != "Windows":
+            raise unittest.SkipTest("Windows required for .pyw files")
 
     def test_start_requests_errors(self):
         log = self.get_log(self.badspider, name="badspider.pyw")

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -993,6 +993,7 @@ class WindowsRunSpiderCommandTest(RunSpiderCommandTest):
     def setUp(self):
         if platform.system() != "Windows":
             raise unittest.SkipTest("Windows required for .pyw files")
+        return super().setUp()
 
     def test_start_requests_errors(self):
         log = self.get_log(self.badspider, name="badspider.pyw")

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -991,7 +991,6 @@ class WindowsRunSpiderCommandTest(RunSpiderCommandTest):
     spider_filename = "myspider.pyw"
 
     def setUp(self):
-        # https://github.com/scrapy/scrapy/issues/6286
         if platform.system() != "Windows":
             raise unittest.SkipTest("Windows required for .pyw files")
 


### PR DESCRIPTION
Fixes https://github.com/scrapy/scrapy/issues/6286