### PR TITLE
Shorten the README and remove broken links to scrapy.org

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -38,74 +38,24 @@
    :target: https://deepwiki.com/scrapy/scrapy
    :alt: Ask DeepWiki
 
-Scrapy is a BSD-licensed fast high-level web crawling and web scraping
-framework, used to crawl websites and extract structured data from their pages.
-It can be used for a wide range of purposes, from data mining to monitoring and
-automated testing.
-
-Scrapy is maintained by Zyte_ (formerly Scrapinghub) and `many other
-contributors`_.
+Scrapy_ is a web scraping framework to extract structured data from websites.
+It is cross-platform, and requires Python 3.9+. It is maintained by Zyte_
+(formerly Scrapinghub) and `many other contributors`_.
 
 .. _many other contributors: https://github.com/scrapy/scrapy/graphs/contributors
+.. _Scrapy: https://scrapy.org/
 .. _Zyte: https://www.zyte.com/
 
-Check the Scrapy homepage at https://scrapy.org for more information,
-including a list of features.
-
-
-Requirements
-============
-
-* Python 3.9+
-* Works on Linux, Windows, macOS, BSD
-
-Install
-=======
-
-The quick way:
+Install with:
 
 .. code:: bash
 
     pip install scrapy
 
-See the install section in the documentation at
-https://docs.scrapy.org/en/latest/intro/install.html for more details.
+And follow the documentation_ to learn how to use it.
 
-Documentation
-=============
+.. _documentation: https://docs.scrapy.org/en/latest/
 
-Documentation is available online at https://docs.scrapy.org/ and in the ``docs``
-directory.
+If you wish to contribute, see Contributing_.
 
-Releases
-========
-
-You can check https://docs.scrapy.org/en/latest/news.html for the release notes.
-
-Community (blog, twitter, mail list, IRC)
-=========================================
-
-See https://scrapy.org/community/ for details.
-
-Contributing
-============
-
-See https://docs.scrapy.org/en/master/contributing.html for details.
-
-Code of Conduct
----------------
-
-Please note that this project is released with a Contributor `Code of Conduct <https://github.com/scrapy/scrapy/blob/master/CODE_OF_CONDUCT.md>`_.
-
-By participating in this project you agree to abide by its terms.
-Please report unacceptable behavior to opensource@zyte.com.
-
-Companies using Scrapy
-======================
-
-See https://scrapy.org/companies/ for a list.
-
-Commercial Support
-==================
-
-See https://scrapy.org/support/ for details.
+.. _Contributing: https://docs.scrapy.org/en/master/contributing.html

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -6,8 +6,13 @@ Contributing to Scrapy
 
 .. important::
 
-    Double check that you are reading the most recent version of this document at
-    https://docs.scrapy.org/en/master/contributing.html
+    Double check that you are reading the most recent version of this document
+    at https://docs.scrapy.org/en/master/contributing.html
+
+    By participating in this project you agree to abide by the terms of our
+    `Code of Conduct
+    <https://github.com/scrapy/scrapy/blob/master/CODE_OF_CONDUCT.md>`_. Please
+    report unacceptable behavior to opensource@zyte.com.
 
 There are many ways to contribute to Scrapy. Here are some of them:
 


### PR DESCRIPTION
The original goal was to remove 2 links to https://scrapy.org/ pages that no longer work after the recent redesign.

However, I went a bit overboard, and took the chance to trim the README quite a bit. I even pondered removing the installation instructions altogether, and let people follow the docs to get install instructions.

I’m OK with reverting to a minimal changeset that simply removes the 2 sections with broken links.