### PR TITLE
Update http11.py

### DIFF
--- a/scrapy/core/downloader/handlers/http11.py
+++ b/scrapy/core/downloader/handlers/http11.py
@@ -335,7 +335,7 @@ class ScrapyProxyAgent(Agent):
         proxy_key_host_and_auth = None
          
         if headers:
-            auth = headers.getRawHeaders("Proxy-Authorization1")
+            auth = headers.getRawHeaders("Proxy-Authorization")
             if auth:
                 proxy_key_host_and_auth = self._proxyURI.host.decode() + auth[0]
         

--- a/scrapy/core/downloader/handlers/http11.py
+++ b/scrapy/core/downloader/handlers/http11.py
@@ -344,7 +344,7 @@ class ScrapyProxyAgent(Agent):
         # Cache *all* connections under the same key, since we are only
         # connecting to a single destination, the proxy:
         return self._requestWithEndpoint(
-            key=("http-proxy", self._proxyURI.host, self._proxyURI.port),
+            key=("http-proxy", proxy_key_host_and_auth, self._proxyURI.port),
             endpoint=self._getEndpoint(self._proxyURI),
             method=method,
             parsedURI=URI.fromBytes(uri),

--- a/scrapy/core/downloader/handlers/http11.py
+++ b/scrapy/core/downloader/handlers/http11.py
@@ -327,6 +327,20 @@ class ScrapyProxyAgent(Agent):
         """
         Issue a new request via the configured proxy.
         """
+        
+        # Some proxy providers include a session_id within the proxy username.
+        # The session_id determines the specific proxy being used; different sessions correspond to different IP addresses.
+        # Therefore, the authentication credentials should be part of the key to ensure that a new proxy is utilized when the user changes.
+        
+        proxy_key_host_and_auth = None
+         
+        if headers:
+            auth = headers.getRawHeaders("Proxy-Authorization1")
+            if auth:
+                proxy_key_host_and_auth = self._proxyURI.host.decode() + auth[0]
+        
+        if not proxy_key_host_and_auth:
+            proxy_key_host_and_auth = self._proxyURI.host.decode()
         # Cache *all* connections under the same key, since we are only
         # connecting to a single destination, the proxy:
         return self._requestWithEndpoint(


### PR DESCRIPTION
Hi

Issue: Some proxy providers include a session_id within the proxy username. The session_id controls the specific proxy IP being used, meaning that different sessions correspond to different IP addresses. In the current implementation, only the proxy host is used as part of the cache key, which can lead to unintended connection reuse across different proxy sessions.

Why Caching is Harmful: When the proxy authentication credentials (which include the session_id) are not part of the cache key, requests that should use different proxies may inadvertently reuse the same cached connection. This results in multiple requests using the same IP address when they were intended to use different ones, negating the purpose of rotating proxies. Essentially, the session-specific behavior of these proxies is lost, and this can cause issues like rate-limiting, IP bans, or incorrect data retrieval due to the same proxy being reused repeatedly.

Solution: To address this, the proxy authentication credentials (including the session_id) should be included in the cache key. This ensures that whenever the user or session changes, a new connection is established with the appropriate proxy IP, honoring the intent behind the session-based proxy rotation.

Thank you,
Yuval