### PR TITLE
Option to include all tags and attrs in LinkExtractor with specified exclusions

### DIFF
--- a/scrapy/linkextractors/lxmlhtml.py
+++ b/scrapy/linkextractors/lxmlhtml.py
@@ -64,6 +64,15 @@ def _canonicalize_link_url(link: Link) -> str:
     return canonicalize_url(link.url, keep_fragments=True)
 
 
+def _is_item_included(sourceList, inclusion, item):
+    if (
+        (not sourceList and not inclusion)
+        or (item in sourceList and inclusion)
+        or (item not in sourceList and not inclusion)
+    ):
+        return True
+
+
 class LxmlParserLinkExtractor:
     def __init__(
         self,
@@ -100,6 +109,8 @@ class LxmlParserLinkExtractor:
         self, document: HtmlElement
     ) -> Iterable[Tuple[HtmlElement, str, str]]:
         for el in document.iter(etree.Element):
+
+            # if not self.scan_tag(_nons(el.tag)):
             if not self.scan_tag(_nons(el.tag)):
                 continue
             attribs = el.attrib
@@ -187,11 +198,13 @@ class LxmlLinkExtractor:
         restrict_css: Union[str, Iterable[str]] = (),
         strip: bool = True,
         restrict_text: Optional[_RegexOrSeveralT] = None,
+        tag_inclusion_mode: bool = True,
+        attr_inclusion_mode: bool = True,
     ):
         tags, attrs = set(arg_to_iter(tags)), set(arg_to_iter(attrs))
         self.link_extractor = LxmlParserLinkExtractor(
-            tag=partial(operator.contains, tags),
-            attr=partial(operator.contains, attrs),
+            tag=partial(_is_item_included, tags, tag_inclusion_mode),
+            attr=partial(_is_item_included, attrs, attr_inclusion_mode),
             unique=unique,
             process=process_value,
             strip=strip,

--- a/tests/test_linkextractors.py
+++ b/tests/test_linkextractors.py
@@ -25,12 +25,8 @@ class Base:
         def test_urls_type(self):
             """Test that the resulting urls are str objects"""
             lx = self.extractor_cls()
-            self.assertTrue(
-                all(
-                    isinstance(link.url, str)
-                    for link in lx.extract_links(self.response)
-                )
-            )
+            links = lx.extract_links(self.response)
+            self.assertTrue(all(isinstance(link.url, str) for link in links))
 
         def test_extract_all_links(self):
             lx = self.extractor_cls()
@@ -456,6 +452,8 @@ class Base:
             )
 
         def test_attrs(self):
+
+            # Test #1
             lx = self.extractor_cls(attrs="href")
             page4_url = "http://example.com/page%204.html"
 
@@ -475,6 +473,7 @@ class Base:
                 ],
             )
 
+            # Test #2
             lx = self.extractor_cls(
                 attrs=("href", "src"), tags=("a", "area", "img"), deny_extensions=()
             )
@@ -495,6 +494,7 @@ class Base:
                 ],
             )
 
+            # Test #3
             lx = self.extractor_cls(attrs=None)
             self.assertEqual(lx.extract_links(self.response), [])
 
@@ -505,6 +505,7 @@ class Base:
             )
             response = HtmlResponse("http://example.com/index.html", body=html)
 
+            # Test #4
             lx = self.extractor_cls(tags=None)
             self.assertEqual(lx.extract_links(response), [])
 
@@ -517,6 +518,7 @@ class Base:
                 ],
             )
 
+            # Test #5
             lx = self.extractor_cls(tags="area")
             self.assertEqual(
                 lx.extract_links(response),
@@ -525,6 +527,7 @@ class Base:
                 ],
             )
 
+            # Test #6
             lx = self.extractor_cls(tags="a")
             self.assertEqual(
                 lx.extract_links(response),
@@ -533,6 +536,7 @@ class Base:
                 ],
             )
 
+            # Test #7
             lx = self.extractor_cls(
                 tags=("a", "img"), attrs=("href", "src"), deny_extensions=()
             )
@@ -553,6 +557,7 @@ class Base:
             """
             response = HtmlResponse("http://example.com/index.html", body=html)
 
+            # Test #8
             lx = self.extractor_cls(tags="div", attrs="data-url")
             self.assertEqual(
                 lx.extract_links(response),
@@ -572,6 +577,7 @@ class Base:
                 ],
             )
 
+            # Test #9
             lx = self.extractor_cls(tags=("div",), attrs=("data-url",))
             self.assertEqual(
                 lx.extract_links(response),
@@ -584,6 +590,284 @@ class Base:
                     ),
                     Link(
                         url="http://example.com/get?id=2",
+                        text="Item 2",
+                        fragment="",
+                        nofollow=False,
+                    ),
+                ],
+            )
+
+            # Test #10
+            lx = self.extractor_cls(tags=None, attrs=None)
+            self.assertEqual(lx.extract_links(response), [])
+
+            # Test #11
+            lx = self.extractor_cls(
+                tags=None,
+                attrs=None,
+                tag_inclusion_mode=False,
+                attr_inclusion_mode=False,
+            )
+            self.assertEqual(
+                lx.extract_links(response),
+                [
+                    Link(
+                        url="http://example.com/item1",
+                        text="Item 1",
+                        fragment="",
+                        nofollow=False,
+                    ),
+                    Link(
+                        url="http://example.com/get?id=1",
+                        text="Item 1",
+                        fragment="",
+                        nofollow=False,
+                    ),
+                    Link(
+                        url="http://example.com/index.html",
+                        text="Item 1",
+                        fragment="",
+                        nofollow=False,
+                    ),
+                    Link(
+                        url="http://example.com/item2",
+                        text="Item 2",
+                        fragment="",
+                        nofollow=False,
+                    ),
+                    Link(
+                        url="http://example.com/get?id=2",
+                        text="Item 2",
+                        fragment="",
+                        nofollow=False,
+                    ),
+                ],
+            )
+            # Test #12
+            lx = self.extractor_cls(
+                tags=None,
+                attrs="data-url",
+                tag_inclusion_mode=False,
+                attr_inclusion_mode=False,
+            )
+            self.assertEqual(
+                lx.extract_links(response),
+                [
+                    Link(
+                        url="http://example.com/item1",
+                        text="Item 1",
+                        fragment="",
+                        nofollow=False,
+                    ),
+                    Link(
+                        url="http://example.com/index.html",
+                        text="Item 1",
+                        fragment="",
+                        nofollow=False,
+                    ),
+                    Link(
+                        url="http://example.com/item2",
+                        text="Item 2",
+                        fragment="",
+                        nofollow=False,
+                    ),
+                ],
+            )
+
+            # Test #13
+            lx = self.extractor_cls(
+                tags="a",
+                attrs=None,
+                tag_inclusion_mode=False,
+                attr_inclusion_mode=False,
+            )
+            self.assertEqual(
+                lx.extract_links(response),
+                [
+                    Link(
+                        url="http://example.com/item1",
+                        text="Item 1",
+                        fragment="",
+                        nofollow=False,
+                    ),
+                    Link(
+                        url="http://example.com/get?id=1",
+                        text="Item 1",
+                        fragment="",
+                        nofollow=False,
+                    ),
+                    Link(
+                        url="http://example.com/item2",
+                        text="Item 2",
+                        fragment="",
+                        nofollow=False,
+                    ),
+                    Link(
+                        url="http://example.com/get?id=2",
+                        text="Item 2",
+                        fragment="",
+                        nofollow=False,
+                    ),
+                ],
+            )
+
+            # Test #14
+            lx = self.extractor_cls(
+                tags="a",
+                attrs="data-url",
+                tag_inclusion_mode=False,
+                attr_inclusion_mode=False,
+            )
+            self.assertEqual(
+                lx.extract_links(response),
+                [
+                    Link(
+                        url="http://example.com/item1",
+                        text="Item 1",
+                        fragment="",
+                        nofollow=False,
+                    ),
+                    Link(
+                        url="http://example.com/item2",
+                        text="Item 2",
+                        fragment="",
+                        nofollow=False,
+                    ),
+                ],
+            )
+
+            # Test #15
+            lx = self.extractor_cls(
+                tags=None,
+                attrs=None,
+                tag_inclusion_mode=False,
+                attr_inclusion_mode=True,
+            )
+            self.assertEqual(lx.extract_links(response), [])
+
+            # Test #16
+            lx = self.extractor_cls(
+                tags=None,
+                attrs="href",
+                tag_inclusion_mode=False,
+                attr_inclusion_mode=True,
+            )
+            self.assertEqual(
+                lx.extract_links(response),
+                [
+                    Link(
+                        url="http://example.com/index.html",
+                        text="Item 1",
+                        fragment="",
+                        nofollow=False,
+                    )
+                ],
+            )
+
+            # Test #17
+            lx = self.extractor_cls(
+                tags="a", attrs=None, tag_inclusion_mode=True, attr_inclusion_mode=True
+            )
+            self.assertEqual(lx.extract_links(response), [])
+
+            # Test #18
+            lx = self.extractor_cls(
+                tags="a",
+                attrs="data-url",
+                tag_inclusion_mode=False,
+                attr_inclusion_mode=True,
+            )
+            self.assertEqual(
+                lx.extract_links(response),
+                [
+                    Link(
+                        url="http://example.com/get?id=1",
+                        text="Item 1",
+                        fragment="",
+                        nofollow=False,
+                    ),
+                    Link(
+                        url="http://example.com/get?id=2",
+                        text="Item 2",
+                        fragment="",
+                        nofollow=False,
+                    ),
+                ],
+            )
+
+            # Test #19
+            lx = self.extractor_cls(
+                tags=None,
+                attrs=None,
+                tag_inclusion_mode=True,
+                attr_inclusion_mode=False,
+            )
+            self.assertEqual(lx.extract_links(response), [])
+
+            # Test #20
+            lx = self.extractor_cls(
+                tags=None,
+                attrs="href",
+                tag_inclusion_mode=True,
+                attr_inclusion_mode=False,
+            )
+            self.assertEqual(lx.extract_links(response), [])
+
+            # Test #21
+            lx = self.extractor_cls(
+                tags="div",
+                attrs=None,
+                tag_inclusion_mode=True,
+                attr_inclusion_mode=False,
+            )
+            self.assertEqual(
+                lx.extract_links(response),
+                [
+                    Link(
+                        url="http://example.com/item1",
+                        text="Item 1",
+                        fragment="",
+                        nofollow=False,
+                    ),
+                    Link(
+                        url="http://example.com/get?id=1",
+                        text="Item 1",
+                        fragment="",
+                        nofollow=False,
+                    ),
+                    Link(
+                        url="http://example.com/item2",
+                        text="Item 2",
+                        fragment="",
+                        nofollow=False,
+                    ),
+                    Link(
+                        url="http://example.com/get?id=2",
+                        text="Item 2",
+                        fragment="",
+                        nofollow=False,
+                    ),
+                ],
+            )
+
+            # Test #22
+            lx = self.extractor_cls(
+                tags="div",
+                attrs="data-url",
+                tag_inclusion_mode=True,
+                attr_inclusion_mode=False,
+            )
+            self.assertEqual(
+                lx.extract_links(response),
+                [
+                    Link(
+                        url="http://example.com/item1",
+                        text="Item 1",
+                        fragment="",
+                        nofollow=False,
+                    ),
+                    Link(
+                        url="http://example.com/item2",
                         text="Item 2",
                         fragment="",
                         nofollow=False,


### PR DESCRIPTION
Fixes #6321 

**Requirement summary**
As of now, the tags and attributes are passed in via the parameters tags, attrs to the constructor of the class LxmlLinkExtractor. These are used only in _inclusion_ mode - meaning the extractor will return the tags and the attrs that contain these values. 
The new requirement is to add a capability to exclude certain tags and attributes.

**Approach**
The idea is to introduce the concept of modes. 

1. Inclusion mode - in this mode, the tags and attrs values that are passed in will be _included_ in the response
2. Exclusion mode - in this mode, the tags and attrs that are passed in will be _filtered out_ from the response

To achieve the concept of modes, two new variables are introduced to LxmlLinkExtractor class.

1. tag_inclusion_mode - this indicates the mode for the tags
2. attr_inclusion_mode - this indicates the mode for the attrs

These are boolean variables. True indicates inclusion , False indicates exclusion

For example, lets say the user wants to include the tag "div" and exclude the attribute "href". The user has to pass in 

1. tag_inclusion_mode = True 
2. attr_inclusion_mode = False.
4. tags = "div"
5. attrs = "href"

Please refer to the complete behaviour illustrated with the help of test cases [here](https://github.com/jith912/scrapy/wiki/Tests-for-LinkExtractor-Mode)

Note: I have added the test case numbers in the PRs just for my convenience. Will remove it at the point of merging the PR

