### PR TITLE
Better fix for test_non_pickable_object on Windows.

### DIFF
--- a/tests/test_squeues.py
+++ b/tests/test_squeues.py
@@ -130,9 +130,7 @@ class PickleFifoDiskQueueTest(t.FifoDiskQueueTest, FifoDiskQueueTestMixin):
         ) as exc_info:
             q.push(sel)
         assert isinstance(exc_info.value.__context__, TypeError)
-        # This seems to help with https://github.com/scrapy/queuelib/issues/70.
-        # It will need to remain under a queuelib version check after that bug is fixed.
-        del exc_info
+        q.close()
 
 
 class ChunkSize1PickleFifoDiskQueueTest(PickleFifoDiskQueueTest):


### PR DESCRIPTION
Failures in Scrapy and queuelib are independent, even though they are similar.