### PR TITLE
Fix test_s3_export StubAssertionError by allowing ChecksumAlgorithm

### DIFF
--- a/tests/test_feedexport.py
+++ b/tests/test_feedexport.py
@@ -2633,6 +2633,8 @@ class BatchDeliveriesTest(FeedExportTestBase):
                         "Body": ANY,
                         "Bucket": bucket,
                         "Key": ANY,
+                        # Accept any checksum param that boto might send
+                        "ChecksumAlgorithm": ANY,
                     },
                     service_response={},
                 )


### PR DESCRIPTION
Description
This update modifies the S3FeedStorage test to include "ChecksumAlgorithm" unconditionally in expected_params.

Benefits
Ensures compatibility with newer boto3 versions (>=1.36.0) where ChecksumAlgorithm is included by default.
Simplifies test logic by avoiding version-based conditions.

Fixes
Resolves #6619.