### PR TITLE
Deprecation removals.

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -89,6 +89,30 @@ def requires_uvloop(request):
         pytest.skip("uvloop is not installed")
 
 
+@pytest.fixture(autouse=True)
+def requires_botocore(request):
+    if not request.node.get_closest_marker("requires_botocore"):
+        return
+    try:
+        import botocore
+
+        del botocore
+    except ImportError:
+        pytest.skip("botocore is not installed")
+
+
+@pytest.fixture(autouse=True)
+def requires_boto3(request):
+    if not request.node.get_closest_marker("requires_boto3"):
+        return
+    try:
+        import boto3
+
+        del boto3
+    except ImportError:
+        pytest.skip("boto3 is not installed")
+
+
 def pytest_configure(config):
     if config.getoption("--reactor") == "asyncio":
         install_reactor("twisted.internet.asyncioreactor.AsyncioSelectorReactor")

--- a/docs/topics/commands.rst
+++ b/docs/topics/commands.rst
@@ -278,8 +278,6 @@ Supported options:
 
 * ``--overwrite-output FILE`` or ``-O FILE``: dump scraped items into FILE, overwriting any existing file. To define the output format, set a colon at the end of the output URI (i.e. ``-O FILE:FORMAT``)
 
-* ``--output-format FORMAT`` or ``-t FORMAT``: deprecated way to define format to use for dumping items, does not work in combination with ``-O``
-
 Usage examples::
 
     $ scrapy crawl myspider
@@ -290,9 +288,6 @@ Usage examples::
 
     $ scrapy crawl -O myfile:json myspider
     [ ... myspider starts crawling and saves the result in myfile in json format overwriting the original content... ]
-
-    $ scrapy crawl -o myfile -t csv myspider
-    [ ... myspider starts crawling and appends the result to the file myfile in csv format ... ]
 
 .. command:: check
 

--- a/extras/scrapy_zsh_completion
+++ b/extras/scrapy_zsh_completion
@@ -41,7 +41,6 @@ _scrapy() {
 		(runspider)
 		    local options=(
 			{'(--output)-o','(-o)--output='}'[dump scraped items into FILE (use - for stdout)]:file:_files'
-			{'(--output-format)-t','(-t)--output-format='}'[format to use for dumping items with -o]:format:(FORMAT)'
 			'*-a[set spider argument (may be repeated)]:value pair:(NAME=VALUE)'
 			'1:spider file:_files -g \*.py'
 		    )
@@ -99,7 +98,6 @@ _scrapy() {
 		(crawl)
 		    local options=(
 			{'(--output)-o','(-o)--output='}'[dump scraped items into FILE (use - for stdout)]:file:_files'
-			{'(--output-format)-t','(-t)--output-format='}'[format to use for dumping items with -o]:format:(FORMAT)'
 			'*-a[set spider argument (may be repeated)]:value pair:(NAME=VALUE)'
 			'1:spider:_scrapy_spiders'
 		    )

--- a/pytest.ini
+++ b/pytest.ini
@@ -22,7 +22,3 @@ markers =
     only_not_asyncio: marks tests as only enabled when --reactor=asyncio is not passed
     requires_uvloop: marks tests as only enabled when uvloop is known to be working
 filterwarnings =
-    ignore:scrapy.downloadermiddlewares.decompression is deprecated
-    ignore:Module scrapy.utils.reqser is deprecated
-    ignore:typing.re is deprecated
-    ignore:typing.io is deprecated

--- a/pytest.ini
+++ b/pytest.ini
@@ -21,4 +21,6 @@ markers =
     only_asyncio: marks tests as only enabled when --reactor=asyncio is passed
     only_not_asyncio: marks tests as only enabled when --reactor=asyncio is not passed
     requires_uvloop: marks tests as only enabled when uvloop is known to be working
+    requires_botocore: marks tests that need botocore (but not boto3)
+    requires_boto3: marks tests that need botocore and boto3
 filterwarnings =

--- a/scrapy/commands/__init__.py
+++ b/scrapy/commands/__init__.py
@@ -162,12 +162,6 @@ class BaseRunSpiderCommand(ScrapyCommand):
             help="dump scraped items into FILE, overwriting any existing file,"
             " to define format set a colon at the end of the output URI (i.e. -O FILE:FORMAT)",
         )
-        parser.add_argument(
-            "-t",
-            "--output-format",
-            metavar="FORMAT",
-            help="format to use for dumping items",
-        )
 
     def process_options(self, args: list[str], opts: argparse.Namespace) -> None:
         super().process_options(args, opts)
@@ -179,8 +173,7 @@ class BaseRunSpiderCommand(ScrapyCommand):
             feeds = feed_process_params_from_cli(
                 self.settings,
                 opts.output,
-                opts.output_format,
-                opts.overwrite_output,
+                overwrite_output=opts.overwrite_output,
             )
             self.settings.set("FEEDS", feeds, priority="cmdline")
 

--- a/scrapy/crawler.py
+++ b/scrapy/crawler.py
@@ -141,7 +141,7 @@ class Crawler:
             raise RuntimeError("Crawling already taking place")
         if self._started:
             raise RuntimeError(
-                "Running Crawler.crawl() more than once on the same instance is forbidden."
+                "Cannot run Crawler.crawl() more than once on the same instance."
             )
         self.crawling = self._started = True
 

--- a/scrapy/crawler.py
+++ b/scrapy/crawler.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import logging
 import pprint
 import signal
-import warnings
 from typing import TYPE_CHECKING, Any, TypeVar, cast
 
 from twisted.internet.defer import (
@@ -17,7 +16,6 @@ from zope.interface.verify import verifyClass
 from scrapy import Spider, signals
 from scrapy.addons import AddonManager
 from scrapy.core.engine import ExecutionEngine
-from scrapy.exceptions import ScrapyDeprecationWarning
 from scrapy.extension import ExtensionManager
 from scrapy.interfaces import ISpiderLoader
 from scrapy.logformatter import LogFormatter
@@ -142,10 +140,8 @@ class Crawler:
         if self.crawling:
             raise RuntimeError("Crawling already taking place")
         if self._started:
-            warnings.warn(
-                "Running Crawler.crawl() more than once is deprecated.",
-                ScrapyDeprecationWarning,
-                stacklevel=2,
+            raise RuntimeError(
+                "Running Crawler.crawl() more than once on the same instance is forbidden."
             )
         self.crawling = self._started = True
 

--- a/scrapy/downloadermiddlewares/httpcompression.py
+++ b/scrapy/downloadermiddlewares/httpcompression.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import warnings
 from itertools import chain
 from logging import getLogger
 from typing import TYPE_CHECKING, Any
@@ -15,7 +14,6 @@ from scrapy.utils._compression import (
     _unbrotli,
     _unzstd,
 )
-from scrapy.utils.deprecate import ScrapyDeprecationWarning
 from scrapy.utils.gz import gunzip
 
 if TYPE_CHECKING:
@@ -72,21 +70,7 @@ class HttpCompressionMiddleware:
     def from_crawler(cls, crawler: Crawler) -> Self:
         if not crawler.settings.getbool("COMPRESSION_ENABLED"):
             raise NotConfigured
-        try:
-            return cls(crawler=crawler)
-        except TypeError:
-            warnings.warn(
-                "HttpCompressionMiddleware subclasses must either modify "
-                "their '__init__' method to support a 'crawler' parameter or "
-                "reimplement their 'from_crawler' method.",
-                ScrapyDeprecationWarning,
-            )
-            mw = cls()
-            mw.stats = crawler.stats
-            mw._max_size = crawler.settings.getint("DOWNLOAD_MAXSIZE")
-            mw._warn_size = crawler.settings.getint("DOWNLOAD_WARNSIZE")
-            crawler.signals.connect(mw.open_spider, signals.spider_opened)
-            return mw
+        return cls(crawler=crawler)
 
     def open_spider(self, spider: Spider) -> None:
         if hasattr(spider, "download_maxsize"):

--- a/scrapy/downloadermiddlewares/retry.py
+++ b/scrapy/downloadermiddlewares/retry.py
@@ -12,12 +12,10 @@ once the spider has finished crawling all regular (non-failed) pages.
 
 from __future__ import annotations
 
-import warnings
 from logging import Logger, getLogger
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
-from scrapy.exceptions import NotConfigured, ScrapyDeprecationWarning
-from scrapy.settings import BaseSettings, Settings
+from scrapy.exceptions import NotConfigured
 from scrapy.utils.misc import load_object
 from scrapy.utils.python import global_object_name
 from scrapy.utils.response import response_status_message
@@ -29,31 +27,11 @@ if TYPE_CHECKING:
     from scrapy.crawler import Crawler
     from scrapy.http import Response
     from scrapy.http.request import Request
+    from scrapy.settings import BaseSettings
     from scrapy.spiders import Spider
 
 
 retry_logger = getLogger(__name__)
-
-
-def backwards_compatibility_getattr(self: Any, name: str) -> tuple[Any, ...]:
-    if name == "EXCEPTIONS_TO_RETRY":
-        warnings.warn(
-            "Attribute RetryMiddleware.EXCEPTIONS_TO_RETRY is deprecated. "
-            "Use the RETRY_EXCEPTIONS setting instead.",
-            ScrapyDeprecationWarning,
-            stacklevel=2,
-        )
-        return tuple(
-            load_object(x) if isinstance(x, str) else x
-            for x in Settings().getlist("RETRY_EXCEPTIONS")
-        )
-    raise AttributeError(
-        f"{self.__class__.__name__!r} object has no attribute {name!r}"
-    )
-
-
-class BackwardsCompatibilityMetaclass(type):
-    __getattr__ = backwards_compatibility_getattr
 
 
 def get_retry_request(
@@ -144,22 +122,17 @@ def get_retry_request(
     return None
 
 
-class RetryMiddleware(metaclass=BackwardsCompatibilityMetaclass):
+class RetryMiddleware:
     def __init__(self, settings: BaseSettings):
         if not settings.getbool("RETRY_ENABLED"):
             raise NotConfigured
         self.max_retry_times = settings.getint("RETRY_TIMES")
         self.retry_http_codes = {int(x) for x in settings.getlist("RETRY_HTTP_CODES")}
         self.priority_adjust = settings.getint("RETRY_PRIORITY_ADJUST")
-
-        try:
-            self.exceptions_to_retry = self.__getattribute__("EXCEPTIONS_TO_RETRY")
-        except AttributeError:
-            # If EXCEPTIONS_TO_RETRY is not "overridden"
-            self.exceptions_to_retry = tuple(
-                load_object(x) if isinstance(x, str) else x
-                for x in settings.getlist("RETRY_EXCEPTIONS")
-            )
+        self.exceptions_to_retry = tuple(
+            load_object(x) if isinstance(x, str) else x
+            for x in settings.getlist("RETRY_EXCEPTIONS")
+        )
 
     @classmethod
     def from_crawler(cls, crawler: Crawler) -> Self:
@@ -199,5 +172,3 @@ class RetryMiddleware(metaclass=BackwardsCompatibilityMetaclass):
             max_retry_times=max_retry_times,
             priority_adjust=priority_adjust,
         )
-
-    __getattr__ = backwards_compatibility_getattr

--- a/scrapy/utils/conf.py
+++ b/scrapy/utils/conf.py
@@ -3,14 +3,13 @@ from __future__ import annotations
 import numbers
 import os
 import sys
-import warnings
 from collections.abc import Iterable
 from configparser import ConfigParser
 from operator import itemgetter
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Callable, cast
 
-from scrapy.exceptions import ScrapyDeprecationWarning, UsageError
+from scrapy.exceptions import UsageError
 from scrapy.settings import BaseSettings
 from scrapy.utils.deprecate import update_classpath
 from scrapy.utils.python import without_none_values
@@ -21,7 +20,7 @@ if TYPE_CHECKING:
 
 def build_component_list(
     compdict: MutableMapping[Any, Any],
-    custom: Any = None,
+    *,
     convert: Callable[[Any], Any] = update_classpath,
 ) -> list[Any]:
     """Compose a component list from a { class: order } dictionary."""
@@ -59,19 +58,6 @@ def build_component_list(
                     f"Invalid value {value} for component {name}, "
                     "please provide a real number or None instead"
                 )
-
-    if custom is not None:
-        warnings.warn(
-            "The 'custom' attribute of build_component_list() is deprecated. "
-            "Please merge its value into 'compdict' manually or change your "
-            "code to use Settings.getwithbase().",
-            category=ScrapyDeprecationWarning,
-            stacklevel=2,
-        )
-        if isinstance(custom, (list, tuple)):
-            _check_components(custom)
-            return type(custom)(convert(c) for c in custom)  # type: ignore[return-value]
-        compdict.update(custom)
 
     _validate_values(compdict)
     compdict = without_none_values(_map_keys(compdict))
@@ -159,7 +145,7 @@ def feed_complete_default_values_from_settings(
 def feed_process_params_from_cli(
     settings: BaseSettings,
     output: list[str],
-    output_format: str | None = None,
+    *,
     overwrite_output: list[str] | None = None,
 ) -> dict[str, dict[str, Any]]:
     """
@@ -186,36 +172,8 @@ def feed_process_params_from_cli(
             raise UsageError(
                 "Please use only one of -o/--output and -O/--overwrite-output"
             )
-        if output_format:
-            raise UsageError(
-                "-t/--output-format is a deprecated command line option"
-                " and does not work in combination with -O/--overwrite-output."
-                " To specify a format please specify it after a colon at the end of the"
-                " output URI (i.e. -O <URI>:<FORMAT>)."
-                " Example working in the tutorial: "
-                "scrapy crawl quotes -O quotes.json:json"
-            )
         output = overwrite_output
         overwrite = True
-
-    if output_format:
-        if len(output) == 1:
-            check_valid_format(output_format)
-            message = (
-                "The -t/--output-format command line option is deprecated in favor of "
-                "specifying the output format within the output URI using the -o/--output or the"
-                " -O/--overwrite-output option (i.e. -o/-O <URI>:<FORMAT>). See the documentation"
-                " of the -o or -O option or the following examples for more information. "
-                "Examples working in the tutorial: "
-                "scrapy crawl quotes -o quotes.csv:csv   or   "
-                "scrapy crawl quotes -O quotes.json:json"
-            )
-            warnings.warn(message, ScrapyDeprecationWarning, stacklevel=2)
-            return {output[0]: {"format": output_format}}
-        raise UsageError(
-            "The -t command-line option cannot be used if multiple output "
-            "URIs are specified"
-        )
 
     result: dict[str, dict[str, Any]] = {}
     for element in output:

--- a/scrapy/utils/reactor.py
+++ b/scrapy/utils/reactor.py
@@ -4,12 +4,11 @@ import asyncio
 import sys
 from contextlib import suppress
 from typing import TYPE_CHECKING, Any, Generic, TypeVar
-from warnings import catch_warnings, filterwarnings, warn
+from warnings import catch_warnings, filterwarnings
 
 from twisted.internet import asyncioreactor, error
 from twisted.internet.base import DelayedCall
 
-from scrapy.exceptions import ScrapyDeprecationWarning
 from scrapy.utils.misc import load_object
 
 if TYPE_CHECKING:
@@ -77,22 +76,6 @@ def set_asyncio_event_loop_policy() -> None:
     This should only be used to install the reactor.
     """
     _get_asyncio_event_loop_policy()
-
-
-def get_asyncio_event_loop_policy() -> AbstractEventLoopPolicy:
-    warn(
-        "Call to deprecated function "
-        "scrapy.utils.reactor.get_asyncio_event_loop_policy().\n"
-        "\n"
-        "Please use get_event_loop, new_event_loop and set_event_loop"
-        " from asyncio instead, as the corresponding policy methods may lead"
-        " to unexpected behaviour.\n"
-        "This function is replaced by set_asyncio_event_loop_policy and"
-        " is meant to be used only when the reactor is being installed.",
-        category=ScrapyDeprecationWarning,
-        stacklevel=2,
-    )
-    return _get_asyncio_event_loop_policy()
 
 
 def _get_asyncio_event_loop_policy() -> AbstractEventLoopPolicy:

--- a/scrapy/utils/request.py
+++ b/scrapy/utils/request.py
@@ -30,17 +30,9 @@ if TYPE_CHECKING:
     from scrapy.crawler import Crawler
 
 
-def _serialize_headers(headers: Iterable[bytes], request: Request) -> Iterable[bytes]:
-    for header in headers:
-        if header in request.headers:
-            yield header
-            yield from request.headers.getlist(header)
-
-
 _fingerprint_cache: WeakKeyDictionary[
     Request, dict[tuple[tuple[bytes, ...] | None, bool], bytes]
-]
-_fingerprint_cache = WeakKeyDictionary()
+] = WeakKeyDictionary()
 
 
 def fingerprint(

--- a/tests/test_crawler.py
+++ b/tests/test_crawler.py
@@ -7,7 +7,6 @@ import sys
 import warnings
 from pathlib import Path
 
-import pytest
 from packaging.version import parse as parse_version
 from pexpect.popen_spawn import PopenSpawn
 from pytest import mark, raises
@@ -84,12 +83,11 @@ class CrawlerTestCase(BaseCrawlerTest):
             Crawler(DefaultSpider())
 
     @inlineCallbacks
-    def test_crawler_crawl_twice_deprecated(self):
+    def test_crawler_crawl_twice_unsupported(self):
         crawler = get_raw_crawler(NoRequestsSpider, BASE_SETTINGS)
         yield crawler.crawl()
-        with pytest.warns(
-            ScrapyDeprecationWarning,
-            match=r"Running Crawler.crawl\(\) more than once is deprecated",
+        with raises(
+            RuntimeError, match="more than once on the same instance is forbidden"
         ):
             yield crawler.crawl()
 

--- a/tests/test_crawler.py
+++ b/tests/test_crawler.py
@@ -84,10 +84,7 @@ class CrawlerTestCase(BaseCrawlerTest):
     def test_crawler_crawl_twice_unsupported(self):
         crawler = get_raw_crawler(NoRequestsSpider, BASE_SETTINGS)
         yield crawler.crawl()
-        with raises(
-            RuntimeError,
-            match="Cannot run Crawler.crawl() more than once on the same instance",
-        ):
+        with raises(RuntimeError, match="more than once on the same instance"):
             yield crawler.crawl()
 
     def test_get_addon(self):

--- a/tests/test_crawler.py
+++ b/tests/test_crawler.py
@@ -85,7 +85,8 @@ class CrawlerTestCase(BaseCrawlerTest):
         crawler = get_raw_crawler(NoRequestsSpider, BASE_SETTINGS)
         yield crawler.crawl()
         with raises(
-            RuntimeError, match="more than once on the same instance is forbidden"
+            RuntimeError,
+            match="Cannot run Crawler.crawl() more than once on the same instance",
         ):
             yield crawler.crawl()
 

--- a/tests/test_downloader_handlers.py
+++ b/tests/test_downloader_handlers.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from tempfile import mkdtemp, mkstemp
 from unittest import SkipTest, mock
 
+import pytest
 from testfixtures import LogCapture
 from twisted.cred import checkers, credentials, portal
 from twisted.internet import defer, error, reactor
@@ -32,7 +33,7 @@ from scrapy.responsetypes import responsetypes
 from scrapy.spiders import Spider
 from scrapy.utils.misc import build_from_crawler
 from scrapy.utils.python import to_bytes
-from scrapy.utils.test import get_crawler, skip_if_no_boto
+from scrapy.utils.test import get_crawler
 from tests import NON_EXISTING_RESOLVABLE
 from tests.mockserver import (
     Echo,
@@ -824,9 +825,9 @@ class HttpDownloadHandlerMock:
         return request
 
 
+@pytest.mark.requires_botocore
 class S3AnonTestCase(unittest.TestCase):
     def setUp(self):
-        skip_if_no_boto()
         crawler = get_crawler()
         self.s3reqh = build_from_crawler(
             S3DownloadHandler,
@@ -845,6 +846,7 @@ class S3AnonTestCase(unittest.TestCase):
         self.assertEqual(httpreq.url, "http://aws-publicdatasets.s3.amazonaws.com/")
 
 
+@pytest.mark.requires_botocore
 class S3TestCase(unittest.TestCase):
     download_handler_cls: type = S3DownloadHandler
 
@@ -856,7 +858,6 @@ class S3TestCase(unittest.TestCase):
     AWS_SECRET_ACCESS_KEY = "uV3F3YluFJax1cknvbcGwgjvx4QpvB+leU8dUj2o"
 
     def setUp(self):
-        skip_if_no_boto()
         crawler = get_crawler()
         s3reqh = build_from_crawler(
             S3DownloadHandler,

--- a/tests/test_downloadermiddleware_httpcompression.py
+++ b/tests/test_downloadermiddleware_httpcompression.py
@@ -3,7 +3,6 @@ from io import BytesIO
 from logging import WARNING
 from pathlib import Path
 from unittest import SkipTest, TestCase
-from warnings import catch_warnings
 
 from testfixtures import LogCapture
 from w3lib.encoding import resolve_encoding
@@ -12,7 +11,7 @@ from scrapy.downloadermiddlewares.httpcompression import (
     ACCEPTED_ENCODINGS,
     HttpCompressionMiddleware,
 )
-from scrapy.exceptions import IgnoreRequest, NotConfigured, ScrapyDeprecationWarning
+from scrapy.exceptions import IgnoreRequest, NotConfigured
 from scrapy.http import HtmlResponse, Request, Response
 from scrapy.responsetypes import responsetypes
 from scrapy.spiders import Spider
@@ -700,29 +699,3 @@ class HttpCompressionTest(TestCase):
         except ImportError:
             raise SkipTest("no zstd support (zstandard)")
         self._test_download_warnsize_request_meta("zstd")
-
-
-class HttpCompressionSubclassTest(TestCase):
-    def test_init_missing_stats(self):
-        class HttpCompressionMiddlewareSubclass(HttpCompressionMiddleware):
-            def __init__(self):
-                super().__init__()
-
-        crawler = get_crawler(Spider)
-        with catch_warnings(record=True) as caught_warnings:
-            HttpCompressionMiddlewareSubclass.from_crawler(crawler)
-        messages = tuple(
-            str(warning.message)
-            for warning in caught_warnings
-            if warning.category is ScrapyDeprecationWarning
-        )
-        self.assertEqual(
-            messages,
-            (
-                (
-                    "HttpCompressionMiddleware subclasses must either modify "
-                    "their '__init__' method to support a 'crawler' parameter "
-                    "or reimplement their 'from_crawler' method."
-                ),
-            ),
-        )

--- a/tests/test_downloadermiddleware_retry.py
+++ b/tests/test_downloadermiddleware_retry.py
@@ -1,6 +1,5 @@
 import logging
 import unittest
-import warnings
 
 from testfixtures import LogCapture
 from twisted.internet import defer
@@ -121,37 +120,6 @@ class RetryTest(unittest.TestCase):
         mw = RetryMiddleware.from_crawler(crawler)
         req = Request(f"http://www.scrapytest.org/{exc.__name__}")
         self._test_retry_exception(req, exc("foo"), mw)
-
-    def test_exception_to_retry_custom_middleware(self):
-        exc = ValueError
-
-        with warnings.catch_warnings(record=True) as warns:
-
-            class MyRetryMiddleware(RetryMiddleware):
-                EXCEPTIONS_TO_RETRY = RetryMiddleware.EXCEPTIONS_TO_RETRY + (exc,)
-
-            self.assertEqual(len(warns), 1)
-
-        mw2 = MyRetryMiddleware.from_crawler(self.crawler)
-        req = Request(f"http://www.scrapytest.org/{exc.__name__}")
-        req = mw2.process_exception(req, exc("foo"), self.spider)
-        assert isinstance(req, Request)
-        self.assertEqual(req.meta["retry_times"], 1)
-
-    def test_exception_to_retry_custom_middleware_self(self):
-        class MyRetryMiddleware(RetryMiddleware):
-            def process_exception(self, request, exception, spider):
-                if isinstance(exception, self.EXCEPTIONS_TO_RETRY):
-                    return self._retry(request, exception, spider)
-
-        exc = OSError
-        mw2 = MyRetryMiddleware.from_crawler(self.crawler)
-        req = Request(f"http://www.scrapytest.org/{exc.__name__}")
-        with warnings.catch_warnings(record=True) as warns:
-            req = mw2.process_exception(req, exc("foo"), self.spider)
-        assert isinstance(req, Request)
-        self.assertEqual(req.meta["retry_times"], 1)
-        self.assertEqual(len(warns), 1)
 
     def _test_retry_exception(self, req, exception, mw=None):
         if mw is None:

--- a/tests/test_feedexport.py
+++ b/tests/test_feedexport.py
@@ -49,7 +49,7 @@ from scrapy.extensions.feedexport import (
 )
 from scrapy.settings import Settings
 from scrapy.utils.python import to_unicode
-from scrapy.utils.test import get_crawler, mock_google_cloud_storage, skip_if_no_boto
+from scrapy.utils.test import get_crawler, mock_google_cloud_storage
 from tests.mockserver import MockFTPServer, MockServer
 from tests.spiders import ItemSpider
 
@@ -239,10 +239,8 @@ class BlockingFeedStorageTest(unittest.TestCase):
         self.assertRaises(OSError, b.open, spider=spider)
 
 
+@pytest.mark.requires_boto3
 class S3FeedStorageTest(unittest.TestCase):
-    def setUp(self):
-        skip_if_no_boto()
-
     def test_parse_credentials(self):
         aws_credentials = {
             "AWS_ACCESS_KEY_ID": "settings_key",
@@ -2614,9 +2612,9 @@ class BatchDeliveriesTest(FeedExportTestBase):
             crawler.stats.get_value("feedexport/success_count/FileFeedStorage"), 12
         )
 
+    @pytest.mark.requires_boto3
     @defer.inlineCallbacks
     def test_s3_export(self):
-        skip_if_no_boto()
         bucket = "mybucket"
         items = [
             self.MyItem({"foo": "bar1", "egg": "spam1"}),

--- a/tests/test_pipeline_files.py
+++ b/tests/test_pipeline_files.py
@@ -11,6 +11,7 @@ from unittest import mock
 from urllib.parse import urlparse
 
 import attr
+import pytest
 from itemadapter import ItemAdapter
 from twisted.internet import defer
 from twisted.trial import unittest
@@ -30,7 +31,6 @@ from scrapy.utils.test import (
     get_crawler,
     get_ftp_content_and_delete,
     get_gcs_content_and_delete,
-    skip_if_no_boto,
 )
 from tests.mockserver import MockFTPServer
 
@@ -507,11 +507,10 @@ class FilesPipelineTestCaseCustomSettings(unittest.TestCase):
         self.assertEqual(fs_store.basedir, str(path))
 
 
+@pytest.mark.requires_botocore
 class TestS3FilesStore(unittest.TestCase):
     @defer.inlineCallbacks
     def test_persist(self):
-        skip_if_no_boto()
-
         bucket = "mybucket"
         key = "export.csv"
         uri = f"s3://{bucket}/{key}"
@@ -557,8 +556,6 @@ class TestS3FilesStore(unittest.TestCase):
 
     @defer.inlineCallbacks
     def test_stat(self):
-        skip_if_no_boto()
-
         bucket = "mybucket"
         key = "export.csv"
         uri = f"s3://{bucket}/{key}"

--- a/tests/test_pipeline_images.py
+++ b/tests/test_pipeline_images.py
@@ -3,10 +3,8 @@ from __future__ import annotations
 import dataclasses
 import io
 import random
-import warnings
 from shutil import rmtree
 from tempfile import mkdtemp
-from unittest.mock import patch
 
 import attr
 from itemadapter import ItemAdapter
@@ -156,7 +154,7 @@ class ImagesPipelineTestCase(unittest.TestCase):
         with self.assertRaises(ImageException):
             next(self.pipeline.get_images(response=resp3, request=req, info=object()))
 
-    def test_get_images_new(self):
+    def test_get_images(self):
         self.pipeline.min_width = 0
         self.pipeline.min_height = 0
         self.pipeline.thumbs = {"small": (20, 20)}
@@ -181,54 +179,6 @@ class ImagesPipelineTestCase(unittest.TestCase):
         )
         self.assertEqual(thumb_img, thumb_img)
         self.assertEqual(orig_thumb_buf.getvalue(), thumb_buf.getvalue())
-
-    def test_get_images_old(self):
-        self.pipeline.thumbs = {"small": (20, 20)}
-        orig_im, buf = _create_image("JPEG", "RGB", (50, 50), (0, 0, 0))
-        resp = Response(url="https://dev.mydeco.com/mydeco.gif", body=buf.getvalue())
-        req = Request(url="https://dev.mydeco.com/mydeco.gif")
-
-        def overridden_convert_image(image, size=None):
-            im, buf = _create_image("JPEG", "RGB", (50, 50), (0, 0, 0))
-            return im, buf
-
-        with patch.object(self.pipeline, "convert_image", overridden_convert_image):
-            with warnings.catch_warnings(record=True) as w:
-                warnings.simplefilter("always")
-                get_images_gen = self.pipeline.get_images(
-                    response=resp, request=req, info=object()
-                )
-                path, new_im, new_buf = next(get_images_gen)
-                self.assertEqual(
-                    path, "full/3fd165099d8e71b8a48b2683946e64dbfad8b52d.jpg"
-                )
-                self.assertEqual(orig_im.mode, new_im.mode)
-                self.assertEqual(orig_im.getcolors(), new_im.getcolors())
-                self.assertEqual(buf.getvalue(), new_buf.getvalue())
-
-                thumb_path, thumb_img, thumb_buf = next(get_images_gen)
-                self.assertEqual(
-                    thumb_path,
-                    "thumbs/small/3fd165099d8e71b8a48b2683946e64dbfad8b52d.jpg",
-                )
-                self.assertEqual(orig_im.mode, thumb_img.mode)
-                self.assertEqual(orig_im.getcolors(), thumb_img.getcolors())
-                self.assertEqual(buf.getvalue(), thumb_buf.getvalue())
-
-                expected_warning_msg = (
-                    ".convert_image() method overridden in a deprecated way, "
-                    "overridden method does not accept response_body argument."
-                )
-                self.assertEqual(
-                    len(
-                        [
-                            warning
-                            for warning in w
-                            if expected_warning_msg in str(warning.message)
-                        ]
-                    ),
-                    1,
-                )
 
     def test_convert_image(self):
         SIZE = (100, 100)

--- a/tox.ini
+++ b/tox.ini
@@ -241,7 +241,7 @@ deps =
     {[testenv]deps}
     botocore>=1.4.87
 commands =
-    pytest --cov=scrapy --cov-report=xml --cov-report= {posargs:tests -k s3}
+    pytest --cov=scrapy --cov-report=xml --cov-report= {posargs:tests -m requires_botocore}
 
 [testenv:botocore-pinned]
 basepython = {[pinned]basepython}
@@ -252,4 +252,4 @@ install_command = {[pinned]install_command}
 setenv =
     {[pinned]setenv}
 commands =
-    pytest --cov=scrapy --cov-report=xml --cov-report= {posargs:tests -k s3}
+    pytest --cov=scrapy --cov-report=xml --cov-report= {posargs:tests -m requires_botocore}


### PR DESCRIPTION
* ``--output-format/-t`` argument: deprecated in 2.1.0
* Running `Crawler.crawl()` more than once on the same instance: deprecated in 2.11.0
* Subclassing `HttpCompressionMiddleware` without `from_crawler()` support: deprecated in 2.5.0
* `RetryMiddleware.EXCEPTIONS_TO_RETRY`: deprecated in 2.10.0
* S3 feed exports without `boto3`: deprecated in 2.10.0
* `_FeedSlot` as an alias for `FeedSlot`: deprecated in 2.10.0
* `NoimagesDrop`: deprecated in 2.8.0
* `convert_image()` without `response_body`: deprecated in 2.8.0
* The `custom` argument of `build_component_list()`: deprecated in 2.10.0
* `get_asyncio_event_loop_policy()`: deprecated in 2.9.0

I'm not 100% sure that nothing needs to be changed for the `botocore`/`botocore-pinned` test envs.

I still hesitate to remove the `FEED_URI` support even though it's deprecated for several years.

