### PR TITLE
Remove a duplicate test.

### DIFF
--- a/tests/test_downloadermiddleware_httpcache.py
+++ b/tests/test_downloadermiddleware_httpcache.py
@@ -14,7 +14,7 @@ from scrapy.utils.test import get_crawler
 
 
 class _BaseTest(unittest.TestCase):
-    storage_class = "scrapy.extensions.httpcache.DbmCacheStorage"
+    storage_class = "scrapy.extensions.httpcache.FilesystemCacheStorage"
     policy_class = "scrapy.extensions.httpcache.RFC2616Policy"
 
     def setUp(self):
@@ -161,11 +161,7 @@ class DbmStorageWithCustomDbmModuleTest(DbmStorageTest):
             self.assertEqual(storage.dbmodule.__name__, self.dbm_module)
 
 
-class FilesystemStorageTest(DefaultStorageTest):
-    storage_class = "scrapy.extensions.httpcache.FilesystemCacheStorage"
-
-
-class FilesystemStorageGzipTest(FilesystemStorageTest):
+class FilesystemStorageGzipTest(DefaultStorageTest):
     def _get_settings(self, **new_settings):
         new_settings.setdefault("HTTPCACHE_GZIP", True)
         return super()._get_settings(**new_settings)


### PR DESCRIPTION
Related to #6645 and #6649. 

This also makes some methods that previously ran with `DbmCacheStorage` to run with `FilesystemCacheStorage` (but if that breaks anything it's a bug in them). Not sure which methods, though, maybe just `tests.test_downloadermiddleware_httpcache._BaseTest.test_dont_cache()`.