### PR TITLE
Make HttpCompressionMiddleware warn if got unsupported compression in response

### DIFF
--- a/scrapy/downloadermiddlewares/httpcompression.py
+++ b/scrapy/downloadermiddlewares/httpcompression.py
@@ -46,6 +46,12 @@ else:
     ACCEPTED_ENCODINGS.append(b"zstd")
 
 
+class UnsupportedCompressionWarning(Warning):
+    """Warning category for unsupported compression algorithms"""
+
+    pass
+
+
 class HttpCompressionMiddleware:
     """This middleware allows compressed (gzip, deflate) traffic to be
     sent/received from web sites"""
@@ -178,6 +184,14 @@ class HttpCompressionMiddleware:
             return _inflate(body, max_size=max_size)
         if encoding == b"br" and b"br" in ACCEPTED_ENCODINGS:
             return _unbrotli(body, max_size=max_size)
-        if encoding == b"zstd" and b"zstd" in ACCEPTED_ENCODINGS:
+        if encoding == b"zstd" and  b"zstd" in ACCEPTED_ENCODINGS:
             return _unzstd(body, max_size=max_size)
+        warnings.warn(
+            f"Got unsupported compression format: {encoding}."
+            f"Consider changing your headers, excluding {encoding} from 'Accept-Encoding'"
+            "or install brotli (brotlicffi) or zstandard, "
+            "depending on what compression algorithm are being used."
+            "Now returning response body as is.",
+            UnsupportedCompressionWarning,
+        )
         return body


### PR DESCRIPTION
If brotli (or other brotli decompression package) or zstandard are not installed, HttpCompressionMiddleware will return  uncompressed response body without any warning, 
How to get this behaviour: add 'br' or 'zstd'  to header 'Accept-Encoding' to Request manually or via DEFAULT_REQUEST_HEADERS dictionary in settings.py.