### PR TITLE
Verified PyPI releases (a.k.a. PEP740)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,16 +10,20 @@ concurrency:
 
 jobs:
   publish:
+    name: Upload release to PyPI
     runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/Scrapy
+    permissions:
+      id-token: write
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
           python-version: "3.13"
       - run: | 
-          pip install --upgrade build twine
+          python -m pip install --upgrade build
           python -m build
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@v1.10.3
-        with:
-          password: ${{ secrets.PYPI_TOKEN }}
+        uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
Motivated by _[Are we PEP 740 yet?](https://trailofbits.github.io/are-we-pep740-yet/)_

> What is PEP 740?
>
> [PEP 740](https://peps.python.org/pep-0740/) is a Python standard for defining cryptographically verifiable attestations hosted by indices like PyPI.
What are attestations?
> 
> Attestations are digitally signed, publicly verifiable statements about Python packages, including their provenance (e.g., the exact source repository that produced them).
>
> Attestations are built on top of [Sigstore](https://sigstore.dev/) and use short-lived signing keys bound to trusted identities (like [Trusted Publishers](https://docs.pypi.org/trusted-publishers/)), making them misuse-resistant and less susceptible to key loss and theft.

PyPI's Scrapy project is ready to accept uploads from Github Action

<img width="775" alt="image" src="https://github.com/user-attachments/assets/37b7a8f1-37e7-4d2c-b07b-326637378a6a">

