### PR TITLE
Link to scrapy.org from the docs

### DIFF
--- a/docs/_templates/layout.html
+++ b/docs/_templates/layout.html
@@ -1,0 +1,23 @@
+{% extends "!layout.html" %}
+
+{# Overriden to include a link to scrapy.org, not just to the docs root #}
+{%- block sidebartitle %}
+
+{# the logo helper function was removed in Sphinx 6 and deprecated since Sphinx 4 #}
+{# the master_doc variable was renamed to root_doc in Sphinx 4 (master_doc still exists in later Sphinx versions) #}
+{%- set _logo_url = logo_url|default(pathto('_static/' + (logo or ""), 1)) %}
+{%- set _root_doc = root_doc|default(master_doc) %}
+<a href="https://scrapy.org">scrapy.org</a> / <a href="{{ pathto(_root_doc) }}">docs</a>
+
+{%- if READTHEDOCS or DEBUG %}
+  {%- if theme_version_selector or theme_language_selector %}
+    <div class="switch-menus">
+      <div class="version-switch"></div>
+      <div class="language-switch"></div>
+    </div>
+  {%- endif %}
+{%- endif %}
+
+{%- include "searchbox.html" %}
+
+{%- endblock %}


### PR DESCRIPTION
Overrides [the sidebar block](https://github.com/readthedocs/sphinx_rtd_theme/blob/5a263753d52c1628c88392fbf52c729f5a8e79b5/sphinx_rtd_theme/layout.html#L114-L138) to switch [this](https://github.com/readthedocs/sphinx_rtd_theme/blob/5a263753d52c1628c88392fbf52c729f5a8e79b5/sphinx_rtd_theme/layout.html#L120-L125) to:

```html
<a href="https://scrapy.org">scrapy.org</a> / <a href="{{ pathto(_root_doc) }}">docs</a>
```