### PR TITLE
fix: Reactor info logged twice

### DIFF
--- a/scrapy/crawler.py
+++ b/scrapy/crawler.py
@@ -123,7 +123,7 @@ class Crawler:
             else:
                 from twisted.internet import reactor  # noqa: F401
 
-            if logged_reactor_info is False:
+            if not logged_reactor_info:
                 log_reactor_info()
                 logged_reactor_info = True
 
@@ -132,7 +132,7 @@ class Crawler:
             if is_asyncio_reactor_installed() and event_loop:
                 verify_installed_asyncio_event_loop(event_loop)
 
-            if logged_reactor_info is False:
+            if not logged_reactor_info:
                 log_reactor_info()
 
         self.extensions = ExtensionManager.from_crawler(self)

--- a/scrapy/crawler.py
+++ b/scrapy/crawler.py
@@ -113,7 +113,6 @@ class Crawler:
 
         reactor_class: str = self.settings["TWISTED_REACTOR"]
         event_loop: str = self.settings["ASYNCIO_EVENT_LOOP"]
-
         if self._init_reactor:
             # this needs to be done after the spider settings are merged,
             # but before something imports twisted.internet.reactor
@@ -121,7 +120,6 @@ class Crawler:
                 install_reactor(reactor_class, event_loop)
             else:
                 from twisted.internet import reactor  # noqa: F401
-
         if reactor_class:
             verify_installed_reactor(reactor_class)
             if is_asyncio_reactor_installed() and event_loop:

--- a/scrapy/crawler.py
+++ b/scrapy/crawler.py
@@ -113,6 +113,8 @@ class Crawler:
 
         reactor_class: str = self.settings["TWISTED_REACTOR"]
         event_loop: str = self.settings["ASYNCIO_EVENT_LOOP"]
+        logged_reactor_info: bool = False
+
         if self._init_reactor:
             # this needs to be done after the spider settings are merged,
             # but before something imports twisted.internet.reactor
@@ -120,13 +122,18 @@ class Crawler:
                 install_reactor(reactor_class, event_loop)
             else:
                 from twisted.internet import reactor  # noqa: F401
-            log_reactor_info()
+
+            if logged_reactor_info is False:
+                log_reactor_info()
+                logged_reactor_info = True
+
         if reactor_class:
             verify_installed_reactor(reactor_class)
             if is_asyncio_reactor_installed() and event_loop:
                 verify_installed_asyncio_event_loop(event_loop)
 
-            log_reactor_info()
+            if logged_reactor_info is False:
+                log_reactor_info()
 
         self.extensions = ExtensionManager.from_crawler(self)
         self.settings.freeze()

--- a/scrapy/crawler.py
+++ b/scrapy/crawler.py
@@ -113,7 +113,6 @@ class Crawler:
 
         reactor_class: str = self.settings["TWISTED_REACTOR"]
         event_loop: str = self.settings["ASYNCIO_EVENT_LOOP"]
-        logged_reactor_info: bool = False
 
         if self._init_reactor:
             # this needs to be done after the spider settings are merged,
@@ -123,17 +122,13 @@ class Crawler:
             else:
                 from twisted.internet import reactor  # noqa: F401
 
-            if not logged_reactor_info:
-                log_reactor_info()
-                logged_reactor_info = True
-
         if reactor_class:
             verify_installed_reactor(reactor_class)
             if is_asyncio_reactor_installed() and event_loop:
                 verify_installed_asyncio_event_loop(event_loop)
 
-            if not logged_reactor_info:
-                log_reactor_info()
+        if self._init_reactor or reactor_class:
+            log_reactor_info()
 
         self.extensions = ExtensionManager.from_crawler(self)
         self.settings.freeze()


### PR DESCRIPTION
fix: #6636

Tested manually with:
```
python tests/CrawlerRunner/change_reactor.py
```
and
```
scrapy shell -s TWISTED_REACTOR="twisted.internet.asyncioreactor.AsyncioSelectorReactor"
```