### PR TITLE
Add 'tests/keys/mitmproxy-dhparam.pem' to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ test-output.*
 .mypy_cache/
 /tests/keys/localhost.crt
 /tests/keys/localhost.key
+/tests/keys/mitmproxy-dhparam.pem
 
 # Windows
 Thumbs.db


### PR DESCRIPTION
The file tests/keys/mitmproxy-dhparam.pem was generated after running tox. I've added it to the .gitignore file to prevent accidental commits of this test-generated artifact. Please let me know if this is the appropriate way to handle it or if any additional steps are needed.