### PR TITLE
Install typing stubs for boto3 and botocore.

### DIFF
--- a/scrapy/core/downloader/handlers/s3.py
+++ b/scrapy/core/downloader/handlers/s3.py
@@ -59,7 +59,8 @@ class S3DownloadHandler:
             assert aws_access_key_id is not None
             assert aws_secret_access_key is not None
             SignerCls = botocore.auth.AUTH_TYPE_MAPS["s3"]
-            self._signer = SignerCls(
+            # botocore.auth.BaseSigner doesn't have an __init__() with args, only subclasses do
+            self._signer = SignerCls(  # type: ignore[call-arg]
                 botocore.credentials.Credentials(
                     aws_access_key_id, aws_secret_access_key, aws_session_token
                 )

--- a/scrapy/extensions/feedexport.py
+++ b/scrapy/extensions/feedexport.py
@@ -238,13 +238,16 @@ class S3FeedStorage(BlockingFeedStorage):
         self.acl: Optional[str] = acl
         self.endpoint_url: Optional[str] = endpoint_url
         self.region_name: Optional[str] = region_name
+        # It can be either botocore.client.BaseClient or mypy_boto3_s3.S3Client,
+        # there seems to be no good way to infer it statically.
+        self.s3_client: Any
 
         if IS_BOTO3_AVAILABLE:
             import boto3.session
 
-            session = boto3.session.Session()
+            boto3_session = boto3.session.Session()
 
-            self.s3_client = session.client(
+            self.s3_client = boto3_session.client(
                 "s3",
                 aws_access_key_id=self.access_key,
                 aws_secret_access_key=self.secret_key,
@@ -261,9 +264,9 @@ class S3FeedStorage(BlockingFeedStorage):
 
             import botocore.session
 
-            session = botocore.session.get_session()
+            botocore_session = botocore.session.get_session()
 
-            self.s3_client = session.create_client(
+            self.s3_client = botocore_session.create_client(
                 "s3",
                 aws_access_key_id=self.access_key,
                 aws_secret_access_key=self.secret_key,

--- a/tox.ini
+++ b/tox.ini
@@ -48,12 +48,15 @@ basepython = python3
 deps =
     mypy==1.10.0
     typing-extensions==4.11.0
-    types-attrs==19.1.0
     types-lxml==2024.4.14
-    types-Pillow==10.2.0.20240423
-    types-Pygments==2.17.0.20240310
-    types-pyOpenSSL==24.0.0.20240417
-    types-setuptools==69.5.0.20240423
+    types-Pygments==2.18.0.20240506
+    types-pyOpenSSL==24.1.0.20240425
+    types-setuptools==69.5.0.20240518
+    botocore-stubs==1.34.94
+    boto3-stubs[s3]==1.34.108
+    attrs >= 18.2.0
+    Pillow >= 10.3.0
+    pytest >= 8.2.0
     # 2.1.2 fixes a typing bug: https://github.com/scrapy/w3lib/pull/211
     w3lib >= 2.1.2
 commands =


### PR DESCRIPTION
Also installs pytest and switches attrs and Pillow from separate stubs to built-in ones following the separate stub package descriptions.