### PR TITLE
Fix getting annotations for _parse_sitemap() at the runtime.

### DIFF
--- a/scrapy/spiders/sitemap.py
+++ b/scrapy/spiders/sitemap.py
@@ -2,6 +2,9 @@ from __future__ import annotations
 
 import logging
 import re
+
+# Iterable is needed at the run time for the SitemapSpider._parse_sitemap() annotation
+from collections.abc import Iterable, Sequence  # noqa: TC003
 from typing import TYPE_CHECKING, Any, cast
 
 from scrapy.http import Request, Response, XmlResponse
@@ -11,8 +14,6 @@ from scrapy.utils.gz import gunzip, gzip_magic_number
 from scrapy.utils.sitemap import Sitemap, sitemap_urls_from_robots
 
 if TYPE_CHECKING:
-    from collections.abc import Iterable, Sequence
-
     # typing.Self requires Python 3.11
     from typing_extensions import Self
 

--- a/tests/test_poet.py
+++ b/tests/test_poet.py
@@ -1,0 +1,20 @@
+"""Tests that make sure parts needed for the scrapy-poet stack work."""
+
+from typing import get_type_hints
+
+from scrapy import Spider
+from scrapy.spiders import CrawlSpider, CSVFeedSpider, SitemapSpider, XMLFeedSpider
+
+
+def test_callbacks():
+    """Making sure annotations on all non-abstract callbacks can be resolved."""
+
+    for cb in [
+        Spider._parse,
+        CrawlSpider._parse,
+        CrawlSpider._callback,
+        XMLFeedSpider._parse,
+        CSVFeedSpider._parse,
+        SitemapSpider._parse_sitemap,
+    ]:
+        get_type_hints(cb)

--- a/tests/test_spider.py
+++ b/tests/test_spider.py
@@ -4,7 +4,7 @@ import warnings
 from io import BytesIO
 from logging import WARNING
 from pathlib import Path
-from typing import Any
+from typing import Any, get_type_hints
 from unittest import mock
 
 from testfixtures import LogCapture
@@ -827,3 +827,18 @@ class NoParseMethodSpiderTest(unittest.TestCase):
         exc_msg = "Spider.parse callback is not defined"
         with self.assertRaisesRegex(NotImplementedError, exc_msg):
             spider.parse(resp)
+
+
+class CallbackDepsTest(unittest.TestCase):
+    """Making sure annotations on all non-abstract callbacks can be resolved."""
+
+    def test_callbacks(self):
+        for cb in [
+            Spider._parse,
+            CrawlSpider._parse,
+            CrawlSpider._callback,
+            XMLFeedSpider._parse,
+            CSVFeedSpider._parse,
+            SitemapSpider._parse_sitemap,
+        ]:
+            get_type_hints(cb)

--- a/tests/test_spider.py
+++ b/tests/test_spider.py
@@ -4,7 +4,7 @@ import warnings
 from io import BytesIO
 from logging import WARNING
 from pathlib import Path
-from typing import Any, get_type_hints
+from typing import Any
 from unittest import mock
 
 from testfixtures import LogCapture
@@ -827,18 +827,3 @@ class NoParseMethodSpiderTest(unittest.TestCase):
         exc_msg = "Spider.parse callback is not defined"
         with self.assertRaisesRegex(NotImplementedError, exc_msg):
             spider.parse(resp)
-
-
-class CallbackDepsTest(unittest.TestCase):
-    """Making sure annotations on all non-abstract callbacks can be resolved."""
-
-    def test_callbacks(self):
-        for cb in [
-            Spider._parse,
-            CrawlSpider._parse,
-            CrawlSpider._callback,
-            XMLFeedSpider._parse,
-            CSVFeedSpider._parse,
-            SitemapSpider._parse_sitemap,
-        ]:
-            get_type_hints(cb)


### PR DESCRIPTION
Fixes #6665 (hopefully there are no other functions where this is important).