### PR TITLE
spider name is optional 1157 [WIP]

### DIFF
--- a/scrapy/spiders/__init__.py
+++ b/scrapy/spiders/__init__.py
@@ -28,6 +28,14 @@ if TYPE_CHECKING:
     from scrapy.utils.log import SpiderLoggerAdapter
 
 
+class classproperty:
+    def __init__(self, fget):
+        self.fget = fget
+
+    def __get__(self, cls, owner):
+        return self.fget(owner)
+
+
 class Spider(object_ref):
     """Base class for scrapy spiders. All spiders must inherit from this
     class.
@@ -44,6 +52,10 @@ class Spider(object_ref):
         self.__dict__.update(kwargs)
         if not hasattr(self, "start_urls"):
             self.start_urls: list[str] = []
+
+    @classproperty
+    def name(cls):
+        return cls.__name__
 
     @property
     def logger(self) -> SpiderLoggerAdapter:

--- a/tests/test_spiderloader/__init__.py
+++ b/tests/test_spiderloader/__init__.py
@@ -47,7 +47,8 @@ class SpiderLoaderTest(unittest.TestCase):
 
     def test_list(self):
         self.assertEqual(
-            set(self.spider_loader.list()), {"spider1", "spider2", "spider3", "spider4"}
+            set(self.spider_loader.list()),
+            {"spider1", "spider2", "spider3", "spider4", "Spider0"},
         )
 
     def test_load(self):
@@ -57,7 +58,7 @@ class SpiderLoaderTest(unittest.TestCase):
     def test_find_by_request(self):
         self.assertEqual(
             self.spider_loader.find_by_request(Request("http://scrapy1.org/test")),
-            ["spider1"],
+            ["Spider0", "spider1"],
         )
         self.assertEqual(
             self.spider_loader.find_by_request(Request("http://scrapy2.org/test")),
@@ -65,7 +66,7 @@ class SpiderLoaderTest(unittest.TestCase):
         )
         self.assertEqual(
             set(self.spider_loader.find_by_request(Request("http://scrapy3.org/test"))),
-            {"spider1", "spider2"},
+            {"spider1", "spider2", "Spider0"},
         )
         self.assertEqual(
             self.spider_loader.find_by_request(Request("http://scrapy999.org/test")), []
@@ -93,7 +94,15 @@ class SpiderLoaderTest(unittest.TestCase):
 
     def test_load_base_spider(self):
         module = "tests.test_spiderloader.test_spiders.spider0"
-        settings = Settings({"SPIDER_MODULES": [module]})
+        settings = Settings(
+            {
+                "SPIDER_MODULES": [
+                    module,
+                    "scrapy.spiders.crawl",
+                    "scrapy.spiders.sitemap",
+                ]
+            }
+        )
         self.spider_loader = SpiderLoader.from_settings(settings)
         assert len(self.spider_loader._spiders) == 0
 
@@ -217,7 +226,9 @@ class DuplicateSpiderNameLoaderTest(unittest.TestCase):
             self.assertNotIn("'spider4'", msg)
 
             spiders = set(spider_loader.list())
-            self.assertEqual(spiders, {"spider1", "spider2", "spider3", "spider4"})
+            self.assertEqual(
+                spiders, {"spider1", "spider2", "spider3", "spider4", "Spider0"}
+            )
 
     def test_multiple_dupename_warning(self):
         # copy 2 spider modules so as to have duplicate spider name
@@ -247,4 +258,6 @@ class DuplicateSpiderNameLoaderTest(unittest.TestCase):
             self.assertNotIn("'spider4'", msg)
 
             spiders = set(spider_loader.list())
-            self.assertEqual(spiders, {"spider1", "spider2", "spider3", "spider4"})
+            self.assertEqual(
+                spiders, {"spider1", "spider2", "spider3", "spider4", "Spider0"}
+            )


### PR DESCRIPTION
Fixes https://github.com/scrapy/scrapy/issues/1157

based on approach from https://github.com/scrapy/scrapy/pull/1649  (where I had issues to resolve merge conflict as that pull request was from 2015) so technically only spider class updated to return spider class name as default value of `name` attribute  (so it doesn't require to additionally set `name` for spider)


As mentioned on https://github.com/scrapy/scrapy/issues/1157#issuecomment-1816782204 other multiple components (and unknown number of 3rd party scrapy plugins/custom middlewares) directly call `spider.name` attribute.


From https://github.com/scrapy/scrapy/pull/1649#issuecomment-178697597

>The problem is that after this change base classes (including scrapy.Spider?) will appear in `scrapy list` command; this is confusing and not backwards compatible. We may add a special attribute which can be set explicitly to mark spider as a base class (e.g. show=False or base=True), but as by default there won't be such attribute this change will require users to add it to all base spiders. So it is backwards-incompatible again. This all is obvious in hindsight, but only your PR helped me to realize that.

Yes at this stage it indeed count all classes inherited from `scrapy.Spider` including spiders that current spiderloader do not load.

Because `scrapy.utols.spideriter_spider_classes` works differently it this will be applied:
https://github.com/scrapy/scrapy/blob/35212ec5b05a3af14c9f87a6193ab24e33d62f9f/scrapy/utils/spider.py#L51-L62
