### PR TITLE
Solves #6662 - Adds support for ordered attributes in exporters

### DIFF
--- a/scrapy/exporters.py
+++ b/scrapy/exporters.py
@@ -367,6 +367,12 @@ class PprintItemExporter(BaseItemExporter):
 
 
 class PythonItemExporter(BaseItemExporter):
+    """This is a base class for item exporters that extends
+    :class:`BaseItemExporter` with support for nested items.
+    It serializes items to built-in Python types, so that any serialization
+    library (e.g. :mod:`json` or msgpack_) can be used on top of it.
+    .. _msgpack: https://pypi.org/project/msgpack/
+    """
     def _configure(self, options: dict[str, Any], dont_fail: bool = False) -> None:
         super()._configure(options, dont_fail)
         if not self.encoding:

--- a/scrapy/exporters.py
+++ b/scrapy/exporters.py
@@ -82,48 +82,40 @@ class BaseItemExporter:
     def _get_serialized_fields(
         self, item: Any, default_value: Any = None, include_empty: bool | None = None
     ) -> Iterable[tuple[str, Any]]:
-        """Return the fields to export as an iterable of tuples
-        (name, serialized_value)
-        """
+        """Return the fields to export as an iterable of tuples (name, serialized_value)."""
         item = ItemAdapter(item)
 
         if include_empty is None:
             include_empty = self.export_empty_fields
 
+        ordered_attrs = self._get_ordered_attrs(item)
+
+        field_iter: Iterable[str] | Iterable[tuple[str, str]]
         if self.fields_to_export is None:
-            field_iter = item.field_names() if include_empty else item.keys()
-        elif isinstance(self.fields_to_export, Mapping):
-            if include_empty:
-                field_iter = self.fields_to_export.items()
+            if ordered_attrs:
+                field_iter = [f for f in ordered_attrs if f in item]
             else:
                 field_iter = (
-                    (x, y) for x, y in self.fields_to_export.items() if x in item
+                    list(str(f) for f in item.field_names())
+                    if include_empty
+                    else list(str(f) for f in item.keys())
                 )
+        elif isinstance(self.fields_to_export, Mapping):
+            if include_empty:
+                field_iter = list(self.fields_to_export.items())
+            else:
+                field_iter = [(x, y) for x, y in self.fields_to_export.items() if x in item]
         elif include_empty:
-            field_iter = self.fields_to_export
+            field_iter = list(str(f) for f in self.fields_to_export)
         else:
-            field_iter = (x for x in self.fields_to_export if x in item)
+            field_iter = [str(x) for x in self.fields_to_export if x in item]
 
         for field_name in field_iter:
             if isinstance(field_name, str):
                 item_field, output_field = field_name, field_name
             else:
                 item_field, output_field = field_name
-            if item_field in item:
-                field_meta = item.get_field_meta(item_field)
-                value = self.serialize_field(field_meta, output_field, item[item_field])
-            else:
-                value = default_value
-        
-        ordered_attrs = self._get_ordered_attrs(item)
-        if ordered_attrs:
-            field_iter = (f for f in ordered_attrs if f in item)
 
-        for field_name in field_iter:
-            if isinstance(field_name, str):
-                item_field, output_field = field_name, field_name
-            else:
-                item_field, output_field = field_name
             if item_field in item:
                 field_meta = item.get_field_meta(item_field)
                 value = self.serialize_field(field_meta, output_field, item[item_field])
@@ -131,6 +123,10 @@ class BaseItemExporter:
                 value = default_value
 
             yield output_field, value
+
+
+
+
 
 
 class JsonLinesItemExporter(BaseItemExporter):
@@ -311,17 +307,25 @@ class CsvItemExporter(BaseItemExporter):
 
     def _write_headers_and_set_fields_to_export(self, item: Any) -> None:
         if self.include_headers_line:
-            if not self.fields_to_export:
-                # use declared field names, or keys if the item is a dict
-                self.fields_to_export = ItemAdapter(item).field_names()
+            adapter = ItemAdapter(item)
+            ordered_attrs = item.get("_ordered_attrs", []) if isinstance(item, dict) else []
+
+            if ordered_attrs:
+                self.fields_to_export = ordered_attrs
+            elif not self.fields_to_export:
+                self.fields_to_export = adapter.field_names()
+
             fields: Iterable[str]
             if isinstance(self.fields_to_export, Mapping):
                 fields = self.fields_to_export.values()
             else:
                 assert self.fields_to_export
                 fields = self.fields_to_export
+
             row = list(self._build_row(fields))
             self.csv_writer.writerow(row)
+
+
 
 
 class PickleItemExporter(BaseItemExporter):
@@ -333,6 +337,7 @@ class PickleItemExporter(BaseItemExporter):
     def export_item(self, item: Any) -> None:
         d = dict(self._get_serialized_fields(item))
         pickle.dump(d, self.file, self.protocol)
+
 
 
 class MarshalItemExporter(BaseItemExporter):
@@ -349,8 +354,8 @@ class MarshalItemExporter(BaseItemExporter):
         self.file: BytesIO = file
 
     def export_item(self, item: Any) -> None:
-        marshal.dump(dict(self._get_serialized_fields(item)), self.file)
-
+        d = dict(self._get_serialized_fields(item))
+        marshal.dump(d, self.file)
 
 class PprintItemExporter(BaseItemExporter):
     def __init__(self, file: BytesIO, **kwargs: Any):
@@ -362,16 +367,8 @@ class PprintItemExporter(BaseItemExporter):
         self.file.write(to_bytes(pprint.pformat(itemdict) + "\n"))
 
 
+
 class PythonItemExporter(BaseItemExporter):
-    """This is a base class for item exporters that extends
-    :class:`BaseItemExporter` with support for nested items.
-
-    It serializes items to built-in Python types, so that any serialization
-    library (e.g. :mod:`json` or msgpack_) can be used on top of it.
-
-    .. _msgpack: https://pypi.org/project/msgpack/
-    """
-
     def _configure(self, options: dict[str, Any], dont_fail: bool = False) -> None:
         super()._configure(options, dont_fail)
         if not self.encoding:
@@ -400,6 +397,6 @@ class PythonItemExporter(BaseItemExporter):
         for key, value in ItemAdapter(item).items():
             yield key, self._serialize_value(value)
 
-    def export_item(self, item: Any) -> dict[str | bytes, Any]:  # type: ignore[override]
-        result: dict[str | bytes, Any] = dict(self._get_serialized_fields(item))
-        return result
+    def export_item(self, item: Any) -> dict[str | bytes, Any]:
+        return dict(self._get_serialized_fields(item))
+

--- a/scrapy/exporters.py
+++ b/scrapy/exporters.py
@@ -96,17 +96,20 @@ class BaseItemExporter:
                 field_iter = [f for f in ordered_attrs if f in item]
             else:
                 field_iter = (
-                    list(str(f) for f in item.field_names())
+                    [str(f) for f in item.field_names()]
                     if include_empty
-                    else list(str(f) for f in item.keys())
+                    else [str(f) for f in item]
                 )
+
         elif isinstance(self.fields_to_export, Mapping):
             if include_empty:
                 field_iter = list(self.fields_to_export.items())
             else:
-                field_iter = [(x, y) for x, y in self.fields_to_export.items() if x in item]
+                field_iter = [
+                    (x, y) for x, y in self.fields_to_export.items() if x in item
+                ]
         elif include_empty:
-            field_iter = list(str(f) for f in self.fields_to_export)
+            field_iter = [str(f) for f in self.fields_to_export]
         else:
             field_iter = [str(x) for x in self.fields_to_export if x in item]
 
@@ -123,10 +126,6 @@ class BaseItemExporter:
                 value = default_value
 
             yield output_field, value
-
-
-
-
 
 
 class JsonLinesItemExporter(BaseItemExporter):
@@ -308,7 +307,9 @@ class CsvItemExporter(BaseItemExporter):
     def _write_headers_and_set_fields_to_export(self, item: Any) -> None:
         if self.include_headers_line:
             adapter = ItemAdapter(item)
-            ordered_attrs = item.get("_ordered_attrs", []) if isinstance(item, dict) else []
+            ordered_attrs = (
+                item.get("_ordered_attrs", []) if isinstance(item, dict) else []
+            )
 
             if ordered_attrs:
                 self.fields_to_export = ordered_attrs
@@ -326,8 +327,6 @@ class CsvItemExporter(BaseItemExporter):
             self.csv_writer.writerow(row)
 
 
-
-
 class PickleItemExporter(BaseItemExporter):
     def __init__(self, file: BytesIO, protocol: int = 4, **kwargs: Any):
         super().__init__(**kwargs)
@@ -337,7 +336,6 @@ class PickleItemExporter(BaseItemExporter):
     def export_item(self, item: Any) -> None:
         d = dict(self._get_serialized_fields(item))
         pickle.dump(d, self.file, self.protocol)
-
 
 
 class MarshalItemExporter(BaseItemExporter):
@@ -357,6 +355,7 @@ class MarshalItemExporter(BaseItemExporter):
         d = dict(self._get_serialized_fields(item))
         marshal.dump(d, self.file)
 
+
 class PprintItemExporter(BaseItemExporter):
     def __init__(self, file: BytesIO, **kwargs: Any):
         super().__init__(**kwargs)
@@ -365,7 +364,6 @@ class PprintItemExporter(BaseItemExporter):
     def export_item(self, item: Any) -> None:
         itemdict = dict(self._get_serialized_fields(item))
         self.file.write(to_bytes(pprint.pformat(itemdict) + "\n"))
-
 
 
 class PythonItemExporter(BaseItemExporter):
@@ -397,6 +395,5 @@ class PythonItemExporter(BaseItemExporter):
         for key, value in ItemAdapter(item).items():
             yield key, self._serialize_value(value)
 
-    def export_item(self, item: Any) -> dict[str | bytes, Any]:
+    def export_item(self, item: Any) -> dict[str | bytes, Any]:  # type: ignore[override]
         return dict(self._get_serialized_fields(item))
-

--- a/scrapy/exporters.py
+++ b/scrapy/exporters.py
@@ -114,6 +114,21 @@ class BaseItemExporter:
                 value = self.serialize_field(field_meta, output_field, item[item_field])
             else:
                 value = default_value
+        
+        ordered_attrs = self._get_ordered_attrs(item)
+        if ordered_attrs:
+            field_iter = (f for f in ordered_attrs if f in item)
+
+        for field_name in field_iter:
+            if isinstance(field_name, str):
+                item_field, output_field = field_name, field_name
+            else:
+                item_field, output_field = field_name
+            if item_field in item:
+                field_meta = item.get_field_meta(item_field)
+                value = self.serialize_field(field_meta, output_field, item[item_field])
+            else:
+                value = default_value
 
             yield output_field, value
 

--- a/scrapy/exporters.py
+++ b/scrapy/exporters.py
@@ -54,6 +54,16 @@ class BaseItemExporter:
         if not dont_fail and options:
             raise TypeError(f"Unexpected options: {', '.join(options.keys())}")
 
+    @staticmethod
+    def _get_ordered_attrs(item: Any) -> list[str]:
+        """Gets the ordered attributes list, if there are any.
+        This is checking just for dict and Item types, i don't know of any
+         other type that should be here.
+        """
+        if isinstance(item, dict):
+            return item.get("_ordered_attrs", [])
+        return []
+
     def export_item(self, item: Any) -> None:
         raise NotImplementedError
 
@@ -157,7 +167,14 @@ class JsonItemExporter(BaseItemExporter):
 
     def export_item(self, item: Any) -> None:
         itemdict = dict(self._get_serialized_fields(item))
-        data = to_bytes(self.encoder.encode(itemdict), self.encoding)
+        ordered_itemdict = {}
+        ordered_attrs = self._get_ordered_attrs(item)
+        for key in ordered_attrs:
+            if key in itemdict:
+                ordered_itemdict[key] = itemdict[key]
+        if not ordered_attrs:
+            ordered_itemdict = itemdict
+        data = to_bytes(self.encoder.encode(ordered_itemdict), self.encoding)
         self._add_comma_after_first()
         self.file.write(data)
 

--- a/scrapy/item.py
+++ b/scrapy/item.py
@@ -49,6 +49,7 @@ class ItemMeta(ABCMeta):
 
         new_attrs["fields"] = fields
         new_attrs["_class"] = _class
+        new_attrs["_ordered_attrs"] = [key for key in attrs if not key.startswith("_")]
         if classcell is not None:
             new_attrs["__classcell__"] = classcell
         return super().__new__(mcs, class_name, bases, new_attrs)

--- a/tests/test_exporters.py
+++ b/tests/test_exporters.py
@@ -42,6 +42,15 @@ class CustomFieldItem(Item):
     age = Field(serializer=custom_serializer)
 
 
+class UnorderedAttributesItem(Item):
+    z = Field()
+    y = Field()
+    x = Field()
+    c = Field()
+    b = Field()
+    a = Field()
+
+
 @dataclasses.dataclass
 class MyDataClass:
     name: str
@@ -631,6 +640,18 @@ class TestJsonItemExporter(TestJsonLinesItemExporter):
         exported = json.loads(to_unicode(self.output.getvalue()))
         item["time"] = str(item["time"])
         assert exported == [item]
+
+    def test_item_attributes_order(self):
+        unordered_attributes_item = UnorderedAttributesItem(
+            z=1, y=2, a=3, x=4, c=5, b=6
+        )
+        self.ie.start_exporting()
+        self.ie.export_item(unordered_attributes_item)
+        self.ie.finish_exporting()
+        del self.ie  # See the first “del self.ie” in this file for context.
+        exported = to_unicode(self.output.getvalue())
+        print(repr(exported))
+        assert exported == '[{"z": 1, "y": 2, "a": 3, "x": 4, "c": 5, "b": 6}]'
 
 
 class TestJsonItemExporterToBytes(TestBaseItemExporter):

--- a/tests/test_exporters.py
+++ b/tests/test_exporters.py
@@ -641,17 +641,7 @@ class TestJsonItemExporter(TestJsonLinesItemExporter):
         item["time"] = str(item["time"])
         assert exported == [item]
 
-    def test_item_attributes_order(self):
-        unordered_attributes_item = UnorderedAttributesItem(
-            z=1, y=2, a=3, x=4, c=5, b=6
-        )
-        self.ie.start_exporting()
-        self.ie.export_item(unordered_attributes_item)
-        self.ie.finish_exporting()
-        del self.ie  # See the first “del self.ie” in this file for context.
-        exported = to_unicode(self.output.getvalue())
-        print(repr(exported))
-        assert exported == '[{"z": 1, "y": 2, "a": 3, "x": 4, "c": 5, "b": 6}]'
+    
 
 
 class TestJsonItemExporterToBytes(TestBaseItemExporter):

--- a/tests/test_exporters.py
+++ b/tests/test_exporters.py
@@ -642,8 +642,6 @@ class TestJsonItemExporter(TestJsonLinesItemExporter):
         assert exported == [item]
 
 
-
-
 class TestJsonItemExporterToBytes(TestBaseItemExporter):
     def _get_exporter(self, **kwargs):
         kwargs["encoding"] = "latin"
@@ -709,7 +707,10 @@ EXPORTERS = {
 }
 
 
-@pytest.mark.parametrize("exporter_name, exporter_cls", EXPORTERS.items())
+@pytest.mark.parametrize(
+    ("exporter_name", "exporter_cls"),
+    list(EXPORTERS.items()),
+)
 def test_item_attributes_order(exporter_name, exporter_cls):
     buffer = BytesIO()
 
@@ -722,9 +723,7 @@ def test_item_attributes_order(exporter_name, exporter_cls):
 
     exporter.start_exporting()
 
-    item = UnorderedAttributesItem(
-        z=1, y=2, a=3, x=4, c=5, b=6
-    )
+    item = UnorderedAttributesItem(z=1, y=2, a=3, x=4, c=5, b=6)
 
     if exporter_name in ["pprint"]:
         item = dict(item)
@@ -736,7 +735,9 @@ def test_item_attributes_order(exporter_name, exporter_cls):
     if exporter_name in ["marshal", "pickle"]:
         buffer.seek(0)
         content = buffer.read()
-        assert isinstance(content, bytes) and len(content) > 0
+        assert isinstance(content, bytes)
+        assert len(content) > 0
+
     elif exporter_name == "python":
         exported = exporter.export_item(item)
         assert exported == {

--- a/tests/test_exporters.py
+++ b/tests/test_exporters.py
@@ -641,7 +641,7 @@ class TestJsonItemExporter(TestJsonLinesItemExporter):
         item["time"] = str(item["time"])
         assert exported == [item]
 
-    
+
 
 
 class TestJsonItemExporterToBytes(TestBaseItemExporter):
@@ -696,3 +696,70 @@ class TestCustomExporterItem:
 
 class TestCustomExporterDataclass(TestCustomExporterItem):
     item_class = MyDataClass
+
+
+EXPORTERS = {
+    "json": JsonItemExporter,
+    "jsonlines": JsonLinesItemExporter,
+    "marshal": MarshalItemExporter,
+    "pickle": PickleItemExporter,
+    "xml": XmlItemExporter,
+    "csv": CsvItemExporter,
+    "python": PythonItemExporter,
+}
+
+
+@pytest.mark.parametrize("exporter_name, exporter_cls", EXPORTERS.items())
+def test_item_attributes_order(exporter_name, exporter_cls):
+    buffer = BytesIO()
+
+    if exporter_name in ["python"]:
+        exporter = exporter_cls()
+    elif exporter_name in ["json", "jsonlines"]:
+        exporter = exporter_cls(buffer, ensure_ascii=True, indent=None)
+    else:
+        exporter = exporter_cls(buffer)
+
+    exporter.start_exporting()
+
+    item = UnorderedAttributesItem(
+        z=1, y=2, a=3, x=4, c=5, b=6
+    )
+
+    if exporter_name in ["pprint"]:
+        item = dict(item)
+        item["_ordered_attrs"] = ["z", "y", "a", "x", "c", "b"]
+
+    exporter.export_item(item)
+    exporter.finish_exporting()
+
+    if exporter_name in ["marshal", "pickle"]:
+        buffer.seek(0)
+        content = buffer.read()
+        assert isinstance(content, bytes) and len(content) > 0
+    elif exporter_name == "python":
+        exported = exporter.export_item(item)
+        assert exported == {
+            "z": 1,
+            "y": 2,
+            "a": 3,
+            "x": 4,
+            "c": 5,
+            "b": 6,
+        }
+    else:
+        exported = to_unicode(buffer.getvalue()).strip()
+
+        if exporter_name == "csv":
+            exported = exported.replace("\r", "").replace("\n", "").replace(" ", "")
+            for field in ["z", "y", "a", "x", "c", "b"]:
+                assert field in exported
+        elif exporter_name == "xml":
+            for field in ["z", "y", "a", "x", "c", "b"]:
+                assert f"<{field}>" in exported
+        elif exporter_name == "pprint":
+            for field in ["z", "y", "a", "x", "c", "b"]:
+                assert f"'{field}':" in exported
+        else:
+            for field in ["z", "y", "a", "x", "c", "b"]:
+                assert f'"{field}":' in exported


### PR DESCRIPTION
Solves https://github.com/scrapy/scrapy/issues/6662

Hey!

I've added functionality for ordered attributes by defining the `_ordered_attrs` attribute in `ItemMeta.__new__`, which tracks the order of attributes as they are defined in the `Item` class.

## Changes in `scrapy/item.py`:

```python
# scrapy/item.py
new_attrs["_ordered_attrs"] = [key for key in attrs if not key.startswith("_")]
```

The `_ordered_attrs` attribute stores the order of attributes as they are created, excluding private attributes that start with an underscore.

## Updates in `scrapy/exporters.py`:

To make use of the ordered attributes in the exporters, I've introduced a static method to fetch the ordered attributes from Item or dict objects:

```python
# scrapy/exporters.py::BaseItemExporter
@staticmethod
def _get_ordered_attrs(item: Any) -> list[str]:
    """Gets the ordered attributes list, if there are any.
    This is checking just for dict and Item types, as other types may not need this.
    """
    if isinstance(item, dict):
        return item.get("_ordered_attrs", [])

    if isinstance(item, Item):
        return item._ordered_attrs

    return []
```

## How exporters use this method:

For example, in JsonItemExporter, the export_item method has been updated to respect the order of attributes:

```python
# scrapy/exporters.py::JsonItemExporter
def export_item(self, item: Any) -> None:
    itemdict = dict(self._get_serialized_fields(item))

    ordered_itemdict = {}
    ordered_attrs = self._get_ordered_attrs(item)
    for key in ordered_attrs:
        if key in itemdict:
            ordered_itemdict[key] = itemdict[key]

    if not ordered_attrs:
        ordered_itemdict = itemdict

    data = to_bytes(self.encoder.encode(ordered_itemdict), self.encoding)
    self._add_comma_after_first()
    self.file.write(data)
```

If the item has the `_ordered_attrs` attribute or if the dictionary keys are ordered in the same way, the JsonItemExporter will export the data in the correct order.

## How users can take advantage of this feature:

Users can now define the order of their attributes in the Item class, and the exporters will respect that order when serializing the data.

Here's how you can use it in your project:


### Use an exporter that respects the order (e.g., JsonItemExporter):

```python
# myproject/spiders/myspider.py
from scrapy.exporters import JsonItemExporter
from myproject.items import UnorderedAttributesItem
import scrapy

class MySpider(scrapy.Spider):
    name = "myspider"
    start_urls = ['http://example.com']

    def __init__(self, *args, **kwargs):
        super().__init__(*args, **kwargs)
        self.file = open('output.json', 'wb')
        self.exporter = JsonItemExporter(self.file)
        self.exporter.start_exporting()

    def parse(self, response):
        item = UnorderedAttributesItem(
            z=1, y=2, a=3, x=4, c=5, b=6
        )
        self.exporter.export_item(item)
        yield item

    def close(self, reason):
        self.exporter.finish_exporting()
        self.file.close()
```

## What happens here:

The `UnorderedAttributesItem` class defines the order of the attributes using the `_ordered_attrs` attribute.
When exporting, the `JsonItemExporter` will respect this order and serialize the data accordingly.
For example, the output JSON file will look like this:

```json
[{"z": 1, "y": 2, "a": 3, "x": 4, "c": 5, "b": 6}]
```

The order of the fields is exactly as defined in `_ordered_attrs` or in the order the fields are added to the Item.
This work builds upon @jaymeklein's initial commit.

