### PR TITLE
Unpin markupsafe in extra-deps.

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -147,9 +147,6 @@ deps =
     {[testenv]deps}
     boto3
     google-cloud-storage
-    # Twisted[http2] currently forces old mitmproxy because of h2 version
-    # restrictions in their deps, so we need to pin old markupsafe here too.
-    markupsafe < 2.1.0
     robotexclusionrulesparser
     Pillow
     Twisted[http2]


### PR DESCRIPTION
This pin currently causes version conflicts but it's also no longer needed as current `Twisted` allows `h2==4.1.0` which is compatible with current `mitmproxy`.