### PR TITLE
Deprecate scrapy.utils.defer.process_chain_both().

### DIFF
--- a/scrapy/utils/defer.py
+++ b/scrapy/utils/defer.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 import asyncio
 import inspect
+import warnings
 from asyncio import Future
 from functools import wraps
 from types import CoroutineType
@@ -35,7 +36,7 @@ from twisted.internet.task import Cooperator
 from twisted.python import failure
 from twisted.python.failure import Failure
 
-from scrapy.exceptions import IgnoreRequest
+from scrapy.exceptions import IgnoreRequest, ScrapyDeprecationWarning
 from scrapy.utils.reactor import _get_asyncio_event_loop, is_asyncio_reactor_installed
 
 if TYPE_CHECKING:
@@ -281,6 +282,12 @@ def process_chain_both(
     **kw: _P.kwargs,
 ) -> Deferred:
     """Return a Deferred built by chaining the given callbacks and errbacks"""
+    warnings.warn(
+        "process_chain_both() is deprecated and will be removed in a future"
+        " Scrapy version.",
+        ScrapyDeprecationWarning,
+        stacklevel=2,
+    )
     d: Deferred = Deferred()
     for cb, eb in zip(callbacks, errbacks):
         d.addCallback(cb, *a, **kw)

--- a/tests/test_utils_defer.py
+++ b/tests/test_utils_defer.py
@@ -14,7 +14,6 @@ from scrapy.utils.defer import (
     mustbe_deferred,
     parallel_async,
     process_chain,
-    process_chain_both,
     process_parallel,
 )
 
@@ -79,19 +78,6 @@ class DeferUtilsTest(unittest.TestCase):
         except TypeError:
             gotexc = True
         self.assertTrue(gotexc)
-
-    @defer.inlineCallbacks
-    def test_process_chain_both(self):
-        x = yield process_chain_both(
-            [cb_fail, cb2, cb3], [None, eb1, None], "res", "v1", "v2"
-        )
-        self.assertEqual(x, "(cb3 (eb1 TypeError v1 v2) v1 v2)")
-
-        fail = Failure(ZeroDivisionError())
-        x = yield process_chain_both(
-            [eb1, cb2, cb3], [eb1, None, None], fail, "v1", "v2"
-        )
-        self.assertEqual(x, "(cb3 (cb2 (eb1 ZeroDivisionError v1 v2) v1 v2) v1 v2)")
 
     @defer.inlineCallbacks
     def test_process_parallel(self):


### PR DESCRIPTION
This function was never used except by `MiddlewareManager._process_chain_both()` which was also never used and was removed in 2021.