### PR TITLE
[Fix Bug] Enhance URI formatting to support old-style placeholders

### DIFF
--- a/scrapy/extensions/feedexport.py
+++ b/scrapy/extensions/feedexport.py
@@ -34,6 +34,7 @@ from scrapy.utils.ftp import ftp_store_file
 from scrapy.utils.log import failure_to_exc_info
 from scrapy.utils.misc import build_from_crawler, load_object
 from scrapy.utils.python import without_none_values
+from scrapy.utils.url import uri_handle_old_format_style
 
 if TYPE_CHECKING:
     from collections.abc import Iterable
@@ -538,7 +539,7 @@ class FeedExporter:
             self.slots.append(
                 self._start_new_batch(
                     batch_id=1,
-                    uri=uri % uri_params,
+                    uri=uri_handle_old_format_style(uri, uri_params),
                     feed_options=feed_options,
                     spider=spider,
                     uri_template=uri,


### PR DESCRIPTION
**Fixes: [#5794](https://github.com/scrapy/scrapy/issues/5794)**

**Enhance URI formatting to support old-style and named placeholders**

This commit improves the handling of URIs containing old-style placeholders (%s, %d) and named placeholders. Major enhancements include:
- **Implementation of `uri_handle_old_format_style`**: This new function safely formats URIs by escaping non-named placeholders and replacing valid named placeholders with provided values, preventing unintended replacements.
- **Comprehensive testing**: Added tests to ensure URI formatting correctly handles both named and traditional placeholders. For example, the URI `ftp://__PLACEHOLDER__user:2%23um25%21M%23JZ@ftp.example.com/%(foo)s/%(bar)s/%(aa` now correctly replaces `foo` and `bar` with respective values from a dictionary without raising errors due to malformed placeholders like `%2` or incomplete sequences such as `%(aa`.

The result will be ` ftp://__PLACEHOLDER__user:2%23um25%21M%23JZ@ftp.example.com/uri_params_spider/baz/%(aa`

**Impact of Changes**:
These updates significantly enhance the robustness and flexibility of URI handling, particularly in scenarios where legacy formatting styles are present. The changes ensure that our parsing logic can seamlessly handle complex URIs without errors, improving the reliability of our data extraction workflows.
