### PR TITLE
Make the release notes URL work better on PyPI.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,8 +58,7 @@ Homepage = "https://scrapy.org/"
 Documentation = "https://docs.scrapy.org/"
 Source = "https://github.com/scrapy/scrapy"
 Tracker = "https://github.com/scrapy/scrapy/issues"
-Changelog = "https://github.com/scrapy/scrapy/commits/master/"
-releasenotes = "https://docs.scrapy.org/en/latest/news.html"
+"Release notes" = "https://docs.scrapy.org/en/latest/news.html"
 
 [project.scripts]
 scrapy = "scrapy.cmdline:execute"


### PR DESCRIPTION
Follow more strict https://docs.pypi.org/project_metadata/#icons instead of https://packaging.python.org/en/latest/specifications/well-known-project-urls/