### PR TITLE
fix(docs): pillow domain is shut down permanently

### DIFF
--- a/docs/news.rst
+++ b/docs/news.rst
@@ -6862,7 +6862,7 @@ First release of Scrapy.
 .. _parsel.csstranslator.HTMLTranslator: https://parsel.readthedocs.io/en/latest/parsel.html#parsel.csstranslator.HTMLTranslator
 .. _parsel.csstranslator.XPathExpr: https://parsel.readthedocs.io/en/latest/parsel.html#parsel.csstranslator.XPathExpr
 .. _PEP 257: https://peps.python.org/pep-0257/
-.. _Pillow: https://python-pillow.org/
+.. _Pillow: https://github.com/python-pillow/Pillow
 .. _pyOpenSSL: https://www.pyopenssl.org/en/stable/
 .. _queuelib: https://github.com/scrapy/queuelib
 .. _registered with IANA: https://www.iana.org/assignments/media-types/media-types.xhtml


### PR DESCRIPTION
### Change

Pillow website is shut down permanently. Target github repository before website is taken by evil 3rd party.

### Reference

See https://github.com/python-pillow/Pillow/issues/8585