### PR TITLE
Json separators added

### DIFF
--- a/scrapy/exporters.py
+++ b/scrapy/exporters.py
@@ -122,7 +122,7 @@ class JsonLinesItemExporter(BaseItemExporter):
 
 
 class JsonItemExporter(BaseItemExporter):
-    def __init__(self, file: BytesIO, **kwargs: Any):
+    def __init__(self, file: BytesIO, separators=(",", ":"), **kwargs: Any):
         super().__init__(dont_fail=True, **kwargs)
         self.file: BytesIO = file
         # there is a small difference between the behaviour or JsonItemExporter.indent
@@ -133,6 +133,7 @@ class JsonItemExporter(BaseItemExporter):
         )
         self._kwargs.setdefault("indent", json_indent)
         self._kwargs.setdefault("ensure_ascii", not self.encoding)
+        self._kwargs.setdefault("separators", separators)
         self.encoder = ScrapyJSONEncoder(**self._kwargs)
         self.first_item = True
 

--- a/tests/test_exporters.py
+++ b/tests/test_exporters.py
@@ -623,6 +623,28 @@ class JsonItemExporterTest(JsonLinesItemExporterTest):
         }
         self.assertEqual(exported, [expected])
 
+    def test_json_exporter_separators_compact(self):
+        #Test compact separators (no spaces between keys and values).
+        self.ie = self._get_exporter(separators=(",", ":"))
+        self.ie.start_exporting()
+        self.ie.export_item(self.i)
+        self.ie.finish_exporting()
+        del self.ie
+        exported = to_unicode(self.output.getvalue().strip())
+        expected = json.dumps([ItemAdapter(self.i).asdict()], separators=(",", ":"))
+        self.assertEqual(exported, expected)
+
+    def test_json_exporter_separators_with_spaces(self):
+        #Test separators with spaces around keys and values.
+        self.ie = self._get_exporter(separators=(", ", ": "))
+        self.ie.start_exporting()
+        self.ie.export_item(self.i)
+        self.ie.finish_exporting()
+        del self.ie
+        exported = to_unicode(self.output.getvalue().strip())
+        expected = json.dumps([ItemAdapter(self.i).asdict()], separators=(", ", ": "))
+        self.assertEqual(exported, expected)
+
     def test_nested_dict_item(self):
         i1 = {"name": "Joseph\xa3", "age": "22"}
         i2 = self.item_class(name="Maria", age=i1)


### PR DESCRIPTION
Add Support for Custom JSON Separators in JsonItemExporter

Overview:
This pull request introduces support for custom JSON separators in JsonItemExporter, allowing users to control the formatting of exported JSON data. This enhancement provides flexibility for compact or more readable JSON output.
Changes Made

    
![Screenshot from 2025-02-07 11-09-29](https://github.com/user-attachments/assets/a9fb7148-f38a-4464-aa34-765a06bff704)

Added a separators option to JsonItemExporter, allowing customization of JSON separators.
    Updated ScrapyJSONEncoder usage to respect the provided separators argument.
    Added unit tests to validate different separator configurations, including:
        Compact JSON (separators=(",", ":")).
        Readable JSON (separators=(", ", ": ")).

Why This Change?
    Some users require compact JSON output for efficiency.
    Others prefer more readable formatting with spaces or maybe "\" or "|" 
    Aligns with json.dumps() flexibility, making Scrapy’s exporter more customizable.

What about testing ?
    Added new test cases in JsonItemExporterTest to validate separator functionality.
    Ensured all existing tests pass successfully.
