### PR TITLE
Format codebase using Black

### DIFF
--- a/scrapy/addons.py
+++ b/scrapy/addons.py
@@ -47,8 +47,6 @@ class AddonManager:
                     )
         logger.info(
             "Enabled addons:\n%(addons)s",
-            {
-                "addons": self.addons,
-            },
+            {"addons": self.addons,},
             extra={"crawler": self.crawler},
         )

--- a/scrapy/commands/__init__.py
+++ b/scrapy/commands/__init__.py
@@ -171,9 +171,7 @@ class BaseRunSpiderCommand(ScrapyCommand):
             raise UsageError("Invalid -a value, use -a NAME=VALUE", print_help=False)
         if opts.output or opts.overwrite_output:
             feeds = feed_process_params_from_cli(
-                self.settings,
-                opts.output,
-                overwrite_output=opts.overwrite_output,
+                self.settings, opts.output, overwrite_output=opts.overwrite_output,
             )
             self.settings.set("FEEDS", feeds, priority="cmdline")
 

--- a/scrapy/commands/genspider.py
+++ b/scrapy/commands/genspider.py
@@ -119,11 +119,7 @@ class Command(ScrapyCommand):
                 self.exitcode = os.system(f'scrapy edit "{name}"')  # nosec
 
     def _generate_template_variables(
-        self,
-        module: str,
-        name: str,
-        url: str,
-        template_name: str,
+        self, module: str, name: str, url: str, template_name: str,
     ) -> dict[str, Any]:
         capitalized_module = "".join(s.capitalize() for s in module.split("_"))
         return {

--- a/scrapy/commands/parse.py
+++ b/scrapy/commands/parse.py
@@ -138,10 +138,12 @@ class Command(BaseRunSpiderCommand):
     @overload
     def iterate_spider_output(
         self, result: AsyncGenerator[_T] | Coroutine[Any, Any, _T]
-    ) -> Deferred[_T]: ...
+    ) -> Deferred[_T]:
+        ...
 
     @overload
-    def iterate_spider_output(self, result: _T) -> Iterable[Any]: ...
+    def iterate_spider_output(self, result: _T) -> Iterable[Any]:
+        ...
 
     def iterate_spider_output(self, result: Any) -> Iterable[Any] | Deferred[Any]:
         if inspect.isasyncgen(result):

--- a/scrapy/core/downloader/__init__.py
+++ b/scrapy/core/downloader/__init__.py
@@ -32,10 +32,7 @@ class Slot:
     """Downloader slot"""
 
     def __init__(
-        self,
-        concurrency: int,
-        delay: float,
-        randomize_delay: bool,
+        self, concurrency: int, delay: float, randomize_delay: bool,
     ):
         self.concurrency: int = concurrency
         self.delay: float = delay

--- a/scrapy/core/downloader/contextfactory.py
+++ b/scrapy/core/downloader/contextfactory.py
@@ -175,16 +175,11 @@ def load_context_factory_from_settings(
     # try method-aware context factory
     try:
         context_factory = build_from_crawler(
-            context_factory_cls,
-            crawler,
-            method=ssl_method,
+            context_factory_cls, crawler, method=ssl_method,
         )
     except TypeError:
         # use context factory defaults
-        context_factory = build_from_crawler(
-            context_factory_cls,
-            crawler,
-        )
+        context_factory = build_from_crawler(context_factory_cls, crawler,)
         msg = (
             f"{settings['DOWNLOADER_CLIENTCONTEXTFACTORY']} does not accept "
             "a `method` argument (type OpenSSL.SSL method, e.g. "

--- a/scrapy/core/downloader/handlers/__init__.py
+++ b/scrapy/core/downloader/handlers/__init__.py
@@ -27,9 +27,8 @@ logger = logging.getLogger(__name__)
 
 
 class DownloadHandlerProtocol(Protocol):
-    def download_request(
-        self, request: Request, spider: Spider
-    ) -> Deferred[Response]: ...
+    def download_request(self, request: Request, spider: Spider) -> Deferred[Response]:
+        ...
 
 
 class DownloadHandlers:
@@ -76,10 +75,7 @@ class DownloadHandlers:
             dhcls: type[DownloadHandlerProtocol] = load_object(path)
             if skip_lazy and getattr(dhcls, "lazy", True):
                 return None
-            dh = build_from_crawler(
-                dhcls,
-                self._crawler,
-            )
+            dh = build_from_crawler(dhcls, self._crawler,)
         except NotConfigured as ex:
             self._notconfigured[scheme] = str(ex)
             return None

--- a/scrapy/core/downloader/handlers/http10.py
+++ b/scrapy/core/downloader/handlers/http10.py
@@ -51,8 +51,7 @@ class HTTP10DownloadHandler:
         host, port = to_unicode(factory.host), factory.port
         if factory.scheme == b"https":
             client_context_factory = build_from_crawler(
-                self.ClientContextFactory,
-                self._crawler,
+                self.ClientContextFactory, self._crawler,
             )
             return reactor.connectSSL(host, port, factory, client_context_factory)
         return reactor.connectTCP(host, port, factory)

--- a/scrapy/core/downloader/handlers/s3.py
+++ b/scrapy/core/downloader/handlers/s3.py
@@ -68,10 +68,7 @@ class S3DownloadHandler:
                 )
             )
 
-        _http_handler = build_from_crawler(
-            httpdownloadhandler,
-            crawler,
-        )
+        _http_handler = build_from_crawler(httpdownloadhandler, crawler,)
         self._download_http = _http_handler.download_request
 
     @classmethod

--- a/scrapy/core/engine.py
+++ b/scrapy/core/engine.py
@@ -458,9 +458,7 @@ class ExecutionEngine:
 
         dfd.addBoth(
             lambda _: self.signals.send_catch_log_deferred(
-                signal=signals.spider_closed,
-                spider=spider,
-                reason=reason,
+                signal=signals.spider_closed, spider=spider, reason=reason,
             )
         )
         dfd.addErrback(log_failure("Error while sending spider_close signal"))

--- a/scrapy/core/http2/stream.py
+++ b/scrapy/core/http2/stream.py
@@ -476,9 +476,7 @@ class Stream:
 
         body = self._response["body"].getvalue()
         response_cls = responsetypes.from_args(
-            headers=self._response["headers"],
-            url=self._request.url,
-            body=body,
+            headers=self._response["headers"], url=self._request.url, body=body,
         )
 
         response = response_cls(

--- a/scrapy/core/scheduler.py
+++ b/scrapy/core/scheduler.py
@@ -327,10 +327,7 @@ class Scheduler(BaseScheduler):
         assert self.crawler
         assert self.pqclass
         return build_from_crawler(
-            self.pqclass,
-            self.crawler,
-            downstream_queue_cls=self.mqclass,
-            key="",
+            self.pqclass, self.crawler, downstream_queue_cls=self.mqclass, key="",
         )
 
     def _dq(self) -> ScrapyPriorityQueue:

--- a/scrapy/core/scraper.py
+++ b/scrapy/core/scraper.py
@@ -355,8 +355,7 @@ class Scraper:
                         download_failure, request, spider, errmsg
                     )
                     logger.log(
-                        *logformatter_adapter(logkws),
-                        extra={"spider": spider},
+                        *logformatter_adapter(logkws), extra={"spider": spider},
                     )
 
         if spider_failure is not download_failure:

--- a/scrapy/crawler.py
+++ b/scrapy/crawler.py
@@ -106,8 +106,7 @@ class Crawler:
         self.logformatter = lf_cls.from_crawler(self)
 
         self.request_fingerprinter = build_from_crawler(
-            load_object(self.settings["REQUEST_FINGERPRINTER_CLASS"]),
-            self,
+            load_object(self.settings["REQUEST_FINGERPRINTER_CLASS"]), self,
         )
 
         reactor_class: str = self.settings["TWISTED_REACTOR"]

--- a/scrapy/downloadermiddlewares/httpcompression.py
+++ b/scrapy/downloadermiddlewares/httpcompression.py
@@ -51,10 +51,7 @@ class HttpCompressionMiddleware:
     sent/received from websites"""
 
     def __init__(
-        self,
-        stats: StatsCollector | None = None,
-        *,
-        crawler: Crawler | None = None,
+        self, stats: StatsCollector | None = None, *, crawler: Crawler | None = None,
     ):
         if not crawler:
             self.stats = stats

--- a/scrapy/downloadermiddlewares/redirect.py
+++ b/scrapy/downloadermiddlewares/redirect.py
@@ -27,10 +27,7 @@ def _build_redirect_request(
     source_request: Request, *, url: str, **kwargs: Any
 ) -> Request:
     redirect_request = source_request.replace(
-        url=url,
-        **kwargs,
-        cls=None,
-        cookies=None,
+        url=url, **kwargs, cls=None, cookies=None,
     )
     if "_scheme_proxy" in redirect_request.meta:
         source_request_scheme = urlparse_cached(source_request).scheme
@@ -126,10 +123,7 @@ class BaseRedirectMiddleware:
         self, request: Request, redirect_url: str
     ) -> Request:
         redirect_request = _build_redirect_request(
-            request,
-            url=redirect_url,
-            method="GET",
-            body="",
+            request, url=redirect_url, method="GET", body="",
         )
         redirect_request.headers.pop("Content-Type", None)
         redirect_request.headers.pop("Content-Length", None)

--- a/scrapy/dupefilters.py
+++ b/scrapy/dupefilters.py
@@ -79,8 +79,7 @@ class RFPDupeFilter(BaseDupeFilter):
     def from_crawler(cls, crawler: Crawler) -> Self:
         assert crawler.request_fingerprinter
         return cls.from_settings(
-            crawler.settings,
-            fingerprinter=crawler.request_fingerprinter,
+            crawler.settings, fingerprinter=crawler.request_fingerprinter,
         )
 
     def request_seen(self, request: Request) -> bool:

--- a/scrapy/extensions/feedexport.py
+++ b/scrapy/extensions/feedexport.py
@@ -242,11 +242,7 @@ class S3FeedStorage(BlockingFeedStorage):
 
     @classmethod
     def from_crawler(
-        cls,
-        crawler: Crawler,
-        uri: str,
-        *,
-        feed_options: dict[str, Any] | None = None,
+        cls, crawler: Crawler, uri: str, *, feed_options: dict[str, Any] | None = None,
     ) -> Self:
         return build_storage(
             cls,
@@ -317,11 +313,7 @@ class FTPFeedStorage(BlockingFeedStorage):
 
     @classmethod
     def from_crawler(
-        cls,
-        crawler: Crawler,
-        uri: str,
-        *,
-        feed_options: dict[str, Any] | None = None,
+        cls, crawler: Crawler, uri: str, *, feed_options: dict[str, Any] | None = None,
     ) -> Self:
         return build_storage(
             cls,

--- a/scrapy/extensions/periodic_log.py
+++ b/scrapy/extensions/periodic_log.py
@@ -80,13 +80,7 @@ class PeriodicLog:
         assert crawler.stats
         assert ext_stats is not None
         assert ext_delta is not None
-        o = cls(
-            crawler.stats,
-            interval,
-            ext_stats,
-            ext_delta,
-            ext_timing_enabled,
-        )
+        o = cls(crawler.stats, interval, ext_stats, ext_delta, ext_timing_enabled,)
         crawler.signals.connect(o.spider_opened, signal=signals.spider_opened)
         crawler.signals.connect(o.spider_closed, signal=signals.spider_closed)
         return o

--- a/scrapy/http/cookies.py
+++ b/scrapy/http/cookies.py
@@ -27,9 +27,7 @@ IPV4_RE = re.compile(r"\.\d+$", re.ASCII)
 
 class CookieJar:
     def __init__(
-        self,
-        policy: CookiePolicy | None = None,
-        check_expired_frequency: int = 10000,
+        self, policy: CookiePolicy | None = None, check_expired_frequency: int = 10000,
     ):
         self.policy: CookiePolicy = policy or DefaultCookiePolicy()
         self.jar: _CookieJar = _CookieJar(self.policy)

--- a/scrapy/http/request/__init__.py
+++ b/scrapy/http/request/__init__.py
@@ -199,10 +199,12 @@ class Request(object_ref):
     @overload
     def replace(
         self, *args: Any, cls: type[RequestTypeVar], **kwargs: Any
-    ) -> RequestTypeVar: ...
+    ) -> RequestTypeVar:
+        ...
 
     @overload
-    def replace(self, *args: Any, cls: None = None, **kwargs: Any) -> Self: ...
+    def replace(self, *args: Any, cls: None = None, **kwargs: Any) -> Self:
+        ...
 
     def replace(
         self, *args: Any, cls: type[Request] | None = None, **kwargs: Any
@@ -216,10 +218,7 @@ class Request(object_ref):
 
     @classmethod
     def from_curl(
-        cls,
-        curl_command: str,
-        ignore_unknown_options: bool = True,
-        **kwargs: Any,
+        cls, curl_command: str, ignore_unknown_options: bool = True, **kwargs: Any,
     ) -> Self:
         """Create a Request object from a string containing a `cURL
         <https://curl.se/>`_ command. It populates the HTTP method, the

--- a/scrapy/http/request/json_request.py
+++ b/scrapy/http/request/json_request.py
@@ -53,10 +53,12 @@ class JsonRequest(Request):
     @overload
     def replace(
         self, *args: Any, cls: type[RequestTypeVar], **kwargs: Any
-    ) -> RequestTypeVar: ...
+    ) -> RequestTypeVar:
+        ...
 
     @overload
-    def replace(self, *args: Any, cls: None = None, **kwargs: Any) -> Self: ...
+    def replace(self, *args: Any, cls: None = None, **kwargs: Any) -> Self:
+        ...
 
     def replace(
         self, *args: Any, cls: type[Request] | None = None, **kwargs: Any

--- a/scrapy/http/response/__init__.py
+++ b/scrapy/http/response/__init__.py
@@ -136,10 +136,12 @@ class Response(object_ref):
     @overload
     def replace(
         self, *args: Any, cls: type[ResponseTypeVar], **kwargs: Any
-    ) -> ResponseTypeVar: ...
+    ) -> ResponseTypeVar:
+        ...
 
     @overload
-    def replace(self, *args: Any, cls: None = None, **kwargs: Any) -> Self: ...
+    def replace(self, *args: Any, cls: None = None, **kwargs: Any) -> Self:
+        ...
 
     def replace(
         self, *args: Any, cls: type[Response] | None = None, **kwargs: Any

--- a/scrapy/logformatter.py
+++ b/scrapy/logformatter.py
@@ -106,10 +106,7 @@ class LogFormatter:
         return {
             "level": logging.DEBUG,
             "msg": SCRAPEDMSG,
-            "args": {
-                "src": src,
-                "item": item,
-            },
+            "args": {"src": src, "item": item,},
         }
 
     def dropped(
@@ -123,10 +120,7 @@ class LogFormatter:
         return {
             "level": logging.WARNING,
             "msg": DROPPEDMSG,
-            "args": {
-                "exception": exception,
-                "item": item,
-            },
+            "args": {"exception": exception, "item": item,},
         }
 
     def item_error(
@@ -144,9 +138,7 @@ class LogFormatter:
         return {
             "level": logging.ERROR,
             "msg": ITEMERRORMSG,
-            "args": {
-                "item": item,
-            },
+            "args": {"item": item,},
         }
 
     def spider_error(
@@ -163,10 +155,7 @@ class LogFormatter:
         return {
             "level": logging.ERROR,
             "msg": SPIDERERRORMSG,
-            "args": {
-                "request": request,
-                "referer": referer_str(request),
-            },
+            "args": {"request": request, "referer": referer_str(request),},
         }
 
     def download_error(

--- a/scrapy/pipelines/files.py
+++ b/scrapy/pipelines/files.py
@@ -82,7 +82,8 @@ class StatInfo(TypedDict, total=False):
 
 
 class FilesStoreProtocol(Protocol):
-    def __init__(self, basedir: str): ...
+    def __init__(self, basedir: str):
+        ...
 
     def persist_file(
         self,
@@ -91,11 +92,13 @@ class FilesStoreProtocol(Protocol):
         info: MediaPipeline.SpiderInfo,
         meta: dict[str, Any] | None = None,
         headers: dict[str, str] | None = None,
-    ) -> Deferred[Any] | None: ...
+    ) -> Deferred[Any] | None:
+        ...
 
     def stat_file(
         self, path: str, info: MediaPipeline.SpiderInfo
-    ) -> StatInfo | Deferred[StatInfo]: ...
+    ) -> StatInfo | Deferred[StatInfo]:
+        ...
 
 
 class FSFilesStore:

--- a/scrapy/pipelines/images.py
+++ b/scrapy/pipelines/images.py
@@ -80,9 +80,7 @@ class ImagesPipeline(FilesPipeline):
             settings = Settings(settings)
 
         resolve = functools.partial(
-            self._key_for_pipe,
-            base_class_name="ImagesPipeline",
-            settings=settings,
+            self._key_for_pipe, base_class_name="ImagesPipeline", settings=settings,
         )
         self.expires: int = settings.getint(resolve("IMAGES_EXPIRES"), self.EXPIRES)
 

--- a/scrapy/pqueues.py
+++ b/scrapy/pqueues.py
@@ -40,13 +40,17 @@ def _path_safe(text: str) -> str:
 class QueueProtocol(Protocol):
     """Protocol for downstream queues of ``ScrapyPriorityQueue``."""
 
-    def push(self, request: Request) -> None: ...
+    def push(self, request: Request) -> None:
+        ...
 
-    def pop(self) -> Request | None: ...
+    def pop(self) -> Request | None:
+        ...
 
-    def close(self) -> None: ...
+    def close(self) -> None:
+        ...
 
-    def __len__(self) -> int: ...
+    def __len__(self) -> int:
+        ...
 
 
 class ScrapyPriorityQueue:
@@ -110,9 +114,7 @@ class ScrapyPriorityQueue:
 
     def qfactory(self, key: int) -> QueueProtocol:
         return build_from_crawler(
-            self.downstream_queue_cls,
-            self.crawler,
-            self.key + "/" + str(key),
+            self.downstream_queue_cls, self.crawler, self.key + "/" + str(key),
         )
 
     def priority(self, request: Request) -> int:

--- a/scrapy/settings/__init__.py
+++ b/scrapy/settings/__init__.py
@@ -333,10 +333,7 @@ class BaseSettings(MutableMapping[_SettingsKeyT, Any]):
             self.attributes[name].set(value, priority)
 
     def setdefault(
-        self,
-        name: _SettingsKeyT,
-        default: Any = None,
-        priority: int | str = "project",
+        self, name: _SettingsKeyT, default: Any = None, priority: int | str = "project",
     ) -> Any:
         if name not in self:
             self.set(name, default, priority)

--- a/scrapy/utils/conf.py
+++ b/scrapy/utils/conf.py
@@ -71,8 +71,7 @@ def arglist_to_dict(arglist: list[str]) -> dict[str, str]:
 
 
 def closest_scrapy_cfg(
-    path: str | os.PathLike = ".",
-    prevpath: str | os.PathLike | None = None,
+    path: str | os.PathLike = ".", prevpath: str | os.PathLike | None = None,
 ) -> str:
     """Return the path to the closest scrapy.cfg file by traversing the current
     directory and its parents

--- a/scrapy/utils/datatypes.py
+++ b/scrapy/utils/datatypes.py
@@ -43,8 +43,7 @@ class CaselessDict(dict):
         return super().__new__(cls, *args, **kwargs)
 
     def __init__(
-        self,
-        seq: Mapping[AnyStr, Any] | Iterable[tuple[AnyStr, Any]] | None = None,
+        self, seq: Mapping[AnyStr, Any] | Iterable[tuple[AnyStr, Any]] | None = None,
     ):
         super().__init__()
         if seq:

--- a/scrapy/utils/defer.py
+++ b/scrapy/utils/defer.py
@@ -75,21 +75,22 @@ def defer_result(result: Any) -> Deferred[Any]:
 @overload
 def mustbe_deferred(
     f: Callable[_P, Deferred[_T]], *args: _P.args, **kw: _P.kwargs
-) -> Deferred[_T]: ...
+) -> Deferred[_T]:
+    ...
 
 
 @overload
 def mustbe_deferred(
-    f: Callable[_P, Coroutine[Deferred[Any], Any, _T]],
-    *args: _P.args,
-    **kw: _P.kwargs,
-) -> Deferred[_T]: ...
+    f: Callable[_P, Coroutine[Deferred[Any], Any, _T]], *args: _P.args, **kw: _P.kwargs,
+) -> Deferred[_T]:
+    ...
 
 
 @overload
 def mustbe_deferred(
     f: Callable[_P, _T], *args: _P.args, **kw: _P.kwargs
-) -> Deferred[_T]: ...
+) -> Deferred[_T]:
+    ...
 
 
 def mustbe_deferred(
@@ -354,11 +355,13 @@ _CT = TypeVar("_CT", bound=Union[Awaitable, CoroutineType, Future])
 
 
 @overload
-def deferred_from_coro(o: _CT) -> Deferred: ...
+def deferred_from_coro(o: _CT) -> Deferred:
+    ...
 
 
 @overload
-def deferred_from_coro(o: _T) -> _T: ...
+def deferred_from_coro(o: _T) -> _T:
+    ...
 
 
 def deferred_from_coro(o: _T) -> Deferred | _T:

--- a/scrapy/utils/deprecate.py
+++ b/scrapy/utils/deprecate.py
@@ -140,11 +140,13 @@ DEPRECATION_RULES: list[tuple[str, str]] = []
 
 
 @overload
-def update_classpath(path: str) -> str: ...
+def update_classpath(path: str) -> str:
+    ...
 
 
 @overload
-def update_classpath(path: Any) -> Any: ...
+def update_classpath(path: Any) -> Any:
+    ...
 
 
 def update_classpath(path: Any) -> Any:

--- a/scrapy/utils/iterators.py
+++ b/scrapy/utils/iterators.py
@@ -214,15 +214,18 @@ def csviter(
 
 
 @overload
-def _body_or_str(obj: Response | str | bytes) -> str: ...
+def _body_or_str(obj: Response | str | bytes) -> str:
+    ...
 
 
 @overload
-def _body_or_str(obj: Response | str | bytes, unicode: Literal[True]) -> str: ...
+def _body_or_str(obj: Response | str | bytes, unicode: Literal[True]) -> str:
+    ...
 
 
 @overload
-def _body_or_str(obj: Response | str | bytes, unicode: Literal[False]) -> bytes: ...
+def _body_or_str(obj: Response | str | bytes, unicode: Literal[False]) -> bytes:
+    ...
 
 
 def _body_or_str(obj: Response | str | bytes, unicode: bool = True) -> str | bytes:

--- a/scrapy/utils/log.py
+++ b/scrapy/utils/log.py
@@ -64,18 +64,10 @@ DEFAULT_LOGGING = {
     "version": 1,
     "disable_existing_loggers": False,
     "loggers": {
-        "filelock": {
-            "level": "ERROR",
-        },
-        "hpack": {
-            "level": "ERROR",
-        },
-        "scrapy": {
-            "level": "DEBUG",
-        },
-        "twisted": {
-            "level": "ERROR",
-        },
+        "filelock": {"level": "ERROR",},
+        "hpack": {"level": "ERROR",},
+        "scrapy": {"level": "DEBUG",},
+        "twisted": {"level": "ERROR",},
     },
 }
 

--- a/scrapy/utils/python.py
+++ b/scrapy/utils/python.py
@@ -306,11 +306,13 @@ def equal_attributes(
 
 
 @overload
-def without_none_values(iterable: Mapping[_KT, _VT]) -> dict[_KT, _VT]: ...
+def without_none_values(iterable: Mapping[_KT, _VT]) -> dict[_KT, _VT]:
+    ...
 
 
 @overload
-def without_none_values(iterable: Iterable[_KT]) -> Iterable[_KT]: ...
+def without_none_values(iterable: Iterable[_KT]) -> Iterable[_KT]:
+    ...
 
 
 def without_none_values(
@@ -344,6 +346,7 @@ if hasattr(sys, "pypy_version_info"):
         # Collecting weakreferences can take two collections on PyPy.
         gc.collect()
         gc.collect()
+
 
 else:
 

--- a/scrapy/utils/request.py
+++ b/scrapy/utils/request.py
@@ -99,7 +99,8 @@ def fingerprint(
 
 
 class RequestFingerprinterProtocol(Protocol):
-    def fingerprint(self, request: Request) -> bytes: ...
+    def fingerprint(self, request: Request) -> bytes:
+        ...
 
 
 class RequestFingerprinter:
@@ -139,11 +140,7 @@ class RequestFingerprinter:
         return self._fingerprint(request)
 
 
-def request_authenticate(
-    request: Request,
-    username: str,
-    password: str,
-) -> None:
+def request_authenticate(request: Request, username: str, password: str,) -> None:
     """Authenticate the given request (in place) using the HTTP basic access
     authentication mechanism (RFC 2617) and the given username and password
     """

--- a/scrapy/utils/response.py
+++ b/scrapy/utils/response.py
@@ -41,8 +41,7 @@ _metaref_cache: WeakKeyDictionary[Response, tuple[None, None] | tuple[float, str
 
 
 def get_meta_refresh(
-    response: TextResponse,
-    ignore_tags: Iterable[str] = ("script", "noscript"),
+    response: TextResponse, ignore_tags: Iterable[str] = ("script", "noscript"),
 ) -> tuple[None, None] | tuple[float, str]:
     """Parse the http-equiv refresh parameter from the given response"""
     if response not in _metaref_cache:
@@ -72,8 +71,7 @@ def _remove_html_comments(body: bytes) -> bytes:
 
 
 def open_in_browser(
-    response: TextResponse,
-    _openfunc: Callable[[str], Any] = webbrowser.open,
+    response: TextResponse, _openfunc: Callable[[str], Any] = webbrowser.open,
 ) -> Any:
     """Open *response* in a local web browser, adjusting the `base tag`_ for
     external links to work, e.g. so that images and styles are displayed.

--- a/scrapy/utils/spider.py
+++ b/scrapy/utils/spider.py
@@ -25,15 +25,18 @@ _T = TypeVar("_T")
 
 # https://stackoverflow.com/questions/60222982
 @overload
-def iterate_spider_output(result: AsyncGenerator[_T]) -> AsyncGenerator[_T]: ...  # type: ignore[overload-overlap]
+def iterate_spider_output(result: AsyncGenerator[_T]) -> AsyncGenerator[_T]:
+    ...  # type: ignore[overload-overlap]
 
 
 @overload
-def iterate_spider_output(result: CoroutineType[Any, Any, _T]) -> Deferred[_T]: ...
+def iterate_spider_output(result: CoroutineType[Any, Any, _T]) -> Deferred[_T]:
+    ...
 
 
 @overload
-def iterate_spider_output(result: _T) -> Iterable[Any]: ...
+def iterate_spider_output(result: _T) -> Iterable[Any]:
+    ...
 
 
 def iterate_spider_output(
@@ -73,7 +76,8 @@ def spidercls_for_request(
     default_spidercls: type[Spider],
     log_none: bool = ...,
     log_multiple: bool = ...,
-) -> type[Spider]: ...
+) -> type[Spider]:
+    ...
 
 
 @overload
@@ -83,7 +87,8 @@ def spidercls_for_request(
     default_spidercls: Literal[None],
     log_none: bool = ...,
     log_multiple: bool = ...,
-) -> type[Spider] | None: ...
+) -> type[Spider] | None:
+    ...
 
 
 @overload
@@ -93,7 +98,8 @@ def spidercls_for_request(
     *,
     log_none: bool = ...,
     log_multiple: bool = ...,
-) -> type[Spider] | None: ...
+) -> type[Spider] | None:
+    ...
 
 
 def spidercls_for_request(

--- a/scrapy/utils/testproc.py
+++ b/scrapy/utils/testproc.py
@@ -20,10 +20,7 @@ class ProcessTest:
     cwd = os.getcwd()  # trial chdirs to temp dir
 
     def execute(
-        self,
-        args: Iterable[str],
-        check_code: bool = True,
-        settings: str | None = None,
+        self, args: Iterable[str], check_code: bool = True, settings: str | None = None,
     ) -> Deferred[TestProcessProtocol]:
         from twisted.internet import reactor
 


### PR DESCRIPTION
### Apply Black Code Formatting to the Project

This pull request applies the [Black](https://black.readthedocs.io/en/stable/) code formatter to the Scrapy codebase to ensure consistent code style and improve readability.

**Changes:**

- Reformatted 39 files according to Black's style guidelines
- No functional changes to the code; only formatting adjustments
- Improves code consistency across the project

**Reasoning:**

- Enhances code readability and maintainability
- Aligns the codebase with widely accepted Python formatting standards
- Facilitates future contributions by providing a consistent coding style

**Notes:**

- It's recommended to run Black on any future code changes to maintain consistency

---

By adopting Black, we aim to streamline the development process and reduce the overhead of code style discussions in pull requests.