### PR TITLE
Add `AsyncCrawlerProcess` and `Crawler.crawl_async()`

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -19,6 +19,8 @@ collect_ignore = [
     "tests/mockserver.py",
     "tests/pipelines.py",
     "tests/spiders.py",
+    # contains scripts to be run by tests/test_crawler.py::AsyncCrawlerProcessSubprocess
+    *_py_files("tests/AsyncCrawlerProcess"),
     # contains scripts to be run by tests/test_crawler.py::AsyncCrawlerRunnerSubprocess
     *_py_files("tests/AsyncCrawlerRunner"),
     # contains scripts to be run by tests/test_crawler.py::CrawlerProcessSubprocess

--- a/docs/topics/api.rst
+++ b/docs/topics/api.rst
@@ -124,6 +124,11 @@ how you :ref:`configure the downloader middlewares
 .. autoclass:: CrawlerRunner
    :members:
 
+.. autoclass:: AsyncCrawlerProcess
+   :show-inheritance:
+   :members:
+   :inherited-members:
+
 .. autoclass:: CrawlerProcess
    :show-inheritance:
    :members:

--- a/docs/topics/api.rst
+++ b/docs/topics/api.rst
@@ -107,6 +107,15 @@ how you :ref:`configure the downloader middlewares
 
         Returns a deferred that is fired when the crawl is finished.
 
+    .. method:: crawl_async(*args, **kwargs)
+        :async:
+
+        Starts the crawler by instantiating its spider class with the given
+        ``args`` and ``kwargs`` arguments, while setting the execution engine in
+        motion. Should be called only once.
+
+        Completes when the crawl is finished.
+
     .. automethod:: stop
 
 .. autoclass:: AsyncCrawlerRunner

--- a/docs/topics/asyncio.rst
+++ b/docs/topics/asyncio.rst
@@ -20,7 +20,8 @@ To enable :mod:`asyncio` support, your :setting:`TWISTED_REACTOR` setting needs
 to be set to ``'twisted.internet.asyncioreactor.AsyncioSelectorReactor'``,
 which is the default value.
 
-If you are using :class:`~scrapy.crawler.CrawlerRunner`, you also need to
+If you are using :class:`~scrapy.crawler.AsyncCrawlerRunner` or
+:class:`~scrapy.crawler.CrawlerRunner`, you also need to
 install the :class:`~twisted.internet.asyncioreactor.AsyncioSelectorReactor`
 reactor manually. You can do that using
 :func:`~scrapy.utils.reactor.install_reactor`:

--- a/docs/topics/settings.rst
+++ b/docs/topics/settings.rst
@@ -330,7 +330,8 @@ exception is raised.
 
 These settings are:
 
--   :setting:`ASYNCIO_EVENT_LOOP`
+-   :setting:`ASYNCIO_EVENT_LOOP` (when not using
+    :class:`~scrapy.crawler.AsyncCrawlerProcess`)
 
 -   :setting:`DNS_RESOLVER` and settings used by the corresponding
     component, e.g. :setting:`DNSCACHE_ENABLED`, :setting:`DNSCACHE_SIZE`
@@ -338,11 +339,22 @@ These settings are:
 
 -   :setting:`REACTOR_THREADPOOL_MAXSIZE`
 
--   :setting:`TWISTED_REACTOR`
+-   :setting:`TWISTED_REACTOR` (when not using
+    :class:`~scrapy.crawler.AsyncCrawlerProcess`)
 
 :setting:`ASYNCIO_EVENT_LOOP` and :setting:`TWISTED_REACTOR` are used upon
 installing the reactor. The rest of the settings are applied when starting
 the reactor.
+
+There is an additional restriction for :setting:`TWISTED_REACTOR` and
+:setting:`ASYNCIO_EVENT_LOOP` when using
+:class:`~scrapy.crawler.AsyncCrawlerProcess`: when this class is instantiated,
+it installs :class:`~twisted.internet.asyncioreactor.AsyncioSelectorReactor`,
+ignoring the value of :setting:`TWISTED_REACTOR` and using the value of
+:setting:`ASYNCIO_EVENT_LOOP` that was passed to
+:meth:`AsyncCrawlerProcess.__init__()
+<scrapy.crawler.AsyncCrawlerProcess.__init__>`, so the latter setting cannot be
+modified by spiders or add-ons after that.
 
 
 .. _topics-settings-ref:
@@ -1977,9 +1989,11 @@ Import path of a given :mod:`~twisted.internet.reactor`.
 
 Scrapy will install this reactor if no other reactor is installed yet, such as
 when the ``scrapy`` CLI program is invoked or when using the
+:class:`~scrapy.crawler.AsyncCrawlerProcess` class or the
 :class:`~scrapy.crawler.CrawlerProcess` class.
 
-If you are using the :class:`~scrapy.crawler.CrawlerRunner` class, you also
+If you are using the :class:`~scrapy.crawler.AsyncCrawlerRunner` class or the
+:class:`~scrapy.crawler.CrawlerRunner` class, you also
 need to install the correct reactor manually. You can do that using
 :func:`~scrapy.utils.reactor.install_reactor`:
 
@@ -1988,12 +2002,12 @@ need to install the correct reactor manually. You can do that using
 If a reactor is already installed,
 :func:`~scrapy.utils.reactor.install_reactor` has no effect.
 
-:meth:`CrawlerRunner.__init__ <scrapy.crawler.CrawlerRunner.__init__>` raises
-:exc:`Exception` if the installed reactor does not match the
+:class:`~scrapy.crawler.AsyncCrawlerRunner` and other similar classes raise an
+exception if the installed reactor does not match the
 :setting:`TWISTED_REACTOR` setting; therefore, having top-level
 :mod:`~twisted.internet.reactor` imports in project files and imported
-third-party libraries will make Scrapy raise :exc:`Exception` when
-it checks which reactor is installed.
+third-party libraries will make Scrapy raise an exception when it checks which
+reactor is installed.
 
 In order to use the reactor installed by Scrapy:
 
@@ -2025,7 +2039,7 @@ In order to use the reactor installed by Scrapy:
             self.crawler.engine.close_spider(self, "timeout")
 
 
-which raises :exc:`Exception`, becomes:
+which raises an exception, becomes:
 
 .. code-block:: python
 

--- a/scrapy/core/engine.py
+++ b/scrapy/core/engine.py
@@ -22,6 +22,7 @@ from scrapy.exceptions import CloseSpider, DontCloseSpider, IgnoreRequest
 from scrapy.http import Request, Response
 from scrapy.utils.defer import (
     deferred_f_from_coro_f,
+    deferred_from_coro,
     maybe_deferred_to_future,
 )
 from scrapy.utils.log import failure_to_exc_info, logformatter_adapter
@@ -122,8 +123,10 @@ class ExecutionEngine:
             )
         return scheduler_cls
 
-    @deferred_f_from_coro_f
-    async def start(self, _start_request_processing=True) -> None:
+    def start(self, _start_request_processing=True) -> Deferred[None]:
+        return deferred_from_coro(self.start_async(_start_request_processing))
+
+    async def start_async(self, _start_request_processing=True) -> None:
         if self.running:
             raise RuntimeError("Engine already running")
         self.start_time = time()
@@ -392,8 +395,10 @@ class ExecutionEngine:
         finally:
             self._slot.nextcall.schedule()
 
-    @deferred_f_from_coro_f
-    async def open_spider(
+    def open_spider(self, spider: Spider, close_if_idle: bool = True) -> Deferred[None]:
+        return deferred_from_coro(self.open_spider_async(spider, close_if_idle))
+
+    async def open_spider_async(
         self,
         spider: Spider,
         close_if_idle: bool = True,

--- a/scrapy/crawler.py
+++ b/scrapy/crawler.py
@@ -21,7 +21,7 @@ from scrapy.extension import ExtensionManager
 from scrapy.interfaces import ISpiderLoader
 from scrapy.settings import BaseSettings, Settings, overridden_settings
 from scrapy.signalmanager import SignalManager
-from scrapy.utils.defer import deferred_to_future
+from scrapy.utils.defer import deferred_from_coro, deferred_to_future
 from scrapy.utils.log import (
     LogCounterHandler,
     configure_logging,
@@ -33,9 +33,10 @@ from scrapy.utils.log import (
 from scrapy.utils.misc import build_from_crawler, load_object
 from scrapy.utils.ossignal import install_shutdown_handlers, signal_names
 from scrapy.utils.reactor import (
-    _get_asyncio_event_loop,
+    _asyncio_reactor_path,
     install_reactor,
     is_asyncio_reactor_installed,
+    is_reactor_installed,
     verify_installed_asyncio_event_loop,
     verify_installed_reactor,
 )
@@ -421,7 +422,7 @@ class CrawlerRunner(CrawlerRunnerBase):
 
         Returns a deferred that is fired when they all have ended.
         """
-        return DeferredList([c.stop() for c in list(self.crawlers)])
+        return DeferredList(c.stop() for c in self.crawlers)
 
     @inlineCallbacks
     def join(self) -> Generator[Deferred[Any], Any, None]:
@@ -489,12 +490,16 @@ class AsyncCrawlerRunner(CrawlerRunnerBase):
                 "it must be a spider class (or a Crawler object)"
             )
         if not is_asyncio_reactor_installed():
-            raise RuntimeError("AsyncCrawlerRunner requires AsyncioSelectorReactor.")
+            raise RuntimeError(
+                f"{type(self).__name__} requires AsyncioSelectorReactor."
+            )
         crawler = self.create_crawler(crawler_or_spidercls)
         return self._crawl(crawler, *args, **kwargs)
 
     def _crawl(self, crawler: Crawler, *args: Any, **kwargs: Any) -> asyncio.Task[None]:
-        loop = _get_asyncio_event_loop()
+        # At this point the asyncio loop has been installed either by the user
+        # or by AsyncCrawlerProcess (but it isn't running yet, so no asyncio.create_task()).
+        loop = asyncio.get_event_loop()
         self.crawlers.add(crawler)
         task = loop.create_task(crawler.crawl_async(*args, **kwargs))
         self._active.add(task)
@@ -513,7 +518,10 @@ class AsyncCrawlerRunner(CrawlerRunnerBase):
 
         Completes when they all have ended.
         """
-        await asyncio.gather(*[c.stop_async() for c in list(self.crawlers)])
+        if self.crawlers:
+            await asyncio.wait(
+                [asyncio.create_task(c.stop_async()) for c in self.crawlers]
+            )
 
     async def join(self) -> None:
         """
@@ -521,33 +529,10 @@ class AsyncCrawlerRunner(CrawlerRunnerBase):
         executions.
         """
         while self._active:
-            await asyncio.gather(*self._active)
+            await asyncio.wait(self._active)
 
 
-class CrawlerProcess(CrawlerRunner):
-    """
-    A class to run multiple scrapy crawlers in a process simultaneously.
-
-    This class extends :class:`~scrapy.crawler.CrawlerRunner` by adding support
-    for starting a :mod:`~twisted.internet.reactor` and handling shutdown
-    signals, like the keyboard interrupt command Ctrl-C. It also configures
-    top-level logging.
-
-    This utility should be a better fit than
-    :class:`~scrapy.crawler.CrawlerRunner` if you aren't running another
-    :mod:`~twisted.internet.reactor` within your application.
-
-    The CrawlerProcess object must be instantiated with a
-    :class:`~scrapy.settings.Settings` object.
-
-    :param install_root_handler: whether to install root logging handler
-        (default: True)
-
-    This class shouldn't be needed (since Scrapy is responsible of using it
-    accordingly) unless writing scripts that manually handle the crawling
-    process. See :ref:`run-from-script` for an example.
-    """
-
+class CrawlerProcessBase(CrawlerRunnerBase):
     def __init__(
         self,
         settings: dict[str, Any] | Settings | None = None,
@@ -556,7 +541,6 @@ class CrawlerProcess(CrawlerRunner):
         super().__init__(settings)
         configure_logging(self.settings, install_root_handler)
         log_scrapy_info(self.settings)
-        self._initialized_reactor: bool = False
 
     def _signal_shutdown(self, signum: int, _: Any) -> None:
         from twisted.internet import reactor
@@ -579,12 +563,84 @@ class CrawlerProcess(CrawlerRunner):
         )
         reactor.callFromThread(self._stop_reactor)
 
+    def _setup_reactor(self, install_signal_handlers: bool) -> None:
+        from twisted.internet import reactor
+
+        resolver_class = load_object(self.settings["DNS_RESOLVER"])
+        # We pass self, which is CrawlerProcess, instead of Crawler here,
+        # which works because the default resolvers only use crawler.settings.
+        resolver = build_from_crawler(resolver_class, self, reactor=reactor)  # type: ignore[arg-type]
+        resolver.install_on_reactor()
+        tp = reactor.getThreadPool()
+        tp.adjustPoolsize(maxthreads=self.settings.getint("REACTOR_THREADPOOL_MAXSIZE"))
+        reactor.addSystemEventTrigger("before", "shutdown", self._stop_dfd)
+        if install_signal_handlers:
+            reactor.addSystemEventTrigger(
+                "after", "startup", install_shutdown_handlers, self._signal_shutdown
+            )
+
+    def _stop_dfd(self) -> Deferred[Any]:
+        raise NotImplementedError
+
+    @inlineCallbacks
+    def _graceful_stop_reactor(self) -> Generator[Deferred[Any], Any, None]:
+        try:
+            yield self._stop_dfd()
+        finally:
+            self._stop_reactor()
+
+    def _stop_reactor(self, _: Any = None) -> None:
+        from twisted.internet import reactor
+
+        # raised if already stopped or in shutdown stage
+        with contextlib.suppress(RuntimeError):
+            reactor.stop()
+
+
+class CrawlerProcess(CrawlerProcessBase, CrawlerRunner):
+    """
+    A class to run multiple scrapy crawlers in a process simultaneously.
+
+    This class extends :class:`~scrapy.crawler.CrawlerRunner` by adding support
+    for starting a :mod:`~twisted.internet.reactor` and handling shutdown
+    signals, like the keyboard interrupt command Ctrl-C. It also configures
+    top-level logging.
+
+    This utility should be a better fit than
+    :class:`~scrapy.crawler.CrawlerRunner` if you aren't running another
+    :mod:`~twisted.internet.reactor` within your application.
+
+    The CrawlerProcess object must be instantiated with a
+    :class:`~scrapy.settings.Settings` object.
+
+    :param install_root_handler: whether to install root logging handler
+        (default: True)
+
+    This class shouldn't be needed (since Scrapy is responsible of using it
+    accordingly) unless writing scripts that manually handle the crawling
+    process. See :ref:`run-from-script` for an example.
+
+    This class provides Deferred-based APIs. Use :class:`AsyncCrawlerProcess`
+    for modern coroutine APIs.
+    """
+
+    def __init__(
+        self,
+        settings: dict[str, Any] | Settings | None = None,
+        install_root_handler: bool = True,
+    ):
+        super().__init__(settings, install_root_handler)
+        self._initialized_reactor: bool = False
+
     def _create_crawler(self, spidercls: type[Spider] | str) -> Crawler:
         if isinstance(spidercls, str):
             spidercls = self.spider_loader.load(spidercls)
         init_reactor = not self._initialized_reactor
         self._initialized_reactor = True
         return Crawler(spidercls, self.settings, init_reactor=init_reactor)
+
+    def _stop_dfd(self) -> Deferred[Any]:
+        return self.stop()
 
     def start(
         self, stop_after_crawl: bool = True, install_signal_handlers: bool = True
@@ -612,30 +668,86 @@ class CrawlerProcess(CrawlerRunner):
                 return
             d.addBoth(self._stop_reactor)
 
-        resolver_class = load_object(self.settings["DNS_RESOLVER"])
-        # We pass self, which is CrawlerProcess, instead of Crawler here,
-        # which works because the default resolvers only use crawler.settings.
-        resolver = build_from_crawler(resolver_class, self, reactor=reactor)  # type: ignore[arg-type]
-        resolver.install_on_reactor()
-        tp = reactor.getThreadPool()
-        tp.adjustPoolsize(maxthreads=self.settings.getint("REACTOR_THREADPOOL_MAXSIZE"))
-        reactor.addSystemEventTrigger("before", "shutdown", self.stop)
-        if install_signal_handlers:
-            reactor.addSystemEventTrigger(
-                "after", "startup", install_shutdown_handlers, self._signal_shutdown
-            )
+        self._setup_reactor(install_signal_handlers)
         reactor.run(installSignalHandlers=install_signal_handlers)  # blocking call
 
-    @inlineCallbacks
-    def _graceful_stop_reactor(self) -> Generator[Deferred[Any], Any, None]:
-        try:
-            yield self.stop()
-        finally:
-            self._stop_reactor()
 
-    def _stop_reactor(self, _: Any = None) -> None:
+class AsyncCrawlerProcess(CrawlerProcessBase, AsyncCrawlerRunner):
+    """
+    A class to run multiple scrapy crawlers in a process simultaneously.
+
+    This class extends :class:`~scrapy.crawler.AsyncCrawlerRunner` by adding support
+    for starting a :mod:`~twisted.internet.reactor` and handling shutdown
+    signals, like the keyboard interrupt command Ctrl-C. It also configures
+    top-level logging.
+
+    This utility should be a better fit than
+    :class:`~scrapy.crawler.AsyncCrawlerRunner` if you aren't running another
+    :mod:`~twisted.internet.reactor` within your application.
+
+    The AsyncCrawlerProcess object must be instantiated with a
+    :class:`~scrapy.settings.Settings` object.
+
+    :param install_root_handler: whether to install root logging handler
+        (default: True)
+
+    This class shouldn't be needed (since Scrapy is responsible of using it
+    accordingly) unless writing scripts that manually handle the crawling
+    process. See :ref:`run-from-script` for an example.
+
+    This class provides coroutine APIs. It requires
+    :class:`~twisted.internet.asyncioreactor.AsyncioSelectorReactor`.
+    """
+
+    def __init__(
+        self,
+        settings: dict[str, Any] | Settings | None = None,
+        install_root_handler: bool = True,
+    ):
+        super().__init__(settings, install_root_handler)
+        # We want the asyncio event loop to be installed early, so that it's
+        # always the correct one. And as we do that, we can also install the
+        # reactor here.
+        # The ASYNCIO_EVENT_LOOP setting cannot be overridden by add-ons and
+        # spiders when using AsyncCrawlerProcess.
+        loop_path = self.settings["ASYNCIO_EVENT_LOOP"]
+        if is_reactor_installed():
+            # The user could install a reactor before this class is instantiated.
+            # We need to make sure the reactor is the correct one and the loop
+            # type matches the setting.
+            verify_installed_reactor(_asyncio_reactor_path)
+            if loop_path:
+                verify_installed_asyncio_event_loop(loop_path)
+        else:
+            install_reactor(_asyncio_reactor_path, loop_path)
+        self._initialized_reactor = True
+
+    def _stop_dfd(self) -> Deferred[Any]:
+        return deferred_from_coro(self.stop())
+
+    def start(
+        self, stop_after_crawl: bool = True, install_signal_handlers: bool = True
+    ) -> None:
+        """
+        This method starts a :mod:`~twisted.internet.reactor`, adjusts its pool
+        size to :setting:`REACTOR_THREADPOOL_MAXSIZE`, and installs a DNS cache
+        based on :setting:`DNSCACHE_ENABLED` and :setting:`DNSCACHE_SIZE`.
+
+        If ``stop_after_crawl`` is True, the reactor will be stopped after all
+        crawlers have finished, using :meth:`join`.
+
+        :param bool stop_after_crawl: stop or not the reactor when all
+            crawlers have finished
+
+        :param bool install_signal_handlers: whether to install the OS signal
+            handlers from Twisted and Scrapy (default: True)
+        """
         from twisted.internet import reactor
 
-        # raised if already stopped or in shutdown stage
-        with contextlib.suppress(RuntimeError):
-            reactor.stop()
+        if stop_after_crawl:
+            loop = asyncio.get_event_loop()
+            join_task = loop.create_task(self.join())
+            join_task.add_done_callback(self._stop_reactor)
+
+        self._setup_reactor(install_signal_handlers)
+        reactor.run(installSignalHandlers=install_signal_handlers)  # blocking call

--- a/scrapy/utils/reactor.py
+++ b/scrapy/utils/reactor.py
@@ -10,6 +10,7 @@ from twisted.internet import asyncioreactor, error
 from twisted.internet.defer import Deferred
 
 from scrapy.utils.misc import load_object
+from scrapy.utils.python import global_object_name
 
 if TYPE_CHECKING:
     from asyncio import AbstractEventLoop, AbstractEventLoopPolicy
@@ -87,6 +88,9 @@ class CallLaterOnce(Generic[_T]):
         await maybe_deferred_to_future(d)
 
 
+_asyncio_reactor_path = "twisted.internet.asyncioreactor.AsyncioSelectorReactor"
+
+
 def set_asyncio_event_loop_policy() -> None:
     """The policy functions from asyncio often behave unexpectedly,
     so we restrict their use to the absolutely essential case.
@@ -161,21 +165,34 @@ def set_asyncio_event_loop(event_loop_path: str | None) -> AbstractEventLoop:
 
 
 def verify_installed_reactor(reactor_path: str) -> None:
-    """Raises :exc:`Exception` if the installed
+    """Raise :exc:`RuntimeError` if the installed
     :mod:`~twisted.internet.reactor` does not match the specified import
-    path."""
+    path or if no reactor is installed."""
+    if not is_reactor_installed():
+        raise RuntimeError(
+            "verify_installed_reactor() called without an installed reactor."
+        )
+
     from twisted.internet import reactor
 
-    reactor_class = load_object(reactor_path)
-    if not reactor.__class__ == reactor_class:
+    expected_reactor_type = load_object(reactor_path)
+    reactor_type = type(reactor)
+    if not reactor_type == expected_reactor_type:
         raise RuntimeError(
-            "The installed reactor "
-            f"({reactor.__module__}.{reactor.__class__.__name__}) does not "
-            f"match the requested one ({reactor_path})"
+            f"The installed reactor ({global_object_name(reactor_type)}) "
+            f"does not match the requested one ({reactor_path})"
         )
 
 
 def verify_installed_asyncio_event_loop(loop_path: str) -> None:
+    """Raise :exc:`RuntimeError` if the even loop of the installed
+    :class:`~twisted.internet.asyncioreactor.AsyncioSelectorReactor`
+    does not match the specified import path or if no reactor is installed."""
+    if not is_reactor_installed():
+        raise RuntimeError(
+            "verify_installed_asyncio_event_loop() called without an installed reactor."
+        )
+
     from twisted.internet import reactor
 
     loop_class = load_object(loop_path)
@@ -185,16 +202,16 @@ def verify_installed_asyncio_event_loop(loop_path: str) -> None:
         f"{reactor._asyncioEventloop.__class__.__module__}"
         f".{reactor._asyncioEventloop.__class__.__qualname__}"
     )
-    specified = f"{loop_class.__module__}.{loop_class.__qualname__}"
     raise RuntimeError(
         "Scrapy found an asyncio Twisted reactor already "
         f"installed, and its event loop class ({installed}) does "
         "not match the one specified in the ASYNCIO_EVENT_LOOP "
-        f"setting ({specified})"
+        f"setting ({global_object_name(loop_class)})"
     )
 
 
 def is_reactor_installed() -> bool:
+    """Check whether a :mod:`~twisted.internet.reactor` is installed."""
     return "twisted.internet.reactor" in sys.modules
 
 

--- a/tests/AsyncCrawlerProcess/args_settings.py
+++ b/tests/AsyncCrawlerProcess/args_settings.py
@@ -1,0 +1,25 @@
+from typing import Any
+
+import scrapy
+from scrapy.crawler import AsyncCrawlerProcess, Crawler
+
+
+class NoRequestsSpider(scrapy.Spider):
+    name = "no_request"
+
+    @classmethod
+    def from_crawler(cls, crawler: Crawler, *args: Any, **kwargs: Any):
+        spider = super().from_crawler(crawler, *args, **kwargs)
+        spider.settings.set("FOO", kwargs.get("foo"))
+        return spider
+
+    async def start(self):
+        self.logger.info(f"The value of FOO is {self.settings.getint('FOO')}")
+        return
+        yield
+
+
+process = AsyncCrawlerProcess(settings={})
+
+process.crawl(NoRequestsSpider, foo=42)
+process.start()

--- a/tests/AsyncCrawlerProcess/asyncio_custom_loop.py
+++ b/tests/AsyncCrawlerProcess/asyncio_custom_loop.py
@@ -1,16 +1,5 @@
-import asyncio
-import sys
-
-from twisted.internet import asyncioreactor
-from uvloop import Loop
-
 import scrapy
-from scrapy.crawler import CrawlerProcess
-
-if sys.platform == "win32":
-    asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
-asyncio.set_event_loop(Loop())
-asyncioreactor.install()
+from scrapy.crawler import AsyncCrawlerProcess
 
 
 class NoRequestsSpider(scrapy.Spider):
@@ -21,7 +10,7 @@ class NoRequestsSpider(scrapy.Spider):
         yield
 
 
-process = CrawlerProcess(
+process = AsyncCrawlerProcess(
     settings={
         "TWISTED_REACTOR": "twisted.internet.asyncioreactor.AsyncioSelectorReactor",
         "ASYNCIO_EVENT_LOOP": "uvloop.Loop",

--- a/tests/AsyncCrawlerProcess/asyncio_deferred_signal.py
+++ b/tests/AsyncCrawlerProcess/asyncio_deferred_signal.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import asyncio
+import sys
+
+from scrapy import Spider
+from scrapy.crawler import AsyncCrawlerProcess
+from scrapy.utils.defer import deferred_from_coro
+
+
+class UppercasePipeline:
+    async def _open_spider(self, spider):
+        spider.logger.info("async pipeline opened!")
+        await asyncio.sleep(0.1)
+
+    def open_spider(self, spider):
+        return deferred_from_coro(self._open_spider(spider))
+
+    def process_item(self, item, spider):
+        return {"url": item["url"].upper()}
+
+
+class UrlSpider(Spider):
+    name = "url_spider"
+    start_urls = ["data:,"]
+    custom_settings = {
+        "ITEM_PIPELINES": {UppercasePipeline: 100},
+    }
+
+    def parse(self, response):
+        yield {"url": response.url}
+
+
+if __name__ == "__main__":
+    ASYNCIO_EVENT_LOOP: str | None
+    try:
+        ASYNCIO_EVENT_LOOP = sys.argv[1]
+    except IndexError:
+        ASYNCIO_EVENT_LOOP = None
+
+    process = AsyncCrawlerProcess(
+        settings={
+            "TWISTED_REACTOR": "twisted.internet.asyncioreactor.AsyncioSelectorReactor",
+            "ASYNCIO_EVENT_LOOP": ASYNCIO_EVENT_LOOP,
+        }
+    )
+    process.crawl(UrlSpider)
+    process.start()

--- a/tests/AsyncCrawlerProcess/asyncio_enabled_no_reactor.py
+++ b/tests/AsyncCrawlerProcess/asyncio_enabled_no_reactor.py
@@ -1,0 +1,27 @@
+import scrapy
+from scrapy.crawler import AsyncCrawlerProcess
+from scrapy.utils.reactor import is_asyncio_reactor_installed
+
+
+class ReactorCheckExtension:
+    def __init__(self):
+        if not is_asyncio_reactor_installed():
+            raise RuntimeError("ReactorCheckExtension requires the asyncio reactor.")
+
+
+class NoRequestsSpider(scrapy.Spider):
+    name = "no_request"
+
+    async def start(self):
+        return
+        yield
+
+
+process = AsyncCrawlerProcess(
+    settings={
+        "TWISTED_REACTOR": "twisted.internet.asyncioreactor.AsyncioSelectorReactor",
+        "EXTENSIONS": {ReactorCheckExtension: 0},
+    }
+)
+process.crawl(NoRequestsSpider)
+process.start()

--- a/tests/AsyncCrawlerProcess/asyncio_enabled_reactor.py
+++ b/tests/AsyncCrawlerProcess/asyncio_enabled_reactor.py
@@ -1,0 +1,53 @@
+import scrapy
+from scrapy.crawler import AsyncCrawlerProcess
+from scrapy.utils.reactor import (
+    install_reactor,
+    is_asyncio_reactor_installed,
+    is_reactor_installed,
+)
+
+if is_reactor_installed():
+    raise RuntimeError(
+        "Reactor already installed before is_asyncio_reactor_installed()."
+    )
+
+try:
+    is_asyncio_reactor_installed()
+except RuntimeError:
+    pass
+else:
+    raise RuntimeError("is_asyncio_reactor_installed() did not raise RuntimeError.")
+
+if is_reactor_installed():
+    raise RuntimeError(
+        "Reactor already installed after is_asyncio_reactor_installed()."
+    )
+
+install_reactor("twisted.internet.asyncioreactor.AsyncioSelectorReactor")
+
+if not is_asyncio_reactor_installed():
+    raise RuntimeError("Wrong reactor installed after install_reactor().")
+
+
+class ReactorCheckExtension:
+    def __init__(self):
+        if not is_asyncio_reactor_installed():
+            raise RuntimeError("ReactorCheckExtension requires the asyncio reactor.")
+
+
+class NoRequestsSpider(scrapy.Spider):
+    name = "no_request"
+
+    async def start(self):
+        return
+        yield
+
+
+process = AsyncCrawlerProcess(
+    settings={
+        "TWISTED_REACTOR": "twisted.internet.asyncioreactor.AsyncioSelectorReactor",
+        "EXTENSIONS": {ReactorCheckExtension: 0},
+    }
+)
+process.crawl(NoRequestsSpider)
+process.start()

--- a/tests/AsyncCrawlerProcess/asyncio_enabled_reactor_different_loop.py
+++ b/tests/AsyncCrawlerProcess/asyncio_enabled_reactor_different_loop.py
@@ -2,15 +2,13 @@ import asyncio
 import sys
 
 from twisted.internet import asyncioreactor
-from uvloop import Loop
 
 import scrapy
-from scrapy.crawler import CrawlerProcess
+from scrapy.crawler import AsyncCrawlerProcess
 
 if sys.platform == "win32":
     asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
-asyncio.set_event_loop(Loop())
-asyncioreactor.install()
+asyncioreactor.install(asyncio.get_event_loop())
 
 
 class NoRequestsSpider(scrapy.Spider):
@@ -21,7 +19,7 @@ class NoRequestsSpider(scrapy.Spider):
         yield
 
 
-process = CrawlerProcess(
+process = AsyncCrawlerProcess(
     settings={
         "TWISTED_REACTOR": "twisted.internet.asyncioreactor.AsyncioSelectorReactor",
         "ASYNCIO_EVENT_LOOP": "uvloop.Loop",

--- a/tests/AsyncCrawlerProcess/asyncio_enabled_reactor_same_loop.py
+++ b/tests/AsyncCrawlerProcess/asyncio_enabled_reactor_same_loop.py
@@ -5,12 +5,12 @@ from twisted.internet import asyncioreactor
 from uvloop import Loop
 
 import scrapy
-from scrapy.crawler import CrawlerProcess
+from scrapy.crawler import AsyncCrawlerProcess
 
 if sys.platform == "win32":
     asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
 asyncio.set_event_loop(Loop())
-asyncioreactor.install()
+asyncioreactor.install(asyncio.get_event_loop())
 
 
 class NoRequestsSpider(scrapy.Spider):
@@ -21,7 +21,7 @@ class NoRequestsSpider(scrapy.Spider):
         yield
 
 
-process = CrawlerProcess(
+process = AsyncCrawlerProcess(
     settings={
         "TWISTED_REACTOR": "twisted.internet.asyncioreactor.AsyncioSelectorReactor",
         "ASYNCIO_EVENT_LOOP": "uvloop.Loop",

--- a/tests/AsyncCrawlerProcess/caching_hostname_resolver.py
+++ b/tests/AsyncCrawlerProcess/caching_hostname_resolver.py
@@ -1,0 +1,35 @@
+import sys
+
+import scrapy
+from scrapy.crawler import AsyncCrawlerProcess
+
+
+class CachingHostnameResolverSpider(scrapy.Spider):
+    """
+    Finishes in a finite amount of time (does not hang indefinitely in the DNS resolution)
+    """
+
+    name = "caching_hostname_resolver_spider"
+
+    async def start(self):
+        yield scrapy.Request(self.url)
+
+    def parse(self, response):
+        for _ in range(10):
+            yield scrapy.Request(
+                response.url, dont_filter=True, callback=self.ignore_response
+            )
+
+    def ignore_response(self, response):
+        self.logger.info(repr(response.ip_address))
+
+
+if __name__ == "__main__":
+    process = AsyncCrawlerProcess(
+        settings={
+            "RETRY_ENABLED": False,
+            "DNS_RESOLVER": "scrapy.resolver.CachingHostnameResolver",
+        }
+    )
+    process.crawl(CachingHostnameResolverSpider, url=sys.argv[1])
+    process.start()

--- a/tests/AsyncCrawlerProcess/caching_hostname_resolver_ipv6.py
+++ b/tests/AsyncCrawlerProcess/caching_hostname_resolver_ipv6.py
@@ -1,0 +1,22 @@
+import scrapy
+from scrapy.crawler import AsyncCrawlerProcess
+
+
+class CachingHostnameResolverSpider(scrapy.Spider):
+    """
+    Finishes without a twisted.internet.error.DNSLookupError exception
+    """
+
+    name = "caching_hostname_resolver_spider"
+    start_urls = ["http://[::1]"]
+
+
+if __name__ == "__main__":
+    process = AsyncCrawlerProcess(
+        settings={
+            "RETRY_ENABLED": False,
+            "DNS_RESOLVER": "scrapy.resolver.CachingHostnameResolver",
+        }
+    )
+    process.crawl(CachingHostnameResolverSpider)
+    process.start()

--- a/tests/AsyncCrawlerProcess/default_name_resolver.py
+++ b/tests/AsyncCrawlerProcess/default_name_resolver.py
@@ -1,0 +1,18 @@
+import scrapy
+from scrapy.crawler import AsyncCrawlerProcess
+
+
+class IPv6Spider(scrapy.Spider):
+    """
+    Raises a twisted.internet.error.DNSLookupError:
+    the default name resolver does not handle IPv6 addresses.
+    """
+
+    name = "ipv6_spider"
+    start_urls = ["http://[::1]"]
+
+
+if __name__ == "__main__":
+    process = AsyncCrawlerProcess(settings={"RETRY_ENABLED": False})
+    process.crawl(IPv6Spider)
+    process.start()

--- a/tests/AsyncCrawlerProcess/multi.py
+++ b/tests/AsyncCrawlerProcess/multi.py
@@ -1,0 +1,17 @@
+import scrapy
+from scrapy.crawler import AsyncCrawlerProcess
+
+
+class NoRequestsSpider(scrapy.Spider):
+    name = "no_request"
+
+    async def start(self):
+        return
+        yield
+
+
+process = AsyncCrawlerProcess(settings={})
+
+process.crawl(NoRequestsSpider)
+process.crawl(NoRequestsSpider)
+process.start()

--- a/tests/AsyncCrawlerProcess/reactor_default.py
+++ b/tests/AsyncCrawlerProcess/reactor_default.py
@@ -1,0 +1,18 @@
+from twisted.internet import reactor  # noqa: F401
+
+import scrapy
+from scrapy.crawler import AsyncCrawlerProcess
+
+
+class NoRequestsSpider(scrapy.Spider):
+    name = "no_request"
+
+    async def start(self):
+        return
+        yield
+
+
+process = AsyncCrawlerProcess(settings={})
+
+d = process.crawl(NoRequestsSpider)
+process.start()

--- a/tests/AsyncCrawlerProcess/simple.py
+++ b/tests/AsyncCrawlerProcess/simple.py
@@ -1,0 +1,16 @@
+import scrapy
+from scrapy.crawler import AsyncCrawlerProcess
+
+
+class NoRequestsSpider(scrapy.Spider):
+    name = "no_request"
+
+    async def start(self):
+        return
+        yield
+
+
+process = AsyncCrawlerProcess(settings={})
+
+process.crawl(NoRequestsSpider)
+process.start()

--- a/tests/AsyncCrawlerProcess/sleeping.py
+++ b/tests/AsyncCrawlerProcess/sleeping.py
@@ -1,0 +1,20 @@
+import asyncio
+import sys
+
+import scrapy
+from scrapy.crawler import AsyncCrawlerProcess
+
+
+class SleepingSpider(scrapy.Spider):
+    name = "sleeping"
+
+    start_urls = ["data:,;"]
+
+    async def parse(self, response):
+        await asyncio.sleep(int(sys.argv[1]))
+
+
+process = AsyncCrawlerProcess(settings={})
+
+process.crawl(SleepingSpider)
+process.start()

--- a/tests/AsyncCrawlerProcess/twisted_reactor_asyncio.py
+++ b/tests/AsyncCrawlerProcess/twisted_reactor_asyncio.py
@@ -1,0 +1,15 @@
+import scrapy
+from scrapy.crawler import AsyncCrawlerProcess
+
+
+class AsyncioReactorSpider(scrapy.Spider):
+    name = "asyncio_reactor"
+
+
+process = AsyncCrawlerProcess(
+    settings={
+        "TWISTED_REACTOR": "twisted.internet.asyncioreactor.AsyncioSelectorReactor",
+    }
+)
+process.crawl(AsyncioReactorSpider)
+process.start()

--- a/tests/AsyncCrawlerProcess/twisted_reactor_custom_settings.py
+++ b/tests/AsyncCrawlerProcess/twisted_reactor_custom_settings.py
@@ -1,0 +1,14 @@
+import scrapy
+from scrapy.crawler import AsyncCrawlerProcess
+
+
+class AsyncioReactorSpider(scrapy.Spider):
+    name = "asyncio_reactor"
+    custom_settings = {
+        "TWISTED_REACTOR": "twisted.internet.asyncioreactor.AsyncioSelectorReactor",
+    }
+
+
+process = AsyncCrawlerProcess()
+process.crawl(AsyncioReactorSpider)
+process.start()

--- a/tests/AsyncCrawlerProcess/twisted_reactor_custom_settings_same.py
+++ b/tests/AsyncCrawlerProcess/twisted_reactor_custom_settings_same.py
@@ -1,0 +1,22 @@
+import scrapy
+from scrapy.crawler import AsyncCrawlerProcess
+
+
+class AsyncioReactorSpider1(scrapy.Spider):
+    name = "asyncio_reactor1"
+    custom_settings = {
+        "TWISTED_REACTOR": "twisted.internet.asyncioreactor.AsyncioSelectorReactor",
+    }
+
+
+class AsyncioReactorSpider2(scrapy.Spider):
+    name = "asyncio_reactor2"
+    custom_settings = {
+        "TWISTED_REACTOR": "twisted.internet.asyncioreactor.AsyncioSelectorReactor",
+    }
+
+
+process = AsyncCrawlerProcess()
+process.crawl(AsyncioReactorSpider1)
+process.crawl(AsyncioReactorSpider2)
+process.start()

--- a/tests/AsyncCrawlerProcess/twisted_reactor_custom_settings_select.py
+++ b/tests/AsyncCrawlerProcess/twisted_reactor_custom_settings_select.py
@@ -1,0 +1,14 @@
+import scrapy
+from scrapy.crawler import AsyncCrawlerProcess
+
+
+class AsyncioReactorSpider(scrapy.Spider):
+    name = "asyncio_reactor"
+    custom_settings = {
+        "TWISTED_REACTOR": "twisted.internet.selectreactor.SelectReactor",
+    }
+
+
+process = AsyncCrawlerProcess()
+process.crawl(AsyncioReactorSpider)
+process.start()

--- a/tests/AsyncCrawlerRunner/custom_loop_different.py
+++ b/tests/AsyncCrawlerRunner/custom_loop_different.py
@@ -1,0 +1,31 @@
+from twisted.internet.task import react
+
+from scrapy import Spider
+from scrapy.crawler import AsyncCrawlerRunner
+from scrapy.utils.defer import deferred_f_from_coro_f
+from scrapy.utils.log import configure_logging
+from scrapy.utils.reactor import install_reactor
+
+
+class NoRequestsSpider(Spider):
+    name = "no_request"
+
+    custom_settings = {
+        "TWISTED_REACTOR": "twisted.internet.asyncioreactor.AsyncioSelectorReactor",
+        "ASYNCIO_EVENT_LOOP": "uvloop.Loop",
+    }
+
+    async def start(self):
+        return
+        yield
+
+
+@deferred_f_from_coro_f
+async def main(reactor):
+    configure_logging()
+    runner = AsyncCrawlerRunner()
+    await runner.crawl(NoRequestsSpider)
+
+
+install_reactor("twisted.internet.asyncioreactor.AsyncioSelectorReactor")
+react(main)

--- a/tests/AsyncCrawlerRunner/custom_loop_same.py
+++ b/tests/AsyncCrawlerRunner/custom_loop_same.py
@@ -1,0 +1,31 @@
+from twisted.internet.task import react
+
+from scrapy import Spider
+from scrapy.crawler import AsyncCrawlerRunner
+from scrapy.utils.defer import deferred_f_from_coro_f
+from scrapy.utils.log import configure_logging
+from scrapy.utils.reactor import install_reactor
+
+
+class NoRequestsSpider(Spider):
+    name = "no_request"
+
+    custom_settings = {
+        "TWISTED_REACTOR": "twisted.internet.asyncioreactor.AsyncioSelectorReactor",
+        "ASYNCIO_EVENT_LOOP": "uvloop.Loop",
+    }
+
+    async def start(self):
+        return
+        yield
+
+
+@deferred_f_from_coro_f
+async def main(reactor):
+    configure_logging()
+    runner = AsyncCrawlerRunner()
+    await runner.crawl(NoRequestsSpider)
+
+
+install_reactor("twisted.internet.asyncioreactor.AsyncioSelectorReactor", "uvloop.Loop")
+react(main)

--- a/tests/CrawlerProcess/asyncio_enabled_reactor_different_loop.py
+++ b/tests/CrawlerProcess/asyncio_enabled_reactor_different_loop.py
@@ -4,12 +4,12 @@ import sys
 from twisted.internet import asyncioreactor
 from twisted.python import log
 
+import scrapy
+from scrapy.crawler import CrawlerProcess
+
 if sys.platform == "win32":
     asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
-asyncioreactor.install(asyncio.get_event_loop())
-
-import scrapy  # noqa: E402
-from scrapy.crawler import CrawlerProcess  # noqa: E402
+asyncioreactor.install()
 
 
 class NoRequestsSpider(scrapy.Spider):

--- a/tests/CrawlerRunner/custom_loop_different.py
+++ b/tests/CrawlerRunner/custom_loop_different.py
@@ -1,0 +1,29 @@
+from twisted.internet.task import react
+
+from scrapy import Spider
+from scrapy.crawler import CrawlerRunner
+from scrapy.utils.log import configure_logging
+from scrapy.utils.reactor import install_reactor
+
+
+class NoRequestsSpider(Spider):
+    name = "no_request"
+
+    custom_settings = {
+        "TWISTED_REACTOR": "twisted.internet.asyncioreactor.AsyncioSelectorReactor",
+        "ASYNCIO_EVENT_LOOP": "uvloop.Loop",
+    }
+
+    async def start(self):
+        return
+        yield
+
+
+def main(reactor):
+    configure_logging()
+    runner = CrawlerRunner()
+    return runner.crawl(NoRequestsSpider)
+
+
+install_reactor("twisted.internet.asyncioreactor.AsyncioSelectorReactor")
+react(main)

--- a/tests/CrawlerRunner/custom_loop_same.py
+++ b/tests/CrawlerRunner/custom_loop_same.py
@@ -1,0 +1,29 @@
+from twisted.internet.task import react
+
+from scrapy import Spider
+from scrapy.crawler import CrawlerRunner
+from scrapy.utils.log import configure_logging
+from scrapy.utils.reactor import install_reactor
+
+
+class NoRequestsSpider(Spider):
+    name = "no_request"
+
+    custom_settings = {
+        "TWISTED_REACTOR": "twisted.internet.asyncioreactor.AsyncioSelectorReactor",
+        "ASYNCIO_EVENT_LOOP": "uvloop.Loop",
+    }
+
+    async def start(self):
+        return
+        yield
+
+
+def main(reactor):
+    configure_logging()
+    runner = CrawlerRunner()
+    return runner.crawl(NoRequestsSpider)
+
+
+install_reactor("twisted.internet.asyncioreactor.AsyncioSelectorReactor", "uvloop.Loop")
+react(main)

--- a/tests/test_crawler.py
+++ b/tests/test_crawler.py
@@ -1020,6 +1020,25 @@ class TestCrawlerRunnerSubprocess(ScriptRunnerMixin):
         )
         assert "DEBUG: Using asyncio event loop" in log
 
+    @pytest.mark.requires_uvloop
+    def test_custom_loop_same(self):
+        log = self.run_script("custom_loop_same.py")
+        assert "Spider closed (finished)" in log
+        assert (
+            "Using reactor: twisted.internet.asyncioreactor.AsyncioSelectorReactor"
+            in log
+        )
+        assert "Using asyncio event loop: uvloop.Loop" in log
+
+    @pytest.mark.requires_uvloop
+    def test_custom_loop_different(self):
+        log = self.run_script("custom_loop_different.py")
+        assert "Spider closed (finished)" not in log
+        assert (
+            "does not match the one specified in the ASYNCIO_EVENT_LOOP "
+            "setting (uvloop.Loop)"
+        ) in log
+
 
 class TestAsyncCrawlerRunnerSubprocess(ScriptRunnerMixin):
     script_dir = Path(__file__).parent.resolve() / "AsyncCrawlerRunner"
@@ -1062,6 +1081,25 @@ class TestAsyncCrawlerRunnerSubprocess(ScriptRunnerMixin):
             log,
             re.DOTALL,
         )
+
+    @pytest.mark.requires_uvloop
+    def test_custom_loop_same(self):
+        log = self.run_script("custom_loop_same.py")
+        assert "Spider closed (finished)" in log
+        assert (
+            "Using reactor: twisted.internet.asyncioreactor.AsyncioSelectorReactor"
+            in log
+        )
+        assert "Using asyncio event loop: uvloop.Loop" in log
+
+    @pytest.mark.requires_uvloop
+    def test_custom_loop_different(self):
+        log = self.run_script("custom_loop_different.py")
+        assert "Spider closed (finished)" not in log
+        assert (
+            "does not match the one specified in the ASYNCIO_EVENT_LOOP "
+            "setting (uvloop.Loop)"
+        ) in log
 
 
 @pytest.mark.parametrize(

--- a/tests/test_crawler.py
+++ b/tests/test_crawler.py
@@ -5,6 +5,7 @@ import signal
 import subprocess
 import sys
 import warnings
+from abc import ABC, abstractmethod
 from pathlib import Path
 from typing import Any
 
@@ -18,7 +19,13 @@ from zope.interface.exceptions import MultipleInvalid
 
 import scrapy
 from scrapy import Spider
-from scrapy.crawler import AsyncCrawlerRunner, Crawler, CrawlerProcess, CrawlerRunner
+from scrapy.crawler import (
+    AsyncCrawlerProcess,
+    AsyncCrawlerRunner,
+    Crawler,
+    CrawlerProcess,
+    CrawlerRunner,
+)
 from scrapy.exceptions import ScrapyDeprecationWarning
 from scrapy.extensions.throttle import AutoThrottle
 from scrapy.settings import Settings, default_settings
@@ -590,6 +597,17 @@ class TestCrawlerProcess(TestBaseCrawler):
         self.assertOptionIsDefault(runner.settings, "RETRY_ENABLED")
 
 
+class TestAsyncCrawlerProcess(TestBaseCrawler):
+    def test_crawler_process_accepts_dict(self):
+        runner = AsyncCrawlerProcess({"foo": "bar"})
+        assert runner.settings["foo"] == "bar"
+        self.assertOptionIsDefault(runner.settings, "RETRY_ENABLED")
+
+    def test_crawler_process_accepts_None(self):
+        runner = AsyncCrawlerProcess()
+        self.assertOptionIsDefault(runner.settings, "RETRY_ENABLED")
+
+
 class ExceptionSpider(scrapy.Spider):
     name = "exception"
 
@@ -692,8 +710,15 @@ class TestAsyncCrawlerRunnerHasSpider(TestCrawlerRunnerHasSpider):
         pytest.skip("This test is only for CrawlerRunner")
 
 
-class ScriptRunnerMixin:
-    script_dir: Path
+class ScriptRunnerMixin(ABC):
+    @property
+    @abstractmethod
+    def script_dir(self) -> Path:
+        raise NotImplementedError
+
+    @staticmethod
+    def get_script_dir(name: str) -> Path:
+        return Path(__file__).parent.resolve() / name
 
     def get_script_args(self, script_name: str, *script_args: str) -> list[str]:
         script_path = self.script_dir / script_name
@@ -711,8 +736,10 @@ class ScriptRunnerMixin:
         return stderr.decode("utf-8")
 
 
-class TestCrawlerProcessSubprocess(ScriptRunnerMixin, unittest.TestCase):
-    script_dir = Path(__file__).parent.resolve() / "CrawlerProcess"
+class TestCrawlerProcessSubprocessBase(ScriptRunnerMixin, unittest.TestCase):
+    """Common tests between CrawlerProcess and AsyncCrawlerProcess,
+    with the same file names and expectations.
+    """
 
     def test_simple(self):
         log = self.run_script("simple.py")
@@ -737,48 +764,6 @@ class TestCrawlerProcessSubprocess(ScriptRunnerMixin, unittest.TestCase):
         assert (
             "does not match the requested one "
             "(twisted.internet.asyncioreactor.AsyncioSelectorReactor)"
-        ) in log
-
-    def test_reactor_default_twisted_reactor_select(self):
-        log = self.run_script("reactor_default_twisted_reactor_select.py")
-        if platform.system() in ["Windows", "Darwin"]:
-            # The goal of this test function is to test that, when a reactor is
-            # installed (the default one here) and a different reactor is
-            # configured (select here), an error raises.
-            #
-            # In Windows the default reactor is the select reactor, so that
-            # error does not raise.
-            #
-            # If that ever becomes the case on more platforms (i.e. if Linux
-            # also starts using the select reactor by default in a future
-            # version of Twisted), then we will need to rethink this test.
-            assert "Spider closed (finished)" in log
-        else:
-            assert "Spider closed (finished)" not in log
-            assert (
-                "does not match the requested one "
-                "(twisted.internet.selectreactor.SelectReactor)"
-            ) in log
-
-    def test_reactor_select(self):
-        log = self.run_script("reactor_select.py")
-        assert "Spider closed (finished)" not in log
-        assert (
-            "does not match the requested one "
-            "(twisted.internet.asyncioreactor.AsyncioSelectorReactor)"
-        ) in log
-
-    def test_reactor_select_twisted_reactor_select(self):
-        log = self.run_script("reactor_select_twisted_reactor_select.py")
-        assert "Spider closed (finished)" in log
-        assert "ReactorAlreadyInstalledError" not in log
-
-    def test_reactor_select_subclass_twisted_reactor_select(self):
-        log = self.run_script("reactor_select_subclass_twisted_reactor_select.py")
-        assert "Spider closed (finished)" not in log
-        assert (
-            "does not match the requested one "
-            "(twisted.internet.selectreactor.SelectReactor)"
         ) in log
 
     def test_asyncio_enabled_no_reactor(self):
@@ -829,19 +814,6 @@ class TestCrawlerProcessSubprocess(ScriptRunnerMixin, unittest.TestCase):
             assert "TimeoutError" not in log
             assert "twisted.internet.error.DNSLookupError" not in log
 
-    def test_twisted_reactor_select(self):
-        log = self.run_script("twisted_reactor_select.py")
-        assert "Spider closed (finished)" in log
-        assert "Using reactor: twisted.internet.selectreactor.SelectReactor" in log
-
-    @pytest.mark.skipif(
-        platform.system() == "Windows", reason="PollReactor is not supported on Windows"
-    )
-    def test_twisted_reactor_poll(self):
-        log = self.run_script("twisted_reactor_poll.py")
-        assert "Spider closed (finished)" in log
-        assert "Using reactor: twisted.internet.pollreactor.PollReactor" in log
-
     def test_twisted_reactor_asyncio(self):
         log = self.run_script("twisted_reactor_asyncio.py")
         assert "Spider closed (finished)" in log
@@ -863,14 +835,6 @@ class TestCrawlerProcessSubprocess(ScriptRunnerMixin, unittest.TestCase):
         assert "Spider closed (finished)" in log
         assert (
             "Using reactor: twisted.internet.asyncioreactor.AsyncioSelectorReactor"
-            in log
-        )
-
-    def test_twisted_reactor_asyncio_custom_settings_conflict(self):
-        log = self.run_script("twisted_reactor_custom_settings_conflict.py")
-        assert "Using reactor: twisted.internet.selectreactor.SelectReactor" in log
-        assert (
-            "(twisted.internet.selectreactor.SelectReactor) does not match the requested one"
             in log
         )
 
@@ -960,8 +924,94 @@ class TestCrawlerProcessSubprocess(ScriptRunnerMixin, unittest.TestCase):
         p.wait()
 
 
-class TestCrawlerRunnerSubprocess(ScriptRunnerMixin):
-    script_dir = Path(__file__).parent.resolve() / "CrawlerRunner"
+class TestCrawlerProcessSubprocess(TestCrawlerProcessSubprocessBase):
+    @property
+    def script_dir(self) -> Path:
+        return self.get_script_dir("CrawlerProcess")
+
+    def test_reactor_default_twisted_reactor_select(self):
+        log = self.run_script("reactor_default_twisted_reactor_select.py")
+        if platform.system() in ["Windows", "Darwin"]:
+            # The goal of this test function is to test that, when a reactor is
+            # installed (the default one here) and a different reactor is
+            # configured (select here), an error raises.
+            #
+            # In Windows the default reactor is the select reactor, so that
+            # error does not raise.
+            #
+            # If that ever becomes the case on more platforms (i.e. if Linux
+            # also starts using the select reactor by default in a future
+            # version of Twisted), then we will need to rethink this test.
+            assert "Spider closed (finished)" in log
+        else:
+            assert "Spider closed (finished)" not in log
+            assert (
+                "does not match the requested one "
+                "(twisted.internet.selectreactor.SelectReactor)"
+            ) in log
+
+    def test_reactor_select(self):
+        log = self.run_script("reactor_select.py")
+        assert "Spider closed (finished)" not in log
+        assert (
+            "does not match the requested one "
+            "(twisted.internet.asyncioreactor.AsyncioSelectorReactor)"
+        ) in log
+
+    def test_reactor_select_twisted_reactor_select(self):
+        log = self.run_script("reactor_select_twisted_reactor_select.py")
+        assert "Spider closed (finished)" in log
+        assert "ReactorAlreadyInstalledError" not in log
+
+    def test_reactor_select_subclass_twisted_reactor_select(self):
+        log = self.run_script("reactor_select_subclass_twisted_reactor_select.py")
+        assert "Spider closed (finished)" not in log
+        assert (
+            "does not match the requested one "
+            "(twisted.internet.selectreactor.SelectReactor)"
+        ) in log
+
+    def test_twisted_reactor_select(self):
+        log = self.run_script("twisted_reactor_select.py")
+        assert "Spider closed (finished)" in log
+        assert "Using reactor: twisted.internet.selectreactor.SelectReactor" in log
+
+    @pytest.mark.skipif(
+        platform.system() == "Windows", reason="PollReactor is not supported on Windows"
+    )
+    def test_twisted_reactor_poll(self):
+        log = self.run_script("twisted_reactor_poll.py")
+        assert "Spider closed (finished)" in log
+        assert "Using reactor: twisted.internet.pollreactor.PollReactor" in log
+
+    def test_twisted_reactor_asyncio_custom_settings_conflict(self):
+        log = self.run_script("twisted_reactor_custom_settings_conflict.py")
+        assert "Using reactor: twisted.internet.selectreactor.SelectReactor" in log
+        assert (
+            "(twisted.internet.selectreactor.SelectReactor) does not match the requested one"
+            in log
+        )
+
+
+class TestAsyncCrawlerProcessSubprocess(TestCrawlerProcessSubprocessBase):
+    @property
+    def script_dir(self) -> Path:
+        return self.get_script_dir("AsyncCrawlerProcess")
+
+    def test_twisted_reactor_custom_settings_select(self):
+        log = self.run_script("twisted_reactor_custom_settings_select.py")
+        assert "Spider closed (finished)" not in log
+        assert (
+            "(twisted.internet.asyncioreactor.AsyncioSelectorReactor) "
+            "does not match the requested one "
+            "(twisted.internet.selectreactor.SelectReactor)"
+        ) in log
+
+
+class TestCrawlerRunnerSubprocessBase(ScriptRunnerMixin):
+    """Common tests between CrawlerRunner and AsyncCrawlerRunner,
+    with the same file names and expectations.
+    """
 
     def test_simple(self):
         log = self.run_script("simple.py")
@@ -969,14 +1019,6 @@ class TestCrawlerRunnerSubprocess(ScriptRunnerMixin):
         assert (
             "Using reactor: twisted.internet.asyncioreactor.AsyncioSelectorReactor"
             in log
-        )
-
-    def test_explicit_default_reactor(self):
-        log = self.run_script("explicit_default_reactor.py")
-        assert "Spider closed (finished)" in log
-        assert (
-            "Using reactor: twisted.internet.asyncioreactor.AsyncioSelectorReactor"
-            not in log
         )
 
     def test_multi_parallel(self):
@@ -1003,6 +1045,39 @@ class TestCrawlerRunnerSubprocess(ScriptRunnerMixin):
             r"Spider opened.+Closing spider.+Spider opened.+Closing spider",
             log,
             re.DOTALL,
+        )
+
+    @pytest.mark.requires_uvloop
+    def test_custom_loop_same(self):
+        log = self.run_script("custom_loop_same.py")
+        assert "Spider closed (finished)" in log
+        assert (
+            "Using reactor: twisted.internet.asyncioreactor.AsyncioSelectorReactor"
+            in log
+        )
+        assert "Using asyncio event loop: uvloop.Loop" in log
+
+    @pytest.mark.requires_uvloop
+    def test_custom_loop_different(self):
+        log = self.run_script("custom_loop_different.py")
+        assert "Spider closed (finished)" not in log
+        assert (
+            "does not match the one specified in the ASYNCIO_EVENT_LOOP "
+            "setting (uvloop.Loop)"
+        ) in log
+
+
+class TestCrawlerRunnerSubprocess(TestCrawlerRunnerSubprocessBase):
+    @property
+    def script_dir(self) -> Path:
+        return self.get_script_dir("CrawlerRunner")
+
+    def test_explicit_default_reactor(self):
+        log = self.run_script("explicit_default_reactor.py")
+        assert "Spider closed (finished)" in log
+        assert (
+            "Using reactor: twisted.internet.asyncioreactor.AsyncioSelectorReactor"
+            not in log
         )
 
     def test_response_ip_address(self):
@@ -1020,86 +1095,16 @@ class TestCrawlerRunnerSubprocess(ScriptRunnerMixin):
         )
         assert "DEBUG: Using asyncio event loop" in log
 
-    @pytest.mark.requires_uvloop
-    def test_custom_loop_same(self):
-        log = self.run_script("custom_loop_same.py")
-        assert "Spider closed (finished)" in log
-        assert (
-            "Using reactor: twisted.internet.asyncioreactor.AsyncioSelectorReactor"
-            in log
-        )
-        assert "Using asyncio event loop: uvloop.Loop" in log
 
-    @pytest.mark.requires_uvloop
-    def test_custom_loop_different(self):
-        log = self.run_script("custom_loop_different.py")
-        assert "Spider closed (finished)" not in log
-        assert (
-            "does not match the one specified in the ASYNCIO_EVENT_LOOP "
-            "setting (uvloop.Loop)"
-        ) in log
-
-
-class TestAsyncCrawlerRunnerSubprocess(ScriptRunnerMixin):
-    script_dir = Path(__file__).parent.resolve() / "AsyncCrawlerRunner"
-
-    def test_simple(self):
-        log = self.run_script("simple.py")
-        assert "Spider closed (finished)" in log
-        assert (
-            "Using reactor: twisted.internet.asyncioreactor.AsyncioSelectorReactor"
-            in log
-        )
+class TestAsyncCrawlerRunnerSubprocess(TestCrawlerRunnerSubprocessBase):
+    @property
+    def script_dir(self) -> Path:
+        return self.get_script_dir("AsyncCrawlerRunner")
 
     def test_simple_default_reactor(self):
         log = self.run_script("simple_default_reactor.py")
         assert "Spider closed (finished)" not in log
         assert "RuntimeError: AsyncCrawlerRunner requires AsyncioSelectorReactor" in log
-
-    def test_multi_parallel(self):
-        log = self.run_script("multi_parallel.py")
-        assert "Spider closed (finished)" in log
-        assert (
-            "Using reactor: twisted.internet.asyncioreactor.AsyncioSelectorReactor"
-            in log
-        )
-        assert re.search(
-            r"Spider opened.+Spider opened.+Closing spider.+Closing spider",
-            log,
-            re.DOTALL,
-        )
-
-    def test_multi_seq(self):
-        log = self.run_script("multi_seq.py")
-        assert "Spider closed (finished)" in log
-        assert (
-            "Using reactor: twisted.internet.asyncioreactor.AsyncioSelectorReactor"
-            in log
-        )
-        assert re.search(
-            r"Spider opened.+Closing spider.+Spider opened.+Closing spider",
-            log,
-            re.DOTALL,
-        )
-
-    @pytest.mark.requires_uvloop
-    def test_custom_loop_same(self):
-        log = self.run_script("custom_loop_same.py")
-        assert "Spider closed (finished)" in log
-        assert (
-            "Using reactor: twisted.internet.asyncioreactor.AsyncioSelectorReactor"
-            in log
-        )
-        assert "Using asyncio event loop: uvloop.Loop" in log
-
-    @pytest.mark.requires_uvloop
-    def test_custom_loop_different(self):
-        log = self.run_script("custom_loop_different.py")
-        assert "Spider closed (finished)" not in log
-        assert (
-            "does not match the one specified in the ASYNCIO_EVENT_LOOP "
-            "setting (uvloop.Loop)"
-        ) in log
 
 
 @pytest.mark.parametrize(

--- a/tests/test_utils_asyncio.py
+++ b/tests/test_utils_asyncio.py
@@ -6,6 +6,7 @@ from twisted.trial.unittest import TestCase
 
 from scrapy.utils.defer import deferred_f_from_coro_f
 from scrapy.utils.reactor import (
+    _asyncio_reactor_path,
     install_reactor,
     is_asyncio_reactor_installed,
     set_asyncio_event_loop,
@@ -22,7 +23,7 @@ class TestAsyncio(TestCase):
         from twisted.internet import reactor as original_reactor
 
         with warnings.catch_warnings(record=True) as w:
-            install_reactor("twisted.internet.asyncioreactor.AsyncioSelectorReactor")
+            install_reactor(_asyncio_reactor_path)
             assert len(w) == 0
         from twisted.internet import reactor  # pylint: disable=reimported
 
@@ -31,5 +32,5 @@ class TestAsyncio(TestCase):
     @pytest.mark.only_asyncio
     @deferred_f_from_coro_f
     async def test_set_asyncio_event_loop(self):
-        install_reactor("twisted.internet.asyncioreactor.AsyncioSelectorReactor")
+        install_reactor(_asyncio_reactor_path)
         assert set_asyncio_event_loop(None) is asyncio.get_running_loop()


### PR DESCRIPTION
Fixes #6792, fixes #6790. Still doesn't progress #6047, I need to think about it later and it's not a blocker, I just hoped we will get it for free.

It was necessary to stop supporting overriding the `ASYNCIO_EVENT_LOOP` value in add-ons and spiders when using `AsyncCrawlerProcess` because it's hard and maybe impossible to support that without some other compromise, and this solution doesn't require extensive code changes. We moved the reactor initialization from early to late in #6038, because we wanted users to still be able to set `TWISTED_REACTOR` in the per-spider settings after the `Crawler` changes in that PR, but `AsyncCrawlerProcess` implies not doing that, and `ASYNCIO_EVENT_LOOP` should be a smaller problem.

I refactored tests in `test_crawler.py` as most tests are shared between `AsyncCrawlerProcess` and `CrawlerProcess`, the latter having also additional tests related to different reactors.