### PR TITLE
Support dark mode in scrapy's documentation

### DIFF
--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -12,8 +12,8 @@
 /*override some styles in
 sphinx-rtd-dark-mode/static/dark_mode_css/general.css*/
 .theme-switcher {
-    right: 1.2em !important;
-    bottom: 29em !important;
+    right: 0.4em !important;
+    top: 0.6em !important;
     -webkit-box-shadow: 0px 3px 14px 4px rgba(0, 0, 0, 0.30) !important;
     box-shadow: 0px 3px 14px 4px rgba(0, 0, 0, 0.30) !important;
     height: 2em !important;

--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -8,3 +8,11 @@
 .rst-content dl p + ol, .rst-content dl p + ul {
     margin-top: -6px; /* Compensates margin-top: 12px of p  */
 }
+.theme-switcher {
+    right: 1.2em !important;
+    bottom: 29em !important;
+    -webkit-box-shadow: 0px 3px 14px 4px rgba(0, 0, 0, 0.30) !important;
+    box-shadow: 0px 3px 14px 4px rgba(0, 0, 0, 0.30) !important;
+    height: 2em !important;
+    width: 2em !important;
+}

--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -19,3 +19,19 @@ sphinx-rtd-dark-mode/static/dark_mode_css/general.css*/
     height: 2em !important;
     width: 2em !important;
 }
+
+@media (max-width: 768px) {
+    .theme-switcher {
+        right: 0.4em !important;
+        bottom: 2.6em !important;
+        top: auto !important;
+    }
+}
+
+html[data-theme="dark"] .wy-side-nav-search {
+    background-color: #1d577d !important;
+}
+
+html[data-theme="dark"] .wy-nav-top {
+    background-color: #1d577d !important
+}

--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -32,7 +32,8 @@ at the bottom right corner on small screens*/
 
 /*persist blue color at the top left used in
 default rtd theme*/
-html[data-theme="dark"] .wy-side-nav-search, .wy-nav-top {
+html[data-theme="dark"] .wy-side-nav-search,
+html[data-theme="dark"] .wy-nav-top {
     background-color: #1d577d !important;
 }
 
@@ -43,34 +44,13 @@ html[data-theme="dark"] .sig.sig-object {
     background-color: #202325 !important
 }
 
-html[data-theme="dark"] .sig-name{
-    color: #e8e6e3 !important
-}
-
-html[data-theme="dark"] .sig-prename {
-    color: #e8e6e3 !important
-}
-
-html[data-theme="dark"] .property {
-    color: #e8e6e3 !important
-}
-
-html[data-theme="dark"] .sig-param {
-    color: #e8e6e3 !important
-}
-
-html[data-theme="dark"] .sig-paren {
-    color: #e8e6e3 !important
-}
-
-html[data-theme="dark"] .sig-return-icon {
-    color: #e8e6e3 !important
-}
-
-html[data-theme="dark"] .sig-return-typehint {
-    color: #e8e6e3 !important
-}
-
+html[data-theme="dark"] .sig-name,
+html[data-theme="dark"] .sig-prename,
+html[data-theme="dark"] .property,
+html[data-theme="dark"] .sig-param,
+html[data-theme="dark"] .sig-paren,
+html[data-theme="dark"] .sig-return-icon,
+html[data-theme="dark"] .sig-return-typehint,
 html[data-theme="dark"] .optional {
     color: #e8e6e3 !important
 }

--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -8,6 +8,9 @@
 .rst-content dl p + ol, .rst-content dl p + ul {
     margin-top: -6px; /* Compensates margin-top: 12px of p  */
 }
+
+/*override some styles in
+sphinx-rtd-dark-mode/static/dark_mode_css/general.css*/
 .theme-switcher {
     right: 1.2em !important;
     bottom: 29em !important;

--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -20,6 +20,8 @@ sphinx-rtd-dark-mode/static/dark_mode_css/general.css*/
     width: 2em !important;
 }
 
+/*place the toggle button for dark mode
+at the bottom right corner on small screens*/
 @media (max-width: 768px) {
     .theme-switcher {
         right: 0.4em !important;
@@ -28,10 +30,47 @@ sphinx-rtd-dark-mode/static/dark_mode_css/general.css*/
     }
 }
 
-html[data-theme="dark"] .wy-side-nav-search {
+/*persist blue color at the top left used in
+default rtd theme*/
+html[data-theme="dark"] .wy-side-nav-search, .wy-nav-top {
     background-color: #1d577d !important;
 }
 
-html[data-theme="dark"] .wy-nav-top {
-    background-color: #1d577d !important
+/*all the styles below used to present
+API objects nicely in dark mode*/
+html[data-theme="dark"] .sig.sig-object {
+    border-left-color: #3e4446 !important;
+    background-color: #202325 !important
+}
+
+html[data-theme="dark"] .sig-name{
+    color: #e8e6e3 !important
+}
+
+html[data-theme="dark"] .sig-prename {
+    color: #e8e6e3 !important
+}
+
+html[data-theme="dark"] .property {
+    color: #e8e6e3 !important
+}
+
+html[data-theme="dark"] .sig-param {
+    color: #e8e6e3 !important
+}
+
+html[data-theme="dark"] .sig-paren {
+    color: #e8e6e3 !important
+}
+
+html[data-theme="dark"] .sig-return-icon {
+    color: #e8e6e3 !important
+}
+
+html[data-theme="dark"] .sig-return-typehint {
+    color: #e8e6e3 !important
+}
+
+html[data-theme="dark"] .optional {
+    color: #e8e6e3 !important
 }

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -35,6 +35,7 @@ extensions = [
     "sphinx.ext.coverage",
     "sphinx.ext.intersphinx",
     "sphinx.ext.viewcode",
+    "sphinx_rtd_dark_mode",
 ]
 
 templates_path = ["_templates"]

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -175,3 +175,5 @@ hoverxref_role_types = {
     "signal": "tooltip",
 }
 hoverxref_roles = ["command", "reqmeta", "setting", "signal"]
+
+default_dark_mode = False

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -2,3 +2,4 @@ sphinx==8.1.3
 sphinx-hoverxref==1.4.2
 sphinx-notfound-page==1.0.4
 sphinx-rtd-theme==3.0.2
+sphinx-rtd-dark-mode=1.3.0

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -2,4 +2,4 @@ sphinx==8.1.3
 sphinx-hoverxref==1.4.2
 sphinx-notfound-page==1.0.4
 sphinx-rtd-theme==3.0.2
-sphinx-rtd-dark-mode=1.3.0
+sphinx-rtd-dark-mode==1.3.0


### PR DESCRIPTION
This PR attempts to support dark mode for scrapy's documentation by adding [sphinx-rtd-dark-mode](https://pypi.org/project/sphinx-rtd-dark-mode/) extension to sphinx

By default, this extension places the toggle button at the bottom right corner and enables dark mode. It allows to configure whether dark mode should be enabled by default. I wanted to place the toggle button at top right corner so I added custom style in custom.css. This extension adds text to the footer.

It's not an essential feature as there are browser extensions that can enable dark mode for sites, for example [dark reader browser extension](https://darkreader.org/) but I thought it will be nice to have.

I am also mentioning https://github.com/readthedocs/sphinx_rtd_theme/issues/224#issuecomment-722655021 which used dark reader browser extension to export the requried CSS and add it to the config, but this feature is not accessible in the latest update https://github.com/darkreader/darkreader/issues/13#issuecomment-2126082174 so I decided to use sphinx-rtd-dark-mode instead



