### PR TITLE
Refactoring of tests/test_downloadermiddleware_httpcache.py (Solves #6649)

### DIFF
--- a/scrapy/crawler.py
+++ b/scrapy/crawler.py
@@ -237,11 +237,13 @@ class Crawler:
                 "extension manager has been created."
             )
 
-        for component in self._component_cache:
-            self._component_cache[component][1] += 1
-        if cls in self._component_cache:
+        for key, items in self._component_cache.values():
+            items[1] += 1
+
+        in_cache = self._component_cache.get(cls)
+        if in_cache:
             self._component_cache[cls][1] = 0
-            return self._component_cache[cls][0]
+            return in_cache
 
         result = self._get_component(cls, self.extensions.middlewares)
         if len(self._component_cache) >= 5:


### PR DESCRIPTION
I refactored the testdownloadermiddleware_httpcache.py changing its structure.

- First I extracted two classes, StorageTestMixin and PolicyTestMixin, to handle tests specific to storage and policy, respectively
- I also removed storage_class and policy_class from TestBase, since they will only appear later in subclasses, each one containing one possible combination between storage and policy
- Furthermore, I added DummyPolicyTestMixin and RFC2616PolicyTestMixin to handle testes specific to each of those options
- Finally, I created classes that contain the possible combinations of the MixIn classes. Those last classes are:   