### PR TITLE
Deprecate `scrapy.twisted_version`

### DIFF
--- a/scrapy/__init__.py
+++ b/scrapy/__init__.py
@@ -28,7 +28,7 @@ __version__ = (pkgutil.get_data(__package__, "VERSION") or b"").decode("ascii").
 version_info = tuple(int(v) if v.isdigit() else v for v in __version__.split("."))
 
 
-def __getattr__(name: str) -> None | tuple:
+def __getattr__(name):
     if name == "twisted_version":
         import warnings
 

--- a/scrapy/__init__.py
+++ b/scrapy/__init__.py
@@ -4,6 +4,7 @@ Scrapy - a web crawling and web scraping framework written for Python
 
 import pkgutil
 import sys
+import warnings
 
 # Declare top-level shortcuts
 from scrapy.http import FormRequest, Request
@@ -32,9 +33,6 @@ def __getattr__(name: str):
     if name == "twisted_version":
         import warnings
 
-        # Ignore noisy twisted deprecation warnings
-        warnings.filterwarnings("ignore", category=DeprecationWarning, module="twisted")
-
         from twisted import version as _txv
 
         from scrapy.exceptions import ScrapyDeprecationWarning
@@ -48,5 +46,9 @@ def __getattr__(name: str):
     raise AttributeError
 
 
+# Ignore noisy twisted deprecation warnings
+warnings.filterwarnings("ignore", category=DeprecationWarning, module="twisted")
+
 del pkgutil
 del sys
+del warnings

--- a/scrapy/__init__.py
+++ b/scrapy/__init__.py
@@ -49,6 +49,7 @@ def __getattr__(name: str):
 # Ignore noisy twisted deprecation warnings
 warnings.filterwarnings("ignore", category=DeprecationWarning, module="twisted")
 
+
 del pkgutil
 del sys
 del warnings

--- a/scrapy/__init__.py
+++ b/scrapy/__init__.py
@@ -42,7 +42,7 @@ def __getattr__(name: str):
         )
         return _txv.major, _txv.minor, _txv.micro
 
-    raise ImportError
+    raise AttributeError
 
 
 del pkgutil

--- a/scrapy/__init__.py
+++ b/scrapy/__init__.py
@@ -28,7 +28,7 @@ __version__ = (pkgutil.get_data(__package__, "VERSION") or b"").decode("ascii").
 version_info = tuple(int(v) if v.isdigit() else v for v in __version__.split("."))
 
 
-def __getattr__(name: str):
+def __getattr__(name: str) -> None | tuple:
     if name == "twisted_version":
         import warnings
 

--- a/scrapy/__init__.py
+++ b/scrapy/__init__.py
@@ -32,6 +32,9 @@ def __getattr__(name: str):
     if name == "twisted_version":
         import warnings
 
+        # Ignore noisy twisted deprecation warnings
+        warnings.filterwarnings("ignore", category=DeprecationWarning, module="twisted")
+
         from twisted import version as _txv
 
         from scrapy.exceptions import ScrapyDeprecationWarning

--- a/scrapy/__init__.py
+++ b/scrapy/__init__.py
@@ -28,7 +28,7 @@ __version__ = (pkgutil.get_data(__package__, "VERSION") or b"").decode("ascii").
 version_info = tuple(int(v) if v.isdigit() else v for v in __version__.split("."))
 
 
-def __getattr__(name):
+def __getattr__(name: str):
     if name == "twisted_version":
         import warnings
 
@@ -41,6 +41,8 @@ def __getattr__(name):
             ScrapyDeprecationWarning,
         )
         return _txv.major, _txv.minor, _txv.micro
+
+    raise AttributeError()
 
 
 del pkgutil

--- a/scrapy/__init__.py
+++ b/scrapy/__init__.py
@@ -42,7 +42,7 @@ def __getattr__(name: str):
         )
         return _txv.major, _txv.minor, _txv.micro
 
-    raise AttributeError()
+    raise AttributeError
 
 
 del pkgutil

--- a/scrapy/__init__.py
+++ b/scrapy/__init__.py
@@ -42,7 +42,7 @@ def __getattr__(name: str):
         )
         return _txv.major, _txv.minor, _txv.micro
 
-    raise AttributeError
+    raise ImportError
 
 
 del pkgutil

--- a/scrapy/__init__.py
+++ b/scrapy/__init__.py
@@ -4,9 +4,6 @@ Scrapy - a web crawling and web scraping framework written for Python
 
 import pkgutil
 import sys
-import warnings
-
-from twisted import version as _txv
 
 # Declare top-level shortcuts
 from scrapy.http import FormRequest, Request
@@ -17,7 +14,6 @@ from scrapy.spiders import Spider
 __all__ = [
     "__version__",
     "version_info",
-    "twisted_version",
     "Spider",
     "Request",
     "FormRequest",
@@ -30,13 +26,22 @@ __all__ = [
 # Scrapy and Twisted versions
 __version__ = (pkgutil.get_data(__package__, "VERSION") or b"").decode("ascii").strip()
 version_info = tuple(int(v) if v.isdigit() else v for v in __version__.split("."))
-twisted_version = (_txv.major, _txv.minor, _txv.micro)
 
 
-# Ignore noisy twisted deprecation warnings
-warnings.filterwarnings("ignore", category=DeprecationWarning, module="twisted")
+def __getattr__(name: str):
+    if name == "twisted_version":
+        import warnings
+
+        from twisted import version as _txv
+
+        from scrapy.exceptions import ScrapyDeprecationWarning
+
+        warnings.warn(
+            "The scrapy.twisted_version attribute is deprecated, use twisted.version instead",
+            ScrapyDeprecationWarning,
+        )
+        return _txv.major, _txv.minor, _txv.micro
 
 
 del pkgutil
 del sys
-del warnings

--- a/tests/test_scrapy__getattr__.py
+++ b/tests/test_scrapy__getattr__.py
@@ -1,0 +1,20 @@
+import warnings
+
+import pytest
+
+
+def test_deprecated_twisted_version():
+    with warnings.catch_warnings(record=True) as warns:
+        from scrapy import twisted_version
+
+        assert twisted_version is not None
+        assert isinstance(twisted_version, tuple)
+        assert (
+            "The scrapy.twisted_version attribute is deprecated, use twisted.version instead"
+            in warns[0].message.args
+        )
+
+
+def test_non_existent_module():
+    with pytest.raises(ImportError):
+        from scrapy import unknown  # noqa: F401

--- a/tests/test_scrapy__getattr__.py
+++ b/tests/test_scrapy__getattr__.py
@@ -1,7 +1,5 @@
 import warnings
 
-import pytest
-
 
 def test_deprecated_twisted_version():
     with warnings.catch_warnings(record=True) as warns:
@@ -13,8 +11,3 @@ def test_deprecated_twisted_version():
             "The scrapy.twisted_version attribute is deprecated, use twisted.version instead"
             in warns[0].message.args
         )
-
-
-def test_non_existent_module():
-    with pytest.raises(ImportError):
-        from scrapy import unknown  # noqa: F401


### PR DESCRIPTION
fix: #6509