### PR TITLE
Remove build_from_settings() and deprecate from_settings() code

### DIFF
--- a/docs/topics/email.rst
+++ b/docs/topics/email.rst
@@ -27,13 +27,13 @@ the standard ``__init__`` method:
 
     mailer = MailSender()
 
-Or you can instantiate it passing a Scrapy settings object, which will respect
-the :ref:`settings <topics-email-settings>`:
+Or you can instantiate it passing a :class:`scrapy.Crawler` instance, which
+will respect the :ref:`settings <topics-email-settings>`:
 
 .. skip: start
 .. code-block:: python
 
-    mailer = MailSender.from_settings(settings)
+    mailer = MailSender.from_crawler(crawler)
 
 And here is how to use it to send an e-mail (without attachments):
 
@@ -81,13 +81,13 @@ rest of the framework.
     :param smtpssl: enforce using a secure SSL connection
     :type smtpssl: bool
 
-    .. classmethod:: from_settings(settings)
+    .. classmethod:: from_crawler(crawler)
 
-        Instantiate using a Scrapy settings object, which will respect
-        :ref:`these Scrapy settings <topics-email-settings>`.
+        Instantiate using a :class:`scrapy.Crawler` instance, which will
+        respect :ref:`these Scrapy settings <topics-email-settings>`.
 
-        :param settings: the e-mail recipients
-        :type settings: :class:`scrapy.settings.Settings` object
+        :param crawler: the crawler
+        :type settings: :class:`scrapy.Crawler` object
 
     .. method:: send(to, subject, body, cc=None, attachs=(), mimetype='text/plain', charset=None)
 

--- a/docs/topics/request-response.rst
+++ b/docs/topics/request-response.rst
@@ -488,7 +488,7 @@ A request fingerprinter is a class that must implement the following method:
    :param request: request to fingerprint
    :type request: scrapy.http.Request
 
-Additionally, it may also implement the following methods:
+Additionally, it may also implement the following method:
 
 .. classmethod:: from_crawler(cls, crawler)
    :noindex:
@@ -503,13 +503,6 @@ Additionally, it may also implement the following methods:
 
    :param crawler: crawler that uses this request fingerprinter
    :type crawler: :class:`~scrapy.crawler.Crawler` object
-
-.. classmethod:: from_settings(cls, settings)
-
-   If present, and ``from_crawler`` is not defined, this class method is called
-   to create a request fingerprinter instance from a
-   :class:`~scrapy.settings.Settings` object. It must return a new instance of
-   the request fingerprinter.
 
 .. currentmodule:: scrapy.http
 

--- a/scrapy/core/downloader/contextfactory.py
+++ b/scrapy/core/downloader/contextfactory.py
@@ -21,6 +21,7 @@ from scrapy.core.downloader.tls import (
     ScrapyClientTLSOptions,
     openssl_methods,
 )
+from scrapy.exceptions import ScrapyDeprecationWarning
 from scrapy.utils.misc import build_from_crawler, load_object
 
 if TYPE_CHECKING:
@@ -64,6 +65,31 @@ class ScrapyClientContextFactory(BrowserLikePolicyForHTTPS):
 
     @classmethod
     def from_settings(
+        cls,
+        settings: BaseSettings,
+        method: int = SSL.SSLv23_METHOD,
+        *args: Any,
+        **kwargs: Any,
+    ) -> Self:
+        warnings.warn(
+            f"{cls.__name__}.from_settings() is deprecated, use from_crawler() instead.",
+            category=ScrapyDeprecationWarning,
+            stacklevel=2,
+        )
+        return cls._from_settings(settings, method, *args, **kwargs)
+
+    @classmethod
+    def from_crawler(
+        cls,
+        crawler: Crawler,
+        method: int = SSL.SSLv23_METHOD,
+        *args: Any,
+        **kwargs: Any,
+    ) -> Self:
+        return cls._from_settings(crawler.settings, method, *args, **kwargs)
+
+    @classmethod
+    def _from_settings(
         cls,
         settings: BaseSettings,
         method: int = SSL.SSLv23_METHOD,

--- a/scrapy/dupefilters.py
+++ b/scrapy/dupefilters.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
 import logging
+import warnings
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+from scrapy.exceptions import ScrapyDeprecationWarning
 from scrapy.utils.job import job_dir
 from scrapy.utils.request import (
     RequestFingerprinter,
@@ -26,6 +28,15 @@ if TYPE_CHECKING:
 class BaseDupeFilter:
     @classmethod
     def from_settings(cls, settings: BaseSettings) -> Self:
+        warnings.warn(
+            f"{cls.__name__}.from_settings() is deprecated, use from_crawler() instead.",
+            category=ScrapyDeprecationWarning,
+            stacklevel=2,
+        )
+        return cls()
+
+    @classmethod
+    def from_crawler(cls, crawler: Crawler) -> Self:
         return cls()
 
     def request_seen(self, request: Request) -> bool:
@@ -72,16 +83,30 @@ class RFPDupeFilter(BaseDupeFilter):
         *,
         fingerprinter: RequestFingerprinterProtocol | None = None,
     ) -> Self:
-        debug = settings.getbool("DUPEFILTER_DEBUG")
-        return cls(job_dir(settings), debug, fingerprinter=fingerprinter)
+        warnings.warn(
+            f"{cls.__name__}.from_settings() is deprecated, use from_crawler() instead.",
+            category=ScrapyDeprecationWarning,
+            stacklevel=2,
+        )
+        return cls._from_settings(settings, fingerprinter=fingerprinter)
 
     @classmethod
     def from_crawler(cls, crawler: Crawler) -> Self:
         assert crawler.request_fingerprinter
-        return cls.from_settings(
+        return cls._from_settings(
             crawler.settings,
             fingerprinter=crawler.request_fingerprinter,
         )
+
+    @classmethod
+    def _from_settings(
+        cls,
+        settings: BaseSettings,
+        *,
+        fingerprinter: RequestFingerprinterProtocol | None = None,
+    ) -> Self:
+        debug = settings.getbool("DUPEFILTER_DEBUG")
+        return cls(job_dir(settings), debug, fingerprinter=fingerprinter)
 
     def request_seen(self, request: Request) -> bool:
         fp = self.request_fingerprint(request)

--- a/scrapy/extensions/memusage.py
+++ b/scrapy/extensions/memusage.py
@@ -48,7 +48,7 @@ class MemoryUsage:
         self.check_interval: float = crawler.settings.getfloat(
             "MEMUSAGE_CHECK_INTERVAL_SECONDS"
         )
-        self.mail: MailSender = MailSender.from_settings(crawler.settings)
+        self.mail: MailSender = MailSender.from_crawler(crawler)
         crawler.signals.connect(self.engine_started, signal=signals.engine_started)
         crawler.signals.connect(self.engine_stopped, signal=signals.engine_stopped)
 

--- a/scrapy/extensions/statsmailer.py
+++ b/scrapy/extensions/statsmailer.py
@@ -33,7 +33,7 @@ class StatsMailer:
         recipients: list[str] = crawler.settings.getlist("STATSMAILER_RCPTS")
         if not recipients:
             raise NotConfigured
-        mail: MailSender = MailSender.from_settings(crawler.settings)
+        mail: MailSender = MailSender.from_crawler(crawler)
         assert crawler.stats
         o = cls(crawler.stats, recipients, mail)
         crawler.signals.connect(o.spider_closed, signal=signals.spider_closed)

--- a/scrapy/mail.py
+++ b/scrapy/mail.py
@@ -7,6 +7,7 @@ See documentation in docs/topics/email.rst
 from __future__ import annotations
 
 import logging
+import warnings
 from email import encoders as Encoders
 from email.mime.base import MIMEBase
 from email.mime.multipart import MIMEMultipart
@@ -19,6 +20,7 @@ from typing import IO, TYPE_CHECKING, Any
 from twisted.internet import ssl
 from twisted.internet.defer import Deferred
 
+from scrapy.exceptions import ScrapyDeprecationWarning
 from scrapy.utils.misc import arg_to_iter
 from scrapy.utils.python import to_bytes
 
@@ -32,6 +34,7 @@ if TYPE_CHECKING:
     # typing.Self requires Python 3.11
     from typing_extensions import Self
 
+    from scrapy.crawler import Crawler
     from scrapy.settings import BaseSettings
 
 
@@ -72,6 +75,19 @@ class MailSender:
 
     @classmethod
     def from_settings(cls, settings: BaseSettings) -> Self:
+        warnings.warn(
+            f"{cls.__name__}.from_settings() is deprecated, use from_crawler() instead.",
+            category=ScrapyDeprecationWarning,
+            stacklevel=2,
+        )
+        return cls._from_settings(settings)
+
+    @classmethod
+    def from_crawler(cls, crawler: Crawler) -> Self:
+        return cls._from_settings(crawler.settings)
+
+    @classmethod
+    def _from_settings(cls, settings: BaseSettings) -> Self:
         return cls(
             smtphost=settings["MAIL_HOST"],
             mailfrom=settings["MAIL_FROM"],

--- a/scrapy/middleware.py
+++ b/scrapy/middleware.py
@@ -54,14 +54,6 @@ class MiddlewareManager:
     @staticmethod
     def _build_from_settings(objcls: type[_T], settings: BaseSettings) -> _T:
         if hasattr(objcls, "from_settings"):
-            warnings.warn(
-                f"{objcls.__qualname__} has from_settings() but not from_crawler()."
-                " This is deprecated and calling from_settings() will be removed in a future"
-                " Scrapy version. You can implement a simple from_crawler() that calls"
-                " from_settings() with crawler.settings.",
-                category=ScrapyDeprecationWarning,
-                stacklevel=2,
-            )
             instance = objcls.from_settings(settings)  # type: ignore[attr-defined]
             method_name = "from_settings"
         else:

--- a/scrapy/middleware.py
+++ b/scrapy/middleware.py
@@ -65,13 +65,19 @@ class MiddlewareManager:
 
     @classmethod
     def from_settings(cls, settings: Settings, crawler: Crawler | None = None) -> Self:
-        if crawler is None:
-            warnings.warn(
-                "Calling MiddlewareManager.from_settings() without a Crawler instance is deprecated."
-                " As this method will be deprecated in the future, please switch to from_crawler().",
-                category=ScrapyDeprecationWarning,
-                stacklevel=2,
-            )
+        warnings.warn(
+            f"{cls.__name__}.from_settings() is deprecated, use from_crawler() instead.",
+            category=ScrapyDeprecationWarning,
+            stacklevel=2,
+        )
+        return cls._from_settings(settings, crawler)
+
+    @classmethod
+    def from_crawler(cls, crawler: Crawler) -> Self:
+        return cls._from_settings(crawler.settings, crawler)
+
+    @classmethod
+    def _from_settings(cls, settings: Settings, crawler: Crawler | None = None) -> Self:
         mwlist = cls._get_mwlist_from_settings(settings)
         middlewares = []
         enabled = []
@@ -101,10 +107,6 @@ class MiddlewareManager:
             extra={"crawler": crawler},
         )
         return cls(*middlewares)
-
-    @classmethod
-    def from_crawler(cls, crawler: Crawler) -> Self:
-        return cls.from_settings(crawler.settings, crawler)
 
     def _add_middleware(self, mw: Any) -> None:
         if hasattr(mw, "open_spider"):

--- a/scrapy/middleware.py
+++ b/scrapy/middleware.py
@@ -54,6 +54,14 @@ class MiddlewareManager:
     @staticmethod
     def _build_from_settings(objcls: type[_T], settings: BaseSettings) -> _T:
         if hasattr(objcls, "from_settings"):
+            warnings.warn(
+                f"{objcls.__qualname__} has from_settings() but not from_crawler()."
+                " This is deprecated and calling from_settings() will be removed in a future"
+                " Scrapy version. You can implement a simple from_crawler() that calls"
+                " from_settings() with crawler.settings.",
+                category=ScrapyDeprecationWarning,
+                stacklevel=2,
+            )
             instance = objcls.from_settings(settings)  # type: ignore[attr-defined]
             method_name = "from_settings"
         else:

--- a/scrapy/pipelines/files.py
+++ b/scrapy/pipelines/files.py
@@ -35,7 +35,7 @@ from scrapy.utils.datatypes import CaseInsensitiveDict
 from scrapy.utils.deprecate import method_is_overridden
 from scrapy.utils.ftp import ftp_store_file
 from scrapy.utils.log import failure_to_exc_info
-from scrapy.utils.python import get_func_args, to_bytes
+from scrapy.utils.python import get_func_args, global_object_name, to_bytes
 from scrapy.utils.request import referer_str
 
 if TYPE_CHECKING:
@@ -457,7 +457,7 @@ class FilesPipeline(MediaPipeline):
             if settings is not None:
                 warnings.warn(
                     f"FilesPipeline.__init__() was called with a crawler instance and a settings instance"
-                    f" when creating {self.__class__.__qualname__}. The settings instance will be ignored"
+                    f" when creating {global_object_name(self.__class__)}. The settings instance will be ignored"
                     f" and crawler.settings will be used. The settings argument will be removed in a future Scrapy version.",
                     category=ScrapyDeprecationWarning,
                     stacklevel=2,
@@ -501,7 +501,7 @@ class FilesPipeline(MediaPipeline):
     def from_crawler(cls, crawler: Crawler) -> Self:
         if method_is_overridden(cls, FilesPipeline, "from_settings"):
             warnings.warn(
-                f"{cls.__name__} overrides FilesPipeline.from_settings()."
+                f"{global_object_name(cls)} overrides FilesPipeline.from_settings()."
                 f" This method is deprecated and won't be called in future Scrapy versions,"
                 f" please update your code so that it overrides from_crawler() instead.",
                 category=ScrapyDeprecationWarning,
@@ -522,7 +522,7 @@ class FilesPipeline(MediaPipeline):
             if crawler:
                 o._finish_init(crawler)
             warnings.warn(
-                f"{cls.__qualname__}.__init__() doesn't take a crawler argument."
+                f"{global_object_name(cls)}.__init__() doesn't take a crawler argument."
                 " This is deprecated and the argument will be required in future Scrapy versions.",
                 category=ScrapyDeprecationWarning,
             )

--- a/scrapy/pipelines/images.py
+++ b/scrapy/pipelines/images.py
@@ -11,21 +11,14 @@ import hashlib
 import warnings
 from contextlib import suppress
 from io import BytesIO
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any
 
 from itemadapter import ItemAdapter
 
 from scrapy.exceptions import NotConfigured, ScrapyDeprecationWarning
 from scrapy.http import Request, Response
 from scrapy.http.request import NO_CALLBACK
-from scrapy.pipelines.files import (
-    FileException,
-    FilesPipeline,
-    FTPFilesStore,
-    GCSFilesStore,
-    S3FilesStore,
-    _md5sum,
-)
+from scrapy.pipelines.files import FileException, FilesPipeline, _md5sum
 from scrapy.settings import Settings
 from scrapy.utils.python import get_func_args, to_bytes
 
@@ -128,29 +121,7 @@ class ImagesPipeline(FilesPipeline):
 
     @classmethod
     def _from_settings(cls, settings: Settings, crawler: Crawler | None) -> Self:
-        s3store: type[S3FilesStore] = cast(type[S3FilesStore], cls.STORE_SCHEMES["s3"])
-        s3store.AWS_ACCESS_KEY_ID = settings["AWS_ACCESS_KEY_ID"]
-        s3store.AWS_SECRET_ACCESS_KEY = settings["AWS_SECRET_ACCESS_KEY"]
-        s3store.AWS_SESSION_TOKEN = settings["AWS_SESSION_TOKEN"]
-        s3store.AWS_ENDPOINT_URL = settings["AWS_ENDPOINT_URL"]
-        s3store.AWS_REGION_NAME = settings["AWS_REGION_NAME"]
-        s3store.AWS_USE_SSL = settings["AWS_USE_SSL"]
-        s3store.AWS_VERIFY = settings["AWS_VERIFY"]
-        s3store.POLICY = settings["IMAGES_STORE_S3_ACL"]
-
-        gcs_store: type[GCSFilesStore] = cast(
-            type[GCSFilesStore], cls.STORE_SCHEMES["gs"]
-        )
-        gcs_store.GCS_PROJECT_ID = settings["GCS_PROJECT_ID"]
-        gcs_store.POLICY = settings["IMAGES_STORE_GCS_ACL"] or None
-
-        ftp_store: type[FTPFilesStore] = cast(
-            type[FTPFilesStore], cls.STORE_SCHEMES["ftp"]
-        )
-        ftp_store.FTP_USERNAME = settings["FTP_USER"]
-        ftp_store.FTP_PASSWORD = settings["FTP_PASSWORD"]
-        ftp_store.USE_ACTIVE_MODE = settings.getbool("FEED_STORAGE_FTP_ACTIVE")
-
+        cls._update_stores(settings)
         store_uri = settings["IMAGES_STORE"]
         if "crawler" in get_func_args(cls.__init__):
             o = cls(store_uri, crawler=crawler)

--- a/scrapy/pipelines/images.py
+++ b/scrapy/pipelines/images.py
@@ -20,7 +20,7 @@ from scrapy.http import Request, Response
 from scrapy.http.request import NO_CALLBACK
 from scrapy.pipelines.files import FileException, FilesPipeline, _md5sum
 from scrapy.settings import Settings
-from scrapy.utils.python import get_func_args, to_bytes
+from scrapy.utils.python import get_func_args, global_object_name, to_bytes
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Iterable
@@ -82,7 +82,7 @@ class ImagesPipeline(FilesPipeline):
             if settings is not None:
                 warnings.warn(
                     f"ImagesPipeline.__init__() was called with a crawler instance and a settings instance"
-                    f" when creating {self.__class__.__qualname__}. The settings instance will be ignored"
+                    f" when creating {global_object_name(self.__class__)}. The settings instance will be ignored"
                     f" and crawler.settings will be used. The settings argument will be removed in a future Scrapy version.",
                     category=ScrapyDeprecationWarning,
                     stacklevel=2,
@@ -130,7 +130,7 @@ class ImagesPipeline(FilesPipeline):
             if crawler:
                 o._finish_init(crawler)
             warnings.warn(
-                f"{cls.__qualname__}.__init__() doesn't take a crawler argument."
+                f"{global_object_name(cls)}.__init__() doesn't take a crawler argument."
                 " This is deprecated and the argument will be required in future Scrapy versions.",
                 category=ScrapyDeprecationWarning,
             )

--- a/scrapy/pipelines/images.py
+++ b/scrapy/pipelines/images.py
@@ -79,10 +79,23 @@ class ImagesPipeline(FilesPipeline):
             )
 
         super().__init__(
-            store_uri, settings=settings, download_func=download_func, crawler=crawler
+            store_uri,
+            settings=settings if not crawler else None,
+            download_func=download_func,
+            crawler=crawler,
         )
 
-        if isinstance(settings, dict) or settings is None:
+        if crawler is not None:
+            if settings is not None:
+                warnings.warn(
+                    f"ImagesPipeline.__init__() was called with a crawler instance and a settings instance"
+                    f" when creating {self.__class__.__qualname__}. The settings instance will be ignored"
+                    f" and crawler.settings will be used. The settings argument will be removed in a future Scrapy version.",
+                    category=ScrapyDeprecationWarning,
+                    stacklevel=2,
+                )
+            settings = crawler.settings
+        elif isinstance(settings, dict) or settings is None:
             settings = Settings(settings)
 
         resolve = functools.partial(
@@ -140,7 +153,7 @@ class ImagesPipeline(FilesPipeline):
 
         store_uri = settings["IMAGES_STORE"]
         if "crawler" in get_func_args(cls.__init__):
-            o = cls(store_uri, settings=settings, crawler=crawler)
+            o = cls(store_uri, crawler=crawler)
         else:
             o = cls(store_uri, settings=settings)
             if crawler:

--- a/scrapy/pipelines/media.py
+++ b/scrapy/pipelines/media.py
@@ -28,7 +28,7 @@ from scrapy.utils.datatypes import SequenceExclude
 from scrapy.utils.defer import defer_result, mustbe_deferred
 from scrapy.utils.log import failure_to_exc_info
 from scrapy.utils.misc import arg_to_iter
-from scrapy.utils.python import get_func_args
+from scrapy.utils.python import get_func_args, global_object_name
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -85,7 +85,7 @@ class MediaPipeline(ABC):
             if settings is not None:
                 warnings.warn(
                     f"MediaPipeline.__init__() was called with a crawler instance and a settings instance"
-                    f" when creating {self.__class__.__qualname__}. The settings instance will be ignored"
+                    f" when creating {global_object_name(self.__class__)}. The settings instance will be ignored"
                     f" and crawler.settings will be used. The settings argument will be removed in a future Scrapy version.",
                     category=ScrapyDeprecationWarning,
                     stacklevel=2,
@@ -107,7 +107,7 @@ class MediaPipeline(ABC):
         else:
             warnings.warn(
                 f"MediaPipeline.__init__() was called without the crawler argument"
-                f" when creating {self.__class__.__qualname__}."
+                f" when creating {global_object_name(self.__class__)}."
                 f" This is deprecated and the argument will be required in future Scrapy versions.",
                 category=ScrapyDeprecationWarning,
                 stacklevel=2,
@@ -154,7 +154,7 @@ class MediaPipeline(ABC):
         else:
             pipe = cls()
             warnings.warn(
-                f"{cls.__qualname__}.__init__() doesn't take a crawler argument."
+                f"{global_object_name(cls)}.__init__() doesn't take a crawler argument."
                 " This is deprecated and the argument will be required in future Scrapy versions.",
                 category=ScrapyDeprecationWarning,
             )

--- a/scrapy/pipelines/media.py
+++ b/scrapy/pipelines/media.py
@@ -81,7 +81,17 @@ class MediaPipeline(ABC):
     ):
         self.download_func = download_func
 
-        if isinstance(settings, dict) or settings is None:
+        if crawler is not None:
+            if settings is not None:
+                warnings.warn(
+                    f"MediaPipeline.__init__() was called with a crawler instance and a settings instance"
+                    f" when creating {self.__class__.__qualname__}. The settings instance will be ignored"
+                    f" and crawler.settings will be used. The settings argument will be removed in a future Scrapy version.",
+                    category=ScrapyDeprecationWarning,
+                    stacklevel=2,
+                )
+            settings = crawler.settings
+        elif isinstance(settings, dict) or settings is None:
             settings = Settings(settings)
         resolve = functools.partial(
             self._key_for_pipe, base_class_name="MediaPipeline", settings=settings
@@ -92,7 +102,6 @@ class MediaPipeline(ABC):
         self._handle_statuses(self.allow_redirects)
 
         if crawler:
-            # TODO use crawler.settings
             self._finish_init(crawler)
             self._modern_init = True
         else:

--- a/scrapy/spidermiddlewares/urllength.py
+++ b/scrapy/spidermiddlewares/urllength.py
@@ -7,9 +7,10 @@ See documentation in docs/topics/spider-middleware.rst
 from __future__ import annotations
 
 import logging
+import warnings
 from typing import TYPE_CHECKING, Any
 
-from scrapy.exceptions import NotConfigured
+from scrapy.exceptions import NotConfigured, ScrapyDeprecationWarning
 from scrapy.http import Request, Response
 
 if TYPE_CHECKING:
@@ -19,6 +20,7 @@ if TYPE_CHECKING:
     from typing_extensions import Self
 
     from scrapy import Spider
+    from scrapy.crawler import Crawler
     from scrapy.settings import BaseSettings
 
 
@@ -31,6 +33,19 @@ class UrlLengthMiddleware:
 
     @classmethod
     def from_settings(cls, settings: BaseSettings) -> Self:
+        warnings.warn(
+            f"{cls.__name__}.from_settings() is deprecated, use from_crawler() instead.",
+            category=ScrapyDeprecationWarning,
+            stacklevel=2,
+        )
+        return cls._from_settings(settings)
+
+    @classmethod
+    def from_crawler(cls, crawler: Crawler) -> Self:
+        return cls._from_settings(crawler.settings)
+
+    @classmethod
+    def _from_settings(cls, settings: BaseSettings) -> Self:
         maxlength = settings.getint("URLLENGTH_LIMIT")
         if not maxlength:
             raise NotConfigured

--- a/scrapy/utils/misc.py
+++ b/scrapy/utils/misc.py
@@ -26,7 +26,6 @@ if TYPE_CHECKING:
 
     from scrapy import Spider
     from scrapy.crawler import Crawler
-    from scrapy.settings import BaseSettings
 
 
 _ITERABLE_SINGLE_VALUES = dict, Item, str, bytes
@@ -150,7 +149,7 @@ def create_instance(objcls, settings, crawler, *args, **kwargs):
     """
     warnings.warn(
         "The create_instance() function is deprecated. "
-        "Please use build_from_crawler() or build_from_settings() instead.",
+        "Please use build_from_crawler() instead.",
         category=ScrapyDeprecationWarning,
         stacklevel=2,
     )
@@ -176,7 +175,7 @@ def create_instance(objcls, settings, crawler, *args, **kwargs):
 def build_from_crawler(
     objcls: type[T], crawler: Crawler, /, *args: Any, **kwargs: Any
 ) -> T:
-    """Construct a class instance using its ``from_crawler`` constructor.
+    """Construct a class instance using its ``from_crawler`` or ``from_settings`` constructor.
 
     ``*args`` and ``**kwargs`` are forwarded to the constructor.
 
@@ -187,26 +186,6 @@ def build_from_crawler(
         method_name = "from_crawler"
     elif hasattr(objcls, "from_settings"):
         instance = objcls.from_settings(crawler.settings, *args, **kwargs)  # type: ignore[attr-defined]
-        method_name = "from_settings"
-    else:
-        instance = objcls(*args, **kwargs)
-        method_name = "__new__"
-    if instance is None:
-        raise TypeError(f"{objcls.__qualname__}.{method_name} returned None")
-    return cast(T, instance)
-
-
-def build_from_settings(
-    objcls: type[T], settings: BaseSettings, /, *args: Any, **kwargs: Any
-) -> T:
-    """Construct a class instance using its ``from_settings`` constructor.
-
-    ``*args`` and ``**kwargs`` are forwarded to the constructor.
-
-    Raises ``TypeError`` if the resulting instance is ``None``.
-    """
-    if hasattr(objcls, "from_settings"):
-        instance = objcls.from_settings(settings, *args, **kwargs)  # type: ignore[attr-defined]
         method_name = "from_settings"
     else:
         instance = objcls(*args, **kwargs)

--- a/scrapy/utils/misc.py
+++ b/scrapy/utils/misc.py
@@ -185,6 +185,14 @@ def build_from_crawler(
         instance = objcls.from_crawler(crawler, *args, **kwargs)  # type: ignore[attr-defined]
         method_name = "from_crawler"
     elif hasattr(objcls, "from_settings"):
+        warnings.warn(
+            f"{objcls.__qualname__} has from_settings() but not from_crawler()."
+            " This is deprecated and calling from_settings() will be removed in a future"
+            " Scrapy version. You can implement a simple from_crawler() that calls"
+            " from_settings() with crawler.settings.",
+            category=ScrapyDeprecationWarning,
+            stacklevel=2,
+        )
         instance = objcls.from_settings(crawler.settings, *args, **kwargs)  # type: ignore[attr-defined]
         method_name = "from_settings"
     else:

--- a/tests/test_dupefilters.py
+++ b/tests/test_dupefilters.py
@@ -33,14 +33,6 @@ class FromCrawlerRFPDupeFilter(RFPDupeFilter):
         return df
 
 
-class FromSettingsRFPDupeFilter(RFPDupeFilter):
-    @classmethod
-    def from_settings(cls, settings, *, fingerprinter=None):
-        df = super().from_settings(settings, fingerprinter=fingerprinter)
-        df.method = "from_settings"
-        return df
-
-
 class DirectDupeFilter:
     method = "n/a"
 
@@ -55,16 +47,6 @@ class RFPDupeFilterTest(unittest.TestCase):
         scheduler = Scheduler.from_crawler(crawler)
         self.assertTrue(scheduler.df.debug)
         self.assertEqual(scheduler.df.method, "from_crawler")
-
-    def test_df_from_settings_scheduler(self):
-        settings = {
-            "DUPEFILTER_DEBUG": True,
-            "DUPEFILTER_CLASS": FromSettingsRFPDupeFilter,
-        }
-        crawler = get_crawler(settings_dict=settings)
-        scheduler = Scheduler.from_crawler(crawler)
-        self.assertTrue(scheduler.df.debug)
-        self.assertEqual(scheduler.df.method, "from_settings")
 
     def test_df_direct_scheduler(self):
         settings = {

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -2,7 +2,7 @@ from twisted.trial import unittest
 
 from scrapy.exceptions import NotConfigured
 from scrapy.middleware import MiddlewareManager
-from scrapy.settings import Settings
+from scrapy.utils.test import get_crawler
 
 
 class M1:
@@ -22,8 +22,6 @@ class M2:
 
     def close_spider(self, spider):
         pass
-
-    pass
 
 
 class M3:
@@ -83,7 +81,7 @@ class MiddlewareManagerTest(unittest.TestCase):
         self.assertEqual(mwman.middlewares, (m1, m2, m3))
 
     def test_enabled_from_settings(self):
-        settings = Settings()
-        mwman = TestMiddlewareManager.from_settings(settings)
+        crawler = get_crawler()
+        mwman = TestMiddlewareManager.from_crawler(crawler)
         classes = [x.__class__ for x in mwman.middlewares]
         self.assertEqual(classes, [M1, M3])

--- a/tests/test_pipeline_files.py
+++ b/tests/test_pipeline_files.py
@@ -755,7 +755,7 @@ class BuildFromCrawlerTestCase(unittest.TestCase):
             def from_crawler(cls, crawler):
                 settings = crawler.settings
                 store_uri = settings["FILES_STORE"]
-                o = cls(store_uri, settings=settings, crawler=crawler)
+                o = cls(store_uri, crawler=crawler)
                 o._from_crawler_called = True
                 return o
 

--- a/tests/test_pipeline_files.py
+++ b/tests/test_pipeline_files.py
@@ -17,7 +17,6 @@ from itemadapter import ItemAdapter
 from twisted.internet import defer
 from twisted.trial import unittest
 
-from scrapy import Spider
 from scrapy.http import Request, Response
 from scrapy.item import Field, Item
 from scrapy.pipelines.files import (
@@ -27,7 +26,6 @@ from scrapy.pipelines.files import (
     GCSFilesStore,
     S3FilesStore,
 )
-from scrapy.settings import Settings
 from scrapy.utils.test import (
     assert_gcs_environ,
     get_crawler,
@@ -219,8 +217,8 @@ class FilesPipelineTestCase(unittest.TestCase):
             def file_path(self, request, response=None, info=None, item=None):
                 return f'full/{item.get("path")}'
 
-        file_path = CustomFilesPipeline.from_settings(
-            Settings({"FILES_STORE": self.tempdir})
+        file_path = CustomFilesPipeline.from_crawler(
+            get_crawler(None, {"FILES_STORE": self.tempdir})
         ).file_path
         item = {"path": "path-to-store-file"}
         request = Request("http://example.com")
@@ -237,7 +235,9 @@ class FilesPipelineTestCaseFieldsMixin:
     def test_item_fields_default(self):
         url = "http://www.example.com/files/1.txt"
         item = self.item_class(name="item1", file_urls=[url])
-        pipeline = FilesPipeline.from_settings(Settings({"FILES_STORE": self.tempdir}))
+        pipeline = FilesPipeline.from_crawler(
+            get_crawler(None, {"FILES_STORE": self.tempdir})
+        )
         requests = list(pipeline.get_media_requests(item, None))
         self.assertEqual(requests[0].url, url)
         results = [(True, {"url": url})]
@@ -249,13 +249,14 @@ class FilesPipelineTestCaseFieldsMixin:
     def test_item_fields_override_settings(self):
         url = "http://www.example.com/files/1.txt"
         item = self.item_class(name="item1", custom_file_urls=[url])
-        pipeline = FilesPipeline.from_settings(
-            Settings(
+        pipeline = FilesPipeline.from_crawler(
+            get_crawler(
+                None,
                 {
                     "FILES_STORE": self.tempdir,
                     "FILES_URLS_FIELD": "custom_file_urls",
                     "FILES_RESULT_FIELD": "custom_files",
-                }
+                },
             )
         )
         requests = list(pipeline.get_media_requests(item, None))
@@ -373,8 +374,10 @@ class FilesPipelineTestCaseCustomSettings(unittest.TestCase):
         different settings.
         """
         custom_settings = self._generate_fake_settings()
-        another_pipeline = FilesPipeline.from_settings(Settings(custom_settings))
-        one_pipeline = FilesPipeline(self.tempdir)
+        another_pipeline = FilesPipeline.from_crawler(
+            get_crawler(None, custom_settings)
+        )
+        one_pipeline = FilesPipeline(self.tempdir, crawler=get_crawler(None))
         for pipe_attr, settings_attr, pipe_ins_attr in self.file_cls_attr_settings_map:
             default_value = self.default_cls_settings[pipe_attr]
             self.assertEqual(getattr(one_pipeline, pipe_attr), default_value)
@@ -387,7 +390,7 @@ class FilesPipelineTestCaseCustomSettings(unittest.TestCase):
         If subclasses override class attributes and there are no special settings those values should be kept.
         """
         pipe_cls = self._generate_fake_pipeline()
-        pipe = pipe_cls.from_settings(Settings({"FILES_STORE": self.tempdir}))
+        pipe = pipe_cls.from_crawler(get_crawler(None, {"FILES_STORE": self.tempdir}))
         for pipe_attr, settings_attr, pipe_ins_attr in self.file_cls_attr_settings_map:
             custom_value = getattr(pipe, pipe_ins_attr)
             self.assertNotEqual(custom_value, self.default_cls_settings[pipe_attr])
@@ -400,7 +403,7 @@ class FilesPipelineTestCaseCustomSettings(unittest.TestCase):
         """
         pipeline_cls = self._generate_fake_pipeline()
         settings = self._generate_fake_settings()
-        pipeline = pipeline_cls.from_settings(Settings(settings))
+        pipeline = pipeline_cls.from_crawler(get_crawler(None, settings))
         for pipe_attr, settings_attr, pipe_ins_attr in self.file_cls_attr_settings_map:
             value = getattr(pipeline, pipe_ins_attr)
             setting_value = settings.get(settings_attr)
@@ -416,8 +419,8 @@ class FilesPipelineTestCaseCustomSettings(unittest.TestCase):
         class UserDefinedFilesPipeline(FilesPipeline):
             pass
 
-        user_pipeline = UserDefinedFilesPipeline.from_settings(
-            Settings({"FILES_STORE": self.tempdir})
+        user_pipeline = UserDefinedFilesPipeline.from_crawler(
+            get_crawler(None, {"FILES_STORE": self.tempdir})
         )
         for pipe_attr, settings_attr, pipe_ins_attr in self.file_cls_attr_settings_map:
             # Values from settings for custom pipeline should be set on pipeline instance.
@@ -435,7 +438,9 @@ class FilesPipelineTestCaseCustomSettings(unittest.TestCase):
 
         prefix = UserDefinedFilesPipeline.__name__.upper()
         settings = self._generate_fake_settings(prefix=prefix)
-        user_pipeline = UserDefinedFilesPipeline.from_settings(Settings(settings))
+        user_pipeline = UserDefinedFilesPipeline.from_crawler(
+            get_crawler(None, settings)
+        )
         for pipe_attr, settings_attr, pipe_inst_attr in self.file_cls_attr_settings_map:
             # Values from settings for custom pipeline should be set on pipeline instance.
             custom_value = settings.get(prefix + "_" + settings_attr)
@@ -450,7 +455,7 @@ class FilesPipelineTestCaseCustomSettings(unittest.TestCase):
         pipeline_cls = self._generate_fake_pipeline()
         prefix = pipeline_cls.__name__.upper()
         settings = self._generate_fake_settings(prefix=prefix)
-        user_pipeline = pipeline_cls.from_settings(Settings(settings))
+        user_pipeline = pipeline_cls.from_crawler(get_crawler(None, settings))
         for (
             pipe_cls_attr,
             settings_attr,
@@ -465,8 +470,8 @@ class FilesPipelineTestCaseCustomSettings(unittest.TestCase):
             DEFAULT_FILES_RESULT_FIELD = "this"
             DEFAULT_FILES_URLS_FIELD = "that"
 
-        pipeline = UserDefinedFilesPipeline.from_settings(
-            Settings({"FILES_STORE": self.tempdir})
+        pipeline = UserDefinedFilesPipeline.from_crawler(
+            get_crawler(None, {"FILES_STORE": self.tempdir})
         )
         self.assertEqual(
             pipeline.files_result_field,
@@ -486,7 +491,7 @@ class FilesPipelineTestCaseCustomSettings(unittest.TestCase):
         class UserPipe(FilesPipeline):
             pass
 
-        pipeline_cls = UserPipe.from_settings(Settings(settings))
+        pipeline_cls = UserPipe.from_crawler(get_crawler(None, settings))
 
         for pipe_attr, settings_attr, pipe_inst_attr in self.file_cls_attr_settings_map:
             expected_value = settings.get(settings_attr)
@@ -497,8 +502,8 @@ class FilesPipelineTestCaseCustomSettings(unittest.TestCase):
             def file_path(self, request, response=None, info=None, *, item=None):
                 return Path("subdir") / Path(request.url).name
 
-        pipeline = CustomFilesPipelineWithPathLikeDir.from_settings(
-            Settings({"FILES_STORE": Path("./Temp")})
+        pipeline = CustomFilesPipelineWithPathLikeDir.from_crawler(
+            get_crawler(None, {"FILES_STORE": Path("./Temp")})
         )
         request = Request("http://example.com/image01.jpg")
         self.assertEqual(pipeline.file_path(request), Path("subdir/image01.jpg"))
@@ -695,7 +700,7 @@ def _prepare_request_object(item_url, flags=None):
 class BuildFromCrawlerTestCase(unittest.TestCase):
     def setUp(self):
         self.tempdir = mkdtemp()
-        self.crawler = get_crawler(Spider, {"FILES_STORE": self.tempdir})
+        self.crawler = get_crawler(None, {"FILES_STORE": self.tempdir})
 
     def tearDown(self):
         rmtree(self.tempdir)
@@ -711,8 +716,23 @@ class BuildFromCrawlerTestCase(unittest.TestCase):
             self.assertEqual(len(w), 0)
             assert pipe.store
 
+    def test_has_old_init(self):
+        class Pipeline(FilesPipeline):
+            def __init__(self, store_uri, download_func=None, settings=None):
+                super().__init__(store_uri, download_func, settings)
+                self._init_called = True
+
+        with warnings.catch_warnings(record=True) as w:
+            pipe = Pipeline.from_crawler(self.crawler)
+            assert pipe.crawler == self.crawler
+            assert pipe._fingerprinter
+            self.assertEqual(len(w), 2)
+            assert pipe._init_called
+
     def test_has_from_settings(self):
         class Pipeline(FilesPipeline):
+            _from_settings_called = False
+
             @classmethod
             def from_settings(cls, settings):
                 o = super().from_settings(settings)
@@ -723,27 +743,24 @@ class BuildFromCrawlerTestCase(unittest.TestCase):
             pipe = Pipeline.from_crawler(self.crawler)
             assert pipe.crawler == self.crawler
             assert pipe._fingerprinter
-            self.assertEqual(len(w), 0)
+            self.assertEqual(len(w), 3)
             assert pipe.store
             assert pipe._from_settings_called
 
-    @pytest.mark.xfail(
-        reason="No way to override MediaPipeline.from_crawler having non-trivial __init__"
-    )
     def test_has_from_crawler_and_init(self):
         class Pipeline(FilesPipeline):
+            _from_crawler_called = False
+
             @classmethod
             def from_crawler(cls, crawler):
                 settings = crawler.settings
                 store_uri = settings["FILES_STORE"]
-                # you can either call super().from_crawler() or cls.__init__() but you need both
-                o = cls(store_uri, settings=settings)
+                o = cls(store_uri, settings=settings, crawler=crawler)
                 o._from_crawler_called = True
                 return o
 
         with warnings.catch_warnings(record=True) as w:
             pipe = Pipeline.from_crawler(self.crawler)
-            # this and the next assert will fail as MediaPipeline.from_crawler() wasn't called
             assert pipe.crawler == self.crawler
             assert pipe._fingerprinter
             self.assertEqual(len(w), 0)

--- a/tests/test_pipeline_images.py
+++ b/tests/test_pipeline_images.py
@@ -13,7 +13,6 @@ from twisted.trial import unittest
 from scrapy.http import Request, Response
 from scrapy.item import Field, Item
 from scrapy.pipelines.images import ImageException, ImagesPipeline
-from scrapy.settings import Settings
 from scrapy.utils.test import get_crawler
 
 skip_pillow: str | None
@@ -392,10 +391,7 @@ class ImagesPipelineTestCaseCustomSettings(unittest.TestCase):
         have different settings.
         """
         custom_settings = self._generate_fake_settings()
-        default_settings = Settings()
-        default_sts_pipe = ImagesPipeline(
-            self.tempdir, settings=default_settings, crawler=get_crawler(None)  # TODO
-        )
+        default_sts_pipe = ImagesPipeline(self.tempdir, crawler=get_crawler(None))
         user_sts_pipe = ImagesPipeline.from_crawler(get_crawler(None, custom_settings))
         for pipe_attr, settings_attr in self.img_cls_attribute_names:
             expected_default_value = self.default_pipeline_settings.get(pipe_attr)

--- a/tests/test_pipeline_media.py
+++ b/tests/test_pipeline_media.py
@@ -378,8 +378,7 @@ class MediaPipelineTestCase(BaseMediaPipelineTestCase):
 class MediaPipelineAllowRedirectSettingsTestCase(unittest.TestCase):
 
     def _assert_request_no3xx(self, pipeline_class, settings):
-        crawler = get_crawler(None, settings)
-        pipe = pipeline_class(settings=settings, crawler=crawler)  # TODO
+        pipe = pipeline_class(crawler=get_crawler(None, settings))
         request = Request("http://url")
         pipe._modify_media_request(request)
 

--- a/tests/test_spidermiddleware_urllength.py
+++ b/tests/test_spidermiddleware_urllength.py
@@ -3,7 +3,6 @@ from unittest import TestCase
 from testfixtures import LogCapture
 
 from scrapy.http import Request, Response
-from scrapy.settings import Settings
 from scrapy.spidermiddlewares.urllength import UrlLengthMiddleware
 from scrapy.spiders import Spider
 from scrapy.utils.test import get_crawler
@@ -12,12 +11,10 @@ from scrapy.utils.test import get_crawler
 class TestUrlLengthMiddleware(TestCase):
     def setUp(self):
         self.maxlength = 25
-        settings = Settings({"URLLENGTH_LIMIT": self.maxlength})
-
-        crawler = get_crawler(Spider)
+        crawler = get_crawler(Spider, {"URLLENGTH_LIMIT": self.maxlength})
         self.spider = crawler._create_spider("foo")
         self.stats = crawler.stats
-        self.mw = UrlLengthMiddleware.from_settings(settings)
+        self.mw = UrlLengthMiddleware.from_crawler(crawler)
 
         self.response = Response("http://scrapytest.org")
         self.short_url_req = Request("http://scrapytest.org/")

--- a/tests/test_utils_misc/__init__.py
+++ b/tests/test_utils_misc/__init__.py
@@ -10,7 +10,6 @@ from scrapy.item import Field, Item
 from scrapy.utils.misc import (
     arg_to_iter,
     build_from_crawler,
-    build_from_settings,
     create_instance,
     load_object,
     rel_has_nofollow,
@@ -196,39 +195,6 @@ class UtilsMiscTestCase(unittest.TestCase):
         m.from_crawler.return_value = None
         with self.assertRaises(TypeError):
             build_from_crawler(m, crawler, *args, **kwargs)
-
-    def test_build_from_settings(self):
-        settings = mock.MagicMock()
-        args = (True, 100.0)
-        kwargs = {"key": "val"}
-
-        def _test_with_settings(mock, settings):
-            build_from_settings(mock, settings, *args, **kwargs)
-            if hasattr(mock, "from_settings"):
-                mock.from_settings.assert_called_once_with(settings, *args, **kwargs)
-                self.assertEqual(mock.call_count, 0)
-            else:
-                mock.assert_called_once_with(*args, **kwargs)
-
-        # Check usage of correct constructor using three mocks:
-        #   1. with no alternative constructors
-        #   2. with from_settings() constructor
-        #   3. with from_settings() and from_crawler() constructor
-        spec_sets = (
-            ["__qualname__"],
-            ["__qualname__", "from_settings"],
-            ["__qualname__", "from_settings", "from_crawler"],
-        )
-        for specs in spec_sets:
-            m = mock.MagicMock(spec_set=specs)
-            _test_with_settings(m, settings)
-            m.reset_mock()
-
-        # Check adoption of crawler settings
-        m = mock.MagicMock(spec_set=["__qualname__", "from_settings"])
-        m.from_settings.return_value = None
-        with self.assertRaises(TypeError):
-            build_from_settings(m, settings, *args, **kwargs)
 
     def test_set_environ(self):
         assert os.environ.get("some_test_environ") is None

--- a/tests/test_utils_request.py
+++ b/tests/test_utils_request.py
@@ -8,6 +8,7 @@ from weakref import WeakKeyDictionary
 
 import pytest
 
+from scrapy.exceptions import ScrapyDeprecationWarning
 from scrapy.http import Request
 from scrapy.utils.python import to_bytes
 from scrapy.utils.request import (
@@ -384,7 +385,9 @@ class CustomRequestFingerprinterTestCase(unittest.TestCase):
             "REQUEST_FINGERPRINTER_CLASS": RequestFingerprinter,
             "FINGERPRINT": b"fingerprint",
         }
-        crawler = get_crawler(settings_dict=settings)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", ScrapyDeprecationWarning)
+            crawler = get_crawler(settings_dict=settings)
 
         request = Request("http://www.example.com")
         fingerprint = crawler.request_fingerprinter.fingerprint(request)


### PR DESCRIPTION
Fixes #6534

- [x] Deprecate calling `from_settings()` in `build_from_crawler()` and `MiddlewareManager._build_from_settings()`
- [x] Redo `from_crawler()`/`from_settings()` in `MiddlewareManager`
- [x] ~~Deprecate `ISpiderLoader.from_settings()` and add `ISpiderLoader.from_crawler()` without breaking `verifyClass`~~ It looks like `SpiderLoader` cannot take a crawler and it's created without `build_from_crawler()` anyway.
- [x] Reshuffle `from_crawler()`/`from_settings()` in `MediaPipeline` and its subclasses in a backwards-compatible way