### PR TITLE
Deprecate unused scrapy utils

### DIFF
--- a/scrapy/utils/misc.py
+++ b/scrapy/utils/misc.py
@@ -111,7 +111,7 @@ def md5sum(file: IO[bytes]) -> str:
     """
     warnings.warn(
         (
-            "The scrapy.utils.misc.md5sum function is deprecated, and will be "
+            "The scrapy.utils.misc.md5sum function is deprecated and will be "
             "removed in a future version of Scrapy."
         ),
         ScrapyDeprecationWarning,

--- a/scrapy/utils/python.py
+++ b/scrapy/utils/python.py
@@ -8,12 +8,14 @@ import gc
 import inspect
 import re
 import sys
+import warnings
 import weakref
 from collections.abc import AsyncIterable, Iterable, Mapping
 from functools import partial, wraps
 from itertools import chain
 from typing import TYPE_CHECKING, Any, TypeVar, overload
 
+from scrapy.exceptions import ScrapyDeprecationWarning
 from scrapy.utils.asyncgen import as_async_generator
 
 if TYPE_CHECKING:
@@ -47,6 +49,10 @@ def flatten(x: Iterable[Any]) -> list[Any]:
     >>> flatten(["foo", ["baz", 42], "bar"])
     ['foo', 'baz', 42, 'bar']
     """
+    warnings.warn(
+        "The 'flatten' function is deprecated and will be removed in a future version of Scrapy.",
+        category=ScrapyDeprecationWarning,
+    )
     return list(iflatten(x))
 
 
@@ -54,6 +60,10 @@ def iflatten(x: Iterable[Any]) -> Iterable[Any]:
     """iflatten(sequence) -> iterator
 
     Similar to ``.flatten()``, but returns iterator instead"""
+    warnings.warn(
+        "The 'iflatten' function is deprecated and will be removed in a future version of Scrapy.",
+        category=ScrapyDeprecationWarning,
+    )
     for el in x:
         if is_listlike(el):
             yield from iflatten(el)
@@ -272,6 +282,10 @@ def equal_attributes(
     obj1: Any, obj2: Any, attributes: list[str | Callable[[Any], Any]] | None
 ) -> bool:
     """Compare two objects attributes"""
+    warnings.warn(
+        "The 'equal_attributes' function is deprecated and will be removed in a future version of Scrapy.",
+        category=ScrapyDeprecationWarning,
+    )
     # not attributes given return False by default
     if not attributes:
         return False

--- a/scrapy/utils/python.py
+++ b/scrapy/utils/python.py
@@ -52,6 +52,7 @@ def flatten(x: Iterable[Any]) -> list[Any]:
     warnings.warn(
         "The 'flatten' function is deprecated and will be removed in a future version of Scrapy.",
         category=ScrapyDeprecationWarning,
+        stacklevel=2,
     )
     return list(iflatten(x))
 
@@ -63,6 +64,7 @@ def iflatten(x: Iterable[Any]) -> Iterable[Any]:
     warnings.warn(
         "The 'iflatten' function is deprecated and will be removed in a future version of Scrapy.",
         category=ScrapyDeprecationWarning,
+        stacklevel=2,
     )
     for el in x:
         if is_listlike(el):
@@ -285,6 +287,7 @@ def equal_attributes(
     warnings.warn(
         "The 'equal_attributes' function is deprecated and will be removed in a future version of Scrapy.",
         category=ScrapyDeprecationWarning,
+        stacklevel=2,
     )
     # not attributes given return False by default
     if not attributes:

--- a/scrapy/utils/python.py
+++ b/scrapy/utils/python.py
@@ -50,7 +50,7 @@ def flatten(x: Iterable[Any]) -> list[Any]:
     ['foo', 'baz', 42, 'bar']
     """
     warnings.warn(
-        "The 'flatten' function is deprecated and will be removed in a future version of Scrapy.",
+        "The flatten function is deprecated and will be removed in a future version of Scrapy.",
         category=ScrapyDeprecationWarning,
         stacklevel=2,
     )
@@ -62,7 +62,7 @@ def iflatten(x: Iterable[Any]) -> Iterable[Any]:
 
     Similar to ``.flatten()``, but returns iterator instead"""
     warnings.warn(
-        "The 'iflatten' function is deprecated and will be removed in a future version of Scrapy.",
+        "The iflatten function is deprecated and will be removed in a future version of Scrapy.",
         category=ScrapyDeprecationWarning,
         stacklevel=2,
     )
@@ -285,7 +285,7 @@ def equal_attributes(
 ) -> bool:
     """Compare two objects attributes"""
     warnings.warn(
-        "The 'equal_attributes' function is deprecated and will be removed in a future version of Scrapy.",
+        "The equal_attributes function is deprecated and will be removed in a future version of Scrapy.",
         category=ScrapyDeprecationWarning,
         stacklevel=2,
     )

--- a/scrapy/utils/request.py
+++ b/scrapy/utils/request.py
@@ -139,8 +139,8 @@ class RequestFingerprinter:
 
         if implementation != "SENTINEL":
             message = (
-                "'REQUEST_FINGERPRINTER_IMPLEMENTATION' is a deprecated setting.\n"
-                "And it will be removed in future version of Scrapy."
+                "'REQUEST_FINGERPRINTER_IMPLEMENTATION' is a deprecated setting\n"
+                "and will be removed in a future version of Scrapy."
             )
             warnings.warn(message, category=ScrapyDeprecationWarning, stacklevel=2)
         self._fingerprint = fingerprint
@@ -157,6 +157,10 @@ def request_authenticate(
     """Authenticate the given request (in place) using the HTTP basic access
     authentication mechanism (RFC 2617) and the given username and password
     """
+    warnings.warn(
+        "The 'equal_attributes' function is deprecated and will be removed in a future version of Scrapy.",
+        category=ScrapyDeprecationWarning,
+    )
     request.headers["Authorization"] = basic_auth_header(username, password)
 
 

--- a/scrapy/utils/request.py
+++ b/scrapy/utils/request.py
@@ -160,6 +160,7 @@ def request_authenticate(
     warnings.warn(
         "The 'request_authenticate' function is deprecated and will be removed in a future version of Scrapy.",
         category=ScrapyDeprecationWarning,
+        stacklevel=2,
     )
     request.headers["Authorization"] = basic_auth_header(username, password)
 

--- a/scrapy/utils/request.py
+++ b/scrapy/utils/request.py
@@ -158,7 +158,7 @@ def request_authenticate(
     authentication mechanism (RFC 2617) and the given username and password
     """
     warnings.warn(
-        "The 'request_authenticate' function is deprecated and will be removed in a future version of Scrapy.",
+        "The request_authenticate function is deprecated and will be removed in a future version of Scrapy.",
         category=ScrapyDeprecationWarning,
         stacklevel=2,
     )

--- a/scrapy/utils/request.py
+++ b/scrapy/utils/request.py
@@ -139,8 +139,8 @@ class RequestFingerprinter:
 
         if implementation != "SENTINEL":
             message = (
-                "'REQUEST_FINGERPRINTER_IMPLEMENTATION' is a deprecated setting\n"
-                "and will be removed in a future version of Scrapy."
+                "'REQUEST_FINGERPRINTER_IMPLEMENTATION' is a deprecated setting.\n"
+                "It will be removed in a future version of Scrapy."
             )
             warnings.warn(message, category=ScrapyDeprecationWarning, stacklevel=2)
         self._fingerprint = fingerprint

--- a/scrapy/utils/request.py
+++ b/scrapy/utils/request.py
@@ -158,7 +158,7 @@ def request_authenticate(
     authentication mechanism (RFC 2617) and the given username and password
     """
     warnings.warn(
-        "The 'equal_attributes' function is deprecated and will be removed in a future version of Scrapy.",
+        "The 'request_authenticate' function is deprecated and will be removed in a future version of Scrapy.",
         category=ScrapyDeprecationWarning,
     )
     request.headers["Authorization"] = basic_auth_header(username, password)

--- a/scrapy/utils/serialize.py
+++ b/scrapy/utils/serialize.py
@@ -17,7 +17,7 @@ class ScrapyJSONEncoder(json.JSONEncoder):
 
     def default(self, o: Any) -> Any:
         warnings.warn(
-            "'ScrapyJSONEncoder' is a deprecated setting and will be removed in a future version of Scrapy.",
+            "'ScrapyJSONEncoder' is a deprecated setting.\nIt will be removed in a future version of Scrapy.",
             category=ScrapyDeprecationWarning,
             stacklevel=2,
         )

--- a/scrapy/utils/serialize.py
+++ b/scrapy/utils/serialize.py
@@ -1,8 +1,10 @@
 import datetime
 import decimal
 import json
+import warnings
 from typing import Any
 
+from exceptions import ScrapyDeprecationWarning
 from itemadapter import ItemAdapter, is_item
 from twisted.internet import defer
 
@@ -14,6 +16,11 @@ class ScrapyJSONEncoder(json.JSONEncoder):
     TIME_FORMAT = "%H:%M:%S"
 
     def default(self, o: Any) -> Any:
+        warnings.warn(
+            "'ScrapyJSONEncoder' is a deprecated setting and will be removed in a future version of Scrapy.",
+            category=ScrapyDeprecationWarning,
+            stacklevel=2,
+        )
         if isinstance(o, set):
             return list(o)
         if isinstance(o, datetime.datetime):

--- a/scrapy/utils/serialize.py
+++ b/scrapy/utils/serialize.py
@@ -40,7 +40,7 @@ class ScrapyJSONEncoder(json.JSONEncoder):
 class ScrapyJSONDecoder(json.JSONDecoder):
     def __init__(self, *args, **kwargs):
         warnings.warn(
-            "'ScrapyJSONDecoder' is a deprecated setting.\nIt will be removed in a future version of Scrapy.",
+            "'ScrapyJSONDecoder' class is deprecated and will be removed in a future version of Scrapy.",
             category=ScrapyDeprecationWarning,
             stacklevel=2,
         )

--- a/scrapy/utils/serialize.py
+++ b/scrapy/utils/serialize.py
@@ -16,11 +16,6 @@ class ScrapyJSONEncoder(json.JSONEncoder):
     TIME_FORMAT = "%H:%M:%S"
 
     def default(self, o: Any) -> Any:
-        warnings.warn(
-            "'ScrapyJSONEncoder' is a deprecated setting.\nIt will be removed in a future version of Scrapy.",
-            category=ScrapyDeprecationWarning,
-            stacklevel=2,
-        )
         if isinstance(o, set):
             return list(o)
         if isinstance(o, datetime.datetime):
@@ -43,4 +38,10 @@ class ScrapyJSONEncoder(json.JSONEncoder):
 
 
 class ScrapyJSONDecoder(json.JSONDecoder):
-    pass
+    def __init__(self, *args, **kwargs):
+        warnings.warn(
+            "'ScrapyJSONDecoder' is a deprecated setting.\nIt will be removed in a future version of Scrapy.",
+            category=ScrapyDeprecationWarning,
+            stacklevel=2,
+        )
+        super().__init__(*args, **kwargs)

--- a/scrapy/utils/serialize.py
+++ b/scrapy/utils/serialize.py
@@ -40,7 +40,7 @@ class ScrapyJSONEncoder(json.JSONEncoder):
 class ScrapyJSONDecoder(json.JSONDecoder):
     def __init__(self, *args, **kwargs):
         warnings.warn(
-            "'ScrapyJSONDecoder' class is deprecated and will be removed in a future version of Scrapy.",
+            "The ScrapyJSONDecoder class is deprecated and will be removed in a future version of Scrapy.",
             category=ScrapyDeprecationWarning,
             stacklevel=2,
         )

--- a/scrapy/utils/serialize.py
+++ b/scrapy/utils/serialize.py
@@ -4,10 +4,10 @@ import json
 import warnings
 from typing import Any
 
-from exceptions import ScrapyDeprecationWarning
 from itemadapter import ItemAdapter, is_item
 from twisted.internet import defer
 
+from scrapy.exceptions import ScrapyDeprecationWarning
 from scrapy.http import Request, Response
 
 

--- a/scrapy/utils/test.py
+++ b/scrapy/utils/test.py
@@ -13,11 +13,11 @@ from posixpath import split
 from typing import TYPE_CHECKING, Any, TypeVar
 from unittest import TestCase, mock
 
-from exceptions import ScrapyDeprecationWarning
 from twisted.trial.unittest import SkipTest
 
 from scrapy import Spider
 from scrapy.crawler import Crawler
+from scrapy.exceptions import ScrapyDeprecationWarning
 from scrapy.utils.boto import is_botocore_available
 
 if TYPE_CHECKING:

--- a/scrapy/utils/test.py
+++ b/scrapy/utils/test.py
@@ -128,7 +128,7 @@ def assert_samelines(
     line endings between platforms
     """
     warnings.warn(
-        "'assert_samelines' is deprecated and will be removed in a future version of Scrapy.",
+        "The 'assert_samelines' is a deprecated function and will be removed in a future version of Scrapy.",
         category=ScrapyDeprecationWarning,
     )
     testcase.assertEqual(text1.splitlines(), text2.splitlines(), msg)

--- a/scrapy/utils/test.py
+++ b/scrapy/utils/test.py
@@ -130,6 +130,7 @@ def assert_samelines(
     warnings.warn(
         "The 'assert_samelines' function is deprecated and will be removed in a future version of Scrapy.",
         category=ScrapyDeprecationWarning,
+        stacklevel=2,
     )
     testcase.assertEqual(text1.splitlines(), text2.splitlines(), msg)
 

--- a/scrapy/utils/test.py
+++ b/scrapy/utils/test.py
@@ -128,7 +128,7 @@ def assert_samelines(
     line endings between platforms
     """
     warnings.warn(
-        "The 'assert_samelines' function is deprecated and will be removed in a future version of Scrapy.",
+        "The assert_samelines function is deprecated and will be removed in a future version of Scrapy.",
         category=ScrapyDeprecationWarning,
         stacklevel=2,
     )

--- a/scrapy/utils/test.py
+++ b/scrapy/utils/test.py
@@ -6,12 +6,14 @@ from __future__ import annotations
 
 import asyncio
 import os
+import warnings
 from importlib import import_module
 from pathlib import Path
 from posixpath import split
 from typing import TYPE_CHECKING, Any, TypeVar
 from unittest import TestCase, mock
 
+from exceptions import ScrapyDeprecationWarning
 from twisted.trial.unittest import SkipTest
 
 from scrapy import Spider
@@ -125,6 +127,10 @@ def assert_samelines(
     """Asserts text1 and text2 have the same lines, ignoring differences in
     line endings between platforms
     """
+    warnings.warn(
+        "'assert_samelines' is deprecated and will be removed in a future version of Scrapy.",
+        category=ScrapyDeprecationWarning,
+    )
     testcase.assertEqual(text1.splitlines(), text2.splitlines(), msg)
 
 

--- a/scrapy/utils/test.py
+++ b/scrapy/utils/test.py
@@ -128,7 +128,7 @@ def assert_samelines(
     line endings between platforms
     """
     warnings.warn(
-        "The 'assert_samelines' is a deprecated function and will be removed in a future version of Scrapy.",
+        "The 'assert_samelines' function is deprecated and will be removed in a future version of Scrapy.",
         category=ScrapyDeprecationWarning,
     )
     testcase.assertEqual(text1.splitlines(), text2.splitlines(), msg)

--- a/tests/test_utils_python.py
+++ b/tests/test_utils_python.py
@@ -3,6 +3,7 @@ import operator
 import platform
 import sys
 
+import pytest
 from twisted.trial import unittest
 
 from scrapy.utils.asyncgen import as_async_generator, collect_asyncgen
@@ -151,6 +152,7 @@ class BinaryIsTextTest(unittest.TestCase):
 
 
 class UtilsPythonTestCase(unittest.TestCase):
+    @pytest.mark.filterwarnings("ignore::scrapy.exceptions.ScrapyDeprecationWarning")
     def test_equal_attributes(self):
         class Obj:
             pass

--- a/tests/test_utils_request.py
+++ b/tests/test_utils_request.py
@@ -6,6 +6,8 @@ import warnings
 from hashlib import sha1
 from weakref import WeakKeyDictionary
 
+import pytest
+
 from scrapy.http import Request
 from scrapy.utils.python import to_bytes
 from scrapy.utils.request import (
@@ -19,6 +21,7 @@ from scrapy.utils.test import get_crawler
 
 
 class UtilsRequestTest(unittest.TestCase):
+    @pytest.mark.filterwarnings("ignore::scrapy.exceptions.ScrapyDeprecationWarning")
     def test_request_authenticate(self):
         r = Request("http://www.example.com")
         request_authenticate(r, "someuser", "somepass")


### PR DESCRIPTION
Fixes #6517 

This PR deprecates following unused functions and classes in `scrapy.utils`:
- `flatten`
- `iflatten`
- `equal_attributes`
- `request_authenticate`
- `ScrapyJSONDecoder`
- `assert_samelines`

I have also changed some other warnings for a grammatical uniformity

pls review this PR