### PR TITLE
Bump twine in twinecheck.

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -88,7 +88,7 @@ commands =
 [testenv:twinecheck]
 basepython = python3
 deps =
-    twine==4.0.2
+    twine==5.0.0
     build==1.0.3
 commands =
     python -m build --sdist


### PR DESCRIPTION
The older version is incompatible with just released importlib-metadata.