### PR TITLE
Fixes for Twisted Version Check and Typing Issues

### DIFF
--- a/scrapy/pipelines/media.py
+++ b/scrapy/pipelines/media.py
@@ -16,9 +16,9 @@ from typing import (
 )
 
 from twisted import version as twisted_version
-from twisted.python.versions import Version
 from twisted.internet.defer import Deferred, DeferredList
 from twisted.python.failure import Failure
+from twisted.python.versions import Version
 
 from scrapy.http.request import NO_CALLBACK, Request
 from scrapy.settings import Settings
@@ -209,7 +209,7 @@ class MediaPipeline(ABC):
             result.cleanFailure()
             result.frames = []
             if twisted_version <= Version("twisted", 24, 10, 0):
-                result.stack = []   # type: ignore[method-assign]
+                result.stack = []  # type: ignore[method-assign]
             # This code fixes a memory leak by avoiding to keep references to
             # the Request and Response objects on the Media Pipeline cache.
             #

--- a/scrapy/pipelines/media.py
+++ b/scrapy/pipelines/media.py
@@ -15,6 +15,8 @@ from typing import (
     cast,
 )
 
+from twisted import version as twisted_version
+from twisted.python.versions import Version
 from twisted.internet.defer import Deferred, DeferredList
 from twisted.python.failure import Failure
 
@@ -206,8 +208,8 @@ class MediaPipeline(ABC):
             # minimize cached information for failure
             result.cleanFailure()
             result.frames = []
-            result.stack = []
-
+            if twisted_version <= Version("twisted", 24, 10, 0):
+                result.stack = []   # type: ignore[method-assign]
             # This code fixes a memory leak by avoiding to keep references to
             # the Request and Response objects on the Media Pipeline cache.
             #


### PR DESCRIPTION
Fixes #6504 

#### This PR went through the following changes:
1. Simplified the version check using format `Version` as requested.
2. Added `type: ignore` comments to handle the typing errors flagged by `mypy`.
3. Pre-commit checks have been run.

#### Testing:
- Ran `tox -e typing` with `Twisted>=24.10.0rc1` as suggested
- Reverted the changes to the `tox.ini` file.
- Some other errors were found on windows for the file `scrapy/extensions/debug.py`

Made a new Pr as I got lost with the changes and had to reset my fork
Let me know if you need any more modifications!