### PR TITLE
Show warning if 'FeedExporter' is disabled and -o or -O options are s…

### DIFF
--- a/scrapy/commands/__init__.py
+++ b/scrapy/commands/__init__.py
@@ -4,6 +4,7 @@ Base class for Scrapy commands
 
 import argparse
 import builtins
+import logging
 import os
 from pathlib import Path
 from typing import Any, Dict, Iterable, List, Optional
@@ -12,7 +13,13 @@ from twisted.python import failure
 
 from scrapy.crawler import Crawler, CrawlerProcess
 from scrapy.exceptions import UsageError
-from scrapy.utils.conf import arglist_to_dict, feed_process_params_from_cli
+from scrapy.utils.conf import (
+    arglist_to_dict,
+    build_component_list,
+    feed_process_params_from_cli,
+)
+
+logger = logging.getLogger(__name__)
 
 
 class ScrapyCommand:
@@ -177,6 +184,16 @@ class BaseRunSpiderCommand(ScrapyCommand):
                 opts.overwrite_output,
             )
             self.settings.set("FEEDS", feeds, priority="cmdline")
+
+    def validate_feed_exporter(self, opts):
+        feed_eport_key = "scrapy.extensions.feedexport.FeedExporter"
+
+        if opts.output:
+            extensions = build_component_list(self.settings.getwithbase("EXTENSIONS"))
+            if feed_eport_key not in extensions:
+                logger.warning(
+                    "'FeedExporter' extension must be enabled for Feed Exports to work."
+                )
 
 
 class ScrapyHelpFormatter(argparse.HelpFormatter):

--- a/scrapy/commands/crawl.py
+++ b/scrapy/commands/crawl.py
@@ -23,6 +23,7 @@ class Command(BaseRunSpiderCommand):
             raise UsageError(
                 "running 'scrapy crawl' with more than one spider is not supported"
             )
+        self.validate_feed_exporter(opts)
         spname = args[0]
 
         assert self.crawler_process

--- a/scrapy/commands/parse.py
+++ b/scrapy/commands/parse.py
@@ -405,6 +405,7 @@ class Command(BaseRunSpiderCommand):
             raise UsageError()
         else:
             url = args[0]
+        self.validate_feed_exporter(opts)
 
         # prepare spidercls
         self.set_spidercls(url, opts)

--- a/scrapy/commands/runspider.py
+++ b/scrapy/commands/runspider.py
@@ -40,6 +40,7 @@ class Command(BaseRunSpiderCommand):
     def run(self, args: List[str], opts: argparse.Namespace) -> None:
         if len(args) != 1:
             raise UsageError()
+        self.validate_feed_exporter(opts)
         filename = Path(args[0])
         if not filename.exists():
             raise UsageError(f"File not found: {filename}\n")

--- a/tests/test_command_parse.py
+++ b/tests/test_command_parse.py
@@ -449,3 +449,26 @@ ITEM_PIPELINES = {{'{self.project_name}.pipelines.MyPipeline': 1}}
         self.assertEqual(namespace.depth, 2)
         self.assertEqual(namespace.spider, self.spider_name)
         self.assertTrue(namespace.verbose)
+
+    def test_exporter_disabled(self):
+        with self.assertLogs() as cm:
+            command = parse.Command()
+            settings = Settings()
+            settings.setdict(
+                {"EXTENSIONS": {"scrapy.extensions.feedexport.FeedExporter": None}},
+                priority="project",
+            )
+            command.settings = settings
+            parser = argparse.ArgumentParser(
+                formatter_class=argparse.HelpFormatter, conflict_handler="resolve"
+            )
+            command.add_options(parser)
+            opts, _ = parser.parse_known_args(args=[])
+
+            opts.output = ["example.json"]
+
+            command.validate_feed_exporter(opts)
+            expected = (
+                "'FeedExporter' extension must be enabled for Feed Exports to work."
+            )
+            self.assertTrue(any(expected in str for str in cm.output))

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -22,7 +22,6 @@ from twisted.trial import unittest
 import scrapy
 from scrapy.commands import ScrapyCommand, ScrapyHelpFormatter, crawl, runspider, view
 from scrapy.commands.startproject import IGNORE
-from scrapy.crawler import CrawlerProcess
 from scrapy.settings import Settings
 from scrapy.utils.python import to_unicode
 from scrapy.utils.test import get_testenv
@@ -1093,7 +1092,6 @@ class MySpider(scrapy.Spider):
             )
             command.add_options(parser)
             opts, _ = parser.parse_known_args(args=[])
-            command.crawler_process = CrawlerProcess(settings)
 
             opts.output = ["example.json"]
 


### PR DESCRIPTION
Fixes https://github.com/scrapy/scrapy/issues/5970

## Description
The export options, viz -o or -O, does not work for `crawl`, `parse`, `runspider` commands if the `FeedExporter` extension is disabled. No output file gets generated and there is no information displayed to the user.

## Changes
The `FeedExporter` extension can be disabled through settings.py
```
# Enable or disable extensions
# See https://docs.scrapy.org/en/latest/topics/extensions.html
EXTENSIONS = {
     "scrapy.extensions.feedexport.FeedExporter": None,
}
```
or via custom_settings
```
class BookSpider(scrapy.Spider):
    name = "book"

    custom_settings = { 
        "EXTENSIONS": {
            "scrapy.extensions.feedexport.FeedExporter": None
        },  
    }   

    def parse(self, response):   
        yield 'Hello World'         
```

* A method `validate_feed_exporter` is added to the `scrapy/commands/__init__.py` which checks the status of `FeedExporter` extension and emits a warning in case the -o or -O options are specified in the command.
* This method is getting called in crawl.py, parse.py and runspider.py
* Test cases added to make sure the warning is shown.

### Note:
The current changes only cater the scenario when the `FeedExporter` extension is disabled via `settings.py`. The warning will not be shown if the extension is disabled via `custom_settings`. For more information, please check the [discussion](https://github.com/scrapy/scrapy/pull/6082#issuecomment-2106271697).

## Tests
If `FeedExporter` extension is disabled
```
scrapy crawl book -o data/book_data.json
2024-05-21 11:44:33 [scrapy.utils.log] INFO: Scrapy 2.11.2 started (bot: bar)
2024-05-21 11:44:33 [scrapy.utils.log] INFO: Versions: lxml 5.1.0.0, libxml2 2.12.3, cssselect 1.2.0, parsel 1.8.1, w3lib 2.1.2, Twisted 23.10.0, Python 3.12.1 (v3.12.1:2305ca5144, Dec  7 2023, 17:23:38) [Clang 13.0.0 (clang-1300.0.29.30)], pyOpenSSL 24.0.0 (OpenSSL 3.2.1 30 Jan 2024), cryptography 42.0.5, Platform macOS-14.4.1-arm64-arm-64bit
2024-05-21 11:44:33 [scrapy.commands] WARNING: 'FeedExporter' extension must be enabled for Feed Exports to work.
2024-05-21 11:44:33 [scrapy.addons] INFO: Enabled addons:
[]
2024-05-21 11:44:33 [asyncio] DEBUG: Using selector: KqueueSelector
2024-05-21 11:44:33 [scrapy.utils.log] DEBUG: Using reactor: twisted.internet.asyncioreactor.AsyncioSelectorReactor
2024-05-21 11:44:33 [scrapy.utils.log] DEBUG: Using asyncio event loop: asyncio.unix_events._UnixSelectorEventLoop
2024-05-21 11:44:33 [scrapy.extensions.telnet] INFO: Telnet Password: e50a65220448d065
2024-05-21 11:44:33 [scrapy.middleware] INFO: Enabled extensions:
['scrapy.extensions.corestats.CoreStats',
 'scrapy.extensions.telnet.TelnetConsole',
 'scrapy.extensions.memusage.MemoryUsage',
 'scrapy.extensions.logstats.LogStats']
.
.
.
2024-05-21 11:44:35 [scrapy.core.engine] INFO: Closing spider (finished)
2024-05-21 11:44:35 [scrapy.statscollectors] INFO: Dumping Scrapy stats:
{'downloader/request_bytes': 468,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 5673,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 1,
 'downloader/response_status_count/404': 1,
 'elapsed_time_seconds': 1.315523,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 5, 21, 6, 14, 35, 418127, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 51447,
 'httpcompression/response_count': 2,
 'item_scraped_count': 20,
 'items_per_minute': None,
 'log_count/DEBUG': 25,
 'log_count/INFO': 10,
 'memusage/max': 66338816,
 'memusage/startup': 66338816,
 'response_received_count': 2,
 'responses_per_minute': None,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/404': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2024, 5, 21, 6, 14, 34, 102604, tzinfo=datetime.timezone.utc)}
2024-05-21 11:44:35 [scrapy.core.engine] INFO: Spider closed (finished)
```

It can be noticed that the FeedExporter extension is disabled and a corresponding warning is shown.
