### PR TITLE
Fix typo in title of contracts.rst

### DIFF
--- a/docs/topics/contracts.rst
+++ b/docs/topics/contracts.rst
@@ -1,7 +1,7 @@
 .. _topics-contracts:
 
 =================
-Spiders Contracts
+Spider Contracts
 =================
 
 Testing spiders can get particularly annoying and while nothing prevents you


### PR DESCRIPTION
It looks like the title of this documentation page should be "Spider Contracts", considering that's also the name of the relevant setting mentioned on the same page:

```
SPIDER_CONTRACTS = {
    "myproject.contracts.ResponseCheck": 10,
    "myproject.contracts.ItemValidate": 10,
}
```

Hope that makes sense. If "Spiders Contracts" is indeed the correct term, maybe you could add some info as to why. Thanks!