### PR TITLE
Explictly set html_baseurl on RTD.

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -8,7 +8,7 @@
 #
 # All configuration values have a default; values that are commented out
 # serve to show the default.
-
+import os
 import sys
 from pathlib import Path
 
@@ -186,6 +186,8 @@ html_css_files = [
     "custom.css",
 ]
 
+# Set canonical URL from the Read the Docs Domain
+html_baseurl = os.environ.get("READTHEDOCS_CANONICAL_URL", "")
 
 # Options for LaTeX output
 # ------------------------


### PR DESCRIPTION
https://about.readthedocs.com/blog/2024/07/addons-by-default/