### PR TITLE
Ordered attributes export output (Solves #6662)

### DIFF
--- a/scrapy/exporters.py
+++ b/scrapy/exporters.py
@@ -157,7 +157,12 @@ class JsonItemExporter(BaseItemExporter):
 
     def export_item(self, item: Any) -> None:
         itemdict = dict(self._get_serialized_fields(item))
-        data = to_bytes(self.encoder.encode(itemdict), self.encoding)
+        ordered_itemdict = {}
+        for key in item._ordered_attrs:
+            if key in itemdict:
+                ordered_itemdict[key] = itemdict[key]
+        
+        data = to_bytes(self.encoder.encode(ordered_itemdict), self.encoding)
         self._add_comma_after_first()
         self.file.write(data)
 

--- a/scrapy/exporters.py
+++ b/scrapy/exporters.py
@@ -161,7 +161,7 @@ class JsonItemExporter(BaseItemExporter):
         for key in item._ordered_attrs:
             if key in itemdict:
                 ordered_itemdict[key] = itemdict[key]
-        
+
         data = to_bytes(self.encoder.encode(ordered_itemdict), self.encoding)
         self._add_comma_after_first()
         self.file.write(data)

--- a/scrapy/exporters.py
+++ b/scrapy/exporters.py
@@ -54,6 +54,20 @@ class BaseItemExporter:
         if not dont_fail and options:
             raise TypeError(f"Unexpected options: {', '.join(options.keys())}")
 
+    @staticmethod
+    def _get_ordered_attrs(item: Any) -> list[str]:
+        """Gets the ordered attributes list, if there are any.
+        This is checking just for dict and Item types, i don't know of any
+         other type that should be here.
+        """
+        if isinstance(item, dict):
+            return item.get("_ordered_attrs", [])
+
+        if isinstance(item, Item):
+            return item._ordered_attrs
+
+        return []
+
     def export_item(self, item: Any) -> None:
         raise NotImplementedError
 
@@ -157,10 +171,15 @@ class JsonItemExporter(BaseItemExporter):
 
     def export_item(self, item: Any) -> None:
         itemdict = dict(self._get_serialized_fields(item))
+
         ordered_itemdict = {}
-        for key in item._ordered_attrs:
+        ordered_attrs = self._get_ordered_attrs(item)
+        for key in ordered_attrs:
             if key in itemdict:
                 ordered_itemdict[key] = itemdict[key]
+
+        if not ordered_attrs:
+            ordered_itemdict = itemdict
 
         data = to_bytes(self.encoder.encode(ordered_itemdict), self.encoding)
         self._add_comma_after_first()

--- a/scrapy/item.py
+++ b/scrapy/item.py
@@ -49,6 +49,11 @@ class ItemMeta(ABCMeta):
 
         new_attrs["fields"] = fields
         new_attrs["_class"] = _class
+        new_attrs['_ordered_attrs'] = [
+            key for key in attrs 
+            if not key.startswith("_")
+        ]
+        
         if classcell is not None:
             new_attrs["__classcell__"] = classcell
         return super().__new__(mcs, class_name, bases, new_attrs)

--- a/scrapy/item.py
+++ b/scrapy/item.py
@@ -49,11 +49,8 @@ class ItemMeta(ABCMeta):
 
         new_attrs["fields"] = fields
         new_attrs["_class"] = _class
-        new_attrs['_ordered_attrs'] = [
-            key for key in attrs 
-            if not key.startswith("_")
-        ]
-        
+        new_attrs["_ordered_attrs"] = [key for key in attrs if not key.startswith("_")]
+
         if classcell is not None:
             new_attrs["__classcell__"] = classcell
         return super().__new__(mcs, class_name, bases, new_attrs)

--- a/tests/test_exporters.py
+++ b/tests/test_exporters.py
@@ -42,6 +42,15 @@ class CustomFieldItem(Item):
     age = Field(serializer=custom_serializer)
 
 
+class UnorderedAttributesItem(Item):
+    z = Field()
+    y = Field()
+    x = Field()
+    c = Field()
+    b = Field()
+    a = Field()
+
+
 @dataclasses.dataclass
 class MyDataClass:
     name: str
@@ -631,6 +640,17 @@ class TestJsonItemExporter(TestJsonLinesItemExporter):
         exported = json.loads(to_unicode(self.output.getvalue()))
         item["time"] = str(item["time"])
         assert exported == [item]
+
+    def test_item_attributes_order(self):
+        unordered_attributes_item = UnorderedAttributesItem(
+            z=1, y=2, a=3, x=4, c=5, b=6
+        )
+        self.ie.start_exporting()
+        self.ie.export_item(unordered_attributes_item)
+        self.ie.finish_exporting()
+        del self.ie  # See the first “del self.ie” in this file for context.
+        exported = to_unicode(self.output.getvalue())
+        assert exported == '[{"z": 1, "y": 2, "x": 4, "c": 5, "b": 6, "a": 3}]'
 
 
 class TestJsonItemExporterToBytes(TestBaseItemExporter):


### PR DESCRIPTION
Solves #6662

Hey! I've defined the attribute `_ordered_attrs` in `ItemMeta.__new__` , which gets te object attributes in the order they were created.


```python
#scrapy/item.py
new_attrs["_ordered_attrs"] = [key for key in attrs if not key.startswith("_")]
```

The attributes are being accessed in `exporters.py`:

```python
#scrapy/exporters.py::BaseItemExporter
@staticmethod
def _get_ordered_attrs(item: Any) -> list[str]:
    """Gets the ordered attributes list, if there are any.
    This is checking just for dict and Item types, i don't know of any
     other type that should be here.
    """
    if isinstance(item, dict):
        return item.get("_ordered_attrs", [])

    if isinstance(item, Item):
        return item._ordered_attrs

    return []
```

The exporters can use this method in the following way:

```python
#scrapy/exporters.py::JsonItemExporter
def export_item(self, item: Any) -> None:
    itemdict = dict(self._get_serialized_fields(item))

    ordered_itemdict = {}
    ordered_attrs = self._get_ordered_attrs(item)
    for key in ordered_attrs:
        if key in itemdict:
            ordered_itemdict[key] = itemdict[key]

    if not ordered_attrs:
        ordered_itemdict = itemdict

    data = to_bytes(self.encoder.encode(ordered_itemdict), self.encoding)
    self._add_comma_after_first()
    self.file.write(data)
```

Important to note that it will just follow the same definition order if the object has the `_ordered_attrs` attribute, or the dict has the same key.

The test just defines an `Item` object with unordered attributes, and the assertion is made after the `Item` is exported, checking if the "dumped" follows the same order as the attributes from the input.

```python
def test_item_attributes_order(self):
    unordered_attributes_item = UnorderedAttributesItem(
        z=1, y=2, a=3, x=4, c=5, b=6
    )
    self.ie.start_exporting()
    self.ie.export_item(unordered_attributes_item)
    self.ie.finish_exporting()
    del self.ie  # See the first “del self.ie” in this file for context.
    exported = to_unicode(self.output.getvalue())
    assert exported == '[{"z": 1, "y": 2, "x": 4, "c": 5, "b": 6, "a": 3}]'
```

Hope this
