### PR TITLE
Drop PyPy 3.9, add a pypy3-extra-deps CI job.

### DIFF
--- a/.github/workflows/tests-ubuntu.yml
+++ b/.github/workflows/tests-ubuntu.yml
@@ -30,9 +30,6 @@ jobs:
         - python-version: "3.13"
           env:
             TOXENV: asyncio
-        - python-version: pypy3.9
-          env:
-            TOXENV: pypy3
         - python-version: pypy3.10
           env:
             TOXENV: pypy3
@@ -44,7 +41,7 @@ jobs:
         - python-version: 3.9.19
           env:
             TOXENV: asyncio-pinned
-        - python-version: pypy3.9
+        - python-version: pypy3.10
           env:
             TOXENV: pypy3-pinned
         - python-version: 3.9.19
@@ -57,6 +54,9 @@ jobs:
         - python-version: "3.13"
           env:
             TOXENV: extra-deps
+        - python-version: pypy3.10
+          env:
+            TOXENV: pypy3-extra-deps
         - python-version: "3.13"
           env:
             TOXENV: botocore

--- a/tox.ini
+++ b/tox.ini
@@ -190,15 +190,13 @@ setenv =
 
 [testenv:pypy3]
 basepython = pypy3
-commands =
-    pytest {posargs:--durations=10 docs scrapy tests}
+;commands =
+;    pytest {posargs:--durations=10 docs scrapy tests}
 
 [testenv:pypy3-extra-deps]
 basepython = pypy3
 deps =
     {[testenv:extra-deps]deps}
-commands =
-    pytest {posargs:--durations=10 docs scrapy tests}
 
 [testenv:pypy3-pinned]
 basepython = pypy3.10
@@ -218,8 +216,6 @@ deps =
     lxml==4.6.0
     {[test-requirements]deps}
     PyPyDispatcher==2.1.0
-commands =
-    pytest {posargs:--durations=10 scrapy tests}
 install_command = {[pinned]install_command}
 setenv =
     {[pinned]setenv}

--- a/tox.ini
+++ b/tox.ini
@@ -118,6 +118,7 @@ setenv =
 install_command =
     python -I -m pip install {opts} {packages}
 commands =
+    ; tests for docs fail with parsel < 1.8.0
     pytest --cov-config=pyproject.toml --cov=scrapy --cov-report=xml --cov-report= {posargs:--durations=10 scrapy tests}
 
 [testenv:pinned]
@@ -190,13 +191,15 @@ setenv =
 
 [testenv:pypy3]
 basepython = pypy3
-;commands =
-;    pytest {posargs:--durations=10 docs scrapy tests}
+commands =
+    ; not enabling coverage as it significantly increases the run time
+    pytest {posargs:--durations=10 docs scrapy tests}
 
 [testenv:pypy3-extra-deps]
 basepython = pypy3
 deps =
     {[testenv:extra-deps]deps}
+commands = {[pypy3]commands}
 
 [testenv:pypy3-pinned]
 basepython = pypy3.10
@@ -216,7 +219,9 @@ deps =
     lxml==4.6.0
     {[test-requirements]deps}
     PyPyDispatcher==2.1.0
-commands = {[pinned]commands}
+commands =
+    ; disabling both coverage and docs tests
+    pytest {posargs:--durations=10 scrapy tests}
 install_command = {[pinned]install_command}
 setenv =
     {[pinned]setenv}

--- a/tox.ini
+++ b/tox.ini
@@ -216,6 +216,7 @@ deps =
     lxml==4.6.0
     {[test-requirements]deps}
     PyPyDispatcher==2.1.0
+commands = {[pinned]commands}
 install_command = {[pinned]install_command}
 setenv =
     {[pinned]setenv}

--- a/tox.ini
+++ b/tox.ini
@@ -199,7 +199,7 @@ commands =
 basepython = pypy3
 deps =
     {[testenv:extra-deps]deps}
-commands = {[pypy3]commands}
+commands = {[testenv:pypy3]commands}
 
 [testenv:pypy3-pinned]
 basepython = pypy3.10

--- a/tox.ini
+++ b/tox.ini
@@ -193,10 +193,30 @@ basepython = pypy3
 commands =
     pytest {posargs:--durations=10 docs scrapy tests}
 
-[testenv:pypy3-pinned]
-basepython = pypy3.9
+[testenv:pypy3-extra-deps]
+basepython = pypy3
 deps =
-    {[pinned]deps}
+    {[testenv:extra-deps]deps}
+commands =
+    pytest {posargs:--durations=10 docs scrapy tests}
+
+[testenv:pypy3-pinned]
+basepython = pypy3.10
+deps =
+    cryptography==41.0.5
+    cssselect==0.9.1
+    h2==3.1
+    itemadapter==0.1.0
+    parsel==1.5.0
+    Protego==0.1.15
+    pyOpenSSL==23.3.0
+    queuelib==1.4.2
+    service_identity==18.1.0
+    Twisted[http2]==21.7.0
+    w3lib==1.17.0
+    zope.interface==5.1.0
+    lxml==4.6.0
+    {[test-requirements]deps}
     PyPyDispatcher==2.1.0
 commands =
     pytest {posargs:--durations=10 scrapy tests}


### PR DESCRIPTION
Fixes #6271.

I'm somewhat on the fence with removing PyPy 3.9 though: on one hand it's not supported anymore, on the other hand if we want a `pypy3-pinned` job we need to maintain a separate slightly different list of dep versions as long as the minimum supported version of PyPy is newer than the CPython one.

Additionally, I wonder if we want a `pypy3-asyncio` job and a `pypy3-extra-deps-pinned` one.