### PR TITLE
Added check and re-request for 201 response in media_downloaded

### DIFF
--- a/tests/test_pipeline_files.py
+++ b/tests/test_pipeline_files.py
@@ -147,6 +147,32 @@ class FilesPipelineTestCase(unittest.TestCase):
             p.stop()
 
     @defer.inlineCallbacks
+    def test_media_download_201(self):
+        item_url = "http://example.com/file.pdf"
+        item = _create_item_with_files(item_url)
+        patchers = [
+            mock.patch.object(
+                FilesPipeline,
+                "get_media_requests",
+                return_value=[
+                    Request(
+                        item_url,
+                        meta={"response": Response(item_url, status=201, body=b"data")},
+                    )
+                ],
+            )
+        ]
+
+        for p in patchers:
+            p.start()
+
+        result = yield self.pipeline.process_item(item, None)
+        self.assertEqual(result["file_urls"], ("http://example.com/file.pdf",))
+
+        for p in patchers:
+            p.stop()
+
+    @defer.inlineCallbacks
     def test_file_expired(self):
         item_url = "http://example.com/file2.pdf"
         item = _create_item_with_files(item_url)


### PR DESCRIPTION
Added a check for 201 response, and checking for the 'Location' header in the 201 response. If the 'Location' header exists, a new request is made for the data.

Also added a corresponding unit test.

Fixes [Issue 1615](https://github.com/scrapy/scrapy/issues/1615)
Referenced the discussions on [PR 1806](https://github.com/scrapy/scrapy/pull/1806) and [6309](https://github.com/scrapy/scrapy/pull/6309)