### PR TITLE
Fix running simple tests with --reactor=default.

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -119,6 +119,9 @@ def requires_boto3(request):
 def pytest_configure(config):
     if config.getoption("--reactor") != "default":
         install_reactor("twisted.internet.asyncioreactor.AsyncioSelectorReactor")
+    else:
+        # install the reactor explicitly
+        from twisted.internet import reactor  # noqa: F401
 
 
 # Generate localhost certificate files, needed by some tests


### PR DESCRIPTION
Broken by #6732. When some tests are run individually, e.g. `tests/test_downloadermiddleware_ajaxcrawlable.py`, the code may create a crawler via `get_crawler()` and that calls `is_asyncio_reactor_installed()` while nothing has installed the reactor yet. Technically, these tests don't use the reactor themselves but doing something better for this would complicate 
getting a crawler instance for tests even further. And it's a no-op when you run the full test suite.