### PR TITLE
Made path absolute to enable running pytest from any directory

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -24,7 +24,9 @@ collect_ignore = [
     *_py_files("tests/CrawlerRunner"),
 ]
 
-with Path("tests/ignores.txt").open(encoding="utf-8") as reader:
+base_dir = Path(__file__).parent
+ignore_file_path = base_dir / "tests" / "ignores.txt"
+with ignore_file_path.open(encoding="utf-8") as reader:
     for line in reader:
         file_path = line.strip()
         if file_path and file_path[0] != "#":


### PR DESCRIPTION
This minor change makes the reference to `tests/ignore.txt` absolute instead of relative, allowing tests to run from any other directory, rather than just inside the main directory.