### PR TITLE
fix to extract all tags and attr along with deny option

### DIFF
--- a/scrapy/linkextractors/lxmlhtml.py
+++ b/scrapy/linkextractors/lxmlhtml.py
@@ -67,24 +67,37 @@ def _canonicalize_link_url(link: Link) -> str:
 class LxmlParserLinkExtractor:
     def __init__(
         self,
-        tag: Union[str, Callable[[str], bool]] = "a",
-        attr: Union[str, Callable[[str], bool]] = "href",
+        allow_tag: Union[str, Callable[[str], bool]] = "",
+        allow_attr: Union[str, Callable[[str], bool]] = "",
+        deny_tag: Union[str, Callable[[str], bool]] = "",
+        deny_attr: Union[str, Callable[[str], bool]] = "",
         process: Optional[Callable[[Any], Any]] = None,
         unique: bool = False,
         strip: bool = True,
         canonicalized: bool = False,
     ):
         # mypy doesn't infer types for operator.* and also for partial()
-        self.scan_tag: Callable[[str], bool] = (
-            tag
-            if callable(tag)
-            else cast(Callable[[str], bool], partial(operator.eq, tag))
+        self.scan_allowed_tag: Callable[[str], bool] = (
+            allow_tag
+            if callable(allow_tag)
+            else cast(Callable[[str], bool], partial(operator.eq, allow_tag))
         )
-        self.scan_attr: Callable[[str], bool] = (
-            attr
-            if callable(attr)
-            else cast(Callable[[str], bool], partial(operator.eq, attr))
+        self.scan_allowed_attr: Callable[[str], bool] = (
+            allow_attr
+            if callable(allow_attr)
+            else cast(Callable[[str], bool], partial(operator.eq, allow_attr))
         )
+        self.scan_denied_tag: Callable[[str], bool] = (
+            deny_tag
+            if callable(deny_tag)
+            else cast(Callable[[str], bool], partial(operator.eq, deny_tag))
+        )
+        self.scan_denied_attr: Callable[[str], bool] = (
+            deny_attr
+            if callable(deny_attr)
+            else cast(Callable[[str], bool], partial(operator.eq, deny_attr))
+        )
+
         self.process_attr: Callable[[Any], Any] = (
             process if callable(process) else _identity
         )
@@ -100,12 +113,22 @@ class LxmlParserLinkExtractor:
         self, document: HtmlElement
     ) -> Iterable[Tuple[HtmlElement, str, str]]:
         for el in document.iter(etree.Element):
-            if not self.scan_tag(_nons(el.tag)):
+            if self.scan_denied_tag(_nons(el.tag)) or not self.scan_allowed_tag(
+                _nons(el.tag)
+            ):
                 continue
             attribs = el.attrib
             for attrib in attribs:
-                if not self.scan_attr(attrib):
+                print(attrib)
+                if self.scan_denied_attr(attrib) or not self.scan_allowed_attr(attrib):
+                    if(attrib == 'ping'):
+                        print("not happening")
                     continue
+                if(attrib == 'ping'):
+                    print(el)
+                    print(attrib)
+                    print(attribs[attrib])
+
                 yield el, attrib, attribs[attrib]
 
     def _extract_links(
@@ -178,8 +201,10 @@ class LxmlLinkExtractor:
         allow_domains: Union[str, Iterable[str]] = (),
         deny_domains: Union[str, Iterable[str]] = (),
         restrict_xpaths: Union[str, Iterable[str]] = (),
-        tags: Union[str, Iterable[str]] = ("a", "area"),
-        attrs: Union[str, Iterable[str]] = ("href",),
+        tags: Union[str, Iterable[str]] = (),
+        attrs: Union[str, Iterable[str]] = (),
+        deny_tags: Union[str, Iterable[str]] = (),
+        deny_attrs: Union[str, Iterable[str]] = (),
         canonicalize: bool = False,
         unique: bool = True,
         process_value: Optional[Callable[[Any], Any]] = None,
@@ -188,10 +213,30 @@ class LxmlLinkExtractor:
         strip: bool = True,
         restrict_text: Optional[_RegexOrSeveralT] = None,
     ):
-        tags, attrs = set(arg_to_iter(tags)), set(arg_to_iter(attrs))
+
+        if not tags and not attrs:
+            attrs = {
+                "href",
+            }
+
+        allow_tags, allow_attrs = set(arg_to_iter(tags)), set(arg_to_iter(attrs))
+        deny_tags, deny_attrs = set(arg_to_iter(deny_tags)), set(
+            arg_to_iter(deny_attrs)
+        )
+
         self.link_extractor = LxmlParserLinkExtractor(
-            tag=partial(operator.contains, tags),
-            attr=partial(operator.contains, attrs),
+            allow_tag=(
+                partial(operator.truth)
+                if not allow_tags
+                else partial(operator.contains, allow_tags)
+            ),
+            allow_attr=(
+                partial(operator.truth)
+                if not allow_attrs
+                else partial(operator.contains, allow_attrs)
+            ),
+            deny_tag=partial(operator.contains, deny_tags),
+            deny_attr=partial(operator.contains, deny_attrs),
             unique=unique,
             process=process_value,
             strip=strip,

--- a/scrapy/linkextractors/lxmlhtml.py
+++ b/scrapy/linkextractors/lxmlhtml.py
@@ -67,8 +67,8 @@ def _canonicalize_link_url(link: Link) -> str:
 class LxmlParserLinkExtractor:
     def __init__(
         self,
-        allow_tag: Union[str, Callable[[str], bool]] = "",
-        allow_attr: Union[str, Callable[[str], bool]] = "",
+        tag: Union[str, Callable[[str], bool]] = "",
+        attr: Union[str, Callable[[str], bool]] = "",
         deny_tag: Union[str, Callable[[str], bool]] = "",
         deny_attr: Union[str, Callable[[str], bool]] = "",
         process: Optional[Callable[[Any], Any]] = None,
@@ -78,14 +78,14 @@ class LxmlParserLinkExtractor:
     ):
         # mypy doesn't infer types for operator.* and also for partial()
         self.scan_allowed_tag: Callable[[str], bool] = (
-            allow_tag
-            if callable(allow_tag)
-            else cast(Callable[[str], bool], partial(operator.eq, allow_tag))
+            tag
+            if callable(tag)
+            else cast(Callable[[str], bool], partial(operator.eq, tag))
         )
         self.scan_allowed_attr: Callable[[str], bool] = (
-            allow_attr
-            if callable(allow_attr)
-            else cast(Callable[[str], bool], partial(operator.eq, allow_attr))
+            attr
+            if callable(attr)
+            else cast(Callable[[str], bool], partial(operator.eq, attr))
         )
         self.scan_denied_tag: Callable[[str], bool] = (
             deny_tag
@@ -119,15 +119,8 @@ class LxmlParserLinkExtractor:
                 continue
             attribs = el.attrib
             for attrib in attribs:
-                print(attrib)
                 if self.scan_denied_attr(attrib) or not self.scan_allowed_attr(attrib):
-                    if(attrib == 'ping'):
-                        print("not happening")
                     continue
-                if(attrib == 'ping'):
-                    print(el)
-                    print(attrib)
-                    print(attribs[attrib])
 
                 yield el, attrib, attribs[attrib]
 


### PR DESCRIPTION
Fixes #6321

### Thinking:

1. We cannot keep both the `tags` and `attrs` arguments empty because that would extract all the tags including `div`, `p`, etc. and attributes like `id`, `alt` etc. present in html which defeats the purpose of link extractor. So we would want at least one of them to be given by the user.
2. If we want the user to mention the tags or attributes they wish to ignore, we would need to use additional arguments.

In this code, I have provided a default value of `href` to attr argument in case both are kept empty by the user. No default value for tags attribute.

**Two reasons for this:**
1. We wish to extract all tags with specific attributes that would have links.
2. `href` is the most common attribute that would have links. 
3. Keeping this we can extract all the tags that have href in them at the same time denying the tags and attributes that user wants to ignore. (Which is kind of what this issue aims to resolve)


### Approach:

I have considered two additional arguments `deny_tags` and `deny_attrs` respectively which would have a iterable or str type of tags/attributes that the user wants not to be extracted.

```
            allow_tag=(
                partial(operator.truth)
                if not allow_tags
                else partial(operator.contains, allow_tags)
            ),
```
**Above Code explained**: We pass operator.truth as a partial function to `allow_tag` in the case where the `allow_tag` argument is empty because we would it need to be true for any tags that are scanned by the `_iter_links()` function.

```
                if self.scan_denied_attr(attrib) or not self.scan_allowed_attr(attrib):
```
**Above Code explained**: Here we give first priority to the denied attributes or tags iterable because if the user has mentioned them then they have a strong case of not considering the following tags and attributes.



### Problems:

One issue which I faced, since we have kept href as the default value. If the user provided href value in the deny_attr attributes, it creates a conflict.

For example:
```
<div id="subwrapper">
	<area href="sample1.html" alt="sample1" ping="http://example.com/sample1_1.html">
	<a href="sample2.html">sample 2<img src="sample2.jpg" alt="sample2"></a>
</div>
```

For the above html code, if the user enter the following values into argument,
`LxmlLinkextractor(deny_attr="href)`

Even though there is ping attribute which could be extracted, the following condition `not self.scan_allowed_attr(attrib)` evaluates to true which causes the code to execute the continue statement,
```
if self.scan_denied_attr(attrib) or not self.scan_allowed_attr(attrib):
```



**Any suggestions would we welcomed**