### PR TITLE
Fix WrappedRequest.get_header raising TypeError if default is None

### DIFF
--- a/scrapy/http/cookies.py
+++ b/scrapy/http/cookies.py
@@ -170,7 +170,8 @@ class WrappedRequest:
         return name in self.request.headers
 
     def get_header(self, name, default=None):
-        return to_unicode(self.request.headers.get(name, default), errors="replace")
+        value = self.request.headers.get(name, default)
+        return to_unicode(value, errors="replace") if value else value
 
     def header_items(self):
         return [

--- a/scrapy/http/cookies.py
+++ b/scrapy/http/cookies.py
@@ -171,7 +171,7 @@ class WrappedRequest:
 
     def get_header(self, name, default=None):
         value = self.request.headers.get(name, default)
-        return to_unicode(value, errors="replace") if value else value
+        return to_unicode(value, errors="replace") if value is not None else None
 
     def header_items(self):
         return [

--- a/tests/test_http_cookies.py
+++ b/tests/test_http_cookies.py
@@ -43,6 +43,7 @@ class WrappedRequestTest(TestCase):
     def test_get_header(self):
         self.assertEqual(self.wrapped.get_header("content-type"), "text/html")
         self.assertEqual(self.wrapped.get_header("xxxxx", "def"), "def")
+        self.assertEqual(self.wrapped.get_header("xxxxx"), None)
 
     def test_header_items(self):
         self.assertEqual(self.wrapped.header_items(), [("Content-Type", ["text/html"])])

--- a/tests/test_http_cookies.py
+++ b/tests/test_http_cookies.py
@@ -44,6 +44,12 @@ class WrappedRequestTest(TestCase):
         self.assertEqual(self.wrapped.get_header("content-type"), "text/html")
         self.assertEqual(self.wrapped.get_header("xxxxx", "def"), "def")
         self.assertEqual(self.wrapped.get_header("xxxxx"), None)
+        wrapped = WrappedRequest(
+            Request(
+                "http://www.example.com/page.html", headers={"empty-binary-header": b""}
+            )
+        )
+        self.assertEqual(wrapped.get_header("empty-binary-header"), "")
 
     def test_header_items(self):
         self.assertEqual(self.wrapped.header_items(), [("Content-Type", ["text/html"])])


### PR DESCRIPTION
Fixes https://github.com/scrapy/scrapy/issues/6308 

Alternatives: 

```python
    def get_header(self, name, default=None):
        value = self.request.headers.get(name, default)
        if not value:
            return value
        return to_unicode(value, errors="replace")
 ```
 
 But I don't like repeating value so much 
 
 ```python
    def get_header(self, name, default=None):
        if not (value := self.request.headers.get(name, default)):
            return value
        return to_unicode(value, errors="replace")
 ```
 The parenthesis and walrus operator make the line too convoluted
 
 ```python
     def get_header(self, name, default=None):
         try: 
             to_unicode(self.request.headers.get(name, default), errors="replace")
         except TypeError:
             return default
 ```
Using try/except this way is pythonic, but I'm always afraid I may unexpectedly capture another unrelated exception