### PR TITLE
added  AttributeError: 'NoneType' handling in contract parsing

### DIFF
--- a/scrapy/contracts/__init__.py
+++ b/scrapy/contracts/__init__.py
@@ -121,6 +121,8 @@ class ContractsManager:
             if line.startswith("@"):
                 m = re.match(r"@(\w+)\s*(.*)", line)
                 assert m is not None
+                if m is None:
+                    continue
                 name, args = m.groups()
                 args = re.split(r"\s+", args)
 

--- a/scrapy/contracts/__init__.py
+++ b/scrapy/contracts/__init__.py
@@ -120,7 +120,6 @@ class ContractsManager:
 
             if line.startswith("@"):
                 m = re.match(r"@(\w+)\s*(.*)", line)
-                assert m is not None
                 if m is None:
                     continue
                 name, args = m.groups()

--- a/tests/test_contracts.py
+++ b/tests/test_contracts.py
@@ -195,6 +195,7 @@ class TestSpider(Spider):
         """
         pass
 
+
 class CustomContractSuccessSpider(Spider):
     name = "custom_contract_success_spider"
 
@@ -406,7 +407,9 @@ class ContractsManagerTest(unittest.TestCase):
         self.should_succeed()
 
         # invalid regex with valid contract
-        request = self.conman.from_method(spider.invalid_regex_with_valid_contract, self.results)
+        request = self.conman.from_method(
+            spider.invalid_regex_with_valid_contract, self.results
+        )
         self.should_succeed()
         request.callback(response)
 

--- a/tests/test_contracts.py
+++ b/tests/test_contracts.py
@@ -182,6 +182,18 @@ class TestSpider(Spider):
         """
         pass
 
+    def invalid_regex(self, response):
+        """method with invalid regex
+        @ Scrapy is awsome
+        """
+        pass
+
+    def invalid_regex_with_valid_contract(self, response):
+        """method with invalid regex
+        @ scrapy is awsome
+        @url http://scrapy.org
+        """
+        pass
 
 class CustomContractSuccessSpider(Spider):
     name = "custom_contract_success_spider"
@@ -384,6 +396,19 @@ class ContractsManagerTest(unittest.TestCase):
         self.should_fail()
         message = "ContractFail: Missing fields: name, url"
         assert message in self.results.failures[-1][-1]
+
+    def test_regex(self):
+        spider = TestSpider()
+        response = ResponseMock()
+
+        # invalid regex
+        request = self.conman.from_method(spider.invalid_regex, self.results)
+        self.should_succeed()
+
+        # invalid regex with valid contract
+        request = self.conman.from_method(spider.invalid_regex_with_valid_contract, self.results)
+        self.should_succeed()
+        request.callback(response)
 
     def test_custom_contracts(self):
         self.conman.from_spider(CustomContractSuccessSpider(), self.results)


### PR DESCRIPTION
Added a condition to check if `m` is `None`.

The presence of `@ foo` in the docstring would result in an `AttributeError: 'NoneType' object has no attribute 'groups'`. Checking for `None` will prevent this error.

Closes #6383