### PR TITLE
Add @property usage of custom_settings

### DIFF
--- a/scrapy/spiders/__init__.py
+++ b/scrapy/spiders/__init__.py
@@ -94,7 +94,12 @@ class Spider(object_ref):
 
     @classmethod
     def update_settings(cls, settings: BaseSettings) -> None:
-        settings.setdict(cls.custom_settings or {}, priority="spider")
+        if isinstance(cls.custom_settings, property):
+            custom_settings = cls.custom_settings()
+        else:
+            custom_settings = cls.custom_settings
+
+        settings.setdict(custom_settings or {}, priority="spider")
 
     @classmethod
     def handles_request(cls, request: Request) -> bool:


### PR DESCRIPTION
**Context**

It is often useful to modify some settings in the `custom_settings` of a spider such that they can later be accessed in the crawler like:

```python
@property
def custom_settings(self):
 return FEEDS = {
   f"output/{self.name}_output.jl" : {"overwrite": True}
  }
```
 

Currently there is no way to access a dynamic FEEDS output file path in the spider itself. Consider the following FEEDS in custom settings:

```python
FEEDS = {
 "output/%(name)s_output.jl" : {"overwrite": True}
}
```

The paramters for the crawler name are populated by the FeedExporter extension are not accesible in the spider itself. Therefore if I want to perform some clean up or post scraping operations through my Spider class, I cannot do so.

**What's next?**

Please let me know if this is acceptable idea and I'll the docs and tests whereever necessary.