### PR TITLE
chore(docs): migrate to RTD template v3

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -117,13 +117,6 @@ html_theme = "sphinx_rtd_theme"
 # documentation.
 # html_theme_options = {}
 
-# Add any paths that contain custom themes here, relative to this directory.
-# Add path to the RTD explicitly to robustify builds (otherwise might
-# fail in a clean Debian build env)
-import sphinx_rtd_theme
-
-html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
-
 # The style sheet to use for HTML and HTML Help pages. A file of that name
 # must exist either in Sphinx' static/ path, or in one of the custom paths
 # given in html_static_path.

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,4 @@
 sphinx==6.2.1
-sphinx-hoverxref==1.3.0
-sphinx-notfound-page==1.0.0
-sphinx-rtd-theme==2.0.0
+sphinx-hoverxref==1.4.2
+sphinx-notfound-page==1.0.4
+sphinx-rtd-theme==3.0.2


### PR DESCRIPTION
### Changes

From RTD template v2 to v3.

notable change: Drop support for all versions of Internet Explorer.

### Reference

Mentioned in #6620