### PR TITLE
Fix typo in documentation (closes #6812)

### DIFF
--- a/docs/topics/spiders.rst
+++ b/docs/topics/spiders.rst
@@ -388,7 +388,7 @@ its iteration whenever there are scheduled requests:
 
     async def start(self):
         async for item_or_request in super().start():
-            if self.crawler.engine.needs_backoff():
+            if self.crawler.engine.needs_backout():
                 await self.crawler.signals.wait_for(signals.scheduler_empty)
             yield item_or_request
 


### PR DESCRIPTION
### Summary

This pull request fixes a consistent typo where the term `needs_backoff` was incorrectly used instead of the correct `needs_backout`.

Closes #6812