### PR TITLE
Fix Pylint unsubscriptable-object error in 'edit' command

### DIFF
--- a/scrapy/commands/edit.py
+++ b/scrapy/commands/edit.py
@@ -30,7 +30,13 @@ class Command(ScrapyCommand):
         if len(args) != 1:
             raise UsageError()
 
-        editor = self.settings["EDITOR"]
+        editor = os.environ.get("EDITOR") or self.settings.get("EDITOR")
+        if not editor:
+            self._err(
+                "No editor specified. Please set the EDITOR environment variable or the EDITOR setting."
+            )
+            return
+
         assert self.crawler_process
         try:
             spidercls = self.crawler_process.spider_loader.load(args[0])


### PR DESCRIPTION
Resolves Pylint Error: By using self.settings.get("EDITOR"), we avoid treating self.settings as a subscriptable object, eliminating the Pylint warning. Improved Logic: Adjusting the order to check the environment variable first aligns the code with the description provided in long_desc. Error Handling: Adding a check for None ensures that the program fails gracefully if no editor is specified, improving the robustness of the code.