### PR TITLE
Ignore none value for start_requests

### DIFF
--- a/scrapy/core/engine.py
+++ b/scrapy/core/engine.py
@@ -209,10 +209,12 @@ class ExecutionEngine:
                     self.crawl(request_or_item)
                 elif is_item(request_or_item):
                     self.scraper.start_itemproc(request_or_item, response=None)
+                elif request_or_item == None:
+                    logger.debug(f"Got None among start requests. It will be ignored.")
                 else:
                     logger.error(
                         f"Got {request_or_item!r} among start requests. Only "
-                        f"requests and items are supported. It will be "
+                        f"requests,items and none are supported. It will be "
                         f"ignored."
                     )
 


### PR DESCRIPTION
#456 
We can let `start_requests` return None value to support some blocking function in `start_requests` by polling mode so that the engine schduler will not be blocked by it. This patch convert the massive errors to debug messages.

The following is an example where `pulsar`  which is a message queue like `kafka`  [does not support async for `receive`](https://github.com/apache/pulsar-client-python/issues/55#issuecomment-2358147372). By polling mode, we can easily intergrate with it although the schduling of  requests from `start_requests` is not perfect while @dangra provides [a better method](https://github.com/scrapy/scrapy/issues/456#issuecomment-1654902369).

```python
import scrapy
import pulsar

class PulsarSpider(scrapy.Spider):
    name = "pulsar"

    def __init__(self, name: str | None = None, **kwargs):
        self.client = pulsar.Client('pulsar://localhost:6650')
        self.consumer = self.client.subscribe('my-topic', 
                                              subscription_name='my-sub',
                                              consumer_type=pulsar.ConsumerType.Exclusive)
        super().__init__(name, **kwargs)

    def start_requests(self):
        while(True):
            msg = None
            try:
                msg = self.consumer.receive(10) # 10 milliseconds timeout
            except Exception as e:
                pass
            if msg==None:
                yield None
            else:
                yield scrapy.Request("https://httpbin.org/get",meta={"raw":msg},dont_filter=True)

    def parse(self, response):
        msg = response.meta.get("raw")
        self.consumer.acknowledge(msg)
```