### PR TITLE
Remove log pollution from core.engine signal handler (#6433)

### DIFF
--- a/scrapy/core/engine.py
+++ b/scrapy/core/engine.py
@@ -39,7 +39,6 @@ from scrapy.settings import Settings
 from scrapy.signalmanager import SignalManager
 from scrapy.utils.log import failure_to_exc_info, logformatter_adapter
 from scrapy.utils.misc import build_from_crawler, load_object
-from scrapy.utils.python import global_object_name
 from scrapy.utils.reactor import CallLaterOnce
 
 if TYPE_CHECKING:
@@ -325,10 +324,6 @@ class ExecutionEngine:
         )
         for handler, result in request_scheduled_result:
             if isinstance(result, Failure) and isinstance(result.value, IgnoreRequest):
-                logger.debug(
-                    f"Signal handler {global_object_name(handler)} dropped "
-                    f"request {request} before it reached the scheduler."
-                )
                 return
         if not self.slot.scheduler.enqueue_request(request):  # type: ignore[union-attr]
             self.signals.send_catch_log(

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -499,7 +499,6 @@ def test_request_scheduled_signal(caplog):
     assert scheduler.enqueued == [
         keep_request
     ], f"{scheduler.enqueued!r} != [{keep_request!r}]"
-    assert "dropped request <GET https://drop.example>" in caplog.text
     crawler.signals.disconnect(signal_handler, request_scheduled)
 
 


### PR DESCRIPTION
Removed the debug log message in the `_schedule_request method` of the `ExecutionEngine` class. This change removes unnecessary logging created by the `core.engine` signal handler.

Resolves #6433