### PR TITLE
Improve traceback for exceptions in open_spider method

### DIFF
--- a/scrapy/core/engine.py
+++ b/scrapy/core/engine.py
@@ -389,7 +389,7 @@ class ExecutionEngine:
             self.slot.heartbeat.start(5)
         except Exception as e:
             # Capture detailed traceback
-            tb_str = traceback.format_exception(etype=type(e), value=e, tb=e.__traceback__)
+            tb_str = traceback.format_exception(type(e), e, e.__traceback__)
             self.crawler.stats.set_value('log/traceback', tb_str)
             self.crawler.signals.send_catch_log(
                 signal=signals.spider_error,

--- a/scrapy/core/engine.py
+++ b/scrapy/core/engine.py
@@ -6,8 +6,8 @@ For more information see docs/topics/architecture.rst
 """
 
 import logging
-from time import time
 import traceback
+from time import time
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -384,17 +384,17 @@ class ExecutionEngine:
             yield self.scraper.open_spider(spider)
             assert self.crawler.stats
             self.crawler.stats.open_spider(spider)
-            yield self.signals.send_catch_log_deferred(signals.spider_opened, spider=spider)
+            yield self.signals.send_catch_log_deferred(
+                signals.spider_opened, spider=spider
+            )
             self.slot.nextcall.schedule()
             self.slot.heartbeat.start(5)
         except Exception as e:
             # Capture detailed traceback
             tb_str = traceback.format_exception(type(e), e, e.__traceback__)
-            self.crawler.stats.set_value('log/traceback', tb_str)
+            self.crawler.stats.set_value("log/traceback", tb_str)
             self.crawler.signals.send_catch_log(
-                signal=signals.spider_error,
-                failure=e,
-                spider=spider
+                signal=signals.spider_error, failure=e, spider=spider
             )
             raise
 

--- a/scrapy/core/engine.py
+++ b/scrapy/core/engine.py
@@ -7,6 +7,7 @@ For more information see docs/topics/architecture.rst
 
 import logging
 from time import time
+import traceback
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -366,25 +367,36 @@ class ExecutionEngine:
     def open_spider(
         self, spider: Spider, start_requests: Iterable = (), close_if_idle: bool = True
     ) -> Generator[Deferred, Any, None]:
-        if self.slot is not None:
-            raise RuntimeError(f"No free spider slot when opening {spider.name!r}")
-        logger.info("Spider opened", extra={"spider": spider})
-        nextcall = CallLaterOnce(self._next_request)
-        scheduler = build_from_crawler(self.scheduler_cls, self.crawler)
-        start_requests = yield self.scraper.spidermw.process_start_requests(
-            start_requests, spider
-        )
-        self.slot = Slot(start_requests, close_if_idle, nextcall, scheduler)
-        self.spider = spider
-        if hasattr(scheduler, "open"):
-            if d := scheduler.open(spider):
-                yield d
-        yield self.scraper.open_spider(spider)
-        assert self.crawler.stats
-        self.crawler.stats.open_spider(spider)
-        yield self.signals.send_catch_log_deferred(signals.spider_opened, spider=spider)
-        self.slot.nextcall.schedule()
-        self.slot.heartbeat.start(5)
+        try:
+            if self.slot is not None:
+                raise RuntimeError(f"No free spider slot when opening {spider.name!r}")
+            logger.info("Spider opened", extra={"spider": spider})
+            nextcall = CallLaterOnce(self._next_request)
+            scheduler = build_from_crawler(self.scheduler_cls, self.crawler)
+            start_requests = yield self.scraper.spidermw.process_start_requests(
+                start_requests, spider
+            )
+            self.slot = Slot(start_requests, close_if_idle, nextcall, scheduler)
+            self.spider = spider
+            if hasattr(scheduler, "open"):
+                if d := scheduler.open(spider):
+                    yield d
+            yield self.scraper.open_spider(spider)
+            assert self.crawler.stats
+            self.crawler.stats.open_spider(spider)
+            yield self.signals.send_catch_log_deferred(signals.spider_opened, spider=spider)
+            self.slot.nextcall.schedule()
+            self.slot.heartbeat.start(5)
+        except Exception as e:
+            # Capture detailed traceback
+            tb_str = traceback.format_exception(etype=type(e), value=e, tb=e.__traceback__)
+            self.crawler.stats.set_value('log/traceback', tb_str)
+            self.crawler.signals.send_catch_log(
+                signal=signals.spider_error,
+                failure=e,
+                spider=spider
+            )
+            raise
 
     def _spider_idle(self) -> None:
         """

--- a/scrapy/crawler.py
+++ b/scrapy/crawler.py
@@ -4,6 +4,7 @@ import logging
 import pprint
 import signal
 import warnings
+import traceback
 from typing import TYPE_CHECKING, Any, Dict, Generator, Optional, Set, Type, Union, cast
 
 from twisted.internet.defer import (
@@ -155,7 +156,17 @@ class Crawler:
             self._update_root_log_handler()
             self.engine = self._create_engine()
             start_requests = iter(self.spider.start_requests())
-            yield self.engine.open_spider(self.spider, start_requests)
+            try:
+                yield self.engine.open_spider(self.spider, start_requests)
+            except Exception as e:
+                tb_str = traceback.format_exception(etype=type(e), value=e, tb=e.__traceback__)
+                self.stats.set_value('log/traceback', tb_str)
+                self.signals.send_catch_log(
+                    signal=signals.spider_error,
+                    failure=e,
+                    spider=self.spider
+                )
+                raise
             yield maybeDeferred(self.engine.start)
         except Exception:
             self.crawling = False

--- a/scrapy/crawler.py
+++ b/scrapy/crawler.py
@@ -3,8 +3,8 @@ from __future__ import annotations
 import logging
 import pprint
 import signal
-import warnings
 import traceback
+import warnings
 from typing import TYPE_CHECKING, Any, Dict, Generator, Optional, Set, Type, Union, cast
 
 from twisted.internet.defer import (
@@ -159,12 +159,12 @@ class Crawler:
             try:
                 yield self.engine.open_spider(self.spider, start_requests)
             except Exception as e:
-                tb_str = traceback.format_exception(etype=type(e), value=e, tb=e.__traceback__)
-                self.stats.set_value('log/traceback', tb_str)
+                tb_str = traceback.format_exception(
+                    etype=type(e), value=e, tb=e.__traceback__
+                )
+                self.stats.set_value("log/traceback", tb_str)
                 self.signals.send_catch_log(
-                    signal=signals.spider_error,
-                    failure=e,
-                    spider=self.spider
+                    signal=signals.spider_error, failure=e, spider=self.spider
                 )
                 raise
             yield maybeDeferred(self.engine.start)


### PR DESCRIPTION
This pull request addresses issue #5817 by enhancing the exception handling in the open_spider method of the Engine class. The current implementation does not provide sufficient traceback information when an exception occurs, making it difficult to debug issues. The proposed changes capture and log detailed traceback information, improving the debugging experience for users.

**Changes Made:**
Enhanced Exception Handling:
Wrapped the logic of the open_spider method in a try-except block.
Used the traceback module to capture and format the exception traceback.
Logged the detailed traceback in the crawler’s stats using self.crawler.stats.set_value.
Sent a spider_error signal with the detailed failure information using self.crawler.signals.send_catch_log.