### PR TITLE
start_requests can return items

### DIFF
--- a/docs/topics/signals.rst
+++ b/docs/topics/signals.rst
@@ -159,8 +159,9 @@ item_scraped
     :param spider: the spider which scraped the item
     :type spider: :class:`~scrapy.Spider` object
 
-    :param response: the response from where the item was scraped
-    :type response: :class:`~scrapy.http.Response` object
+    :param response: the response from where the item was scraped, or ``None``
+        if it was yielded from :meth:`~scrapy.Spider.start_requests`.
+    :type response: :class:`~scrapy.http.Response` | ``None``
 
 item_dropped
 ~~~~~~~~~~~~
@@ -179,8 +180,9 @@ item_dropped
     :param spider: the spider which scraped the item
     :type spider: :class:`~scrapy.Spider` object
 
-    :param response: the response from where the item was dropped
-    :type response: :class:`~scrapy.http.Response` object
+    :param response: the response from where the item was dropped, or ``None``
+        if it was yielded from :meth:`~scrapy.Spider.start_requests`.
+    :type response: :class:`~scrapy.http.Response` | ``None``
 
     :param exception: the exception (which must be a
         :exc:`~scrapy.exceptions.DropItem` subclass) which caused the item
@@ -201,8 +203,10 @@ item_error
     :param item: the item that caused the error in the :ref:`topics-item-pipeline`
     :type item: :ref:`item object <item-types>`
 
-    :param response: the response being processed when the exception was raised
-    :type response: :class:`~scrapy.http.Response` object
+    :param response: the response being processed when the exception was
+        raised, or ``None`` if it was yielded from
+        :meth:`~scrapy.Spider.start_requests`.
+    :type response: :class:`~scrapy.http.Response` | ``None``
 
     :param spider: the spider which raised the exception
     :type spider: :class:`~scrapy.Spider` object

--- a/docs/topics/spider-middleware.rst
+++ b/docs/topics/spider-middleware.rst
@@ -176,7 +176,7 @@ object gives you access, for example, to the :ref:`settings <topics-settings>`.
         items).
 
         It receives an iterable (in the ``start_requests`` parameter) and must
-        return another iterable of :class:`~scrapy.Request` objects.
+        return another iterable of :class:`~scrapy.Request` objects and :ref:`item objects.
 
         .. note:: When implementing this method in your spider middleware, you
            should always return an iterable (that follows the input one) and

--- a/docs/topics/spider-middleware.rst
+++ b/docs/topics/spider-middleware.rst
@@ -176,7 +176,7 @@ object gives you access, for example, to the :ref:`settings <topics-settings>`.
         items).
 
         It receives an iterable (in the ``start_requests`` parameter) and must
-        return another iterable of :class:`~scrapy.Request` objects and :ref:`item objects.
+        return another iterable of :class:`~scrapy.Request` objects and/or :ref:`item objects <topics-items>`.
 
         .. note:: When implementing this method in your spider middleware, you
            should always return an iterable (that follows the input one) and

--- a/docs/topics/spiders.rst
+++ b/docs/topics/spiders.rst
@@ -203,7 +203,8 @@ scrapy.Spider
 
    .. method:: start_requests()
 
-       This method must return an iterable with the first Requests to crawl and with :ref:`item objects. for
+       This method must return an iterable with the first Requests to crawl and/or with :ref:`item objects
+       <topics-items>` for
        this spider. It is called by Scrapy when the spider is opened for
        scraping. Scrapy calls it only once, so it is safe to implement
        :meth:`start_requests` as a generator.

--- a/docs/topics/spiders.rst
+++ b/docs/topics/spiders.rst
@@ -203,7 +203,7 @@ scrapy.Spider
 
    .. method:: start_requests()
 
-       This method must return an iterable with the first Requests to crawl for
+       This method must return an iterable with the first Requests to crawl and with :ref:`item objects. for
        this spider. It is called by Scrapy when the spider is opened for
        scraping. Scrapy calls it only once, so it is safe to implement
        :meth:`start_requests` as a generator.

--- a/scrapy/core/engine.py
+++ b/scrapy/core/engine.py
@@ -211,11 +211,10 @@ class ExecutionEngine:
                 elif is_item(request_or_item):
                     self.scraper.start_itemproc(request_or_item, response=None)
                 else:
-                    type_import_path = global_object_name(type(request_or_item))
                     logger.error(
-                        f"Got an instance of {type_import_path} among start "
-                        f"requests. Only requests and items are supported. It "
-                        f"will be ignored."
+                        f"Got {request_or_item!r} among start requests. Only "
+                        f"requests and items are supported. It will be "
+                        f"ignored."
                     )
 
         if self.spider_is_idle() and self.slot.close_if_idle:

--- a/scrapy/core/engine.py
+++ b/scrapy/core/engine.py
@@ -209,8 +209,7 @@ class ExecutionEngine:
                 if isinstance(request_or_item, Request):
                     self.crawl(request_or_item)
                 elif is_item(request_or_item):
-                    src = f"{global_object_name(self.spider.__class__)}.start_requests"
-                    self.scraper.start_itemproc(request_or_item, src)
+                    self.scraper.start_itemproc(request_or_item, response=None)
                 else:
                     type_import_path = global_object_name(type(request_or_item))
                     logger.error(

--- a/scrapy/core/scraper.py
+++ b/scrapy/core/scraper.py
@@ -313,7 +313,6 @@ class Scraper:
         """Process each Request/Item (given in the output parameter) returned
         from the given spider
         """
-        assert self.slot is not None  # typing
         if isinstance(output, Request):
             assert self.crawler.engine is not None  # typing
             self.crawler.engine.crawl(request=output)
@@ -336,6 +335,8 @@ class Scraper:
         *response* is the source of the item data. If the item does not come
         from response data, e.g. it was hard-coded, set it to ``None``.
         """
+        assert self.slot is not None  # typing
+        assert self.crawler.spider is not None  # typing
         self.slot.itemproc_size += 1
         dfd = self.itemproc.process_item(item, self.crawler.spider)
         dfd.addBoth(self._itemproc_finished, item, response, self.crawler.spider)

--- a/scrapy/core/scraper.py
+++ b/scrapy/core/scraper.py
@@ -329,7 +329,7 @@ class Scraper:
             )
         return None
 
-    def start_itemproc(self, item, *, response: Optional[Response]):
+    def start_itemproc(self, item, *, response: Optional[Response]) -> Deferred[Any]:
         """Send *item* to the item pipelines for processing.
 
         *response* is the source of the item data. If the item does not come

--- a/scrapy/logformatter.py
+++ b/scrapy/logformatter.py
@@ -9,6 +9,7 @@ from twisted.python.failure import Failure
 # working around https://github.com/sphinx-doc/sphinx/issues/10400
 from scrapy import Request, Spider  # noqa: TC001
 from scrapy.http import Response  # noqa: TC001
+from scrapy.utils.python import global_object_name
 from scrapy.utils.request import referer_str
 
 if TYPE_CHECKING:
@@ -92,11 +93,13 @@ class LogFormatter:
         }
 
     def scraped(
-        self, item: Any, response: Union[Response, Failure], spider: Spider
+        self, item: Any, response: Union[Response, Failure, None], spider: Spider
     ) -> LogFormatterResult:
         """Logs a message when an item is scraped by a spider."""
         src: Any
-        if isinstance(response, Failure):
+        if response is None:
+            src = f"{global_object_name(spider.__class__)}.start_requests"
+        elif isinstance(response, Failure):
             src = response.getErrorMessage()
         else:
             src = response
@@ -110,7 +113,11 @@ class LogFormatter:
         }
 
     def dropped(
-        self, item: Any, exception: BaseException, response: Response, spider: Spider
+        self,
+        item: Any,
+        exception: BaseException,
+        response: Optional[Response],
+        spider: Spider,
     ) -> LogFormatterResult:
         """Logs a message when an item is dropped while it is passing through the item pipeline."""
         return {
@@ -123,7 +130,11 @@ class LogFormatter:
         }
 
     def item_error(
-        self, item: Any, exception: BaseException, response: Response, spider: Spider
+        self,
+        item: Any,
+        exception: BaseException,
+        response: Optional[Response],
+        spider: Spider,
     ) -> LogFormatterResult:
         """Logs a message when an item causes an error while it is passing
         through the item pipeline.

--- a/tests/spiders.py
+++ b/tests/spiders.py
@@ -328,6 +328,11 @@ class BrokenStartRequestsSpider(FollowAllSpider):
         yield from super().parse(response)
 
 
+class StartRequestsItemSpider(FollowAllSpider):
+    def start_requests(self):
+        yield {"name": "test item"}
+
+
 class SingleRequestSpider(MetaSpider):
     seed = None
     callback_func = None

--- a/tests/spiders.py
+++ b/tests/spiders.py
@@ -351,6 +351,14 @@ class StartRequestsItemSpider(FollowAllSpider):
         yield {"name": "test item"}
 
 
+class StartRequestsGoodAndBadOutput(FollowAllSpider):
+    def start_requests(self):
+        yield {"a": "a"}
+        yield Request("data:,a")
+        yield "data:,b"
+        yield object()
+
+
 class SingleRequestSpider(MetaSpider):
     seed = None
     callback_func = None

--- a/tests/test_crawl.py
+++ b/tests/test_crawl.py
@@ -212,7 +212,7 @@ class CrawlTestCase(TestCase):
         self.assertTrue(
             re.match(
                 (
-                    r"^Got <object object at 0x[0-9a-f]{12}> among start "
+                    r"^Got <object object at 0x[0-9a-f]+> among start "
                     r"requests\. Only requests and items are supported\. It "
                     r"will be ignored\.$"
                 ),

--- a/tests/test_crawl.py
+++ b/tests/test_crawl.py
@@ -212,7 +212,7 @@ class CrawlTestCase(TestCase):
         self.assertTrue(
             re.match(
                 (
-                    r"^Got <object object at 0x[0-9a-f]+> among start "
+                    r"^Got <object object at 0x[0-9a-fA-F]+> among start "
                     r"requests\. Only requests and items are supported\. It "
                     r"will be ignored\.$"
                 ),

--- a/tests/test_crawl.py
+++ b/tests/test_crawl.py
@@ -49,6 +49,7 @@ from tests.spiders import (
     HeadersReceivedErrbackSpider,
     SimpleSpider,
     SingleRequestSpider,
+    StartRequestsItemSpider,
 )
 
 
@@ -183,6 +184,14 @@ class CrawlTestCase(TestCase):
         record = log.records[0]
         self.assertIsNotNone(record.exc_info)
         self.assertIs(record.exc_info[0], ZeroDivisionError)
+
+    @defer.inlineCallbacks
+    def test_start_requests_items(self):
+        with LogCapture("scrapy", level=logging.ERROR) as log:
+            crawler = get_crawler(StartRequestsItemSpider)
+            yield crawler.crawl(mockserver=self.mockserver)
+
+        self.assertEqual(len(log.records), 0)
 
     @defer.inlineCallbacks
     def test_start_requests_laziness(self):

--- a/tests/test_spidermiddleware.py
+++ b/tests/test_spidermiddleware.py
@@ -1,5 +1,5 @@
 import collections.abc
-from typing import Optional, Union
+from typing import Optional
 from unittest import mock
 
 from testfixtures import LogCapture
@@ -328,7 +328,7 @@ class ProcessStartRequestsSimpleMiddleware:
 class ProcessStartRequestsSimple(BaseAsyncSpiderMiddlewareTestCase):
     """process_start_requests tests for simple start_requests"""
 
-    ITEM_TYPE = Union[Request, dict]
+    ITEM_TYPE = (Request, dict)
     MW_SIMPLE = ProcessStartRequestsSimpleMiddleware
 
     def _start_requests(self):

--- a/tests/test_spidermiddleware.py
+++ b/tests/test_spidermiddleware.py
@@ -1,5 +1,5 @@
 import collections.abc
-from typing import Optional
+from typing import Optional, Union
 from unittest import mock
 
 from testfixtures import LogCapture
@@ -112,7 +112,7 @@ class BaseAsyncSpiderMiddlewareTestCase(SpiderMiddlewareTestCase):
     Should work for process_spider_output and, when it's supported, process_start_requests.
     """
 
-    ITEM_TYPE: type
+    ITEM_TYPE: Union[type, tuple]
     RESULT_COUNT = 3  # to simplify checks, let everything return 3 objects
 
     @staticmethod

--- a/tests/test_spidermiddleware.py
+++ b/tests/test_spidermiddleware.py
@@ -1,5 +1,5 @@
 import collections.abc
-from typing import Optional
+from typing import Optional, Union
 from unittest import mock
 
 from testfixtures import LogCapture
@@ -328,12 +328,13 @@ class ProcessStartRequestsSimpleMiddleware:
 class ProcessStartRequestsSimple(BaseAsyncSpiderMiddlewareTestCase):
     """process_start_requests tests for simple start_requests"""
 
-    ITEM_TYPE = Request
+    ITEM_TYPE = Union[Request, dict]
     MW_SIMPLE = ProcessStartRequestsSimpleMiddleware
 
     def _start_requests(self):
-        for i in range(3):
+        for i in range(2):
             yield Request(f"https://example.com/{i}", dont_filter=True)
+        yield {"name": "test item"}
 
     @defer.inlineCallbacks
     def _get_middleware_result(self, *mw_classes, start_index: Optional[int] = None):


### PR DESCRIPTION
resolve https://github.com/scrapy/scrapy/issues/5289
based on code sample from https://github.com/scrapy/scrapy/issues/5289#issuecomment-1522396870

I used this сode sample to test this locally.
<details><summary>script.py</summary>

```python
import scrapy
from scrapy.crawler import CrawlerProcess

class QuotesToScrapeSpider(scrapy.Spider):
    def start_requests(self):
        yield scrapy.Request(url='http://quotes.toscrape.com/', callback=self.parse)
        yield {"quote": ['“It is possible to return items on start_requests. But I don\'t understand Why it\'s needed?“'], "author": ["Georgiy"], "tags": ["scrapy"]}

    def parse(self, response):
        for quote in response.css("div.quote"):
            yield {
                "quote": quote.css("span.text::text").getall(),
                "author": quote.css("small.author::text").getall(),
                "tags": quote.css("a.tag::text").getall()
            }
if __name__ == "__main__":
    p = CrawlerProcess(); p.crawl(QuotesToScrapeSpider); p.start()
```

</details>
At this moment I didn't found test where output(type) of  start_requests checked