### PR TITLE
Install libjpeg-dev on pinned envs to be able to install Pillow.

### DIFF
--- a/.github/workflows/tests-ubuntu.yml
+++ b/.github/workflows/tests-ubuntu.yml
@@ -73,7 +73,7 @@ jobs:
       if: contains(matrix.python-version, 'pypy') || contains(matrix.env.TOXENV, 'pinned')
       run: |
         sudo apt-get update
-        sudo apt-get install libxml2-dev libxslt-dev
+        sudo apt-get install libxml2-dev libxslt-dev libjpeg-dev
 
     - name: Run tests
       env: ${{ matrix.env }}


### PR DESCRIPTION
Looks like the CI runner has just changed from Ubuntu 22.04.5 to Ubuntu 24.04.1 and Pillow can no longer be installed, because it needs to be compiled but `libjpeg-dev` is not installed. As it's unlikely that some binary Pillow build was being installed before (there is no 3.9 wheel for Pillow 7.1.0 on PyPI) I assume `libjpeg-dev` was installed by default in the image before. This change installs it for more envs that need it but the impact should be negligible.