### PR TITLE
Refactor EngineTest tests.

### DIFF
--- a/tests/test_engine_stop_download_bytes.py
+++ b/tests/test_engine_stop_download_bytes.py
@@ -7,7 +7,7 @@ from tests.test_engine import (
     CrawlerRun,
     DataClassItemsSpider,
     DictItemsSpider,
-    EngineTest,
+    EngineTestBase,
     TestSpider,
 )
 
@@ -18,7 +18,7 @@ class BytesReceivedCrawlerRun(CrawlerRun):
         raise StopDownload(fail=False)
 
 
-class BytesReceivedEngineTest(EngineTest):
+class BytesReceivedEngineTest(EngineTestBase):
     @defer.inlineCallbacks
     def test_crawler(self):
         for spider in (

--- a/tests/test_engine_stop_download_headers.py
+++ b/tests/test_engine_stop_download_headers.py
@@ -7,7 +7,7 @@ from tests.test_engine import (
     CrawlerRun,
     DataClassItemsSpider,
     DictItemsSpider,
-    EngineTest,
+    EngineTestBase,
     TestSpider,
 )
 
@@ -18,7 +18,7 @@ class HeadersReceivedCrawlerRun(CrawlerRun):
         raise StopDownload(fail=False)
 
 
-class HeadersReceivedEngineTest(EngineTest):
+class HeadersReceivedEngineTest(EngineTestBase):
     @defer.inlineCallbacks
     def test_crawler(self):
         for spider in (


### PR DESCRIPTION
All `EngineTest.test_*()` tests ran ~~thrice~~ 5 (?) times before this. Related to #6645 