### PR TITLE
Add ruff with basic rules.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,8 @@
 repos:
+- repo: https://github.com/astral-sh/ruff-pre-commit
+  rev: v0.8.1
+  hooks:
+    - id: ruff
 - repo: https://github.com/PyCQA/bandit
   rev: 1.7.9
   hooks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -233,3 +233,24 @@ markers = [
     "requires_boto3: marks tests that need botocore and boto3",
 ]
 filterwarnings = []
+
+[tool.ruff.lint]
+extend-select = [
+]
+ignore = [
+]
+
+[tool.ruff.lint.per-file-ignores]
+# Exclude files that are meant to provide top-level imports
+"scrapy/__init__.py" = ["E402"]
+"scrapy/core/downloader/handlers/http.py" = ["F401"]
+"scrapy/http/__init__.py" = ["F401"]
+"scrapy/linkextractors/__init__.py" = ["E402", "F401"]
+"scrapy/selector/__init__.py" = ["F401"]
+"scrapy/spiders/__init__.py" = ["E402", "F401"]
+
+# Issues pending a review:
+"docs/conf.py" = ["E402"]
+"scrapy/utils/url.py" = ["F403", "F405"]
+"tests/CrawlerRunner/change_reactor.py" = ["E402"]
+"tests/test_loader.py" = ["E741"]

--- a/scrapy/http/request/form.py
+++ b/scrapy/http/request/form.py
@@ -186,7 +186,7 @@ def _get_inputs(
 
     if not dont_click:
         clickable = _get_clickable(clickdata, form)
-        if clickable and clickable[0] not in formdata and not clickable[0] is None:
+        if clickable and clickable[0] not in formdata and clickable[0] is not None:
             values.append(clickable)
 
     formdata_items = formdata.items() if isinstance(formdata, dict) else formdata

--- a/tests/test_pipeline_crawl.py
+++ b/tests/test_pipeline_crawl.py
@@ -218,7 +218,7 @@ class FileDownloadCrawlTestCase(TestCase):
 
 skip_pillow: str | None
 try:
-    from PIL import Image  # noqa: imported just to check for the import error
+    from PIL import Image  # noqa: F401
 except ImportError:
     skip_pillow = "Missing Python Imaging Library, install https://pypi.org/pypi/Pillow"
 else:

--- a/tests/test_pipeline_media.py
+++ b/tests/test_pipeline_media.py
@@ -19,7 +19,7 @@ from scrapy.utils.signal import disconnect_all
 from scrapy.utils.test import get_crawler
 
 try:
-    from PIL import Image  # noqa: imported just to check for the import error
+    from PIL import Image  # noqa: F401
 except ImportError:
     skip_pillow: str | None = (
         "Missing Python Imaging Library, install https://pypi.org/pypi/Pillow"


### PR DESCRIPTION
This adds `ruff check` to `pre-commit`. The enabled rules are the default ones ("By default, Ruff enables Flake8's F rules, along with a subset of the E rules, omitting any stylistic rules that overlap with the use of a formatter, like ruff format or Black."). As next steps we can enable more of the rules and disable the other linters/formatters that are duplicated by ruff.