### PR TITLE
docs: Remove top-level reactor imports from CrawlerProces/CrawlerRunner examples

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -9,6 +9,7 @@ exclude =
 per-file-ignores =
 # Exclude files that are meant to provide top-level imports
 # E402: Module level import not at top of file
+    tests/CrawlerRunner/change_reactor.py:E402
 # F401: Module imported but unused
     scrapy/__init__.py:E402
     scrapy/core/downloader/handlers/http.py:F401

--- a/.flake8
+++ b/.flake8
@@ -9,7 +9,6 @@ exclude =
 per-file-ignores =
 # Exclude files that are meant to provide top-level imports
 # E402: Module level import not at top of file
-    tests/CrawlerRunner/change_reactor.py:E402
 # F401: Module imported but unused
     scrapy/__init__.py:E402
     scrapy/core/downloader/handlers/http.py:F401
@@ -17,6 +16,7 @@ per-file-ignores =
     scrapy/linkextractors/__init__.py:E402,F401
     scrapy/selector/__init__.py:F401
     scrapy/spiders/__init__.py:E402,F401
+    tests/CrawlerRunner/change_reactor.py:E402
 
     # Issues pending a review:
     scrapy/utils/url.py:F403,F405

--- a/.github/workflows/tests-macos.yml
+++ b/.github/workflows/tests-macos.yml
@@ -1,4 +1,4 @@
-name: macOS
+name: macOS.
 on: [push, pull_request]
 
 concurrency:

--- a/.github/workflows/tests-macos.yml
+++ b/.github/workflows/tests-macos.yml
@@ -1,4 +1,4 @@
-name: macOS.
+name: macOS
 on: [push, pull_request]
 
 concurrency:

--- a/docs/topics/practices.rst
+++ b/docs/topics/practices.rst
@@ -134,6 +134,7 @@ Same example but using a non-default reactor, it's only necessary call
     install_reactor("twisted.internet.asyncioreactor.AsyncioSelectorReactor")
     runner = CrawlerRunner()
     d = runner.crawl(MySpider)
+
     from twisted.internet import reactor
 
     d.addBoth(lambda _: reactor.stop())

--- a/docs/topics/practices.rst
+++ b/docs/topics/practices.rst
@@ -202,6 +202,7 @@ Same example using :class:`~scrapy.crawler.CrawlerRunner`:
     runner.crawl(MySpider1)
     runner.crawl(MySpider2)
     d = runner.join()
+
     from twisted.internet import reactor
 
     d.addBoth(lambda _: reactor.stop())

--- a/docs/topics/practices.rst
+++ b/docs/topics/practices.rst
@@ -113,8 +113,7 @@ reactor after ``MySpider`` has finished running.
     reactor.run()  # the script will block here until the crawling is finished
 
 Same example but using a non-default reactor, it's only necessary call
-``install_reactor`` if you are using ``CrawlerRunner`` since ``CrawlerProcess``
- already does this automatically.
+``install_reactor`` if you are using ``CrawlerRunner`` since ``CrawlerProcess`` already does this automatically.
 
 .. code-block:: python
 

--- a/docs/topics/practices.rst
+++ b/docs/topics/practices.rst
@@ -111,7 +111,9 @@ reactor after ``MySpider`` has finished running.
     d.addBoth(lambda _: reactor.stop())
     reactor.run()  # the script will block here until the crawling is finished
 
-Same example but using a non-default reactor, is only necessary call ``install_reactor`` if you are using ``CrawlerRunner`` since ``CrawlerProcess`` already does this automatically.
+Same example but using a non-default reactor, it's only necessary call
+``install_reactor`` if you are using ``CrawlerRunner`` since ``CrawlerProcess``
+ already does this automatically.
 
 .. code-block:: python
 

--- a/docs/topics/practices.rst
+++ b/docs/topics/practices.rst
@@ -128,6 +128,7 @@ Same example but using a non-default reactor, it's only necessary call
 
 
     configure_logging({"LOG_FORMAT": "%(levelname)s: %(message)s"})
+
     from scrapy.utils.reactor import install_reactor
 
     install_reactor("twisted.internet.asyncioreactor.AsyncioSelectorReactor")

--- a/docs/topics/practices.rst
+++ b/docs/topics/practices.rst
@@ -92,7 +92,6 @@ reactor after ``MySpider`` has finished running.
 
 .. code-block:: python
 
-    from twisted.internet import reactor
     import scrapy
     from scrapy.crawler import CrawlerRunner
     from scrapy.utils.log import configure_logging
@@ -107,6 +106,33 @@ reactor after ``MySpider`` has finished running.
     runner = CrawlerRunner()
 
     d = runner.crawl(MySpider)
+    from twisted.internet import reactor
+
+    d.addBoth(lambda _: reactor.stop())
+    reactor.run()  # the script will block here until the crawling is finished
+
+Same example but using a non-default reactor, is only necessary call ``install_reactor`` if you are using ``CrawlerRunner`` since ``CrawlerProcess`` already does this automatically.
+
+.. code-block:: python
+
+    import scrapy
+    from scrapy.crawler import CrawlerRunner
+    from scrapy.utils.log import configure_logging
+
+
+    class MySpider(scrapy.Spider):
+        # Your spider definition
+        ...
+
+
+    configure_logging({"LOG_FORMAT": "%(levelname)s: %(message)s"})
+    from scrapy.utils.reactor import install_reactor
+
+    install_reactor("twisted.internet.asyncioreactor.AsyncioSelectorReactor")
+    runner = CrawlerRunner()
+    d = runner.crawl(MySpider)
+    from twisted.internet import reactor
+
     d.addBoth(lambda _: reactor.stop())
     reactor.run()  # the script will block here until the crawling is finished
 
@@ -151,7 +177,6 @@ Same example using :class:`~scrapy.crawler.CrawlerRunner`:
 .. code-block:: python
 
     import scrapy
-    from twisted.internet import reactor
     from scrapy.crawler import CrawlerRunner
     from scrapy.utils.log import configure_logging
     from scrapy.utils.project import get_project_settings
@@ -173,6 +198,8 @@ Same example using :class:`~scrapy.crawler.CrawlerRunner`:
     runner.crawl(MySpider1)
     runner.crawl(MySpider2)
     d = runner.join()
+    from twisted.internet import reactor
+
     d.addBoth(lambda _: reactor.stop())
 
     reactor.run()  # the script will block here until all crawling jobs are finished
@@ -181,7 +208,7 @@ Same example but running the spiders sequentially by chaining the deferreds:
 
 .. code-block:: python
 
-    from twisted.internet import reactor, defer
+    from twisted.internet import defer
     from scrapy.crawler import CrawlerRunner
     from scrapy.utils.log import configure_logging
     from scrapy.utils.project import get_project_settings
@@ -208,6 +235,8 @@ Same example but running the spiders sequentially by chaining the deferreds:
         yield runner.crawl(MySpider2)
         reactor.stop()
 
+
+    from twisted.internet import reactor
 
     crawl()
     reactor.run()  # the script will block here until the last crawl call is finished

--- a/docs/topics/practices.rst
+++ b/docs/topics/practices.rst
@@ -106,6 +106,7 @@ reactor after ``MySpider`` has finished running.
     runner = CrawlerRunner()
 
     d = runner.crawl(MySpider)
+
     from twisted.internet import reactor
 
     d.addBoth(lambda _: reactor.stop())

--- a/scrapy/crawler.py
+++ b/scrapy/crawler.py
@@ -129,6 +129,8 @@ class Crawler:
             if is_asyncio_reactor_installed() and event_loop:
                 verify_installed_asyncio_event_loop(event_loop)
 
+            log_reactor_info()
+
         self.extensions = ExtensionManager.from_crawler(self)
         self.settings.freeze()
 

--- a/tests/CrawlerRunner/change_reactor.py
+++ b/tests/CrawlerRunner/change_reactor.py
@@ -1,0 +1,31 @@
+from scrapy import Spider
+from scrapy.crawler import CrawlerRunner
+from scrapy.utils.log import configure_logging
+
+
+class NoRequestsSpider(Spider):
+    name = "no_request"
+
+    custom_settings = {
+        "TWISTED_REACTOR": "twisted.internet.asyncioreactor.AsyncioSelectorReactor",
+    }
+
+    def start_requests(self):
+        return []
+
+
+configure_logging({"LOG_FORMAT": "%(levelname)s: %(message)s", "LOG_LEVEL": "DEBUG"})
+
+
+from scrapy.utils.reactor import install_reactor
+
+install_reactor("twisted.internet.asyncioreactor.AsyncioSelectorReactor")
+
+runner = CrawlerRunner()
+
+d = runner.crawl(NoRequestsSpider)
+
+from twisted.internet import reactor
+
+d.addBoth(callback=lambda _: reactor.stop())
+reactor.run()

--- a/tests/test_crawler.py
+++ b/tests/test_crawler.py
@@ -926,3 +926,11 @@ class CrawlerRunnerSubprocess(ScriptRunnerMixin, unittest.TestCase):
         self.assertIn("INFO: Host: not.a.real.domain", log)
         self.assertIn("INFO: Type: <class 'ipaddress.IPv4Address'>", log)
         self.assertIn("INFO: IP address: 127.0.0.1", log)
+
+    def test_change_default_reactor(self):
+        log = self.run_script("change_reactor.py")
+        self.assertIn(
+            "DEBUG: Using reactor: twisted.internet.asyncioreactor.AsyncioSelectorReactor",
+            log,
+        )
+        self.assertIn("DEBUG: Using asyncio event loop", log)


### PR DESCRIPTION
fix #6361 