### PR TITLE
Add ability to include all tags and attributes to LinkExtractor.

### DIFF
--- a/scrapy/linkextractors/lxmlhtml.py
+++ b/scrapy/linkextractors/lxmlhtml.py
@@ -186,22 +186,22 @@ class LxmlLinkExtractor:
         use_all_tags = tags is True
         use_all_attrs = attrs is True
 
-        tags_set = set() if use_all_tags else set(arg_to_iter(tags))
-        attrs_set = set() if use_all_attrs else set(arg_to_iter(attrs))
+        tags_set = set(arg_to_iter(tags)) if not use_all_tags else True
+        attrs_set = set(arg_to_iter(attrs)) if not use_all_attrs else True
         deny_tags_set = set(arg_to_iter(deny_tags))
         deny_attrs_set = set(arg_to_iter(deny_attrs))
 
-        def tag_checker(tag):
-            return tag not in deny_tags_set
+        def create_checker(allowed, denied):
+            if allowed is True:
+                return lambda x: x not in denied
 
-        if not use_all_tags:
-            tag_checker = partial(operator.contains, tags_set)
+            if denied:
+                return lambda x: x in allowed
 
-        def attr_checker(attr):
-            return attr not in deny_attrs_set
+            return partial(operator.contains, allowed)
 
-        if not use_all_attrs:
-            attr_checker = partial(operator.contains, attrs_set)
+        tag_checker = create_checker(tags_set, deny_tags_set)
+        attr_checker = create_checker(attrs_set, deny_attrs_set)
 
         self.link_extractor = LxmlParserLinkExtractor(
             tag=tag_checker,

--- a/tests/test_linkextractors.py
+++ b/tests/test_linkextractors.py
@@ -424,6 +424,42 @@ class Base:
             lx = self.extractor_cls(attrs=None)
             assert lx.extract_links(self.response) == []
 
+            lx = self.extractor_cls(attrs=False)
+            assert lx.extract_links(self.response) == []
+
+            lx = self.extractor_cls(
+                attrs=True, tags=("a", "area", "img"), deny_extensions=()
+            )
+            assert lx.extract_links(self.response) == [
+                Link(url="http://example.com/sample1.html", text=""),
+                Link(url="http://example.com/sample1", text=""),
+                Link(url="http://example.com/sample2.html", text="sample 2"),
+                Link(url="http://example.com/sample2.jpg", text=""),
+                Link(url="http://example.com/sample2", text=""),
+                Link(url="http://example.com/sample3.html", text="sample 3 text"),
+                Link(url="http://example.com/sample%203", text="sample 3 text"),
+                Link(
+                    url="http://example.com/sample3.html#foo",
+                    text="sample 3 repetition with fragment",
+                ),
+                Link(url="http://www.google.com/something", text=""),
+                Link(url="http://example.com/innertag.html", text="inner tag"),
+                Link(url=page4_url, text="href with whitespaces"),
+            ]
+
+            lx = self.extractor_cls(
+                attrs=True,
+                tags=("a", "area", "img"),
+                deny_attrs=("href",),
+                deny_extensions=(),
+            )
+            assert lx.extract_links(self.response) == [
+                Link(url="http://example.com/sample1", text=""),
+                Link(url="http://example.com/sample2.jpg", text=""),
+                Link(url="http://example.com/sample2", text=""),
+                Link(url="http://example.com/sample%203", text="sample 3 text"),
+            ]
+
         def test_tags(self):
             html = (
                 b'<html><area href="sample1.html"></area>'
@@ -432,6 +468,9 @@ class Base:
             response = HtmlResponse("http://example.com/index.html", body=html)
 
             lx = self.extractor_cls(tags=None)
+            assert lx.extract_links(response) == []
+
+            lx = self.extractor_cls(tags=False)
             assert lx.extract_links(response) == []
 
             lx = self.extractor_cls()
@@ -455,6 +494,34 @@ class Base:
             )
             assert lx.extract_links(response) == [
                 Link(url="http://example.com/sample2.html", text="sample 2"),
+                Link(url="http://example.com/sample2.jpg", text=""),
+            ]
+
+            lx = self.extractor_cls(
+                tags=True,
+                attrs=(
+                    "href",
+                    "src",
+                ),
+                deny_extensions=(),
+            )
+            assert lx.extract_links(response) == [
+                Link(url="http://example.com/sample1.html", text=""),
+                Link(url="http://example.com/sample2.html", text="sample 2"),
+                Link(url="http://example.com/sample2.jpg", text=""),
+            ]
+
+            lx = self.extractor_cls(
+                tags=True,
+                attrs=(
+                    "href",
+                    "src",
+                ),
+                deny_tags=("a",),
+                deny_extensions=(),
+            )
+            assert lx.extract_links(response) == [
+                Link(url="http://example.com/sample1.html", text=""),
                 Link(url="http://example.com/sample2.jpg", text=""),
             ]
 
@@ -494,6 +561,102 @@ class Base:
                 Link(
                     url="http://example.com/get?id=2",
                     text="Item 2",
+                    fragment="",
+                    nofollow=False,
+                ),
+            ]
+
+            lx = self.extractor_cls(tags=None, attrs=None)
+            assert lx.extract_links(response) == []
+
+            lx = self.extractor_cls(tags=False, attrs=False)
+            assert lx.extract_links(response) == []
+
+            lx = self.extractor_cls(tags=True, attrs=True)
+            assert lx.extract_links(response) == [
+                Link(
+                    url="http://example.com/item1",
+                    text="Item 1",
+                    fragment="",
+                    nofollow=False,
+                ),
+                Link(
+                    url="http://example.com/get?id=1",
+                    text="Item 1",
+                    fragment="",
+                    nofollow=False,
+                ),
+                Link(
+                    url="http://example.com/index.html",
+                    text="Item 1",
+                    fragment="",
+                    nofollow=False,
+                ),
+                Link(
+                    url="http://example.com/item2",
+                    text="Item 2",
+                    fragment="",
+                    nofollow=False,
+                ),
+                Link(
+                    url="http://example.com/get?id=2",
+                    text="Item 2",
+                    fragment="",
+                    nofollow=False,
+                ),
+            ]
+
+            lx = self.extractor_cls(
+                tags=True,
+            )
+            assert lx.extract_links(response) == [
+                Link(
+                    url="http://example.com/index.html",
+                    text="Item 1",
+                    fragment="",
+                    nofollow=False,
+                ),
+            ]
+
+            lx = self.extractor_cls(
+                attrs=True,
+            )
+            assert lx.extract_links(response) == [
+                Link(
+                    url="http://example.com/index.html",
+                    text="Item 1",
+                    fragment="",
+                    nofollow=False,
+                ),
+            ]
+
+            lx = self.extractor_cls(tags=True, attrs=True, deny_attrs=("id",))
+            assert lx.extract_links(response) == [
+                Link(
+                    url="http://example.com/get?id=1",
+                    text="Item 1",
+                    fragment="",
+                    nofollow=False,
+                ),
+                Link(
+                    url="http://example.com/index.html",
+                    text="Item 1",
+                    fragment="",
+                    nofollow=False,
+                ),
+                Link(
+                    url="http://example.com/get?id=2",
+                    text="Item 2",
+                    fragment="",
+                    nofollow=False,
+                ),
+            ]
+
+            lx = self.extractor_cls(tags=True, attrs=True, deny_tags=("div",))
+            assert lx.extract_links(response) == [
+                Link(
+                    url="http://example.com/index.html",
+                    text="Item 1",
                     fragment="",
                     nofollow=False,
                 ),


### PR DESCRIPTION
Feature: Implement option to include all tags and attributes in LinkExtractor

This pull request introduces new functionality to the LinkExtractor class, allowing users to consider all HTML tags and attributes for link extraction by setting the `tags` or `attrs` arguments to `True`.

Specific tags and attributes can then be excluded using the new `deny_tags` and `deny_attrs` arguments. This enables a more flexible approach where users can default to extracting all links and then selectively filter out unwanted ones, addressing the need for a more inclusive link extraction strategy.

I uncluded 13 new test cases with different combinations of tags, attrs, deny_tags, deny_attrs parmeters, to make sure the new parameters work as expected both in isolation and combined.

Note 1: With `attrs=True`, this implementation currently extracts values from attributes like `alt="something"` and `title="something"` in addition to actual link attributes like `href` and `src`. I wanted to inquire whether this is the desired behavior when the user intends to consider all attributes.

Note 2: This is my first ever open source contribution as part of a university assignment, so any feedback on this pull request would be greatly appreciated. 

Note 3: I have noticed that there is an open pull request on that issue that has been pending for several months, so I have attempted to provide an independent implementation.

Resolves #6321