### PR TITLE
Add unit tests for scrapy/utils/benchserver.py

### DIFF
--- a/scrapy/utils/benchserver.py
+++ b/scrapy/utils/benchserver.py
@@ -31,10 +31,11 @@ def _getarg(request, name: bytes, default: Any = None, type=str):
     return type(request.args[name][0]) if name in request.args else default
 
 
-def main():
+if __name__ == "__main__":
     from twisted.internet import reactor
 
     root = Root()
+    factory = Site(root)
     httpPort = reactor.listenTCP(8998, Site(root))
 
     def _print_listening() -> None:
@@ -43,7 +44,3 @@ def main():
 
     reactor.callWhenRunning(_print_listening)
     reactor.run()
-
-
-if __name__ == "__main__":
-    main()

--- a/scrapy/utils/benchserver.py
+++ b/scrapy/utils/benchserver.py
@@ -31,11 +31,10 @@ def _getarg(request, name: bytes, default: Any = None, type=str):
     return type(request.args[name][0]) if name in request.args else default
 
 
-if __name__ == "__main__":
+def main():
     from twisted.internet import reactor
 
     root = Root()
-    factory = Site(root)
     httpPort = reactor.listenTCP(8998, Site(root))
 
     def _print_listening() -> None:
@@ -44,3 +43,7 @@ if __name__ == "__main__":
 
     reactor.callWhenRunning(_print_listening)
     reactor.run()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_utils_benchserver.py
+++ b/tests/test_utils_benchserver.py
@@ -1,0 +1,58 @@
+from unittest import mock
+
+from twisted.trial import unittest
+from twisted.web.test.requesthelper import DummyRequest
+
+from scrapy.utils import benchserver
+
+
+class TestBenchServer(unittest.TestCase):
+    def setUp(self):
+        self.root = benchserver.Root()
+
+    def test_getarg(self):
+        request = DummyRequest(b"/")
+        request.args = {b"total": [b"200"]}
+        result = benchserver._getarg(request, b"total", 100, int)
+        self.assertEqual(result, 200)
+
+    def test_getarg_default(self):
+        request = DummyRequest(b"/")
+        request.args = {}
+        result = benchserver._getarg(request, b"total", 100, int)
+        self.assertEqual(result, 100)
+
+    def test_render(self):
+        request = DummyRequest(b"/")
+        request.args = {b"total": [b"200"], b"show": [b"20"]}
+        self.root.render(request)
+        response_body = b"".join(request.written)
+
+        self.assertIn(b"<html>", response_body)
+        self.assertIn(b"</html>", response_body)
+        self.assertIn(b"<body>", response_body)
+        self.assertIn(b"</body>", response_body)
+        self.assertIn(b"follow", response_body)
+
+        self.assertEqual(response_body.count(b"<a "), 20)
+
+        for line in response_body.split(b"<br>")[:-1]:
+            self.assertRegex(line, rb"<a href='/follow\?.*n=\d+'>follow \d+</a>")
+            link_number = int(line.split(b"follow ")[1].split(b"</a>")[0])
+            self.assertTrue(
+                1 <= link_number <= 200, f"Link number {link_number} is out of range"
+            )
+
+    def test_getChild(self):
+        request = DummyRequest(b"/")
+        child = self.root.getChild("name", request)
+        self.assertEqual(child, self.root)
+
+    @mock.patch("twisted.internet.reactor.callWhenRunning")
+    @mock.patch("twisted.internet.reactor.listenTCP")
+    @mock.patch("twisted.internet.reactor.run")
+    def test_main(self, mock_run, mock_listenTCP, mock_callWhenRunning):
+        benchserver.main()
+        mock_listenTCP.assert_called_once()
+        mock_run.assert_called_once()
+        mock_callWhenRunning.assert_called_once_with(mock.ANY)

--- a/tests/test_utils_benchserver.py
+++ b/tests/test_utils_benchserver.py
@@ -1,5 +1,3 @@
-from unittest import mock
-
 from twisted.trial import unittest
 from twisted.web.test.requesthelper import DummyRequest
 
@@ -47,12 +45,3 @@ class TestBenchServer(unittest.TestCase):
         request = DummyRequest(b"/")
         child = self.root.getChild("name", request)
         self.assertEqual(child, self.root)
-
-    @mock.patch("twisted.internet.reactor.callWhenRunning")
-    @mock.patch("twisted.internet.reactor.listenTCP")
-    @mock.patch("twisted.internet.reactor.run")
-    def test_main(self, mock_run, mock_listenTCP, mock_callWhenRunning):
-        benchserver.main()
-        mock_listenTCP.assert_called_once()
-        mock_run.assert_called_once()
-        mock_callWhenRunning.assert_called_once_with(mock.ANY)


### PR DESCRIPTION
This PR adds unit tests for `scrapy/utils/benchserver.py`, increasing its test coverage from ~30% to ~70%. 
