### PR TITLE
Optimize mockserver calls

### DIFF
--- a/tests/test_closespider.py
+++ b/tests/test_closespider.py
@@ -13,12 +13,14 @@ from tests.spiders import (
 
 
 class TestCloseSpider(TestCase):
-    def setUp(self):
-        self.mockserver = MockServer()
-        self.mockserver.__enter__()
+    @classmethod
+    def setUpClass(cls):
+        cls.mockserver = MockServer()
+        cls.mockserver.__enter__()
 
-    def tearDown(self):
-        self.mockserver.__exit__(None, None, None)
+    @classmethod
+    def tearDownClass(cls):
+        cls.mockserver.__exit__(None, None, None)
 
     @defer.inlineCallbacks
     def test_closespider_itemcount(self):

--- a/tests/test_crawl.py
+++ b/tests/test_crawl.py
@@ -56,12 +56,14 @@ from tests.spiders import (
 
 
 class CrawlTestCase(TestCase):
-    def setUp(self):
-        self.mockserver = MockServer()
-        self.mockserver.__enter__()
+    @classmethod
+    def setUpClass(cls):
+        cls.mockserver = MockServer()
+        cls.mockserver.__enter__()
 
-    def tearDown(self):
-        self.mockserver.__exit__(None, None, None)
+    @classmethod
+    def tearDownClass(cls):
+        cls.mockserver.__exit__(None, None, None)
 
     @defer.inlineCallbacks
     def test_follow_all(self):
@@ -448,12 +450,14 @@ with multiples lines
 
 
 class CrawlSpiderTestCase(TestCase):
-    def setUp(self):
-        self.mockserver = MockServer()
-        self.mockserver.__enter__()
+    @classmethod
+    def setUpClass(cls):
+        cls.mockserver = MockServer()
+        cls.mockserver.__enter__()
 
-    def tearDown(self):
-        self.mockserver.__exit__(None, None, None)
+    @classmethod
+    def tearDownClass(cls):
+        cls.mockserver.__exit__(None, None, None)
 
     @defer.inlineCallbacks
     def _run_spider(self, spider_cls):

--- a/tests/test_downloader_handlers.py
+++ b/tests/test_downloader_handlers.py
@@ -693,12 +693,14 @@ class Http11MockServerTestCase(unittest.TestCase):
 
     settings_dict: dict | None = None
 
-    def setUp(self):
-        self.mockserver = MockServer()
-        self.mockserver.__enter__()
+    @classmethod
+    def setUpClass(cls):
+        cls.mockserver = MockServer()
+        cls.mockserver.__enter__()
 
-    def tearDown(self):
-        self.mockserver.__exit__(None, None, None)
+    @classmethod
+    def tearDownClass(cls):
+        cls.mockserver.__exit__(None, None, None)
 
     @defer.inlineCallbacks
     def test_download_with_content_length(self):

--- a/tests/test_downloaderslotssettings.py
+++ b/tests/test_downloaderslotssettings.py
@@ -50,13 +50,17 @@ class DownloaderSlotsSettingsTestSpider(MetaSpider):
 
 
 class CrawlTestCase(TestCase):
-    def setUp(self):
-        self.mockserver = MockServer()
-        self.mockserver.__enter__()
-        self.runner = CrawlerRunner()
+    @classmethod
+    def setUpClass(cls):
+        cls.mockserver = MockServer()
+        cls.mockserver.__enter__()
 
-    def tearDown(self):
-        self.mockserver.__exit__(None, None, None)
+    @classmethod
+    def tearDownClass(cls):
+        cls.mockserver.__exit__(None, None, None)
+
+    def setUp(self):
+        self.runner = CrawlerRunner()
 
     @defer.inlineCallbacks
     def test_delay(self):

--- a/tests/test_feedexport.py
+++ b/tests/test_feedexport.py
@@ -636,13 +636,19 @@ class FeedExportTestBase(ABC, unittest.TestCase):
         filename = "".join(chars)
         return Path(self.temp_dir, inter_dir, filename)
 
+    @classmethod
+    def setUpClass(cls):
+        cls.mockserver = MockServer()
+        cls.mockserver.__enter__()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.mockserver.__exit__(None, None, None)
+
     def setUp(self):
         self.temp_dir = tempfile.mkdtemp()
-        self.mockserver = MockServer()
-        self.mockserver.__enter__()
 
     def tearDown(self):
-        self.mockserver.__exit__(None, None, None)
         shutil.rmtree(self.temp_dir, ignore_errors=True)
 
     @defer.inlineCallbacks

--- a/tests/test_logformatter.py
+++ b/tests/test_logformatter.py
@@ -262,18 +262,22 @@ class DropSomeItemsPipeline:
 
 
 class ShowOrSkipMessagesTestCase(TwistedTestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.mockserver = MockServer()
+        cls.mockserver.__enter__()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.mockserver.__exit__(None, None, None)
+
     def setUp(self):
-        self.mockserver = MockServer()
-        self.mockserver.__enter__()
         self.base_settings = {
             "LOG_LEVEL": "DEBUG",
             "ITEM_PIPELINES": {
                 DropSomeItemsPipeline: 300,
             },
         }
-
-    def tearDown(self):
-        self.mockserver.__exit__(None, None, None)
 
     @defer.inlineCallbacks
     def test_show_messages(self):

--- a/tests/test_pipeline_crawl.py
+++ b/tests/test_pipeline_crawl.py
@@ -64,10 +64,16 @@ class FileDownloadCrawlTestCase(TestCase):
         "ed3f6538dc15d4d9179dae57319edc5f",
     }
 
-    def setUp(self):
-        self.mockserver = MockServer()
-        self.mockserver.__enter__()
+    @classmethod
+    def setUpClass(cls):
+        cls.mockserver = MockServer()
+        cls.mockserver.__enter__()
 
+    @classmethod
+    def tearDownClass(cls):
+        cls.mockserver.__exit__(None, None, None)
+
+    def setUp(self):
         # prepare a directory for storing files
         self.tmpmediastore = Path(mkdtemp())
         self.settings = {
@@ -80,7 +86,6 @@ class FileDownloadCrawlTestCase(TestCase):
     def tearDown(self):
         shutil.rmtree(self.tmpmediastore)
         self.items = []
-        self.mockserver.__exit__(None, None, None)
 
     def _on_item_scraped(self, item):
         self.items.append(item)

--- a/tests/test_pipelines.py
+++ b/tests/test_pipelines.py
@@ -77,12 +77,14 @@ class ItemSpider(Spider):
 
 
 class PipelineTestCase(unittest.TestCase):
-    def setUp(self):
-        self.mockserver = MockServer()
-        self.mockserver.__enter__()
+    @classmethod
+    def setUpClass(cls):
+        cls.mockserver = MockServer()
+        cls.mockserver.__enter__()
 
-    def tearDown(self):
-        self.mockserver.__exit__(None, None, None)
+    @classmethod
+    def tearDownClass(cls):
+        cls.mockserver.__exit__(None, None, None)
 
     def _on_item_scraped(self, item):
         self.assertIsInstance(item, dict)

--- a/tests/test_proxy_connect.py
+++ b/tests/test_proxy_connect.py
@@ -62,14 +62,21 @@ def _wrong_credentials(proxy_url):
 
 
 class ProxyConnectTestCase(TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.mockserver = MockServer()
+        cls.mockserver.__enter__()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.mockserver.__exit__(None, None, None)
+
     def setUp(self):
         try:
             import mitmproxy  # noqa: F401
         except ImportError:
             self.skipTest("mitmproxy is not installed")
 
-        self.mockserver = MockServer()
-        self.mockserver.__enter__()
         self._oldenv = os.environ.copy()
 
         self._proxy = MitmProxy()
@@ -78,7 +85,6 @@ class ProxyConnectTestCase(TestCase):
         os.environ["http_proxy"] = proxy_url
 
     def tearDown(self):
-        self.mockserver.__exit__(None, None, None)
         self._proxy.stop()
         os.environ = self._oldenv
 

--- a/tests/test_request_attribute_binding.py
+++ b/tests/test_request_attribute_binding.py
@@ -57,12 +57,14 @@ class AlternativeCallbacksMiddleware:
 
 
 class CrawlTestCase(TestCase):
-    def setUp(self):
-        self.mockserver = MockServer()
-        self.mockserver.__enter__()
+    @classmethod
+    def setUpClass(cls):
+        cls.mockserver = MockServer()
+        cls.mockserver.__enter__()
 
-    def tearDown(self):
-        self.mockserver.__exit__(None, None, None)
+    @classmethod
+    def tearDownClass(cls):
+        cls.mockserver.__exit__(None, None, None)
 
     @defer.inlineCallbacks
     def test_response_200(self):

--- a/tests/test_request_cb_kwargs.py
+++ b/tests/test_request_cb_kwargs.py
@@ -154,12 +154,14 @@ class KeywordArgumentsSpider(MockServerSpider):
 class CallbackKeywordArgumentsTestCase(TestCase):
     maxDiff = None
 
-    def setUp(self):
-        self.mockserver = MockServer()
-        self.mockserver.__enter__()
+    @classmethod
+    def setUpClass(cls):
+        cls.mockserver = MockServer()
+        cls.mockserver.__enter__()
 
-    def tearDown(self):
-        self.mockserver.__exit__(None, None, None)
+    @classmethod
+    def tearDownClass(cls):
+        cls.mockserver.__exit__(None, None, None)
 
     @defer.inlineCallbacks
     def test_callback_kwargs(self):

--- a/tests/test_request_left.py
+++ b/tests/test_request_left.py
@@ -25,12 +25,14 @@ class SignalCatcherSpider(Spider):
 
 
 class TestCatching(TestCase):
-    def setUp(self):
-        self.mockserver = MockServer()
-        self.mockserver.__enter__()
+    @classmethod
+    def setUpClass(cls):
+        cls.mockserver = MockServer()
+        cls.mockserver.__enter__()
 
-    def tearDown(self):
-        self.mockserver.__exit__(None, None, None)
+    @classmethod
+    def tearDownClass(cls):
+        cls.mockserver.__exit__(None, None, None)
 
     @defer.inlineCallbacks
     def test_success(self):

--- a/tests/test_signals.py
+++ b/tests/test_signals.py
@@ -21,13 +21,17 @@ class ItemSpider(Spider):
 
 
 class AsyncSignalTestCase(unittest.TestCase):
-    def setUp(self):
-        self.mockserver = MockServer()
-        self.mockserver.__enter__()
-        self.items = []
+    @classmethod
+    def setUpClass(cls):
+        cls.mockserver = MockServer()
+        cls.mockserver.__enter__()
 
-    def tearDown(self):
-        self.mockserver.__exit__(None, None, None)
+    @classmethod
+    def tearDownClass(cls):
+        cls.mockserver.__exit__(None, None, None)
+
+    def setUp(self):
+        self.items = []
 
     async def _on_item_scraped(self, item):
         item = await get_from_asyncio_queue(item)

--- a/tests/test_spidermiddleware_httperror.py
+++ b/tests/test_spidermiddleware_httperror.py
@@ -172,12 +172,14 @@ class TestHttpErrorMiddlewareHandleAll(TestCase):
 
 
 class TestHttpErrorMiddlewareIntegrational(TrialTestCase):
-    def setUp(self):
-        self.mockserver = MockServer()
-        self.mockserver.__enter__()
+    @classmethod
+    def setUpClass(cls):
+        cls.mockserver = MockServer()
+        cls.mockserver.__enter__()
 
-    def tearDown(self):
-        self.mockserver.__exit__(None, None, None)
+    @classmethod
+    def tearDownClass(cls):
+        cls.mockserver.__exit__(None, None, None)
 
     @defer.inlineCallbacks
     def test_middleware_works(self):


### PR DESCRIPTION
Fixes #6637, related to #6645.

A better solution, as mentioned in the issue, would be switching to pytest fixtures but that's a much bigger thing.