### PR TITLE
Fix error when running `scrapy bench`

### DIFF
--- a/scrapy/commands/bench.py
+++ b/scrapy/commands/bench.py
@@ -67,6 +67,6 @@ class _BenchSpider(scrapy.Spider):
         return [scrapy.Request(url, dont_filter=True)]
 
     def parse(self, response: Response) -> Any:
-        assert isinstance(Response, TextResponse)
+        assert isinstance(response, TextResponse)
         for link in self.link_extractor.extract_links(response):
             yield scrapy.Request(link.url, callback=self.parse)

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -1034,6 +1034,7 @@ class BenchCommandTest(CommandTest):
         )
         self.assertIn("INFO: Crawled", log)
         self.assertNotIn("Unhandled Error", log)
+        self.assertNotIn("log_count/ERROR", log)
 
 
 class ViewCommandTest(CommandTest):


### PR DESCRIPTION
Resolve https://github.com/scrapy/scrapy/issues/6632 (And [the Stack Overflow question](https://stackoverflow.com/q/79386410/4387278)  as well)

`scrapy bench` is erroring due to an incorrect param passed to `isinstance`. The first param must be the object to be verified, but a class was being passed instead. This is leading to `AssertionError` when the command is executed.

Changes here fix it by replacing the `Response` class with the `response` object.

See the difference in the logs when running `scrapy bench` before and after these changes:

<details>
<summary>Before</summary>

```
2025-01-25 13:50:18 [scrapy.core.engine] INFO: Spider opened
2025-01-25 13:50:18 [scrapy.extensions.logstats] INFO: Crawled 0 pages (at 0 pages/min), scraped 0 items (at 0 items/min)
2025-01-25 13:50:18 [scrapy.extensions.telnet] INFO: Telnet console listening on 127.0.0.1:6023
2025-01-25 13:50:18 [scrapy.core.scraper] ERROR: Spider error processing <GET http://localhost:8998?total=100000&show=20> (referer: None)
Traceback (most recent call last):
  File "/Users/lidianetaquehara/Projects/personal/scrapy/scrapy/utils/defer.py", line 327, in iter_errback
    yield next(it)
          ~~~~^^^^
  File "/Users/lidianetaquehara/Projects/personal/scrapy/scrapy/utils/python.py", line 367, in __next__
    return next(self.data)
  File "/Users/lidianetaquehara/Projects/personal/scrapy/scrapy/utils/python.py", line 367, in __next__
    return next(self.data)
  File "/Users/lidianetaquehara/Projects/personal/scrapy/scrapy/core/spidermw.py", line 106, in process_sync
    yield from iterable
  File "/Users/lidianetaquehara/Projects/personal/scrapy/scrapy/spidermiddlewares/referer.py", line 376, in <genexpr>
    return (self._set_referer(r, response) for r in result)
                                                    ^^^^^^
  File "/Users/lidianetaquehara/Projects/personal/scrapy/scrapy/core/spidermw.py", line 106, in process_sync
    yield from iterable
  File "/Users/lidianetaquehara/Projects/personal/scrapy/scrapy/spidermiddlewares/urllength.py", line 57, in <genexpr>
    return (r for r in result if self._filter(r, spider))
                       ^^^^^^
  File "/Users/lidianetaquehara/Projects/personal/scrapy/scrapy/core/spidermw.py", line 106, in process_sync
    yield from iterable
  File "/Users/lidianetaquehara/Projects/personal/scrapy/scrapy/spidermiddlewares/depth.py", line 54, in <genexpr>
    return (r for r in result if self._filter(r, response, spider))
                       ^^^^^^
  File "/Users/lidianetaquehara/Projects/personal/scrapy/scrapy/core/spidermw.py", line 106, in process_sync
    yield from iterable
  File "/Users/lidianetaquehara/Projects/personal/scrapy/scrapy/commands/bench.py", line 70, in parse
    assert isinstance(Response, TextResponse)
           ~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^
AssertionError
2025-01-25 13:50:18 [scrapy.core.engine] INFO: Closing spider (finished)
```
</details>

<details>
<summary>After</summary>

```
2025-01-25 13:51:09 [scrapy.core.engine] INFO: Spider opened
2025-01-25 13:51:09 [scrapy.extensions.logstats] INFO: Crawled 0 pages (at 0 pages/min), scraped 0 items (at 0 items/min)
2025-01-25 13:51:09 [scrapy.extensions.telnet] INFO: Telnet console listening on 127.0.0.1:6023
2025-01-25 13:51:10 [scrapy.extensions.logstats] INFO: Crawled 114 pages (at 6840 pages/min), scraped 0 items (at 0 items/min)
2025-01-25 13:51:11 [scrapy.extensions.logstats] INFO: Crawled 227 pages (at 6780 pages/min), scraped 0 items (at 0 items/min)
2025-01-25 13:51:12 [scrapy.extensions.logstats] INFO: Crawled 331 pages (at 6240 pages/min), scraped 0 items (at 0 items/min)
2025-01-25 13:51:13 [scrapy.extensions.logstats] INFO: Crawled 436 pages (at 6300 pages/min), scraped 0 items (at 0 items/min)
2025-01-25 13:51:14 [scrapy.extensions.logstats] INFO: Crawled 540 pages (at 6240 pages/min), scraped 0 items (at 0 items/min)
2025-01-25 13:51:15 [scrapy.extensions.logstats] INFO: Crawled 652 pages (at 6720 pages/min), scraped 0 items (at 0 items/min)
2025-01-25 13:51:16 [scrapy.extensions.logstats] INFO: Crawled 745 pages (at 5580 pages/min), scraped 0 items (at 0 items/min)
2025-01-25 13:51:17 [scrapy.extensions.logstats] INFO: Crawled 845 pages (at 6000 pages/min), scraped 0 items (at 0 items/min)
2025-01-25 13:51:18 [scrapy.extensions.logstats] INFO: Crawled 909 pages (at 3840 pages/min), scraped 0 items (at 0 items/min)
2025-01-25 13:51:19 [scrapy.core.engine] INFO: Closing spider (closespider_timeout)
2025-01-25 13:51:19 [scrapy.extensions.logstats] INFO: Crawled 1013 pages (at 6240 pages/min), scraped 0 items (at 0 items/min)
```
</details>