### PR TITLE
Issue #6321: Link extractor all tags and attributes option

### DIFF
--- a/scrapy/linkextractors/lxmlhtml.py
+++ b/scrapy/linkextractors/lxmlhtml.py
@@ -57,23 +57,27 @@ class LxmlParserLinkExtractor:
         unique=False,
         strip=True,
         canonicalized=False,
+        all_tags = False,
+        all_attrs = False,
     ):
         self.scan_tag = tag if callable(tag) else partial(operator.eq, tag)
         self.scan_attr = attr if callable(attr) else partial(operator.eq, attr)
         self.process_attr = process if callable(process) else _identity
         self.unique = unique
         self.strip = strip
+        self.all_tags = all_tags
+        self.all_attrs = all_attrs
         self.link_key = (
             operator.attrgetter("url") if canonicalized else _canonicalize_link_url
         )
 
     def _iter_links(self, document):
         for el in document.iter(etree.Element):
-            if not self.scan_tag(_nons(el.tag)):
+            if not self.scan_tag(_nons(el.tag)) and not self.all_tags:
                 continue
             attribs = el.attrib
             for attrib in attribs:
-                if not self.scan_attr(attrib):
+                if not self.scan_attr(attrib) and not self.all_attrs:
                     continue
                 yield (el, attrib, attribs[attrib])
 
@@ -146,7 +150,11 @@ class LxmlLinkExtractor:
         restrict_css=(),
         strip=True,
         restrict_text=None,
+        all_tags = False,
+        all_attrs = False,
     ):
+        all_tags = tags is None
+        all_attrs = attrs is None
         tags, attrs = set(arg_to_iter(tags)), set(arg_to_iter(attrs))
         self.link_extractor = LxmlParserLinkExtractor(
             tag=partial(operator.contains, tags),
@@ -155,6 +163,8 @@ class LxmlLinkExtractor:
             process=process_value,
             strip=strip,
             canonicalized=not canonicalize,
+            all_attrs=all_attrs,
+            all_tags=all_tags,
         )
         self.allow_res = [
             x if isinstance(x, _re_type) else re.compile(x) for x in arg_to_iter(allow)

--- a/scrapy/linkextractors/lxmlhtml.py
+++ b/scrapy/linkextractors/lxmlhtml.py
@@ -57,8 +57,8 @@ class LxmlParserLinkExtractor:
         unique=False,
         strip=True,
         canonicalized=False,
-        all_tags = False,
-        all_attrs = False,
+        all_tags=False,
+        all_attrs=False,
     ):
         self.scan_tag = tag if callable(tag) else partial(operator.eq, tag)
         self.scan_attr = attr if callable(attr) else partial(operator.eq, attr)
@@ -150,8 +150,8 @@ class LxmlLinkExtractor:
         restrict_css=(),
         strip=True,
         restrict_text=None,
-        all_tags = False,
-        all_attrs = False,
+        all_tags=False,
+        all_attrs=False,
     ):
         all_tags = tags is None
         all_attrs = attrs is None

--- a/tests/test_linkextractors.py
+++ b/tests/test_linkextractors.py
@@ -495,8 +495,28 @@ class Base:
                 ],
             )
 
-            lx = self.extractor_cls(attrs=None)
-            self.assertEqual(lx.extract_links(self.response), [])
+            lx = self.extractor_cls(
+                attrs=None
+                )
+            #self.assertEqual(lx.extract_links(self.response), [])
+            #logger.info(lx.extract_links(self.response))
+            self.assertEqual(
+                lx.extract_links(self.response),
+                [
+                    Link(url="http://example.com/sample1.html", text=""),
+                    Link(url='http://example.com/sample1', text=''),
+                    Link(url="http://example.com/sample2.html", text="sample 2"),
+                    Link(url="http://example.com/sample3.html", text="sample 3 text"),
+                    Link(url='http://example.com/sample%203', text='sample 3 text'),
+                    Link(
+                        url="http://example.com/sample3.html#foo",
+                        text="sample 3 repetition with fragment",
+                    ),
+                    Link(url="http://www.google.com/something", text=""),
+                    Link(url="http://example.com/innertag.html", text="inner tag"),
+                    Link(url=page4_url, text="href with whitespaces"),
+                ],
+            )
 
         def test_tags(self):
             html = (
@@ -506,7 +526,14 @@ class Base:
             response = HtmlResponse("http://example.com/index.html", body=html)
 
             lx = self.extractor_cls(tags=None)
-            self.assertEqual(lx.extract_links(response), [])
+            #self.assertEqual(lx.extract_links(response), [])
+            self.assertEqual(
+                lx.extract_links(response),
+                [
+                    Link(url="http://example.com/sample1.html", text=""),
+                    Link(url="http://example.com/sample2.html", text="sample 2"),
+                ],
+            )
 
             lx = self.extractor_cls()
             self.assertEqual(

--- a/tests/test_linkextractors.py
+++ b/tests/test_linkextractors.py
@@ -495,19 +495,15 @@ class Base:
                 ],
             )
 
-            lx = self.extractor_cls(
-                attrs=None
-                )
-            #self.assertEqual(lx.extract_links(self.response), [])
-            #logger.info(lx.extract_links(self.response))
+            lx = self.extractor_cls(attrs=None)
             self.assertEqual(
                 lx.extract_links(self.response),
                 [
                     Link(url="http://example.com/sample1.html", text=""),
-                    Link(url='http://example.com/sample1', text=''),
+                    Link(url="http://example.com/sample1", text=""),
                     Link(url="http://example.com/sample2.html", text="sample 2"),
                     Link(url="http://example.com/sample3.html", text="sample 3 text"),
-                    Link(url='http://example.com/sample%203', text='sample 3 text'),
+                    Link(url="http://example.com/sample%203", text="sample 3 text"),
                     Link(
                         url="http://example.com/sample3.html#foo",
                         text="sample 3 repetition with fragment",
@@ -526,7 +522,6 @@ class Base:
             response = HtmlResponse("http://example.com/index.html", body=html)
 
             lx = self.extractor_cls(tags=None)
-            #self.assertEqual(lx.extract_links(response), [])
             self.assertEqual(
                 lx.extract_links(response),
                 [


### PR DESCRIPTION
This change addresses the first part of issue #6321, allowing the link extractor the option to consider all tags and attributes by passing None in. Since this is my first contribution, and since the docs say to try and break changes into smaller increments, I was planning to wait to address the deny option of the issue until this was successfully addressed. This is my first contribution so please feel free to tell me how I can improve and any problems you see. Thanks!