### PR TITLE
feat: Add test analytics

### DIFF
--- a/.github/workflows/tests-macos.yml
+++ b/.github/workflows/tests-macos.yml
@@ -33,3 +33,7 @@ jobs:
 
     - name: Upload coverage report
       uses: codecov/codecov-action@v5
+
+    - name: Upload test results
+      if: ${{ !cancelled() }}
+      uses: codecov/test-results-action@v1

--- a/.github/workflows/tests-ubuntu.yml
+++ b/.github/workflows/tests-ubuntu.yml
@@ -88,3 +88,7 @@ jobs:
 
     - name: Upload coverage report
       uses: codecov/codecov-action@v5
+
+    - name: Upload test results
+      if: ${{ !cancelled() }}
+      uses: codecov/test-results-action@v1

--- a/.github/workflows/tests-windows.yml
+++ b/.github/workflows/tests-windows.yml
@@ -64,3 +64,7 @@ jobs:
 
     - name: Upload coverage report
       uses: codecov/codecov-action@v5
+
+    - name: Upload test results
+      if: ${{ !cancelled() }}
+      uses: codecov/test-results-action@v1

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ htmlcov/
 .pytest_cache/
 .coverage.*
 coverage.*
+*.junit.xml
 test-output.*
 .cache/
 .mypy_cache/

--- a/tox.ini
+++ b/tox.ini
@@ -39,7 +39,7 @@ passenv =
 #allow tox virtualenv to upgrade pip/wheel/setuptools
 download = true
 commands =
-    pytest {posargs:--cov-config=pyproject.toml --cov=scrapy --cov-report= --cov-report=term-missing --cov-report=xml --durations=10 docs scrapy tests --doctest-modules}
+    pytest {posargs:--cov-config=pyproject.toml --cov=scrapy --cov-report= --cov-report=term-missing --cov-report=xml --junitxml=testenv.junit.xml -o junit_family=legacy --durations=10 docs scrapy tests --doctest-modules}
 install_command =
     python -I -m pip install -ctests/upper-constraints.txt {opts} {packages}
 
@@ -118,7 +118,7 @@ install_command =
     python -I -m pip install {opts} {packages}
 commands =
     ; tests for docs fail with parsel < 1.8.0
-    pytest {posargs:--cov-config=pyproject.toml --cov=scrapy --cov-report=xml --cov-report= --durations=10 scrapy tests}
+    pytest {posargs:--cov-config=pyproject.toml --cov=scrapy --cov-report=xml --cov-report= --junitxml=pinned.junit.xml -o junit_family=legacy --durations=10 scrapy tests}
 
 [testenv:pinned]
 basepython = {[pinned]basepython}
@@ -254,7 +254,7 @@ deps =
     {[testenv]deps}
     botocore>=1.4.87
 commands =
-    pytest {posargs:--cov-config=pyproject.toml --cov=scrapy --cov-report=xml --cov-report= tests -m requires_botocore}
+    pytest {posargs:--cov-config=pyproject.toml --cov=scrapy --cov-report=xml --cov-report= tests --junitxml=botocore.junit.xml -o junit_family=legacy -m requires_botocore}
 
 [testenv:botocore-pinned]
 basepython = {[pinned]basepython}
@@ -265,4 +265,4 @@ install_command = {[pinned]install_command}
 setenv =
     {[pinned]setenv}
 commands =
-    pytest {posargs:--cov-config=pyproject.toml --cov=scrapy --cov-report=xml --cov-report= tests -m requires_botocore}
+    pytest {posargs:--cov-config=pyproject.toml --cov=scrapy --cov-report=xml --cov-report= tests --junitxml=botocore-pinned.junit.xml -o junit_family=legacy -m requires_botocore}


### PR DESCRIPTION
This PR sets up Codecov [Test Analytics](https://docs.codecov.com/docs/test-analytics), which enhances this project's existing Codecov coverage PR notification with details about failing, flaky, and slow tests. More details can be found [here](https://about.codecov.io/blog/find-failing-and-flaky-tests-with-codecov-test-analytics/), and below is an example screenshot.
![Screenshot 2025-03-20 at 5 26 38 PM](https://github.com/user-attachments/assets/d74ba608-0cec-4e28-813d-38adb6b799a4)

The PR proposes the below edits to this end:
1. Output a JUnit XML file with pytest runs by adding flag `--junitxml={env}.junit.xml`
    - Include option `-o junit_family=legacy` to ensure nicer formatting within the Codecov UI (scrapy's existing Codecov instance can be accessed [here](https://app.codecov.io/github/scrapy/scrapy), where a new tab "Tests" will appear when this PR is merged).
    - Any file with suffix *.junit.xml will be parsed by the Codecov Test Analytics tool. I named the output files `{env}.junit.xml`
2. Add the additional step within the existing GitHub Actions workflow. 
     - Permission to test this update to the workflow is awaiting approval. Please let me know if this is granted and I can do a test run within this PR's runs before any merge to main.
     - Uses `if: ${{ !cancelled() }}` to ensure upload even in the case of test failures
3. Add `*.junit.xml` to `.gitignore` so files generated by local runs do not get committed

Look forward to any feedback!