### PR TITLE
Don't run callbacks of requests from get_media_requests().

### DIFF
--- a/scrapy/pipelines/media.py
+++ b/scrapy/pipelines/media.py
@@ -24,10 +24,6 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-def _DUMMY_CALLBACK(response):
-    return response
-
-
 class MediaPipeline(ABC):
     LOG_FAILED_RESULTS = True
 
@@ -89,10 +85,6 @@ class MediaPipeline(ABC):
 
     def _process_request(self, request, info, item):
         fp = self._fingerprinter.fingerprint(request)
-        if not request.callback or request.callback is NO_CALLBACK:
-            cb = _DUMMY_CALLBACK
-        else:
-            cb = request.callback
         eb = request.errback
         request.callback = NO_CALLBACK
         request.errback = None
@@ -100,14 +92,12 @@ class MediaPipeline(ABC):
         # Return cached result if request was already seen
         if fp in info.downloaded:
             d = defer_result(info.downloaded[fp])
-            d.addCallback(cb)
             if eb:
                 d.addErrback(eb)
             return d
 
         # Otherwise, wait for result
         wad = Deferred()
-        wad.addCallback(cb)
         if eb:
             wad.addErrback(eb)
         info.waiting[fp].append(wad)

--- a/tests/test_pipeline_media.py
+++ b/tests/test_pipeline_media.py
@@ -211,10 +211,6 @@ class MockedMediaPipeline(UserDefinedPipeline):
 class MediaPipelineTestCase(BaseMediaPipelineTestCase):
     pipeline_class = MockedMediaPipeline
 
-    def _callback(self, result):
-        self.pipe._mockcalled.append("request_callback")
-        return result
-
     def _errback(self, result):
         self.pipe._mockcalled.append("request_errback")
         return result
@@ -225,7 +221,6 @@ class MediaPipelineTestCase(BaseMediaPipelineTestCase):
         req = Request(
             "http://url1",
             meta={"response": rsp},
-            callback=self._callback,
             errback=self._errback,
         )
         item = {"requests": req}
@@ -237,7 +232,6 @@ class MediaPipelineTestCase(BaseMediaPipelineTestCase):
                 "get_media_requests",
                 "media_to_download",
                 "media_downloaded",
-                "request_callback",
                 "item_completed",
             ],
         )
@@ -249,7 +243,6 @@ class MediaPipelineTestCase(BaseMediaPipelineTestCase):
         req = Request(
             "http://url1",
             meta={"response": fail},
-            callback=self._callback,
             errback=self._errback,
         )
         item = {"requests": req}


### PR DESCRIPTION
The callback, if it exists, was called with a result dict as the first arg, not with a response, so it didn't make sense to have callbacks on these requests and so I'm almost sure there is no code that has them (I checked several 3rd-party pipelines in the github search, all of them don't use even the errback feature which at least seems to make sense).