### PR TITLE
Update MANIFEST.in.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,9 +1,8 @@
-include README.rst
-include AUTHORS
-include INSTALL
-include LICENSE
-include MANIFEST.in
+include CODE_OF_CONDUCT.md
+include CONTRIBUTING.md
+include INSTALL.md
 include NEWS
+include SECURITY.md
 
 include scrapy/VERSION
 include scrapy/mime.types
@@ -12,16 +11,13 @@ include scrapy/py.typed
 include codecov.yml
 include conftest.py
 include pytest.ini
-include requirements-*.txt
 include tox.ini
 
 recursive-include scrapy/templates *
-recursive-include scrapy license.txt
 recursive-include docs *
 prune docs/build
 
 recursive-include extras *
-recursive-include bin *
 recursive-include tests *
 
 global-exclude __pycache__ *.py[cod]


### PR DESCRIPTION
I noticed than `tox -e twinecheck` prints many warnings and this led to updating `MANIFEST.in` to the current project state. I couldn't add `--strict` to `twine check` though, because both `prune docs/build` and `global-exclude __pycache__ *.py[cod]` cause warnings about no files affected.

Some lines are removed because they are on by default, following https://setuptools.pypa.io/en/latest/userguide/miscellaneous.html. I also used https://pypi.org/project/check-sdist/ to see that the following files are omitted:

```
  .bandit.yml
  .bumpversion.cfg
  .coveragerc
  .flake8
  .git-blame-ignore-revs
  .gitattributes
  .gitignore
  .isort.cfg
  artwork/README.rst
  artwork/qlassik.zip
  artwork/scrapy-blog-logo.xcf
  artwork/scrapy-logo.jpg
  pylintrc
  sep/README.rst
  sep/sep-001.rst
  sep/sep-002.rst
  sep/sep-003.rst
  sep/sep-004.rst
  sep/sep-005.rst
  sep/sep-006.rst
  sep/sep-007.rst
  sep/sep-008.rst
  sep/sep-009.rst
  sep/sep-010.rst
  sep/sep-011.rst
  sep/sep-012.rst
  sep/sep-013.rst
  sep/sep-014.rst
  sep/sep-015.rst
  sep/sep-016.rst
  sep/sep-017.rst
  sep/sep-018.rst
  sep/sep-019.rst
  sep/sep-020.rst
```
which looks OK to me.

Not sure if we should add `check-sdist` to CI.