### PR TITLE
Deprecate w3lib objects importable from scrapy.utils.url

### DIFF
--- a/scrapy/utils/url.py
+++ b/scrapy/utils/url.py
@@ -1,29 +1,30 @@
 """
 This module contains general purpose URL functions not found in the standard
 library.
-
-Some of the functions that used to be imported from this module have been moved
-to the w3lib.url module. Always import those from there instead.
 """
 
 from __future__ import annotations
 
 import re
-from typing import TYPE_CHECKING, Union, cast
+from typing import TYPE_CHECKING, Union
 from urllib.parse import ParseResult, urldefrag, urlparse, urlunparse
 
-# scrapy.utils.url was moved to w3lib.url and import * ensures this
-# move doesn't break old code
-from w3lib.url import *  # pylint: disable=unused-wildcard-import,wildcard-import
-from w3lib.url import _safe_chars, _unquotepath  # noqa: F401
+from w3lib.url import add_or_replace_parameter as _add_or_replace_parameter
+from w3lib.url import any_to_uri as _any_to_uri
+from w3lib.url import parse_url as _parse_url
 
-from scrapy.utils.python import to_unicode
+from scrapy.utils.decorators import deprecated
 
 if TYPE_CHECKING:
     from collections.abc import Iterable
 
     from scrapy import Spider
 
+parse_url = deprecated("w3lib.url.parse_url")(_parse_url)
+add_or_replace_parameter = deprecated("w3lib.url.add_or_replace_parameter")(
+    _add_or_replace_parameter
+)
+any_to_uri = deprecated("w3lib.url.any_to_uri")(_any_to_uri)
 
 UrlT = Union[str, bytes, ParseResult]
 
@@ -48,17 +49,6 @@ def url_has_any_extension(url: UrlT, extensions: Iterable[str]) -> bool:
     """Return True if the url ends with one of the extensions provided"""
     lowercase_path = parse_url(url).path.lower()
     return any(lowercase_path.endswith(ext) for ext in extensions)
-
-
-def parse_url(  # pylint: disable=function-redefined
-    url: UrlT, encoding: str | None = None
-) -> ParseResult:
-    """Return urlparsed url from the given argument (which could be an already
-    parsed url)
-    """
-    if isinstance(url, ParseResult):
-        return url
-    return cast(ParseResult, urlparse(to_unicode(url, encoding)))
 
 
 def escape_ajax(url: str) -> str:

--- a/scrapy/utils/url.py
+++ b/scrapy/utils/url.py
@@ -10,7 +10,6 @@ from typing import TYPE_CHECKING, Union
 from urllib.parse import ParseResult, urldefrag, urlparse, urlunparse
 
 from w3lib.url import add_or_replace_parameter as _add_or_replace_parameter
-from w3lib.url import add_or_replace_parameters as _add_or_replace_parameters
 from w3lib.url import any_to_uri as _any_to_uri
 from w3lib.url import canonicalize_url as _canonicalize_url
 from w3lib.url import file_uri_to_path as _file_uri_to_path
@@ -33,9 +32,14 @@ if TYPE_CHECKING:
 add_or_replace_parameter = deprecated("w3lib.url.add_or_replace_parameter")(
     _add_or_replace_parameter
 )
-add_or_replace_parameters = deprecated("w3lib.url.add_or_replace_parameters")(
-    _add_or_replace_parameters
-)
+try:
+    from w3lib.url import add_or_replace_parameters as _add_or_replace_parameters
+
+    add_or_replace_parameters = deprecated("w3lib.url.add_or_replace_parameters")(
+        _add_or_replace_parameters
+    )
+except ImportError:
+    pass
 any_to_uri = deprecated("w3lib.url.any_to_uri")(_any_to_uri)
 canonicalize_url = deprecated("w3lib.url.canonicalize_url")(_canonicalize_url)
 file_uri_to_path = deprecated("w3lib.url.file_uri_to_path")(_file_uri_to_path)

--- a/scrapy/utils/url.py
+++ b/scrapy/utils/url.py
@@ -20,11 +20,11 @@ if TYPE_CHECKING:
 
     from scrapy import Spider
 
-parse_url = deprecated("w3lib.url.parse_url")(_parse_url)
 add_or_replace_parameter = deprecated("w3lib.url.add_or_replace_parameter")(
     _add_or_replace_parameter
 )
 any_to_uri = deprecated("w3lib.url.any_to_uri")(_any_to_uri)
+parse_url = deprecated("w3lib.url.parse_url")(_parse_url)
 
 UrlT = Union[str, bytes, ParseResult]
 

--- a/scrapy/utils/url.py
+++ b/scrapy/utils/url.py
@@ -7,52 +7,27 @@ from __future__ import annotations
 
 import re
 import warnings
+from importlib import import_module
 from typing import TYPE_CHECKING, Union
 from urllib.parse import ParseResult, urldefrag, urlparse, urlunparse
 
+from w3lib.url import __all__ as public_w3lib_objects
 from w3lib.url import add_or_replace_parameter as _add_or_replace_parameter
 from w3lib.url import any_to_uri as _any_to_uri
-from w3lib.url import canonicalize_url as _canonicalize_url
-from w3lib.url import file_uri_to_path as _file_uri_to_path
-from w3lib.url import is_url as _is_url
-from w3lib.url import parse_data_uri as _parse_data_uri
 from w3lib.url import parse_url as _parse_url
-from w3lib.url import path_to_file_uri as _path_to_file_uri
-from w3lib.url import safe_download_url as _safe_download_url
-from w3lib.url import safe_url_string as _safe_url_string
-from w3lib.url import url_query_cleaner as _url_query_cleaner
-from w3lib.url import url_query_parameter as _url_query_parameter
 
 from scrapy.exceptions import ScrapyDeprecationWarning
-from scrapy.utils.decorators import deprecated
 
 
 def __getattr__(name: str):
-    if name == "_safe_chars":
+    if name in (*public_w3lib_objects, "_unquotepath", "_safe_chars", "parse_url"):
+        obj_type = "attribute" if name == "_safe_chars" else "function"
         warnings.warn(
-            "The scrapy.utils.url._safe_chars attribute is deprecated, use w3lib.url._safe_chars instead.",
+            f"The scrapy.utils.url.{name} {obj_type} is deprecated, use w3lib.url.{name} instead.",
             ScrapyDeprecationWarning,
         )
-        from w3lib.url import _safe_chars
-
-        return _safe_chars
-    if name == "_unquotepath":
-        warnings.warn(
-            "The scrapy.utils.url._unquotepath function is deprecated, use w3lib.url._unquotepath instead.",
-            ScrapyDeprecationWarning,
-        )
-        from w3lib.url import _unquotepath
-
-        return _unquotepath
-    if name == "add_or_replace_parameters":
         try:
-            warnings.warn(
-                "The scrapy.utils.url.add_or_replace_parameters function is deprecated, use w3lib.url.add_or_replace_parameters instead.",
-                ScrapyDeprecationWarning,
-            )
-            from w3lib.url import add_or_replace_parameters
-
-            return add_or_replace_parameters
+            return getattr(import_module("w3lib.url"), name)
         except ImportError:
             raise AttributeError
 
@@ -63,23 +38,6 @@ if TYPE_CHECKING:
     from collections.abc import Iterable
 
     from scrapy import Spider
-
-add_or_replace_parameter = deprecated("w3lib.url.add_or_replace_parameter")(
-    _add_or_replace_parameter
-)
-any_to_uri = deprecated("w3lib.url.any_to_uri")(_any_to_uri)
-canonicalize_url = deprecated("w3lib.url.canonicalize_url")(_canonicalize_url)
-file_uri_to_path = deprecated("w3lib.url.file_uri_to_path")(_file_uri_to_path)
-is_url = deprecated("w3lib.url.is_url")(_is_url)
-parse_data_uri = deprecated("w3lib.url.parse_data_uri")(_parse_data_uri)
-path_to_file_uri = deprecated("w3lib.url.path_to_file_uri")(_path_to_file_uri)
-safe_download_url = deprecated("w3lib.url.safe_download_url")(_safe_download_url)
-safe_url_string = deprecated("w3lib.url.safe_url_string")(_safe_url_string)
-url_query_cleaner = deprecated("w3lib.url.url_query_cleaner")(_url_query_cleaner)
-url_query_parameter = deprecated("w3lib.url.url_query_parameter")(_url_query_parameter)
-
-
-parse_url = deprecated("w3lib.url.parse_url")(_parse_url)
 
 UrlT = Union[str, bytes, ParseResult]
 

--- a/scrapy/utils/url.py
+++ b/scrapy/utils/url.py
@@ -20,16 +20,13 @@ from scrapy.exceptions import ScrapyDeprecationWarning
 
 
 def __getattr__(name: str):
-    if name in (*public_w3lib_objects, "_unquotepath", "_safe_chars", "parse_url"):
+    if name in ("_unquotepath", "_safe_chars", "parse_url", *public_w3lib_objects):
         obj_type = "attribute" if name == "_safe_chars" else "function"
         warnings.warn(
             f"The scrapy.utils.url.{name} {obj_type} is deprecated, use w3lib.url.{name} instead.",
             ScrapyDeprecationWarning,
         )
-        try:
-            return getattr(import_module("w3lib.url"), name)
-        except ImportError:
-            raise AttributeError
+        return getattr(import_module("w3lib.url"), name)
 
     raise AttributeError
 

--- a/scrapy/utils/url.py
+++ b/scrapy/utils/url.py
@@ -6,6 +6,7 @@ library.
 from __future__ import annotations
 
 import re
+import warnings
 from typing import TYPE_CHECKING, Union
 from urllib.parse import ParseResult, urldefrag, urlparse, urlunparse
 
@@ -22,7 +23,41 @@ from w3lib.url import safe_url_string as _safe_url_string
 from w3lib.url import url_query_cleaner as _url_query_cleaner
 from w3lib.url import url_query_parameter as _url_query_parameter
 
+from scrapy.exceptions import ScrapyDeprecationWarning
 from scrapy.utils.decorators import deprecated
+
+
+def __getattr__(name: str):
+    if name == "_safe_chars":
+        warnings.warn(
+            "The scrapy.utils.url._safe_chars attribute is deprecated, use w3lib.url._safe_chars instead.",
+            ScrapyDeprecationWarning,
+        )
+        from w3lib.url import _safe_chars
+
+        return _safe_chars
+    if name == "_unquotepath":
+        warnings.warn(
+            "The scrapy.utils.url._unquotepath function is deprecated, use w3lib.url._unquotepath instead.",
+            ScrapyDeprecationWarning,
+        )
+        from w3lib.url import _unquotepath
+
+        return _unquotepath
+    if name == "add_or_replace_parameters":
+        try:
+            warnings.warn(
+                "The scrapy.utils.url.add_or_replace_parameters function is deprecated, use w3lib.url.add_or_replace_parameters instead.",
+                ScrapyDeprecationWarning,
+            )
+            from w3lib.url import add_or_replace_parameters
+
+            return add_or_replace_parameters
+        except ImportError:
+            raise AttributeError
+
+    raise AttributeError
+
 
 if TYPE_CHECKING:
     from collections.abc import Iterable
@@ -32,14 +67,6 @@ if TYPE_CHECKING:
 add_or_replace_parameter = deprecated("w3lib.url.add_or_replace_parameter")(
     _add_or_replace_parameter
 )
-try:
-    from w3lib.url import add_or_replace_parameters as _add_or_replace_parameters
-
-    add_or_replace_parameters = deprecated("w3lib.url.add_or_replace_parameters")(
-        _add_or_replace_parameters
-    )
-except ImportError:
-    pass
 any_to_uri = deprecated("w3lib.url.any_to_uri")(_any_to_uri)
 canonicalize_url = deprecated("w3lib.url.canonicalize_url")(_canonicalize_url)
 file_uri_to_path = deprecated("w3lib.url.file_uri_to_path")(_file_uri_to_path)

--- a/scrapy/utils/url.py
+++ b/scrapy/utils/url.py
@@ -31,7 +31,7 @@ UrlT = Union[str, bytes, ParseResult]
 
 def url_is_from_any_domain(url: UrlT, domains: Iterable[str]) -> bool:
     """Return True if the url belongs to any of the given domains"""
-    host = parse_url(url).netloc.lower()
+    host = _parse_url(url).netloc.lower()
     if not host:
         return False
     domains = [d.lower() for d in domains]
@@ -47,7 +47,7 @@ def url_is_from_spider(url: UrlT, spider: type[Spider]) -> bool:
 
 def url_has_any_extension(url: UrlT, extensions: Iterable[str]) -> bool:
     """Return True if the url ends with one of the extensions provided"""
-    lowercase_path = parse_url(url).path.lower()
+    lowercase_path = _parse_url(url).path.lower()
     return any(lowercase_path.endswith(ext) for ext in extensions)
 
 
@@ -76,7 +76,7 @@ def escape_ajax(url: str) -> str:
     defrag, frag = urldefrag(url)
     if not frag.startswith("!"):
         return url
-    return add_or_replace_parameter(defrag, "_escaped_fragment_", frag[1:])
+    return _add_or_replace_parameter(defrag, "_escaped_fragment_", frag[1:])
 
 
 def add_http_if_no_scheme(url: str) -> str:
@@ -136,7 +136,7 @@ def guess_scheme(url: str) -> str:
     """Add an URL scheme if missing: file:// for filepath-like input or
     http:// otherwise."""
     if _is_filesystem_path(url):
-        return any_to_uri(url)
+        return _any_to_uri(url)
     return add_http_if_no_scheme(url)
 
 

--- a/scrapy/utils/url.py
+++ b/scrapy/utils/url.py
@@ -10,8 +10,18 @@ from typing import TYPE_CHECKING, Union
 from urllib.parse import ParseResult, urldefrag, urlparse, urlunparse
 
 from w3lib.url import add_or_replace_parameter as _add_or_replace_parameter
+from w3lib.url import add_or_replace_parameters as _add_or_replace_parameters
 from w3lib.url import any_to_uri as _any_to_uri
+from w3lib.url import canonicalize_url as _canonicalize_url
+from w3lib.url import file_uri_to_path as _file_uri_to_path
+from w3lib.url import is_url as _is_url
+from w3lib.url import parse_data_uri as _parse_data_uri
 from w3lib.url import parse_url as _parse_url
+from w3lib.url import path_to_file_uri as _path_to_file_uri
+from w3lib.url import safe_download_url as _safe_download_url
+from w3lib.url import safe_url_string as _safe_url_string
+from w3lib.url import url_query_cleaner as _url_query_cleaner
+from w3lib.url import url_query_parameter as _url_query_parameter
 
 from scrapy.utils.decorators import deprecated
 
@@ -23,7 +33,21 @@ if TYPE_CHECKING:
 add_or_replace_parameter = deprecated("w3lib.url.add_or_replace_parameter")(
     _add_or_replace_parameter
 )
+add_or_replace_parameters = deprecated("w3lib.url.add_or_replace_parameters")(
+    _add_or_replace_parameters
+)
 any_to_uri = deprecated("w3lib.url.any_to_uri")(_any_to_uri)
+canonicalize_url = deprecated("w3lib.url.canonicalize_url")(_canonicalize_url)
+file_uri_to_path = deprecated("w3lib.url.file_uri_to_path")(_file_uri_to_path)
+is_url = deprecated("w3lib.url.is_url")(_is_url)
+parse_data_uri = deprecated("w3lib.url.parse_data_uri")(_parse_data_uri)
+path_to_file_uri = deprecated("w3lib.url.path_to_file_uri")(_path_to_file_uri)
+safe_download_url = deprecated("w3lib.url.safe_download_url")(_safe_download_url)
+safe_url_string = deprecated("w3lib.url.safe_url_string")(_safe_url_string)
+url_query_cleaner = deprecated("w3lib.url.url_query_cleaner")(_url_query_cleaner)
+url_query_parameter = deprecated("w3lib.url.url_query_parameter")(_url_query_parameter)
+
+
 parse_url = deprecated("w3lib.url.parse_url")(_parse_url)
 
 UrlT = Union[str, bytes, ParseResult]

--- a/scrapy/utils/url.py
+++ b/scrapy/utils/url.py
@@ -11,7 +11,7 @@ from importlib import import_module
 from typing import TYPE_CHECKING, Union
 from urllib.parse import ParseResult, urldefrag, urlparse, urlunparse
 
-from w3lib.url import __all__ as public_w3lib_objects
+from w3lib.url import __all__ as _public_w3lib_objects
 from w3lib.url import add_or_replace_parameter as _add_or_replace_parameter
 from w3lib.url import any_to_uri as _any_to_uri
 from w3lib.url import parse_url as _parse_url
@@ -20,7 +20,7 @@ from scrapy.exceptions import ScrapyDeprecationWarning
 
 
 def __getattr__(name: str):
-    if name in ("_unquotepath", "_safe_chars", "parse_url", *public_w3lib_objects):
+    if name in ("_unquotepath", "_safe_chars", "parse_url", *_public_w3lib_objects):
         obj_type = "attribute" if name == "_safe_chars" else "function"
         warnings.warn(
             f"The scrapy.utils.url.{name} {obj_type} is deprecated, use w3lib.url.{name} instead.",

--- a/tests/test_utils_url.py
+++ b/tests/test_utils_url.py
@@ -1,9 +1,7 @@
 import unittest
 import warnings
-from importlib.metadata import version
 
 import pytest
-from packaging.version import Version as parse_version
 
 from scrapy.linkextractors import IGNORED_EXTENSIONS
 from scrapy.spiders import Spider
@@ -12,6 +10,7 @@ from scrapy.utils.url import (
     _is_filesystem_path,
     add_http_if_no_scheme,
     guess_scheme,
+    public_w3lib_objects,
     strip_url,
     url_has_any_extension,
     url_is_from_any_domain,
@@ -615,20 +614,10 @@ class IsPathTestCase(unittest.TestCase):
 @pytest.mark.parametrize(
     "obj_name",
     [
-        "_safe_chars",
         "_unquotepath",
-        "add_or_replace_parameter",
-        "any_to_uri",
-        "canonicalize_url",
-        "file_uri_to_path",
-        "is_url",
-        "parse_data_uri",
+        "_safe_chars",
         "parse_url",
-        "path_to_file_uri",
-        "safe_download_url",
-        "safe_url_string",
-        "url_query_cleaner",
-        "url_query_parameter",
+        *public_w3lib_objects,
     ],
 )
 def test_deprecated_imports_from_w3lib(obj_name):
@@ -641,18 +630,6 @@ def test_deprecated_imports_from_w3lib(obj_name):
         getattr(import_module("scrapy.utils.url"), obj_name)
 
         assert message in warns[0].message.args
-
-
-def test_deprecated_add_or_replace_parameters_import_from_w3lib():
-    if parse_version(version("w3lib")) >= parse_version("1.20.0"):
-        with warnings.catch_warnings(record=True) as warns:
-            assert (
-                "The scrapy.utils.url.add_or_replace_parameters function is deprecated, use w3lib.url.add_or_replace_parameters instead."
-                in warns[0].message.args
-            )
-    else:
-        with pytest.raises(ImportError):
-            pass
 
 
 if __name__ == "__main__":

--- a/tests/test_utils_url.py
+++ b/tests/test_utils_url.py
@@ -1,5 +1,8 @@
 import unittest
 import warnings
+from importlib.metadata import version
+
+from packaging.version import Version as parse_version
 
 from scrapy.linkextractors import IGNORED_EXTENSIONS
 from scrapy.spiders import Spider
@@ -8,7 +11,6 @@ from scrapy.utils.url import (
     _is_filesystem_path,
     add_http_if_no_scheme,
     add_or_replace_parameter,
-    add_or_replace_parameters,
     any_to_uri,
     canonicalize_url,
     file_uri_to_path,
@@ -629,65 +631,75 @@ def test_deprecated_calls_to_w3lib_methods():
             "Call to deprecated function add_or_replace_parameter. Use w3lib.url.add_or_replace_parameter instead."
             in warns[0].message.args
         )
-        add_or_replace_parameters(test_url, {"id": "2"})
-        assert (
-            "Call to deprecated function add_or_replace_parameters. Use w3lib.url.add_or_replace_parameters instead."
-            in warns[1].message.args
-        )
         any_to_uri("/tmp/example.txt")
         assert (
             "Call to deprecated function any_to_uri. Use w3lib.url.any_to_uri instead."
-            in warns[2].message.args
+            in warns[1].message.args
         )
         canonicalize_url(test_url)
         assert (
             "Call to deprecated function canonicalize_url. Use w3lib.url.canonicalize_url instead."
-            in warns[3].message.args
+            in warns[2].message.args
         )
         file_uri_to_path("file://tmp/example.txt")
         assert (
             "Call to deprecated function file_uri_to_path. Use w3lib.url.file_uri_to_path instead."
-            in warns[4].message.args
+            in warns[3].message.args
         )
         is_url(test_url)
         assert (
             "Call to deprecated function is_url. Use w3lib.url.is_url instead."
-            in warns[5].message.args
+            in warns[4].message.args
         )
         parse_data_uri("data:,")
         assert (
             "Call to deprecated function parse_data_uri. Use w3lib.url.parse_data_uri instead."
-            in warns[6].message.args
+            in warns[5].message.args
         )
         path_to_file_uri("file://tmp/example.txt")
         assert (
             "Call to deprecated function path_to_file_uri. Use w3lib.url.path_to_file_uri instead."
-            in warns[7].message.args
+            in warns[6].message.args
         )
         parse_url(test_url)
         assert (
             "Call to deprecated function parse_url. Use w3lib.url.parse_url instead."
-            in warns[8].message.args
+            in warns[7].message.args
         )
         safe_download_url(test_url)
         assert (
             "Call to deprecated function safe_download_url. Use w3lib.url.safe_download_url instead."
-            in warns[9].message.args
+            in warns[8].message.args
         )
         safe_url_string(test_url)
         assert (
             "Call to deprecated function safe_url_string. Use w3lib.url.safe_url_string instead."
-            in warns[10].message.args
+            in warns[9].message.args
         )
         url_query_cleaner(test_url)
         assert (
             "Call to deprecated function url_query_cleaner. Use w3lib.url.url_query_cleaner instead."
-            in warns[11].message.args
+            in warns[10].message.args
         )
         url_query_parameter(test_url, "id")
         assert (
             "Call to deprecated function url_query_parameter. Use w3lib.url.url_query_parameter instead."
-            in warns[12].message.args
+            in warns[11].message.args
+        )
+
+
+@unittest.skipIf(
+    parse_version(version("w3lib")) < parse_version("1.22.0"),
+    "w3lib.url.add_or_replace_parameters is available until version 1.22",
+)
+def test_deprecated_call_to_w3lib_add_or_replace_parameters():
+    with warnings.catch_warnings(record=True) as warns:
+        from scrapy.utils.url import add_or_replace_parameters
+
+        add_or_replace_parameters("https://example.com?id=1", {"id": "2"})
+        assert (
+            "Call to deprecated function add_or_replace_parameters. Use w3lib.url.add_or_replace_parameters instead."
+            in warns[0].message.args
         )
 
 

--- a/tests/test_utils_url.py
+++ b/tests/test_utils_url.py
@@ -1,4 +1,5 @@
 import unittest
+import warnings
 
 from scrapy.linkextractors import IGNORED_EXTENSIONS
 from scrapy.spiders import Spider
@@ -6,7 +7,10 @@ from scrapy.utils.misc import arg_to_iter
 from scrapy.utils.url import (
     _is_filesystem_path,
     add_http_if_no_scheme,
+    add_or_replace_parameter,
+    any_to_uri,
     guess_scheme,
+    parse_url,
     strip_url,
     url_has_any_extension,
     url_is_from_any_domain,
@@ -605,6 +609,25 @@ class IsPathTestCase(unittest.TestCase):
             self.assertEqual(
                 _is_filesystem_path(input_value), output_value, input_value
             )
+
+
+def test_deprecated_calls_to_w3lib_methods():
+    with warnings.catch_warnings(record=True) as warns:
+        add_or_replace_parameter("https://example.com?id=1", "id", "2")
+        assert (
+            "Call to deprecated function add_or_replace_parameter. Use w3lib.url.add_or_replace_parameter instead."
+            in warns[0].message.args
+        )
+        any_to_uri("/tmp/example.txt")
+        assert (
+            "Call to deprecated function any_to_uri. Use w3lib.url.any_to_uri instead."
+            in warns[1].message.args
+        )
+        parse_url("https://example.com")
+        assert (
+            "Call to deprecated function parse_url. Use w3lib.url.parse_url instead."
+            in warns[2].message.args
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_utils_url.py
+++ b/tests/test_utils_url.py
@@ -11,23 +11,11 @@ from scrapy.utils.misc import arg_to_iter
 from scrapy.utils.url import (
     _is_filesystem_path,
     add_http_if_no_scheme,
-    add_or_replace_parameter,
-    any_to_uri,
-    canonicalize_url,
-    file_uri_to_path,
     guess_scheme,
-    is_url,
-    parse_data_uri,
-    parse_url,
-    path_to_file_uri,
-    safe_download_url,
-    safe_url_string,
     strip_url,
     url_has_any_extension,
     url_is_from_any_domain,
     url_is_from_spider,
-    url_query_cleaner,
-    url_query_parameter,
 )
 
 __doctests__ = ["scrapy.utils.url"]
@@ -624,90 +612,47 @@ class IsPathTestCase(unittest.TestCase):
             )
 
 
-def test_deprecated_calls_to_w3lib_methods():
+@pytest.mark.parametrize(
+    "obj_name",
+    [
+        "_safe_chars",
+        "_unquotepath",
+        "add_or_replace_parameter",
+        "any_to_uri",
+        "canonicalize_url",
+        "file_uri_to_path",
+        "is_url",
+        "parse_data_uri",
+        "parse_url",
+        "path_to_file_uri",
+        "safe_download_url",
+        "safe_url_string",
+        "url_query_cleaner",
+        "url_query_parameter",
+    ],
+)
+def test_deprecated_imports_from_w3lib(obj_name):
     with warnings.catch_warnings(record=True) as warns:
-        test_url = "https://example.com?id=1"
-        add_or_replace_parameter(test_url, "id", "2")
-        assert (
-            "Call to deprecated function add_or_replace_parameter. Use w3lib.url.add_or_replace_parameter instead."
-            in warns[0].message.args
-        )
-        any_to_uri("/tmp/example.txt")
-        assert (
-            "Call to deprecated function any_to_uri. Use w3lib.url.any_to_uri instead."
-            in warns[1].message.args
-        )
-        canonicalize_url(test_url)
-        assert (
-            "Call to deprecated function canonicalize_url. Use w3lib.url.canonicalize_url instead."
-            in warns[2].message.args
-        )
-        file_uri_to_path("file://tmp/example.txt")
-        assert (
-            "Call to deprecated function file_uri_to_path. Use w3lib.url.file_uri_to_path instead."
-            in warns[3].message.args
-        )
-        is_url(test_url)
-        assert (
-            "Call to deprecated function is_url. Use w3lib.url.is_url instead."
-            in warns[4].message.args
-        )
-        parse_data_uri("data:,")
-        assert (
-            "Call to deprecated function parse_data_uri. Use w3lib.url.parse_data_uri instead."
-            in warns[5].message.args
-        )
-        path_to_file_uri("tmp/example.txt")
-        assert (
-            "Call to deprecated function path_to_file_uri. Use w3lib.url.path_to_file_uri instead."
-            in warns[6].message.args
-        )
-        parse_url(test_url)
-        assert (
-            "Call to deprecated function parse_url. Use w3lib.url.parse_url instead."
-            in warns[7].message.args
-        )
-        safe_download_url(test_url)
-        assert (
-            "Call to deprecated function safe_download_url. Use w3lib.url.safe_download_url instead."
-            in warns[8].message.args
-        )
-        safe_url_string(test_url)
-        assert (
-            "Call to deprecated function safe_url_string. Use w3lib.url.safe_url_string instead."
-            in warns[9].message.args
-        )
-        url_query_cleaner(test_url)
-        assert (
-            "Call to deprecated function url_query_cleaner. Use w3lib.url.url_query_cleaner instead."
-            in warns[10].message.args
-        )
-        url_query_parameter(test_url, "id")
-        assert (
-            "Call to deprecated function url_query_parameter. Use w3lib.url.url_query_parameter instead."
-            in warns[11].message.args
-        )
+        obj_type = "attribute" if obj_name == "_safe_chars" else "function"
+        message = f"The scrapy.utils.url.{obj_name} {obj_type} is deprecated, use w3lib.url.{obj_name} instead."
+
+        from importlib import import_module
+
+        getattr(import_module("scrapy.utils.url"), obj_name)
+
+        assert message in warns[0].message.args
 
 
-def test_deprecated_imports_from_w3lib():
-    with warnings.catch_warnings(record=True) as warns:
-        assert (
-            "The scrapy.utils.url._safe_chars attribute is deprecated, use w3lib.url._safe_chars instead."
-            in warns[0].message.args
-        )
-        assert (
-            "The scrapy.utils.url._unquotepath function is deprecated, use w3lib.url._unquotepath instead."
-            in warns[1].message.args
-        )
-
-        if parse_version(version("w3lib")) >= parse_version("1.20.0"):
+def test_deprecated_add_or_replace_parameters_import_from_w3lib():
+    if parse_version(version("w3lib")) >= parse_version("1.20.0"):
+        with warnings.catch_warnings(record=True) as warns:
             assert (
                 "The scrapy.utils.url.add_or_replace_parameters function is deprecated, use w3lib.url.add_or_replace_parameters instead."
-                in warns[2].message.args
+                in warns[0].message.args
             )
-        else:
-            with pytest.raises(ImportError):
-                pass
+    else:
+        with pytest.raises(ImportError):
+            pass
 
 
 if __name__ == "__main__":

--- a/tests/test_utils_url.py
+++ b/tests/test_utils_url.py
@@ -687,17 +687,27 @@ def test_deprecated_calls_to_w3lib_methods():
             "Call to deprecated function url_query_parameter. Use w3lib.url.url_query_parameter instead."
             in warns[11].message.args
         )
-        if parse_version(version("w3lib")) >= parse_version("1.20.0"):
-            from scrapy.utils.url import add_or_replace_parameters
 
-            add_or_replace_parameters("https://example.com?id=1", {"id": "2"})
+
+def test_deprecated_imports_from_w3lib():
+    with warnings.catch_warnings(record=True) as warns:
+        assert (
+            "The scrapy.utils.url._safe_chars attribute is deprecated, use w3lib.url._safe_chars instead."
+            in warns[0].message.args
+        )
+        assert (
+            "The scrapy.utils.url._unquotepath function is deprecated, use w3lib.url._unquotepath instead."
+            in warns[1].message.args
+        )
+
+        if parse_version(version("w3lib")) >= parse_version("1.20.0"):
             assert (
-                "Call to deprecated function add_or_replace_parameters. Use w3lib.url.add_or_replace_parameters instead."
-                in warns[12].message.args
+                "The scrapy.utils.url.add_or_replace_parameters function is deprecated, use w3lib.url.add_or_replace_parameters instead."
+                in warns[2].message.args
             )
         else:
             with pytest.raises(ImportError):
-                from scrapy.utils.url import add_or_replace_parameters
+                pass
 
 
 if __name__ == "__main__":

--- a/tests/test_utils_url.py
+++ b/tests/test_utils_url.py
@@ -2,6 +2,7 @@ import unittest
 import warnings
 from importlib.metadata import version
 
+import pytest
 from packaging.version import Version as parse_version
 
 from scrapy.linkextractors import IGNORED_EXTENSIONS
@@ -686,21 +687,17 @@ def test_deprecated_calls_to_w3lib_methods():
             "Call to deprecated function url_query_parameter. Use w3lib.url.url_query_parameter instead."
             in warns[11].message.args
         )
+        if parse_version(version("w3lib")) >= parse_version("1.20.0"):
+            from scrapy.utils.url import add_or_replace_parameters
 
-
-@unittest.skipIf(
-    parse_version(version("w3lib")) < parse_version("1.20.0"),
-    "w3lib.url.add_or_replace_parameters is available until version 1.20.0",
-)
-def test_deprecated_call_to_w3lib_add_or_replace_parameters():
-    with warnings.catch_warnings(record=True) as warns:
-        from scrapy.utils.url import add_or_replace_parameters
-
-        add_or_replace_parameters("https://example.com?id=1", {"id": "2"})
-        assert (
-            "Call to deprecated function add_or_replace_parameters. Use w3lib.url.add_or_replace_parameters instead."
-            in warns[0].message.args
-        )
+            add_or_replace_parameters("https://example.com?id=1", {"id": "2"})
+            assert (
+                "Call to deprecated function add_or_replace_parameters. Use w3lib.url.add_or_replace_parameters instead."
+                in warns[12].message.args
+            )
+        else:
+            with pytest.raises(ImportError):
+                from scrapy.utils.url import add_or_replace_parameters
 
 
 if __name__ == "__main__":

--- a/tests/test_utils_url.py
+++ b/tests/test_utils_url.py
@@ -689,8 +689,8 @@ def test_deprecated_calls_to_w3lib_methods():
 
 
 @unittest.skipIf(
-    parse_version(version("w3lib")) < parse_version("1.22.0"),
-    "w3lib.url.add_or_replace_parameters is available until version 1.22",
+    parse_version(version("w3lib")) < parse_version("1.20.0"),
+    "w3lib.url.add_or_replace_parameters is available until version 1.20.0",
 )
 def test_deprecated_call_to_w3lib_add_or_replace_parameters():
     with warnings.catch_warnings(record=True) as warns:

--- a/tests/test_utils_url.py
+++ b/tests/test_utils_url.py
@@ -656,7 +656,7 @@ def test_deprecated_calls_to_w3lib_methods():
             "Call to deprecated function parse_data_uri. Use w3lib.url.parse_data_uri instead."
             in warns[5].message.args
         )
-        path_to_file_uri("file://tmp/example.txt")
+        path_to_file_uri("tmp/example.txt")
         assert (
             "Call to deprecated function path_to_file_uri. Use w3lib.url.path_to_file_uri instead."
             in warns[6].message.args

--- a/tests/test_utils_url.py
+++ b/tests/test_utils_url.py
@@ -8,9 +8,9 @@ from scrapy.spiders import Spider
 from scrapy.utils.misc import arg_to_iter
 from scrapy.utils.url import (
     _is_filesystem_path,
+    _public_w3lib_objects,
     add_http_if_no_scheme,
     guess_scheme,
-    public_w3lib_objects,
     strip_url,
     url_has_any_extension,
     url_is_from_any_domain,
@@ -617,7 +617,7 @@ class IsPathTestCase(unittest.TestCase):
         "_unquotepath",
         "_safe_chars",
         "parse_url",
-        *public_w3lib_objects,
+        *_public_w3lib_objects,
     ],
 )
 def test_deprecated_imports_from_w3lib(obj_name):

--- a/tests/test_utils_url.py
+++ b/tests/test_utils_url.py
@@ -8,13 +8,23 @@ from scrapy.utils.url import (
     _is_filesystem_path,
     add_http_if_no_scheme,
     add_or_replace_parameter,
+    add_or_replace_parameters,
     any_to_uri,
+    canonicalize_url,
+    file_uri_to_path,
     guess_scheme,
+    is_url,
+    parse_data_uri,
     parse_url,
+    path_to_file_uri,
+    safe_download_url,
+    safe_url_string,
     strip_url,
     url_has_any_extension,
     url_is_from_any_domain,
     url_is_from_spider,
+    url_query_cleaner,
+    url_query_parameter,
 )
 
 __doctests__ = ["scrapy.utils.url"]
@@ -613,20 +623,71 @@ class IsPathTestCase(unittest.TestCase):
 
 def test_deprecated_calls_to_w3lib_methods():
     with warnings.catch_warnings(record=True) as warns:
-        add_or_replace_parameter("https://example.com?id=1", "id", "2")
+        test_url = "https://example.com?id=1"
+        add_or_replace_parameter(test_url, "id", "2")
         assert (
             "Call to deprecated function add_or_replace_parameter. Use w3lib.url.add_or_replace_parameter instead."
             in warns[0].message.args
         )
+        add_or_replace_parameters(test_url, {"id": "2"})
+        assert (
+            "Call to deprecated function add_or_replace_parameters. Use w3lib.url.add_or_replace_parameters instead."
+            in warns[1].message.args
+        )
         any_to_uri("/tmp/example.txt")
         assert (
             "Call to deprecated function any_to_uri. Use w3lib.url.any_to_uri instead."
-            in warns[1].message.args
+            in warns[2].message.args
         )
-        parse_url("https://example.com")
+        canonicalize_url(test_url)
+        assert (
+            "Call to deprecated function canonicalize_url. Use w3lib.url.canonicalize_url instead."
+            in warns[3].message.args
+        )
+        file_uri_to_path("file://tmp/example.txt")
+        assert (
+            "Call to deprecated function file_uri_to_path. Use w3lib.url.file_uri_to_path instead."
+            in warns[4].message.args
+        )
+        is_url(test_url)
+        assert (
+            "Call to deprecated function is_url. Use w3lib.url.is_url instead."
+            in warns[5].message.args
+        )
+        parse_data_uri("data:,")
+        assert (
+            "Call to deprecated function parse_data_uri. Use w3lib.url.parse_data_uri instead."
+            in warns[6].message.args
+        )
+        path_to_file_uri("file://tmp/example.txt")
+        assert (
+            "Call to deprecated function path_to_file_uri. Use w3lib.url.path_to_file_uri instead."
+            in warns[7].message.args
+        )
+        parse_url(test_url)
         assert (
             "Call to deprecated function parse_url. Use w3lib.url.parse_url instead."
-            in warns[2].message.args
+            in warns[8].message.args
+        )
+        safe_download_url(test_url)
+        assert (
+            "Call to deprecated function safe_download_url. Use w3lib.url.safe_download_url instead."
+            in warns[9].message.args
+        )
+        safe_url_string(test_url)
+        assert (
+            "Call to deprecated function safe_url_string. Use w3lib.url.safe_url_string instead."
+            in warns[10].message.args
+        )
+        url_query_cleaner(test_url)
+        assert (
+            "Call to deprecated function url_query_cleaner. Use w3lib.url.url_query_cleaner instead."
+            in warns[11].message.args
+        )
+        url_query_parameter(test_url, "id")
+        assert (
+            "Call to deprecated function url_query_parameter. Use w3lib.url.url_query_parameter instead."
+            in warns[12].message.args
         )
 
 


### PR DESCRIPTION
Close: #4577
Close: #6583

We will emit a warning everytime someone import functions of `w3lib` from `scrapy.utils.url`