### PR TITLE
Added ignore statements for Windows specific typing issues

### DIFF
--- a/scrapy/extensions/debug.py
+++ b/scrapy/extensions/debug.py
@@ -33,8 +33,8 @@ class StackTraceDump:
     def __init__(self, crawler: Crawler):
         self.crawler: Crawler = crawler
         try:
-            signal.signal(signal.SIGUSR2, self.dump_stacktrace)
-            signal.signal(signal.SIGQUIT, self.dump_stacktrace)
+            signal.signal(signal.SIGUSR2, self.dump_stacktrace)  # type: ignore[attr-defined]
+            signal.signal(signal.SIGQUIT, self.dump_stacktrace)  # type: ignore[attr-defined]
         except AttributeError:
             # win32 platforms don't support SIGUSR signals
             pass
@@ -70,7 +70,7 @@ class StackTraceDump:
 class Debugger:
     def __init__(self) -> None:
         try:
-            signal.signal(signal.SIGUSR2, self._enter_debugger)
+            signal.signal(signal.SIGUSR2, self._enter_debugger)  # type: ignore[attr-defined]
         except AttributeError:
             # win32 platforms don't support SIGUSR signals
             pass

--- a/scrapy/utils/console.py
+++ b/scrapy/utils/console.py
@@ -82,7 +82,7 @@ def _embed_standard_shell(
     else:
         import rlcompleter  # noqa: F401
 
-        readline.parse_and_bind("tab:complete")
+        readline.parse_and_bind("tab:complete")  # type: ignore[attr-defined]
 
     @wraps(_embed_standard_shell)
     def wrapper(namespace: dict[str, Any] = namespace, banner: str = "") -> None:


### PR DESCRIPTION
### Windows-Specific Type Ignore Statements

This pull request addresses Windows-specific issues encountered during type checking with MyPy, `# type: ignore` comments have been added to the respective lines to suppress type checking errors that are only relevant to Windows environments:

### Changes Made:
- **In `scrapy/extensions/debug.py` and  `scrapy/utils/console.py`**
  - Added `# type: ignore` to suppress type checking errors for Windows-specific attributes that are not defined.

Pls review it