### PR TITLE
Remove the installation dependency on setuptools.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,6 @@ install_requires = [
     "zope.interface>=5.1.0",
     "protego>=0.1.15",
     "itemadapter>=0.1.0",
-    "setuptools",
     "packaging",
     "tldextract",
     "lxml>=4.4.1",

--- a/tox.ini
+++ b/tox.ini
@@ -50,7 +50,6 @@ deps =
     typing-extensions==4.12.2
     types-lxml==2024.8.7
     types-Pygments==2.18.0.20240506
-    types-setuptools==71.1.0.20240806
     botocore-stubs==1.34.158
     boto3-stubs[s3]==1.34.158
     attrs >= 18.2.0


### PR DESCRIPTION
It was added (in #5122) because we imported `pkg_resources`, which we no longer do since 2.10.