### PR TITLE
Deprecate _parse_response and implement parse_with_rules

### DIFF
--- a/scrapy/spiders/crawl.py
+++ b/scrapy/spiders/crawl.py
@@ -19,8 +19,8 @@ from scrapy.link import Link
 from scrapy.linkextractors import LinkExtractor
 from scrapy.spiders import Spider
 from scrapy.utils.asyncgen import collect_asyncgen
-from scrapy.utils.spider import iterate_spider_output
 from scrapy.utils.deprecate import method_is_overridden
+from scrapy.utils.spider import iterate_spider_output
 
 if TYPE_CHECKING:
     from collections.abc import Iterable, Sequence
@@ -185,12 +185,14 @@ class CrawlSpider(Spider):
         callback: CallbackT | None,
         cb_kwargs: dict[str, Any],
         follow: bool = True,
+        warn: bool = True,
     ) -> AsyncIterator[Any]:
-        warnings.warn(
-            "CrawlSpider._parse_response method is deprecated: "
-            "it will be removed in future Scrapy releases. "
-            "Please use CrawlSpider.parse_with_rules method instead."
-        )
+        if warn:
+            warnings.warn(
+                "CrawlSpider._parse_response method is deprecated: "
+                "it will be removed in future Scrapy releases. "
+                "Please use CrawlSpider.parse_with_rules method instead."
+            )
         self.parse_with_rules(response, callback, cb_kwargs, follow)
 
     def _handle_failure(

--- a/scrapy/spiders/crawl.py
+++ b/scrapy/spiders/crawl.py
@@ -20,6 +20,7 @@ from scrapy.linkextractors import LinkExtractor
 from scrapy.spiders import Spider
 from scrapy.utils.asyncgen import collect_asyncgen
 from scrapy.utils.spider import iterate_spider_output
+from scrapy.utils.deprecate import method_is_overridden
 
 if TYPE_CHECKING:
     from collections.abc import Iterable, Sequence
@@ -96,6 +97,12 @@ class CrawlSpider(Spider):
     def __init__(self, *a: Any, **kw: Any):
         super().__init__(*a, **kw)
         self._compile_rules()
+        if method_is_overridden(self.__class__, CrawlSpider, "_parse_response"):
+            warnings.warn(
+                "CrawlSpider._parse_response method is deprecated: "
+                "it will be removed in future Scrapy releases. "
+                "Please override CrawlSpider.parse_with_rules method instead."
+            )
 
     def _parse(self, response: Response, **kwargs: Any) -> Any:
         return self.parse_with_rules(

--- a/tests/test_spider.py
+++ b/tests/test_spider.py
@@ -476,6 +476,53 @@ class TestCrawlSpider(TestSpider):
         assert "Error while reading start items and requests" in str(log)
         assert "did you miss an 's'?" in str(log)
 
+    def test_parse_response_use(self):
+        class _CrawlSpider(CrawlSpider):
+            name = "test"
+            start_urls = "https://www.example.com"
+            _follow_links = False
+
+        with warnings.catch_warnings(record=True) as w:
+            spider = _CrawlSpider()
+            assert len(w) == 0
+            spider._parse_response(
+                TextResponse(spider.start_urls, body=b""), None, None
+            )
+            print(len(w))
+            assert len(w) == 1
+
+    def test_parse_response_override(self):
+        class _CrawlSpider(CrawlSpider):
+            def _parse_response(self, response, callback, cb_kwargs, follow=True):
+                return super()._parse_response(response, callback, cb_kwargs, follow)
+
+            name = "test"
+            start_urls = "https://www.example.com"
+            _follow_links = False
+
+        with warnings.catch_warnings(record=True) as w:
+            assert len(w) == 0
+            spider = _CrawlSpider()
+            print(len(w))
+            assert len(w) == 1
+            spider._parse_response(
+                TextResponse(spider.start_urls, body=b""), None, None
+            )
+            print(len(w))
+            assert len(w) == 2
+
+    def test_parse_with_rules(self):
+        class _CrawlSpider(CrawlSpider):
+            name = "test"
+            start_urls = "https://www.example.com"
+
+        with warnings.catch_warnings(record=True) as w:
+            spider = _CrawlSpider()
+            spider.parse_with_rules(
+                TextResponse(spider.start_urls, body=b""), None, None
+            )
+            assert len(w) == 0
+
 
 class TestSitemapSpider(TestSpider):
     spider_class = SitemapSpider


### PR DESCRIPTION
Resolves issue #4463. I tried to stick to the solutions discussed in the issue whenever possible. The parse_with_rules method behaves like the prior _parse_response method, but is a public method instead. _parse_response now issues a deprecation warning on use, and when overridden by a subclass. Also added the appropriate tests to check if the warnings are being issued correctly, though I can certainly add more if needed