### PR TITLE
Convert remaining unittest assert* calls, use the tmp_path fixture.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -374,10 +374,6 @@ ignore = [
     "B904",
     # Use capitalized environment variable
     "SIM112",
-
-    # Temporarily silenced PT rules
-    # Use a regular `assert` instead of unittest-style `assertEqual`
-    "PT009",
 ]
 
 [tool.ruff.lint.per-file-ignores]

--- a/scrapy/utils/test.py
+++ b/scrapy/utils/test.py
@@ -156,7 +156,7 @@ def assert_samelines(
         category=ScrapyDeprecationWarning,
         stacklevel=2,
     )
-    testcase.assertEqual(text1.splitlines(), text2.splitlines(), msg)
+    testcase.assertEqual(text1.splitlines(), text2.splitlines(), msg)  # noqa: PT009
 
 
 def get_from_asyncio_queue(value: _T) -> Awaitable[_T]:

--- a/tests/test_downloadermiddleware_robotstxt.py
+++ b/tests/test_downloadermiddleware_robotstxt.py
@@ -1,3 +1,4 @@
+from typing import Any
 from unittest import mock
 
 import pytest
@@ -171,7 +172,11 @@ Disallow: /some/randome/page.html
         middleware = RobotsTxtMiddleware(self.crawler)
         middleware._logerror = mock.MagicMock(side_effect=middleware._logerror)
         deferred = middleware.process_request(Request("http://site.local"), None)
-        deferred.addCallback(lambda _: self.assertTrue(middleware._logerror.called))
+
+        def check_called(_: Any) -> None:
+            assert middleware._logerror.called
+
+        deferred.addCallback(check_called)
         return deferred
 
     def test_robotstxt_immediate_error(self):
@@ -202,7 +207,11 @@ Disallow: /some/randome/page.html
         mw_module_logger.error = mock.MagicMock()
 
         d = self.assertNotIgnored(Request("http://site.local/allowed"), middleware)
-        d.addCallback(lambda _: self.assertFalse(mw_module_logger.error.called))
+
+        def check_not_called(_: Any) -> None:
+            assert not mw_module_logger.error.called  # type: ignore[attr-defined]
+
+        d.addCallback(check_not_called)
         return d
 
     def test_robotstxt_user_agent_setting(self):

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -433,10 +433,12 @@ class TestEngine(TestEngineBase):
         e = ExecutionEngine(get_crawler(MySpider), lambda _: None)
         yield e.open_spider(MySpider(), [])
         e.start()
+
+        def cb(exc: BaseException) -> None:
+            assert str(exc), "Engine already running"
+
         try:
-            yield self.assertFailure(e.start(), RuntimeError).addBoth(
-                lambda exc: self.assertEqual(str(exc), "Engine already running")
-            )
+            yield self.assertFailure(e.start(), RuntimeError).addBoth(cb)
         finally:
             yield e.stop()
 

--- a/tests/test_utils_template.py
+++ b/tests/test_utils_template.py
@@ -1,24 +1,14 @@
-from pathlib import Path
-from shutil import rmtree
-from tempfile import mkdtemp
-
 from scrapy.utils.template import render_templatefile
 
 
 class TestUtilsRenderTemplateFile:
-    def setup_method(self):
-        self.tmp_path = mkdtemp()
-
-    def teardown_method(self):
-        rmtree(self.tmp_path)
-
-    def test_simple_render(self):
+    def test_simple_render(self, tmp_path):
         context = {"project_name": "proj", "name": "spi", "classname": "TheSpider"}
         template = "from ${project_name}.spiders.${name} import ${classname}"
         rendered = "from proj.spiders.spi import TheSpider"
 
-        template_path = Path(self.tmp_path, "templ.py.tmpl")
-        render_path = Path(self.tmp_path, "templ.py")
+        template_path = tmp_path / "templ.py.tmpl"
+        render_path = tmp_path / "templ.py"
 
         template_path.write_text(template, encoding="utf8")
         assert template_path.is_file()  # Failure of test itself


### PR DESCRIPTION
Partial fix for #6658

There are some more `self.assert*` calls via Deferred callbacks, but that doesn't trigger `ruff` and should be rewritten separately anyway. I used `tmp_path` in some easy cases, other `mkdtemp()` etc. calls can be converted later.