### PR TITLE
Reduce deps on unittest, unify inlineCallbacks imports in tests.

### DIFF
--- a/tests/test_closespider.py
+++ b/tests/test_closespider.py
@@ -1,4 +1,4 @@
-from twisted.internet import defer
+from twisted.internet.defer import inlineCallbacks
 from twisted.trial.unittest import TestCase
 
 from scrapy.utils.test import get_crawler
@@ -22,7 +22,7 @@ class TestCloseSpider(TestCase):
     def tearDownClass(cls):
         cls.mockserver.__exit__(None, None, None)
 
-    @defer.inlineCallbacks
+    @inlineCallbacks
     def test_closespider_itemcount(self):
         close_on = 5
         crawler = get_crawler(ItemSpider, {"CLOSESPIDER_ITEMCOUNT": close_on})
@@ -32,7 +32,7 @@ class TestCloseSpider(TestCase):
         itemcount = crawler.stats.get_value("item_scraped_count")
         assert itemcount >= close_on
 
-    @defer.inlineCallbacks
+    @inlineCallbacks
     def test_closespider_pagecount(self):
         close_on = 5
         crawler = get_crawler(FollowAllSpider, {"CLOSESPIDER_PAGECOUNT": close_on})
@@ -42,7 +42,7 @@ class TestCloseSpider(TestCase):
         pagecount = crawler.stats.get_value("response_received_count")
         assert pagecount >= close_on
 
-    @defer.inlineCallbacks
+    @inlineCallbacks
     def test_closespider_pagecount_no_item(self):
         close_on = 5
         max_items = 5
@@ -62,7 +62,7 @@ class TestCloseSpider(TestCase):
         itemcount = crawler.stats.get_value("item_scraped_count")
         assert pagecount <= close_on + itemcount
 
-    @defer.inlineCallbacks
+    @inlineCallbacks
     def test_closespider_pagecount_no_item_with_pagecount(self):
         close_on_pagecount_no_item = 5
         close_on_pagecount = 20
@@ -79,7 +79,7 @@ class TestCloseSpider(TestCase):
         pagecount = crawler.stats.get_value("response_received_count")
         assert pagecount < close_on_pagecount
 
-    @defer.inlineCallbacks
+    @inlineCallbacks
     def test_closespider_errorcount(self):
         close_on = 5
         crawler = get_crawler(ErrorSpider, {"CLOSESPIDER_ERRORCOUNT": close_on})
@@ -91,7 +91,7 @@ class TestCloseSpider(TestCase):
         assert crawler.stats.get_value("spider_exceptions/count") >= close_on
         assert errorcount >= close_on
 
-    @defer.inlineCallbacks
+    @inlineCallbacks
     def test_closespider_timeout(self):
         close_on = 0.1
         crawler = get_crawler(FollowAllSpider, {"CLOSESPIDER_TIMEOUT": close_on})
@@ -101,7 +101,7 @@ class TestCloseSpider(TestCase):
         total_seconds = crawler.stats.get_value("elapsed_time_seconds")
         assert total_seconds >= close_on
 
-    @defer.inlineCallbacks
+    @inlineCallbacks
     def test_closespider_timeout_no_item(self):
         timeout = 1
         crawler = get_crawler(SlowSpider, {"CLOSESPIDER_TIMEOUT_NO_ITEM": timeout})

--- a/tests/test_command_fetch.py
+++ b/tests/test_command_fetch.py
@@ -1,4 +1,4 @@
-from twisted.internet import defer
+from twisted.internet.defer import inlineCallbacks
 from twisted.trial import unittest
 
 from tests.utils.testproc import ProcessTest
@@ -8,17 +8,17 @@ from tests.utils.testsite import SiteTest
 class TestFetchCommand(ProcessTest, SiteTest, unittest.TestCase):
     command = "fetch"
 
-    @defer.inlineCallbacks
+    @inlineCallbacks
     def test_output(self):
         _, out, _ = yield self.execute([self.url("/text")])
         assert out.strip() == b"Works"
 
-    @defer.inlineCallbacks
+    @inlineCallbacks
     def test_redirect_default(self):
         _, out, _ = yield self.execute([self.url("/redirect")])
         assert out.strip() == b"Redirected here"
 
-    @defer.inlineCallbacks
+    @inlineCallbacks
     def test_redirect_disabled(self):
         _, out, err = yield self.execute(
             ["--no-redirect", self.url("/redirect-no-meta-refresh")]
@@ -27,7 +27,7 @@ class TestFetchCommand(ProcessTest, SiteTest, unittest.TestCase):
         assert b"downloader/response_status_count/302" in err, err
         assert b"downloader/response_status_count/200" not in err, err
 
-    @defer.inlineCallbacks
+    @inlineCallbacks
     def test_headers(self):
         _, out, _ = yield self.execute([self.url("/text"), "--headers"])
         out = out.replace(b"\r", b"")  # required on win32

--- a/tests/test_command_parse.py
+++ b/tests/test_command_parse.py
@@ -3,7 +3,7 @@ import os
 import re
 from pathlib import Path
 
-from twisted.internet import defer
+from twisted.internet.defer import inlineCallbacks
 
 from scrapy.commands import parse
 from scrapy.settings import Settings
@@ -171,7 +171,7 @@ ITEM_PIPELINES = {{'{self.project_name}.pipelines.MyPipeline': 1}}
 """
             )
 
-    @defer.inlineCallbacks
+    @inlineCallbacks
     def test_spider_arguments(self):
         _, _, stderr = yield self.execute(
             [
@@ -187,7 +187,7 @@ ITEM_PIPELINES = {{'{self.project_name}.pipelines.MyPipeline': 1}}
         )
         assert "DEBUG: It Works!" in _textmode(stderr)
 
-    @defer.inlineCallbacks
+    @inlineCallbacks
     def test_request_with_meta(self):
         raw_json_string = '{"foo" : "baz"}'
         _, _, stderr = yield self.execute(
@@ -218,7 +218,7 @@ ITEM_PIPELINES = {{'{self.project_name}.pipelines.MyPipeline': 1}}
         )
         assert "DEBUG: It Works!" in _textmode(stderr)
 
-    @defer.inlineCallbacks
+    @inlineCallbacks
     def test_request_with_cb_kwargs(self):
         raw_json_string = '{"foo" : "bar", "key": "value"}'
         _, _, stderr = yield self.execute(
@@ -239,7 +239,7 @@ ITEM_PIPELINES = {{'{self.project_name}.pipelines.MyPipeline': 1}}
             "DEBUG: request.callback signature: (response, foo=None, key=None)" in log
         )
 
-    @defer.inlineCallbacks
+    @inlineCallbacks
     def test_request_without_meta(self):
         _, _, stderr = yield self.execute(
             [
@@ -253,7 +253,7 @@ ITEM_PIPELINES = {{'{self.project_name}.pipelines.MyPipeline': 1}}
         )
         assert "DEBUG: It Works!" in _textmode(stderr)
 
-    @defer.inlineCallbacks
+    @inlineCallbacks
     def test_pipelines(self):
         _, _, stderr = yield self.execute(
             [
@@ -268,7 +268,7 @@ ITEM_PIPELINES = {{'{self.project_name}.pipelines.MyPipeline': 1}}
         )
         assert "INFO: It Works!" in _textmode(stderr)
 
-    @defer.inlineCallbacks
+    @inlineCallbacks
     def test_async_def_asyncio_parse_items_list(self):
         status, out, stderr = yield self.execute(
             [
@@ -283,7 +283,7 @@ ITEM_PIPELINES = {{'{self.project_name}.pipelines.MyPipeline': 1}}
         assert "{'id': 1}" in _textmode(out)
         assert "{'id': 2}" in _textmode(out)
 
-    @defer.inlineCallbacks
+    @inlineCallbacks
     def test_async_def_asyncio_parse_items_single_element(self):
         status, out, stderr = yield self.execute(
             [
@@ -297,7 +297,7 @@ ITEM_PIPELINES = {{'{self.project_name}.pipelines.MyPipeline': 1}}
         assert "INFO: Got response 200" in _textmode(stderr)
         assert "{'foo': 42}" in _textmode(out)
 
-    @defer.inlineCallbacks
+    @inlineCallbacks
     def test_async_def_asyncgen_parse_loop(self):
         status, out, stderr = yield self.execute(
             [
@@ -312,7 +312,7 @@ ITEM_PIPELINES = {{'{self.project_name}.pipelines.MyPipeline': 1}}
         for i in range(10):
             assert f"{{'foo': {i}}}" in _textmode(out)
 
-    @defer.inlineCallbacks
+    @inlineCallbacks
     def test_async_def_asyncgen_parse_exc(self):
         status, out, stderr = yield self.execute(
             [
@@ -327,7 +327,7 @@ ITEM_PIPELINES = {{'{self.project_name}.pipelines.MyPipeline': 1}}
         for i in range(7):
             assert f"{{'foo': {i}}}" in _textmode(out)
 
-    @defer.inlineCallbacks
+    @inlineCallbacks
     def test_async_def_asyncio_parse(self):
         _, _, stderr = yield self.execute(
             [
@@ -340,21 +340,21 @@ ITEM_PIPELINES = {{'{self.project_name}.pipelines.MyPipeline': 1}}
         )
         assert "DEBUG: Got response 200" in _textmode(stderr)
 
-    @defer.inlineCallbacks
+    @inlineCallbacks
     def test_parse_items(self):
         status, out, stderr = yield self.execute(
             ["--spider", self.spider_name, "-c", "parse", self.url("/html")]
         )
         assert "[{}, {'foo': 'bar'}]" in _textmode(out)
 
-    @defer.inlineCallbacks
+    @inlineCallbacks
     def test_parse_items_no_callback_passed(self):
         status, out, stderr = yield self.execute(
             ["--spider", self.spider_name, self.url("/html")]
         )
         assert "[{}, {'foo': 'bar'}]" in _textmode(out)
 
-    @defer.inlineCallbacks
+    @inlineCallbacks
     def test_wrong_callback_passed(self):
         status, out, stderr = yield self.execute(
             ["--spider", self.spider_name, "-c", "dummy", self.url("/html")]
@@ -362,7 +362,7 @@ ITEM_PIPELINES = {{'{self.project_name}.pipelines.MyPipeline': 1}}
         assert re.search(r"# Scraped Items  -+\n\[\]", _textmode(out))
         assert "Cannot find callback" in _textmode(stderr)
 
-    @defer.inlineCallbacks
+    @inlineCallbacks
     def test_crawlspider_matching_rule_callback_set(self):
         """If a rule matches the URL, use it's defined callback."""
         status, out, stderr = yield self.execute(
@@ -370,7 +370,7 @@ ITEM_PIPELINES = {{'{self.project_name}.pipelines.MyPipeline': 1}}
         )
         assert "[{}, {'foo': 'bar'}]" in _textmode(out)
 
-    @defer.inlineCallbacks
+    @inlineCallbacks
     def test_crawlspider_matching_rule_default_callback(self):
         """If a rule match but it has no callback set, use the 'parse' callback."""
         status, out, stderr = yield self.execute(
@@ -378,7 +378,7 @@ ITEM_PIPELINES = {{'{self.project_name}.pipelines.MyPipeline': 1}}
         )
         assert "[{}, {'nomatch': 'default'}]" in _textmode(out)
 
-    @defer.inlineCallbacks
+    @inlineCallbacks
     def test_spider_with_no_rules_attribute(self):
         """Using -r with a spider with no rule should not produce items."""
         status, out, stderr = yield self.execute(
@@ -387,14 +387,14 @@ ITEM_PIPELINES = {{'{self.project_name}.pipelines.MyPipeline': 1}}
         assert re.search(r"# Scraped Items  -+\n\[\]", _textmode(out))
         assert "No CrawlSpider rules found" in _textmode(stderr)
 
-    @defer.inlineCallbacks
+    @inlineCallbacks
     def test_crawlspider_missing_callback(self):
         status, out, stderr = yield self.execute(
             ["--spider", "badcrawl" + self.spider_name, "-r", self.url("/html")]
         )
         assert re.search(r"# Scraped Items  -+\n\[\]", _textmode(out))
 
-    @defer.inlineCallbacks
+    @inlineCallbacks
     def test_crawlspider_no_matching_rule(self):
         """The requested URL has no matching rule, so no items should be scraped"""
         status, out, stderr = yield self.execute(
@@ -403,12 +403,12 @@ ITEM_PIPELINES = {{'{self.project_name}.pipelines.MyPipeline': 1}}
         assert re.search(r"# Scraped Items  -+\n\[\]", _textmode(out))
         assert "Cannot find a rule that matches" in _textmode(stderr)
 
-    @defer.inlineCallbacks
+    @inlineCallbacks
     def test_crawlspider_not_exists_with_not_matched_url(self):
         status, out, stderr = yield self.execute([self.url("/invalid_url")])
         assert status == 0
 
-    @defer.inlineCallbacks
+    @inlineCallbacks
     def test_output_flag(self):
         """Checks if a file was created successfully having
         correct format containing correct data in it.

--- a/tests/test_command_runspider.py
+++ b/tests/test_command_runspider.py
@@ -10,7 +10,6 @@ from typing import TYPE_CHECKING
 from unittest import skipIf
 
 import pytest
-from twisted.trial import unittest
 
 from tests.test_commands import TestCommandBase
 from tests.test_crawler import ExceptionSpider, NoRequestsSpider
@@ -376,7 +375,7 @@ class TestWindowsRunSpiderCommand(TestRunSpiderCommand):
 
     def setUp(self):
         if platform.system() != "Windows":
-            raise unittest.SkipTest("Windows required for .pyw files")
+            pytest.skip("Windows required for .pyw files")
         return super().setUp()
 
     def test_start_errors(self):
@@ -385,4 +384,4 @@ class TestWindowsRunSpiderCommand(TestRunSpiderCommand):
         assert "badspider.pyw" in log
 
     def test_runspider_unable_to_load(self):
-        raise unittest.SkipTest("Already Tested in 'RunSpiderCommandTest' ")
+        pytest.skip("Already Tested in 'RunSpiderCommandTest' ")

--- a/tests/test_command_version.py
+++ b/tests/test_command_version.py
@@ -1,6 +1,6 @@
 import sys
 
-from twisted.internet import defer
+from twisted.internet.defer import inlineCallbacks
 from twisted.trial import unittest
 
 import scrapy
@@ -10,13 +10,13 @@ from tests.utils.testproc import ProcessTest
 class TestVersionCommand(ProcessTest, unittest.TestCase):
     command = "version"
 
-    @defer.inlineCallbacks
+    @inlineCallbacks
     def test_output(self):
         encoding = sys.stdout.encoding or "utf-8"
         _, out, _ = yield self.execute([])
         assert out.strip().decode(encoding) == f"Scrapy {scrapy.__version__}"
 
-    @defer.inlineCallbacks
+    @inlineCallbacks
     def test_verbose_output(self):
         encoding = sys.stdout.encoding or "utf-8"
         _, out, _ = yield self.execute(["-v"])

--- a/tests/test_contracts.py
+++ b/tests/test_contracts.py
@@ -1,7 +1,7 @@
 from unittest import TextTestResult
 
 import pytest
-from twisted.internet import defer
+from twisted.internet.defer import inlineCallbacks
 from twisted.python import failure
 from twisted.trial import unittest
 
@@ -502,7 +502,7 @@ class TestContractsManager(unittest.TestCase):
         assert not self.results.failures
         assert self.results.errors
 
-    @defer.inlineCallbacks
+    @inlineCallbacks
     def test_same_url(self):
         class TestSameUrlSpider(Spider):
             name = "test_same_url"

--- a/tests/test_crawl.py
+++ b/tests/test_crawl.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import json
 import logging
-import unittest
 from ipaddress import IPv4Address
 from socket import gethostbyname
 from typing import Any
@@ -10,7 +9,7 @@ from urllib.parse import urlparse
 
 import pytest
 from testfixtures import LogCapture
-from twisted.internet import defer
+from twisted.internet.defer import inlineCallbacks
 from twisted.internet.ssl import Certificate
 from twisted.python.failure import Failure
 from twisted.trial.unittest import TestCase
@@ -67,21 +66,21 @@ class TestCrawl(TestCase):
     def tearDownClass(cls):
         cls.mockserver.__exit__(None, None, None)
 
-    @defer.inlineCallbacks
+    @inlineCallbacks
     def test_follow_all(self):
         crawler = get_crawler(FollowAllSpider)
         yield crawler.crawl(mockserver=self.mockserver)
         assert len(crawler.spider.urls_visited) == 11  # 10 + start_url
 
-    @defer.inlineCallbacks
+    @inlineCallbacks
     def test_fixed_delay(self):
         yield self._test_delay(total=3, delay=0.2)
 
-    @defer.inlineCallbacks
+    @inlineCallbacks
     def test_randomized_delay(self):
         yield self._test_delay(total=3, delay=0.1, randomize=True)
 
-    @defer.inlineCallbacks
+    @inlineCallbacks
     def _test_delay(self, total, delay, randomize=False):
         crawl_kwargs = {
             "maxlatency": delay * 2,
@@ -110,7 +109,7 @@ class TestCrawl(TestCase):
         average = total_time / (len(times) - 1)
         assert average <= delay / tolerance, "test total or delay values are too small"
 
-    @defer.inlineCallbacks
+    @inlineCallbacks
     def test_timeout_success(self):
         crawler = get_crawler(DelaySpider)
         yield crawler.crawl(n=0.5, mockserver=self.mockserver)
@@ -118,7 +117,7 @@ class TestCrawl(TestCase):
         assert crawler.spider.t2 > 0
         assert crawler.spider.t2 > crawler.spider.t1
 
-    @defer.inlineCallbacks
+    @inlineCallbacks
     def test_timeout_failure(self):
         crawler = get_crawler(DelaySpider, {"DOWNLOAD_TIMEOUT": 0.35})
         yield crawler.crawl(n=0.5, mockserver=self.mockserver)
@@ -135,7 +134,7 @@ class TestCrawl(TestCase):
         assert crawler.spider.t2_err > 0
         assert crawler.spider.t2_err > crawler.spider.t1
 
-    @defer.inlineCallbacks
+    @inlineCallbacks
     def test_retry_503(self):
         crawler = get_crawler(SimpleSpider)
         with LogCapture() as log:
@@ -144,7 +143,7 @@ class TestCrawl(TestCase):
             )
         self._assert_retried(log)
 
-    @defer.inlineCallbacks
+    @inlineCallbacks
     def test_retry_conn_failed(self):
         crawler = get_crawler(SimpleSpider)
         with LogCapture() as log:
@@ -153,10 +152,10 @@ class TestCrawl(TestCase):
             )
         self._assert_retried(log)
 
-    @defer.inlineCallbacks
+    @inlineCallbacks
     def test_retry_dns_error(self):
         if NON_EXISTING_RESOLVABLE:
-            raise unittest.SkipTest("Non-existing hosts are resolvable")
+            pytest.skip("Non-existing hosts are resolvable")
         crawler = get_crawler(SimpleSpider)
         with LogCapture() as log:
             # try to fetch the homepage of a nonexistent domain
@@ -165,7 +164,7 @@ class TestCrawl(TestCase):
             )
         self._assert_retried(log)
 
-    @defer.inlineCallbacks
+    @inlineCallbacks
     def test_start_bug_before_yield(self):
         with LogCapture("scrapy", level=logging.ERROR) as log:
             crawler = get_crawler(BrokenStartSpider)
@@ -176,7 +175,7 @@ class TestCrawl(TestCase):
         assert record.exc_info is not None
         assert record.exc_info[0] is ZeroDivisionError
 
-    @defer.inlineCallbacks
+    @inlineCallbacks
     def test_start_bug_yielding(self):
         with LogCapture("scrapy", level=logging.ERROR) as log:
             crawler = get_crawler(BrokenStartSpider)
@@ -187,7 +186,7 @@ class TestCrawl(TestCase):
         assert record.exc_info is not None
         assert record.exc_info[0] is ZeroDivisionError
 
-    @defer.inlineCallbacks
+    @inlineCallbacks
     def test_start_items(self):
         items = []
 
@@ -202,7 +201,7 @@ class TestCrawl(TestCase):
         assert len(log.records) == 0
         assert items == [{"name": "test item"}]
 
-    @defer.inlineCallbacks
+    @inlineCallbacks
     def test_start_unsupported_output(self):
         """Anything that is not a request is assumed to be an item, avoiding a
         potentially expensive call to itemadapter.is_item(), and letting
@@ -223,7 +222,7 @@ class TestCrawl(TestCase):
         assert len(items) == 3
         assert not any(isinstance(item, Request) for item in items)
 
-    @defer.inlineCallbacks
+    @inlineCallbacks
     def test_start_dupes(self):
         settings = {"CONCURRENT_REQUESTS": 1}
         crawler = get_crawler(DuplicateStartSpider, settings)
@@ -241,7 +240,7 @@ class TestCrawl(TestCase):
         )
         assert crawler.spider.visited == 3
 
-    @defer.inlineCallbacks
+    @inlineCallbacks
     def test_unbounded_response(self):
         # Completeness of responses without Content-Length or Transfer-Encoding
         # can not be determined, we treat them as valid but flagged as "partial"
@@ -275,7 +274,7 @@ with multiples lines
             )
         assert str(log).count("Got response 200") == 1
 
-    @defer.inlineCallbacks
+    @inlineCallbacks
     def test_retry_conn_lost(self):
         # connection lost after receiving data
         crawler = get_crawler(SimpleSpider)
@@ -285,7 +284,7 @@ with multiples lines
             )
         self._assert_retried(log)
 
-    @defer.inlineCallbacks
+    @inlineCallbacks
     def test_retry_conn_aborted(self):
         # connection lost before receiving data
         crawler = get_crawler(SimpleSpider)
@@ -299,7 +298,7 @@ with multiples lines
         assert str(log).count("Retrying") == 2
         assert str(log).count("Gave up retrying") == 1
 
-    @defer.inlineCallbacks
+    @inlineCallbacks
     def test_referer_header(self):
         """Referer header is set by RefererMiddleware unless it is already set"""
         req0 = Request(self.mockserver.url("/echo?headers=1&body=0"), dont_filter=1)
@@ -327,7 +326,7 @@ with multiples lines
         echo3 = json.loads(to_unicode(crawler.spider.meta["responses"][3].body))
         assert echo3["headers"].get("Referer") == ["http://example.com"]
 
-    @defer.inlineCallbacks
+    @inlineCallbacks
     def test_engine_status(self):
         from scrapy.utils.engine import get_engine_status
 
@@ -345,7 +344,7 @@ with multiples lines
         assert s["engine.spider.name"] == crawler.spider.name
         assert s["len(engine.scraper.slot.active)"] == 1
 
-    @defer.inlineCallbacks
+    @inlineCallbacks
     def test_format_engine_status(self):
         from scrapy.utils.engine import format_engine_status
 
@@ -370,7 +369,7 @@ with multiples lines
         assert s["engine.spider.name"] == crawler.spider.name
         assert s["len(engine.scraper.slot.active)"] == "1"
 
-    @defer.inlineCallbacks
+    @inlineCallbacks
     def test_open_spider_error_on_faulty_pipeline(self):
         settings = {
             "ITEM_PIPELINES": {
@@ -378,15 +377,13 @@ with multiples lines
             }
         }
         crawler = get_crawler(SimpleSpider, settings)
-        yield self.assertFailure(
-            crawler.crawl(
+        with pytest.raises(ZeroDivisionError):
+            yield crawler.crawl(
                 self.mockserver.url("/status?n=200"), mockserver=self.mockserver
-            ),
-            ZeroDivisionError,
-        )
+            )
         assert not crawler.crawling
 
-    @defer.inlineCallbacks
+    @inlineCallbacks
     def test_crawlerrunner_accepts_crawler(self):
         crawler = get_crawler(SimpleSpider)
         runner = CrawlerRunner()
@@ -398,7 +395,7 @@ with multiples lines
             )
         assert "Got response 200" in str(log)
 
-    @defer.inlineCallbacks
+    @inlineCallbacks
     def test_crawl_multiple(self):
         runner = CrawlerRunner(get_reactor_settings())
         runner.crawl(
@@ -431,7 +428,7 @@ class TestCrawlSpider(TestCase):
     def tearDownClass(cls):
         cls.mockserver.__exit__(None, None, None)
 
-    @defer.inlineCallbacks
+    @inlineCallbacks
     def _run_spider(self, spider_cls):
         items = []
 
@@ -446,7 +443,7 @@ class TestCrawlSpider(TestCase):
             )
         return log, items, crawler.stats
 
-    @defer.inlineCallbacks
+    @inlineCallbacks
     def test_crawlspider_with_parse(self):
         crawler = get_crawler(CrawlSpiderWithParseMethod)
         with LogCapture() as log:
@@ -456,7 +453,7 @@ class TestCrawlSpider(TestCase):
         assert "[parse] status 201 (foo: None)" in str(log)
         assert "[parse] status 202 (foo: bar)" in str(log)
 
-    @defer.inlineCallbacks
+    @inlineCallbacks
     def test_crawlspider_with_async_callback(self):
         crawler = get_crawler(CrawlSpiderWithAsyncCallback)
         with LogCapture() as log:
@@ -466,7 +463,7 @@ class TestCrawlSpider(TestCase):
         assert "[parse_async] status 201 (foo: None)" in str(log)
         assert "[parse_async] status 202 (foo: bar)" in str(log)
 
-    @defer.inlineCallbacks
+    @inlineCallbacks
     def test_crawlspider_with_async_generator_callback(self):
         crawler = get_crawler(CrawlSpiderWithAsyncGeneratorCallback)
         with LogCapture() as log:
@@ -476,7 +473,7 @@ class TestCrawlSpider(TestCase):
         assert "[parse_async_gen] status 201 (foo: None)" in str(log)
         assert "[parse_async_gen] status 202 (foo: bar)" in str(log)
 
-    @defer.inlineCallbacks
+    @inlineCallbacks
     def test_crawlspider_with_errback(self):
         crawler = get_crawler(CrawlSpiderWithErrback)
         with LogCapture() as log:
@@ -489,7 +486,7 @@ class TestCrawlSpider(TestCase):
         assert "[errback] status 500" in str(log)
         assert "[errback] status 501" in str(log)
 
-    @defer.inlineCallbacks
+    @inlineCallbacks
     def test_crawlspider_process_request_cb_kwargs(self):
         crawler = get_crawler(CrawlSpiderWithProcessRequestCallbackKeywordArguments)
         with LogCapture() as log:
@@ -499,7 +496,7 @@ class TestCrawlSpider(TestCase):
         assert "[parse] status 201 (foo: process_request)" in str(log)
         assert "[parse] status 202 (foo: bar)" in str(log)
 
-    @defer.inlineCallbacks
+    @inlineCallbacks
     def test_async_def_parse(self):
         crawler = get_crawler(AsyncDefSpider)
         with LogCapture() as log:
@@ -509,7 +506,7 @@ class TestCrawlSpider(TestCase):
         assert "Got response 200" in str(log)
 
     @pytest.mark.only_asyncio
-    @defer.inlineCallbacks
+    @inlineCallbacks
     def test_async_def_asyncio_parse(self):
         crawler = get_crawler(
             AsyncDefAsyncioSpider,
@@ -524,7 +521,7 @@ class TestCrawlSpider(TestCase):
         assert "Got response 200" in str(log)
 
     @pytest.mark.only_asyncio
-    @defer.inlineCallbacks
+    @inlineCallbacks
     def test_async_def_asyncio_parse_items_list(self):
         log, items, _ = yield self._run_spider(AsyncDefAsyncioReturnSpider)
         assert "Got response 200" in str(log)
@@ -532,7 +529,7 @@ class TestCrawlSpider(TestCase):
         assert {"id": 2} in items
 
     @pytest.mark.only_asyncio
-    @defer.inlineCallbacks
+    @inlineCallbacks
     def test_async_def_asyncio_parse_items_single_element(self):
         items = []
 
@@ -549,7 +546,7 @@ class TestCrawlSpider(TestCase):
         assert {"foo": 42} in items
 
     @pytest.mark.only_asyncio
-    @defer.inlineCallbacks
+    @inlineCallbacks
     def test_async_def_asyncgen_parse(self):
         log, _, stats = yield self._run_spider(AsyncDefAsyncioGenSpider)
         assert "Got response 200" in str(log)
@@ -557,7 +554,7 @@ class TestCrawlSpider(TestCase):
         assert itemcount == 1
 
     @pytest.mark.only_asyncio
-    @defer.inlineCallbacks
+    @inlineCallbacks
     def test_async_def_asyncgen_parse_loop(self):
         log, items, stats = yield self._run_spider(AsyncDefAsyncioGenLoopSpider)
         assert "Got response 200" in str(log)
@@ -567,7 +564,7 @@ class TestCrawlSpider(TestCase):
             assert {"foo": i} in items
 
     @pytest.mark.only_asyncio
-    @defer.inlineCallbacks
+    @inlineCallbacks
     def test_async_def_asyncgen_parse_exc(self):
         log, items, stats = yield self._run_spider(AsyncDefAsyncioGenExcSpider)
         log = str(log)
@@ -579,7 +576,7 @@ class TestCrawlSpider(TestCase):
             assert {"foo": i} in items
 
     @pytest.mark.only_asyncio
-    @defer.inlineCallbacks
+    @inlineCallbacks
     def test_async_def_asyncgen_parse_complex(self):
         _, items, stats = yield self._run_spider(AsyncDefAsyncioGenComplexSpider)
         itemcount = stats.get_value("item_scraped_count")
@@ -591,37 +588,37 @@ class TestCrawlSpider(TestCase):
             assert {"index2": i} in items
 
     @pytest.mark.only_asyncio
-    @defer.inlineCallbacks
+    @inlineCallbacks
     def test_async_def_asyncio_parse_reqs_list(self):
         log, *_ = yield self._run_spider(AsyncDefAsyncioReqsReturnSpider)
         for req_id in range(3):
             assert f"Got response 200, req_id {req_id}" in str(log)
 
     @pytest.mark.only_not_asyncio
-    @defer.inlineCallbacks
+    @inlineCallbacks
     def test_async_def_deferred_direct(self):
         _, items, _ = yield self._run_spider(AsyncDefDeferredDirectSpider)
         assert items == [{"code": 200}]
 
     @pytest.mark.only_asyncio
-    @defer.inlineCallbacks
+    @inlineCallbacks
     def test_async_def_deferred_wrapped(self):
         log, items, _ = yield self._run_spider(AsyncDefDeferredWrappedSpider)
         assert items == [{"code": 200}]
 
-    @defer.inlineCallbacks
+    @inlineCallbacks
     def test_async_def_deferred_maybe_wrapped(self):
         _, items, _ = yield self._run_spider(AsyncDefDeferredMaybeWrappedSpider)
         assert items == [{"code": 200}]
 
-    @defer.inlineCallbacks
+    @inlineCallbacks
     def test_response_ssl_certificate_none(self):
         crawler = get_crawler(SingleRequestSpider)
         url = self.mockserver.url("/echo?body=test", is_secure=False)
         yield crawler.crawl(seed=url, mockserver=self.mockserver)
         assert crawler.spider.meta["responses"][0].certificate is None
 
-    @defer.inlineCallbacks
+    @inlineCallbacks
     def test_response_ssl_certificate(self):
         crawler = get_crawler(SingleRequestSpider)
         url = self.mockserver.url("/echo?body=test", is_secure=True)
@@ -634,7 +631,7 @@ class TestCrawlSpider(TestCase):
     @pytest.mark.xfail(
         reason="Responses with no body return early and contain no certificate"
     )
-    @defer.inlineCallbacks
+    @inlineCallbacks
     def test_response_ssl_certificate_empty_response(self):
         crawler = get_crawler(SingleRequestSpider)
         url = self.mockserver.url("/status?n=200", is_secure=True)
@@ -644,7 +641,7 @@ class TestCrawlSpider(TestCase):
         assert cert.getSubject().commonName == b"localhost"
         assert cert.getIssuer().commonName == b"localhost"
 
-    @defer.inlineCallbacks
+    @inlineCallbacks
     def test_dns_server_ip_address_none(self):
         crawler = get_crawler(SingleRequestSpider)
         url = self.mockserver.url("/status?n=200")
@@ -652,7 +649,7 @@ class TestCrawlSpider(TestCase):
         ip_address = crawler.spider.meta["responses"][0].ip_address
         assert ip_address is None
 
-    @defer.inlineCallbacks
+    @inlineCallbacks
     def test_dns_server_ip_address(self):
         crawler = get_crawler(SingleRequestSpider)
         url = self.mockserver.url("/echo?body=test")
@@ -662,7 +659,7 @@ class TestCrawlSpider(TestCase):
         assert isinstance(ip_address, IPv4Address)
         assert str(ip_address) == gethostbyname(expected_netloc)
 
-    @defer.inlineCallbacks
+    @inlineCallbacks
     def test_bytes_received_stop_download_callback(self):
         crawler = get_crawler(BytesReceivedCallbackSpider)
         yield crawler.crawl(mockserver=self.mockserver)
@@ -676,7 +673,7 @@ class TestCrawlSpider(TestCase):
             < crawler.spider.full_response_length
         )
 
-    @defer.inlineCallbacks
+    @inlineCallbacks
     def test_bytes_received_stop_download_errback(self):
         crawler = get_crawler(BytesReceivedErrbackSpider)
         yield crawler.crawl(mockserver=self.mockserver)
@@ -692,7 +689,7 @@ class TestCrawlSpider(TestCase):
             < crawler.spider.full_response_length
         )
 
-    @defer.inlineCallbacks
+    @inlineCallbacks
     def test_headers_received_stop_download_callback(self):
         crawler = get_crawler(HeadersReceivedCallbackSpider)
         yield crawler.crawl(mockserver=self.mockserver)
@@ -702,7 +699,7 @@ class TestCrawlSpider(TestCase):
             "headers_received"
         )
 
-    @defer.inlineCallbacks
+    @inlineCallbacks
     def test_headers_received_stop_download_errback(self):
         crawler = get_crawler(HeadersReceivedErrbackSpider)
         yield crawler.crawl(mockserver=self.mockserver)
@@ -714,7 +711,7 @@ class TestCrawlSpider(TestCase):
             "failure"
         ].value.response.headers == crawler.spider.meta.get("headers_received")
 
-    @defer.inlineCallbacks
+    @inlineCallbacks
     def test_spider_errback(self):
         failures = []
 
@@ -731,7 +728,7 @@ class TestCrawlSpider(TestCase):
         assert "HTTP status code is not handled or not allowed" in str(log)
         assert "Spider error processing" not in str(log)
 
-    @defer.inlineCallbacks
+    @inlineCallbacks
     def test_spider_errback_silence(self):
         failures = []
 
@@ -747,7 +744,7 @@ class TestCrawlSpider(TestCase):
         assert "HTTP status code is not handled or not allowed" not in str(log)
         assert "Spider error processing" not in str(log)
 
-    @defer.inlineCallbacks
+    @inlineCallbacks
     def test_spider_errback_exception(self):
         def eb(failure: Failure) -> None:
             raise ValueError("foo")
@@ -759,7 +756,7 @@ class TestCrawlSpider(TestCase):
             )
         assert "Spider error processing" in str(log)
 
-    @defer.inlineCallbacks
+    @inlineCallbacks
     def test_spider_errback_item(self):
         def eb(failure: Failure) -> Any:
             return {"foo": "bar"}
@@ -773,7 +770,7 @@ class TestCrawlSpider(TestCase):
         assert "Spider error processing" not in str(log)
         assert "'item_scraped_count': 1" in str(log)
 
-    @defer.inlineCallbacks
+    @inlineCallbacks
     def test_spider_errback_request(self):
         def eb(failure: Failure) -> Request:
             return Request(self.mockserver.url("/"))
@@ -787,7 +784,7 @@ class TestCrawlSpider(TestCase):
         assert "Spider error processing" not in str(log)
         assert "Crawled (200)" in str(log)
 
-    @defer.inlineCallbacks
+    @inlineCallbacks
     def test_spider_errback_downloader_error(self):
         failures = []
 
@@ -804,7 +801,7 @@ class TestCrawlSpider(TestCase):
         assert "Error downloading" in str(log)
         assert "Spider error processing" not in str(log)
 
-    @defer.inlineCallbacks
+    @inlineCallbacks
     def test_spider_errback_downloader_error_exception(self):
         def eb(failure: Failure) -> None:
             raise ValueError("foo")
@@ -817,7 +814,7 @@ class TestCrawlSpider(TestCase):
         assert "Error downloading" in str(log)
         assert "Spider error processing" in str(log)
 
-    @defer.inlineCallbacks
+    @inlineCallbacks
     def test_spider_errback_downloader_error_item(self):
         def eb(failure: Failure) -> Any:
             return {"foo": "bar"}
@@ -831,7 +828,7 @@ class TestCrawlSpider(TestCase):
         assert "Spider error processing" not in str(log)
         assert "'item_scraped_count': 1" in str(log)
 
-    @defer.inlineCallbacks
+    @inlineCallbacks
     def test_spider_errback_downloader_error_request(self):
         def eb(failure: Failure) -> Request:
             return Request(self.mockserver.url("/"))
@@ -845,7 +842,7 @@ class TestCrawlSpider(TestCase):
         assert "Spider error processing" not in str(log)
         assert "Crawled (200)" in str(log)
 
-    @defer.inlineCallbacks
+    @inlineCallbacks
     def test_raise_closespider(self):
         def cb(response):
             raise CloseSpider
@@ -856,7 +853,7 @@ class TestCrawlSpider(TestCase):
         assert "Closing spider (cancelled)" in str(log)
         assert "Spider error processing" not in str(log)
 
-    @defer.inlineCallbacks
+    @inlineCallbacks
     def test_raise_closespider_reason(self):
         def cb(response):
             raise CloseSpider("my_reason")

--- a/tests/test_dependencies.py
+++ b/tests/test_dependencies.py
@@ -1,25 +1,13 @@
 import os
 import re
 from configparser import ConfigParser
-from importlib import import_module
 from pathlib import Path
 
 import pytest
 from twisted import version as twisted_version
-from twisted.trial import unittest
 
 
 class TestScrapyUtils:
-    def test_required_openssl_version(self):
-        try:
-            module = import_module("OpenSSL")
-        except ImportError:
-            raise unittest.SkipTest("OpenSSL is not available")
-
-        if hasattr(module, "__version__"):
-            installed_version = [int(x) for x in module.__version__.split(".")[:2]]
-            assert installed_version >= [0, 6], "OpenSSL >= 0.6 required"
-
     def test_pinned_twisted_version(self):
         """When running tests within a Tox environment with pinned
         dependencies, make sure that the version of Twisted is the pinned

--- a/tests/test_downloader_handlers.py
+++ b/tests/test_downloader_handlers.py
@@ -440,7 +440,7 @@ class TestFTPBase(unittest.TestCase):
 class TestFTP(TestFTPBase):
     def test_invalid_credentials(self):
         if self.reactor_pytest != "default" and sys.platform == "win32":
-            raise unittest.SkipTest(
+            pytest.skip(
                 "This test produces DirtyReactorAggregateError on Windows with asyncio"
             )
         from twisted.protocols.ftp import ConnectionLost

--- a/tests/test_downloader_handlers_http_base.py
+++ b/tests/test_downloader_handlers_http_base.py
@@ -14,7 +14,7 @@ from unittest import mock
 import pytest
 from testfixtures import LogCapture
 from twisted.internet import defer, error
-from twisted.internet.defer import maybeDeferred
+from twisted.internet.defer import inlineCallbacks, maybeDeferred
 from twisted.protocols.policies import WrappingFactory
 from twisted.trial import unittest
 from twisted.web import resource, server, static, util
@@ -186,7 +186,7 @@ class TestHttpBase(unittest.TestCase, ABC):
             self.download_handler_cls, get_crawler()
         )
 
-    @defer.inlineCallbacks
+    @inlineCallbacks
     def tearDown(self):
         yield self.port.stopListening()
         if hasattr(self.download_handler, "close"):
@@ -229,7 +229,7 @@ class TestHttpBase(unittest.TestCase, ABC):
     async def test_timeout_download_from_spider_nodata_rcvd(self):
         if self.reactor_pytest != "default" and sys.platform == "win32":
             # https://twistedmatrix.com/trac/ticket/10279
-            raise unittest.SkipTest(
+            pytest.skip(
                 "This test produces DirtyReactorAggregateError on Windows with asyncio"
             )
 
@@ -245,7 +245,7 @@ class TestHttpBase(unittest.TestCase, ABC):
     async def test_timeout_download_from_spider_server_hangs(self):
         if self.reactor_pytest != "default" and sys.platform == "win32":
             # https://twistedmatrix.com/trac/ticket/10279
-            raise unittest.SkipTest(
+            pytest.skip(
                 "This test produces DirtyReactorAggregateError on Windows with asyncio"
             )
         # client connects, server send headers and some body bytes but hangs
@@ -531,7 +531,7 @@ class TestSimpleHttpsBase(unittest.TestCase, ABC):
         crawler = get_crawler(settings_dict=settings_dict)
         self.download_handler = build_from_crawler(self.download_handler_cls, crawler)
 
-    @defer.inlineCallbacks
+    @inlineCallbacks
     def tearDown(self):
         yield self.port.stopListening()
         if hasattr(self.download_handler, "close"):
@@ -665,7 +665,7 @@ class TestHttpProxyBase(unittest.TestCase, ABC):
             self.download_handler_cls, get_crawler()
         )
 
-    @defer.inlineCallbacks
+    @inlineCallbacks
     def tearDown(self):
         yield self.port.stopListening()
         if hasattr(self.download_handler, "close"):

--- a/tests/test_downloadermiddleware_httpcompression.py
+++ b/tests/test_downloadermiddleware_httpcompression.py
@@ -2,7 +2,6 @@ from gzip import GzipFile
 from io import BytesIO
 from logging import WARNING
 from pathlib import Path
-from unittest import SkipTest
 
 import pytest
 from testfixtures import LogCapture
@@ -130,7 +129,7 @@ class TestHttpCompression:
             except ImportError:
                 import brotlicffi  # noqa: F401
         except ImportError:
-            raise SkipTest("no brotli")
+            pytest.skip("no brotli")
         response = self._getresponse("br")
         request = response.request
         assert response.headers["Content-Encoding"] == b"br"
@@ -146,11 +145,11 @@ class TestHttpCompression:
             try:
                 import brotli  # noqa: F401
 
-                raise SkipTest("Requires not having brotli support")
+                pytest.skip("Requires not having brotli support")
             except ImportError:
                 import brotlicffi  # noqa: F401
 
-                raise SkipTest("Requires not having brotli support")
+                pytest.skip("Requires not having brotli support")
         except ImportError:
             pass
         response = self._getresponse("br")
@@ -180,7 +179,7 @@ class TestHttpCompression:
         try:
             import zstandard  # noqa: F401
         except ImportError:
-            raise SkipTest("no zstd support (zstandard)")
+            pytest.skip("no zstd support (zstandard)")
         raw_content = None
         for check_key in FORMAT:
             if not check_key.startswith("zstd-"):
@@ -201,7 +200,7 @@ class TestHttpCompression:
         try:
             import zstandard  # noqa: F401
 
-            raise SkipTest("Requires not having zstandard support")
+            pytest.skip("Requires not having zstandard support")
         except ImportError:
             pass
         response = self._getresponse("zstd-static-content-size")
@@ -520,7 +519,7 @@ class TestHttpCompression:
             except ImportError:
                 import brotlicffi  # noqa: F401
         except ImportError:
-            raise SkipTest("no brotli")
+            pytest.skip("no brotli")
         self._test_compression_bomb_setting("br")
 
     def test_compression_bomb_setting_deflate(self):
@@ -533,7 +532,7 @@ class TestHttpCompression:
         try:
             import zstandard  # noqa: F401
         except ImportError:
-            raise SkipTest("no zstd support (zstandard)")
+            pytest.skip("no zstd support (zstandard)")
         self._test_compression_bomb_setting("zstd")
 
     def _test_compression_bomb_spider_attr(self, compression_id):
@@ -556,7 +555,7 @@ class TestHttpCompression:
             except ImportError:
                 import brotlicffi  # noqa: F401
         except ImportError:
-            raise SkipTest("no brotli")
+            pytest.skip("no brotli")
         self._test_compression_bomb_spider_attr("br")
 
     def test_compression_bomb_spider_attr_deflate(self):
@@ -569,7 +568,7 @@ class TestHttpCompression:
         try:
             import zstandard  # noqa: F401
         except ImportError:
-            raise SkipTest("no zstd support (zstandard)")
+            pytest.skip("no zstd support (zstandard)")
         self._test_compression_bomb_spider_attr("zstd")
 
     def _test_compression_bomb_request_meta(self, compression_id):
@@ -590,7 +589,7 @@ class TestHttpCompression:
             except ImportError:
                 import brotlicffi  # noqa: F401
         except ImportError:
-            raise SkipTest("no brotli")
+            pytest.skip("no brotli")
         self._test_compression_bomb_request_meta("br")
 
     def test_compression_bomb_request_meta_deflate(self):
@@ -603,7 +602,7 @@ class TestHttpCompression:
         try:
             import zstandard  # noqa: F401
         except ImportError:
-            raise SkipTest("no zstd support (zstandard)")
+            pytest.skip("no zstd support (zstandard)")
         self._test_compression_bomb_request_meta("zstd")
 
     def _test_download_warnsize_setting(self, compression_id):
@@ -639,7 +638,7 @@ class TestHttpCompression:
             except ImportError:
                 import brotlicffi  # noqa: F401
         except ImportError:
-            raise SkipTest("no brotli")
+            pytest.skip("no brotli")
         self._test_download_warnsize_setting("br")
 
     def test_download_warnsize_setting_deflate(self):
@@ -652,7 +651,7 @@ class TestHttpCompression:
         try:
             import zstandard  # noqa: F401
         except ImportError:
-            raise SkipTest("no zstd support (zstandard)")
+            pytest.skip("no zstd support (zstandard)")
         self._test_download_warnsize_setting("zstd")
 
     def _test_download_warnsize_spider_attr(self, compression_id):
@@ -690,7 +689,7 @@ class TestHttpCompression:
             except ImportError:
                 import brotlicffi  # noqa: F401
         except ImportError:
-            raise SkipTest("no brotli")
+            pytest.skip("no brotli")
         self._test_download_warnsize_spider_attr("br")
 
     def test_download_warnsize_spider_attr_deflate(self):
@@ -703,7 +702,7 @@ class TestHttpCompression:
         try:
             import zstandard  # noqa: F401
         except ImportError:
-            raise SkipTest("no zstd support (zstandard)")
+            pytest.skip("no zstd support (zstandard)")
         self._test_download_warnsize_spider_attr("zstd")
 
     def _test_download_warnsize_request_meta(self, compression_id):
@@ -739,7 +738,7 @@ class TestHttpCompression:
             except ImportError:
                 import brotlicffi  # noqa: F401
         except ImportError:
-            raise SkipTest("no brotli")
+            pytest.skip("no brotli")
         self._test_download_warnsize_request_meta("br")
 
     def test_download_warnsize_request_meta_deflate(self):
@@ -752,5 +751,5 @@ class TestHttpCompression:
         try:
             import zstandard  # noqa: F401
         except ImportError:
-            raise SkipTest("no zstd support (zstandard)")
+            pytest.skip("no zstd support (zstandard)")
         self._test_download_warnsize_request_meta("zstd")

--- a/tests/test_downloadermiddleware_robotstxt.py
+++ b/tests/test_downloadermiddleware_robotstxt.py
@@ -235,12 +235,10 @@ Disallow: /some/randome/page.html
         self, request: Request, middleware: RobotsTxtMiddleware
     ) -> None:
         spider = None  # not actually used
-        await maybe_deferred_to_future(
-            self.assertFailure(
-                middleware.process_request(request, spider),  # type: ignore[arg-type]
-                IgnoreRequest,
+        with pytest.raises(IgnoreRequest):
+            await maybe_deferred_to_future(
+                maybeDeferred(middleware.process_request, request, spider)  # type: ignore[call-overload]
             )
-        )
 
     def assertRobotsTxtRequested(self, base_url: str) -> None:
         calls = self.crawler.engine.download.call_args_list

--- a/tests/test_downloaderslotssettings.py
+++ b/tests/test_downloaderslotssettings.py
@@ -1,6 +1,6 @@
 import time
 
-from twisted.internet import defer
+from twisted.internet.defer import inlineCallbacks
 from twisted.trial.unittest import TestCase
 
 from scrapy import Request
@@ -62,7 +62,7 @@ class CrawlTestCase(TestCase):
     def setUp(self):
         self.runner = CrawlerRunner()
 
-    @defer.inlineCallbacks
+    @inlineCallbacks
     def test_delay(self):
         crawler = get_crawler(DownloaderSlotsSettingsTestSpider)
         yield crawler.crawl(mockserver=self.mockserver)

--- a/tests/test_engine_stop_download_bytes.py
+++ b/tests/test_engine_stop_download_bytes.py
@@ -1,5 +1,5 @@
 from testfixtures import LogCapture
-from twisted.internet import defer
+from twisted.internet.defer import inlineCallbacks
 
 from scrapy.exceptions import StopDownload
 from tests.test_engine import (
@@ -19,7 +19,7 @@ class BytesReceivedCrawlerRun(CrawlerRun):
 
 
 class TestBytesReceivedEngine(TestEngineBase):
-    @defer.inlineCallbacks
+    @inlineCallbacks
     def test_crawler(self):
         for spider in (
             MySpider,

--- a/tests/test_engine_stop_download_headers.py
+++ b/tests/test_engine_stop_download_headers.py
@@ -1,5 +1,5 @@
 from testfixtures import LogCapture
-from twisted.internet import defer
+from twisted.internet.defer import inlineCallbacks
 
 from scrapy.exceptions import StopDownload
 from tests.test_engine import (
@@ -19,7 +19,7 @@ class HeadersReceivedCrawlerRun(CrawlerRun):
 
 
 class TestHeadersReceivedEngine(TestEngineBase):
-    @defer.inlineCallbacks
+    @inlineCallbacks
     def test_crawler(self):
         for spider in (
             MySpider,

--- a/tests/test_exporters.py
+++ b/tests/test_exporters.py
@@ -4,7 +4,6 @@ import marshal
 import pickle
 import re
 import tempfile
-import unittest
 from datetime import datetime
 from io import BytesIO
 from typing import Any
@@ -662,7 +661,7 @@ class TestCustomExporterItem:
 
     def setup_method(self):
         if self.item_class is None:
-            raise unittest.SkipTest("item class is None")
+            pytest.skip("item class is None")
 
     def test_exporter_custom_serializer(self):
         class CustomItemExporter(BaseItemExporter):

--- a/tests/test_extension_periodic_log.py
+++ b/tests/test_extension_periodic_log.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import datetime
-import unittest
 from typing import Any, Callable
 
 from scrapy.extensions.periodic_log import PeriodicLog
@@ -66,7 +65,7 @@ def extension(settings: dict[str, Any] | None = None) -> CustomPeriodicLog:
     return CustomPeriodicLog.from_crawler(crawler)
 
 
-class TestPeriodicLog(unittest.TestCase):
+class TestPeriodicLog:
     def test_extension_enabled(self):
         # Expected that settings for this extension loaded successfully
         # And on certain conditions - extension raising NotConfigured

--- a/tests/test_extension_telnet.py
+++ b/tests/test_extension_telnet.py
@@ -1,6 +1,7 @@
+import pytest
 from twisted.conch.telnet import ITelnetProtocol
 from twisted.cred import credentials
-from twisted.internet import defer
+from twisted.internet.defer import inlineCallbacks
 from twisted.trial import unittest
 
 from scrapy.extensions.telnet import TelnetConsole
@@ -21,15 +22,16 @@ class TelnetExtensionTest(unittest.TestCase):
 
         return console, portal
 
-    @defer.inlineCallbacks
+    @inlineCallbacks
     def test_bad_credentials(self):
         console, portal = self._get_console_and_portal()
         creds = credentials.UsernamePassword(b"username", b"password")
         d = portal.login(creds, None, ITelnetProtocol)
-        yield self.assertFailure(d, ValueError)
+        with pytest.raises(ValueError, match="Invalid credentials"):
+            yield d
         console.stop_listening()
 
-    @defer.inlineCallbacks
+    @inlineCallbacks
     def test_good_credentials(self):
         console, portal = self._get_console_and_portal()
         creds = credentials.UsernamePassword(
@@ -39,7 +41,7 @@ class TelnetExtensionTest(unittest.TestCase):
         yield d
         console.stop_listening()
 
-    @defer.inlineCallbacks
+    @inlineCallbacks
     def test_custom_credentials(self):
         settings = {
             "TELNETCONSOLE_USERNAME": "user",

--- a/tests/test_http2_client_protocol.py
+++ b/tests/test_http2_client_protocol.py
@@ -9,7 +9,7 @@ from ipaddress import IPv4Address
 from pathlib import Path
 from tempfile import mkdtemp
 from typing import TYPE_CHECKING
-from unittest import mock, skipIf
+from unittest import mock
 from urllib.parse import urlencode
 
 import pytest
@@ -183,7 +183,7 @@ def get_client_certificate(
     return PrivateCertificate.loadPEM(pem)
 
 
-@skipIf(not H2_ENABLED, "HTTP/2 support in Twisted is not enabled")
+@pytest.mark.skipif(not H2_ENABLED, reason="HTTP/2 support in Twisted is not enabled")
 class TestHttps2ClientProtocol(TestCase):
     scheme = "https"
     key_file = Path(__file__).parent / "keys" / "localhost.key"

--- a/tests/test_logformatter.py
+++ b/tests/test_logformatter.py
@@ -2,7 +2,7 @@ import logging
 
 import pytest
 from testfixtures import LogCapture
-from twisted.internet import defer
+from twisted.internet.defer import inlineCallbacks
 from twisted.python.failure import Failure
 from twisted.trial.unittest import TestCase
 
@@ -272,7 +272,7 @@ class TestShowOrSkipMessages(TestCase):
             },
         }
 
-    @defer.inlineCallbacks
+    @inlineCallbacks
     def test_show_messages(self):
         crawler = get_crawler(ItemSpider, self.base_settings)
         with LogCapture() as lc:
@@ -281,7 +281,7 @@ class TestShowOrSkipMessages(TestCase):
         assert "Crawled (200) <GET http://127.0.0.1:" in str(lc)
         assert "Dropped: Ignoring item" in str(lc)
 
-    @defer.inlineCallbacks
+    @inlineCallbacks
     def test_skip_messages(self):
         settings = self.base_settings.copy()
         settings["LOG_FORMATTER"] = SkipMessagesLogFormatter

--- a/tests/test_pipeline_crawl.py
+++ b/tests/test_pipeline_crawl.py
@@ -6,7 +6,7 @@ from tempfile import mkdtemp
 from typing import TYPE_CHECKING, Any
 
 from testfixtures import LogCapture
-from twisted.internet import defer
+from twisted.internet.defer import inlineCallbacks
 from twisted.trial.unittest import TestCase
 from w3lib.url import add_or_replace_parameter
 
@@ -144,7 +144,7 @@ class TestFileDownloadCrawl(TestCase):
         # check that no files were written to the media store
         assert not list(self.tmpmediastore.iterdir())
 
-    @defer.inlineCallbacks
+    @inlineCallbacks
     def test_download_media(self):
         crawler = self._create_crawler(MediaDownloadSpider)
         with LogCapture() as log:
@@ -155,7 +155,7 @@ class TestFileDownloadCrawl(TestCase):
             )
         self._assert_files_downloaded(self.items, str(log))
 
-    @defer.inlineCallbacks
+    @inlineCallbacks
     def test_download_media_wrong_urls(self):
         crawler = self._create_crawler(BrokenLinksMediaDownloadSpider)
         with LogCapture() as log:
@@ -166,7 +166,7 @@ class TestFileDownloadCrawl(TestCase):
             )
         self._assert_files_download_failure(crawler, self.items, 404, str(log))
 
-    @defer.inlineCallbacks
+    @inlineCallbacks
     def test_download_media_redirected_default_failure(self):
         crawler = self._create_crawler(RedirectedMediaDownloadSpider)
         with LogCapture() as log:
@@ -178,7 +178,7 @@ class TestFileDownloadCrawl(TestCase):
             )
         self._assert_files_download_failure(crawler, self.items, 302, str(log))
 
-    @defer.inlineCallbacks
+    @inlineCallbacks
     def test_download_media_redirected_allowed(self):
         settings = {
             **self.settings,
@@ -195,7 +195,7 @@ class TestFileDownloadCrawl(TestCase):
         self._assert_files_downloaded(self.items, str(log))
         assert crawler.stats.get_value("downloader/response_status_count/302") == 3
 
-    @defer.inlineCallbacks
+    @inlineCallbacks
     def test_download_media_file_path_error(self):
         cls = load_object(self.pipeline_class)
 

--- a/tests/test_pipeline_files.py
+++ b/tests/test_pipeline_files.py
@@ -16,7 +16,7 @@ from urllib.parse import urlparse
 import attr
 import pytest
 from itemadapter import ItemAdapter
-from twisted.internet import defer
+from twisted.internet.defer import inlineCallbacks
 from twisted.trial import unittest
 
 from scrapy.http import Request, Response
@@ -159,7 +159,7 @@ class TestFilesPipeline(unittest.TestCase):
         fullpath = Path(self.tempdir, "some", "image", "key.jpg")
         assert self.pipeline.store._get_filesystem_path(path) == fullpath
 
-    @defer.inlineCallbacks
+    @inlineCallbacks
     def test_file_not_expired(self):
         item_url = "http://example.com/file.pdf"
         item = _create_item_with_files(item_url)
@@ -186,7 +186,7 @@ class TestFilesPipeline(unittest.TestCase):
         for p in patchers:
             p.stop()
 
-    @defer.inlineCallbacks
+    @inlineCallbacks
     def test_file_expired(self):
         item_url = "http://example.com/file2.pdf"
         item = _create_item_with_files(item_url)
@@ -217,7 +217,7 @@ class TestFilesPipeline(unittest.TestCase):
         for p in patchers:
             p.stop()
 
-    @defer.inlineCallbacks
+    @inlineCallbacks
     def test_file_cached(self):
         item_url = "http://example.com/file3.pdf"
         item = _create_item_with_files(item_url)
@@ -537,7 +537,7 @@ class TestFilesPipelineCustomSettings:
 
 @pytest.mark.requires_botocore
 class TestS3FilesStore(unittest.TestCase):
-    @defer.inlineCallbacks
+    @inlineCallbacks
     def test_persist(self):
         bucket = "mybucket"
         key = "export.csv"
@@ -577,7 +577,7 @@ class TestS3FilesStore(unittest.TestCase):
             # The call to read does not happen with Stubber
             assert buffer.method_calls == [mock.call.seek(0)]
 
-    @defer.inlineCallbacks
+    @inlineCallbacks
     def test_stat(self):
         bucket = "mybucket"
         key = "export.csv"
@@ -614,11 +614,11 @@ class TestS3FilesStore(unittest.TestCase):
     "GCS_PROJECT_ID" not in os.environ, reason="GCS_PROJECT_ID not found"
 )
 class TestGCSFilesStore(unittest.TestCase):
-    @defer.inlineCallbacks
+    @inlineCallbacks
     def test_persist(self):
         uri = os.environ.get("GCS_TEST_FILE_URI")
         if not uri:
-            raise unittest.SkipTest("No GCS URI available for testing")
+            pytest.skip("No GCS URI available for testing")
         data = b"TestGCSFilesStore: \xe2\x98\x83"
         buf = BytesIO(data)
         meta = {"foo": "bar"}
@@ -639,7 +639,7 @@ class TestGCSFilesStore(unittest.TestCase):
         assert blob.content_type == "application/octet-stream"
         assert expected_policy in acl
 
-    @defer.inlineCallbacks
+    @inlineCallbacks
     def test_blob_path_consistency(self):
         """Test to make sure that paths used to store files is the same as the one used to get
         already uploaded files.
@@ -647,7 +647,7 @@ class TestGCSFilesStore(unittest.TestCase):
         try:
             import google.cloud.storage  # noqa: F401
         except ModuleNotFoundError:
-            raise unittest.SkipTest("google-cloud-storage is not installed")
+            pytest.skip("google-cloud-storage is not installed")
         with (
             mock.patch("google.cloud.storage"),
             mock.patch("scrapy.pipelines.files.time"),
@@ -666,7 +666,7 @@ class TestGCSFilesStore(unittest.TestCase):
 
 
 class TestFTPFileStore(unittest.TestCase):
-    @defer.inlineCallbacks
+    @inlineCallbacks
     def test_persist(self):
         data = b"TestFTPFilesStore: \xe2\x98\x83"
         buf = BytesIO(data)

--- a/tests/test_pipelines.py
+++ b/tests/test_pipelines.py
@@ -1,8 +1,7 @@
 import asyncio
 
 import pytest
-from twisted.internet import defer
-from twisted.internet.defer import Deferred
+from twisted.internet.defer import Deferred, inlineCallbacks
 from twisted.trial import unittest
 
 from scrapy import Request, Spider, signals
@@ -100,33 +99,33 @@ class TestPipeline(unittest.TestCase):
         self.items = []
         return crawler
 
-    @defer.inlineCallbacks
+    @inlineCallbacks
     def test_simple_pipeline(self):
         crawler = self._create_crawler(SimplePipeline)
         yield crawler.crawl(mockserver=self.mockserver)
         assert len(self.items) == 1
 
-    @defer.inlineCallbacks
+    @inlineCallbacks
     def test_deferred_pipeline(self):
         crawler = self._create_crawler(DeferredPipeline)
         yield crawler.crawl(mockserver=self.mockserver)
         assert len(self.items) == 1
 
-    @defer.inlineCallbacks
+    @inlineCallbacks
     def test_asyncdef_pipeline(self):
         crawler = self._create_crawler(AsyncDefPipeline)
         yield crawler.crawl(mockserver=self.mockserver)
         assert len(self.items) == 1
 
     @pytest.mark.only_asyncio
-    @defer.inlineCallbacks
+    @inlineCallbacks
     def test_asyncdef_asyncio_pipeline(self):
         crawler = self._create_crawler(AsyncDefAsyncioPipeline)
         yield crawler.crawl(mockserver=self.mockserver)
         assert len(self.items) == 1
 
     @pytest.mark.only_not_asyncio
-    @defer.inlineCallbacks
+    @inlineCallbacks
     def test_asyncdef_not_asyncio_pipeline(self):
         crawler = self._create_crawler(AsyncDefNotAsyncioPipeline)
         yield crawler.crawl(mockserver=self.mockserver)

--- a/tests/test_proxy_connect.py
+++ b/tests/test_proxy_connect.py
@@ -8,7 +8,7 @@ from urllib.parse import urlsplit, urlunsplit
 
 import pytest
 from testfixtures import LogCapture
-from twisted.internet import defer
+from twisted.internet.defer import inlineCallbacks
 from twisted.trial.unittest import TestCase
 
 from scrapy.http import Request
@@ -89,14 +89,14 @@ class TestProxyConnect(TestCase):
         self._proxy.stop()
         os.environ = self._oldenv
 
-    @defer.inlineCallbacks
+    @inlineCallbacks
     def test_https_connect_tunnel(self):
         crawler = get_crawler(SimpleSpider)
         with LogCapture() as log:
             yield crawler.crawl(self.mockserver.url("/status?n=200", is_secure=True))
         self._assert_got_response_code(200, log)
 
-    @defer.inlineCallbacks
+    @inlineCallbacks
     def test_https_tunnel_auth_error(self):
         os.environ["https_proxy"] = _wrong_credentials(os.environ["https_proxy"])
         crawler = get_crawler(SimpleSpider)
@@ -106,7 +106,7 @@ class TestProxyConnect(TestCase):
         # he just sees a TunnelError.
         self._assert_got_tunnel_error(log)
 
-    @defer.inlineCallbacks
+    @inlineCallbacks
     def test_https_tunnel_without_leak_proxy_authorization_header(self):
         request = Request(self.mockserver.url("/echo", is_secure=True))
         crawler = get_crawler(SingleRequestSpider)

--- a/tests/test_request_attribute_binding.py
+++ b/tests/test_request_attribute_binding.py
@@ -1,5 +1,5 @@
 from testfixtures import LogCapture
-from twisted.internet import defer
+from twisted.internet.defer import inlineCallbacks
 from twisted.trial.unittest import TestCase
 
 from scrapy import Request, signals
@@ -66,7 +66,7 @@ class TestCrawl(TestCase):
     def tearDownClass(cls):
         cls.mockserver.__exit__(None, None, None)
 
-    @defer.inlineCallbacks
+    @inlineCallbacks
     def test_response_200(self):
         url = self.mockserver.url("/status?n=200")
         crawler = get_crawler(SingleRequestSpider)
@@ -74,7 +74,7 @@ class TestCrawl(TestCase):
         response = crawler.spider.meta["responses"][0]
         assert response.request.url == url
 
-    @defer.inlineCallbacks
+    @inlineCallbacks
     def test_response_error(self):
         for status in ("404", "500"):
             url = self.mockserver.url(f"/status?n={status}")
@@ -85,7 +85,7 @@ class TestCrawl(TestCase):
             assert failure.request.url == url
             assert response.request.url == url
 
-    @defer.inlineCallbacks
+    @inlineCallbacks
     def test_downloader_middleware_raise_exception(self):
         url = self.mockserver.url("/status?n=200")
         crawler = get_crawler(
@@ -101,7 +101,7 @@ class TestCrawl(TestCase):
         assert failure.request.url == url
         assert isinstance(failure.value, ZeroDivisionError)
 
-    @defer.inlineCallbacks
+    @inlineCallbacks
     def test_downloader_middleware_override_request_in_process_response(self):
         """
         Downloader middleware which returns a response with an specific 'request' attribute.
@@ -144,7 +144,7 @@ class TestCrawl(TestCase):
             ),
         )
 
-    @defer.inlineCallbacks
+    @inlineCallbacks
     def test_downloader_middleware_override_in_process_exception(self):
         """
         An exception is raised but caught by the next middleware, which
@@ -167,7 +167,7 @@ class TestCrawl(TestCase):
         assert response.body == b"Caught ZeroDivisionError"
         assert response.request.url == OVERRIDDEN_URL
 
-    @defer.inlineCallbacks
+    @inlineCallbacks
     def test_downloader_middleware_do_not_override_in_process_exception(self):
         """
         An exception is raised but caught by the next middleware, which
@@ -190,7 +190,7 @@ class TestCrawl(TestCase):
         assert response.body == b"Caught ZeroDivisionError"
         assert response.request.url == url
 
-    @defer.inlineCallbacks
+    @inlineCallbacks
     def test_downloader_middleware_alternative_callback(self):
         """
         Downloader middleware which returns a response with a

--- a/tests/test_request_cb_kwargs.py
+++ b/tests/test_request_cb_kwargs.py
@@ -1,5 +1,5 @@
 from testfixtures import LogCapture
-from twisted.internet import defer
+from twisted.internet.defer import inlineCallbacks
 from twisted.trial.unittest import TestCase
 
 from scrapy.http import Request
@@ -161,7 +161,7 @@ class TestCallbackKeywordArguments(TestCase):
     def tearDownClass(cls):
         cls.mockserver.__exit__(None, None, None)
 
-    @defer.inlineCallbacks
+    @inlineCallbacks
     def test_callback_kwargs(self):
         crawler = get_crawler(KeywordArgumentsSpider)
         with LogCapture() as log:

--- a/tests/test_request_left.py
+++ b/tests/test_request_left.py
@@ -1,4 +1,4 @@
-from twisted.internet import defer
+from twisted.internet.defer import inlineCallbacks
 from twisted.trial.unittest import TestCase
 
 from scrapy.signals import request_left_downloader
@@ -34,25 +34,25 @@ class TestCatching(TestCase):
     def tearDownClass(cls):
         cls.mockserver.__exit__(None, None, None)
 
-    @defer.inlineCallbacks
+    @inlineCallbacks
     def test_success(self):
         crawler = get_crawler(SignalCatcherSpider)
         yield crawler.crawl(self.mockserver.url("/status?n=200"))
         assert crawler.spider.caught_times == 1
 
-    @defer.inlineCallbacks
+    @inlineCallbacks
     def test_timeout(self):
         crawler = get_crawler(SignalCatcherSpider, {"DOWNLOAD_TIMEOUT": 0.1})
         yield crawler.crawl(self.mockserver.url("/delay?n=0.2"))
         assert crawler.spider.caught_times == 1
 
-    @defer.inlineCallbacks
+    @inlineCallbacks
     def test_disconnect(self):
         crawler = get_crawler(SignalCatcherSpider)
         yield crawler.crawl(self.mockserver.url("/drop"))
         assert crawler.spider.caught_times == 1
 
-    @defer.inlineCallbacks
+    @inlineCallbacks
     def test_noconnect(self):
         crawler = get_crawler(SignalCatcherSpider)
         yield crawler.crawl("http://thereisdefinetelynosuchdomain.com")

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -7,7 +7,7 @@ from collections import deque
 from typing import Any, NamedTuple
 
 import pytest
-from twisted.internet import defer
+from twisted.internet.defer import inlineCallbacks
 from twisted.trial.unittest import TestCase
 
 from scrapy.core.downloader import Downloader
@@ -362,11 +362,11 @@ class TestIntegrationWithDownloaderAwareInMemory(TestCase):
             },
         )
 
-    @defer.inlineCallbacks
+    @inlineCallbacks
     def tearDown(self):
         yield self.crawler.stop()
 
-    @defer.inlineCallbacks
+    @inlineCallbacks
     def test_integration_downloader_aware_priority_queue(self):
         with MockServer() as mockserver:
             url = mockserver.url("/status?n=200", is_secure=False)

--- a/tests/test_scheduler_base.py
+++ b/tests/test_scheduler_base.py
@@ -5,6 +5,7 @@ from urllib.parse import urljoin
 import pytest
 from testfixtures import LogCapture
 from twisted.internet import defer
+from twisted.internet.defer import inlineCallbacks
 from twisted.trial.unittest import TestCase
 
 from scrapy.core.scheduler import BaseScheduler
@@ -118,7 +119,7 @@ class SimpleSchedulerTest(TestCase, InterfaceCheckMixin):
     def setUp(self):
         self.scheduler = SimpleScheduler()
 
-    @defer.inlineCallbacks
+    @inlineCallbacks
     def test_enqueue_dequeue(self):
         open_result = yield self.scheduler.open(Spider("foo"))
         assert open_result == "open"
@@ -147,7 +148,7 @@ class SimpleSchedulerTest(TestCase, InterfaceCheckMixin):
 class MinimalSchedulerCrawlTest(TestCase):
     scheduler_cls = MinimalScheduler
 
-    @defer.inlineCallbacks
+    @inlineCallbacks
     def test_crawl(self):
         with MockServer() as mockserver:
             settings = {

--- a/tests/test_signals.py
+++ b/tests/test_signals.py
@@ -1,5 +1,5 @@
 import pytest
-from twisted.internet import defer
+from twisted.internet.defer import inlineCallbacks
 from twisted.trial.unittest import TestCase
 
 from scrapy import Request, Spider, signals
@@ -53,7 +53,7 @@ class MockServerTestCase(TestCase):
         self.items.append(item)
 
     @pytest.mark.only_asyncio
-    @defer.inlineCallbacks
+    @inlineCallbacks
     def test_simple_pipeline(self):
         crawler = get_crawler(ItemSpider)
         crawler.signals.connect(self._on_item_scraped, signals.item_scraped)

--- a/tests/test_spidermiddleware.py
+++ b/tests/test_spidermiddleware.py
@@ -8,6 +8,7 @@ from unittest import mock
 import pytest
 from testfixtures import LogCapture
 from twisted.internet import defer
+from twisted.internet.defer import inlineCallbacks
 from twisted.trial.unittest import TestCase
 
 from scrapy.core.spidermw import SpiderMiddlewareManager
@@ -129,7 +130,7 @@ class TestBaseAsyncSpiderMiddleware(TestSpiderMiddleware):
         yield {"foo": 2}
         yield {"foo": 3}
 
-    @defer.inlineCallbacks
+    @inlineCallbacks
     def _get_middleware_result(self, *mw_classes, start_index: int | None = None):
         setting = self._construct_mw_setting(*mw_classes, start_index=start_index)
         self.crawler = get_crawler(
@@ -142,7 +143,7 @@ class TestBaseAsyncSpiderMiddleware(TestSpiderMiddleware):
         )
         return result
 
-    @defer.inlineCallbacks
+    @inlineCallbacks
     def _test_simple_base(
         self, *mw_classes, downgrade: bool = False, start_index: int | None = None
     ):
@@ -159,7 +160,7 @@ class TestBaseAsyncSpiderMiddleware(TestSpiderMiddleware):
             ProcessSpiderOutputSimpleMiddleware in mw_classes
         )
 
-    @defer.inlineCallbacks
+    @inlineCallbacks
     def _test_asyncgen_base(
         self, *mw_classes, downgrade: bool = False, start_index: int | None = None
     ):
@@ -299,7 +300,7 @@ class ProcessSpiderOutputCoroutineMiddleware:
 
 
 class TestProcessSpiderOutputInvalidResult(TestBaseAsyncSpiderMiddleware):
-    @defer.inlineCallbacks
+    @inlineCallbacks
     def test_non_iterable(self):
         with pytest.raises(
             _InvalidOutput,
@@ -309,7 +310,7 @@ class TestProcessSpiderOutputInvalidResult(TestBaseAsyncSpiderMiddleware):
                 ProcessSpiderOutputNonIterableMiddleware,
             )
 
-    @defer.inlineCallbacks
+    @inlineCallbacks
     def test_coroutine(self):
         with pytest.raises(
             _InvalidOutput,
@@ -444,7 +445,7 @@ class TestBuiltinMiddlewareSimple(TestBaseAsyncSpiderMiddleware):
     MW_ASYNCGEN = ProcessSpiderOutputAsyncGenMiddleware
     MW_UNIVERSAL = ProcessSpiderOutputUniversalMiddleware
 
-    @defer.inlineCallbacks
+    @inlineCallbacks
     def _get_middleware_result(self, *mw_classes, start_index: int | None = None):
         setting = self._construct_mw_setting(*mw_classes, start_index=start_index)
         self.crawler = get_crawler(Spider, {"SPIDER_MIDDLEWARES": setting})
@@ -519,7 +520,7 @@ class TestProcessSpiderException(TestBaseAsyncSpiderMiddleware):
     def _scrape_func(self, *args, **kwargs):
         1 / 0
 
-    @defer.inlineCallbacks
+    @inlineCallbacks
     def _test_asyncgen_nodowngrade(self, *mw_classes):
         with pytest.raises(
             _InvalidOutput, match="Async iterable returned from .+ cannot be downgraded"

--- a/tests/test_spidermiddleware_httperror.py
+++ b/tests/test_spidermiddleware_httperror.py
@@ -2,7 +2,7 @@ import logging
 
 import pytest
 from testfixtures import LogCapture
-from twisted.internet import defer
+from twisted.internet.defer import inlineCallbacks
 from twisted.trial.unittest import TestCase
 
 from scrapy.http import Request, Response
@@ -182,7 +182,7 @@ class TestHttpErrorMiddlewareIntegrational(TestCase):
     def tearDownClass(cls):
         cls.mockserver.__exit__(None, None, None)
 
-    @defer.inlineCallbacks
+    @inlineCallbacks
     def test_middleware_works(self):
         crawler = get_crawler(_HttpErrorSpider)
         yield crawler.crawl(mockserver=self.mockserver)
@@ -196,7 +196,7 @@ class TestHttpErrorMiddlewareIntegrational(TestCase):
         assert get_value("httperror/response_ignored_status_count/402") == 1
         assert get_value("httperror/response_ignored_status_count/500") == 1
 
-    @defer.inlineCallbacks
+    @inlineCallbacks
     def test_logging(self):
         crawler = get_crawler(_HttpErrorSpider)
         with LogCapture() as log:
@@ -210,7 +210,7 @@ class TestHttpErrorMiddlewareIntegrational(TestCase):
         assert "Ignoring response <200" not in str(log)
         assert "Ignoring response <402" not in str(log)
 
-    @defer.inlineCallbacks
+    @inlineCallbacks
     def test_logging_level(self):
         # HttpError logs ignored responses with level INFO
         crawler = get_crawler(_HttpErrorSpider)

--- a/tests/test_spidermiddleware_output_chain.py
+++ b/tests/test_spidermiddleware_output_chain.py
@@ -1,5 +1,5 @@
 from testfixtures import LogCapture
-from twisted.internet import defer
+from twisted.internet.defer import inlineCallbacks
 from twisted.trial.unittest import TestCase
 
 from scrapy import Request, Spider
@@ -308,14 +308,14 @@ class TestSpiderMiddleware(TestCase):
     def tearDownClass(cls):
         cls.mockserver.__exit__(None, None, None)
 
-    @defer.inlineCallbacks
+    @inlineCallbacks
     def crawl_log(self, spider):
         crawler = get_crawler(spider)
         with LogCapture() as log:
             yield crawler.crawl(mockserver=self.mockserver)
         return log
 
-    @defer.inlineCallbacks
+    @inlineCallbacks
     def test_recovery(self):
         """
         (0) Recover from an exception in a spider callback. The final item count should be 3
@@ -328,7 +328,7 @@ class TestSpiderMiddleware(TestCase):
         assert str(log).count("Middleware: TabError exception caught") == 1
         assert "'item_scraped_count': 3" in str(log)
 
-    @defer.inlineCallbacks
+    @inlineCallbacks
     def test_recovery_asyncgen(self):
         """
         Same as test_recovery but with an async callback.
@@ -338,7 +338,7 @@ class TestSpiderMiddleware(TestCase):
         assert str(log).count("Middleware: TabError exception caught") == 1
         assert "'item_scraped_count': 3" in str(log)
 
-    @defer.inlineCallbacks
+    @inlineCallbacks
     def test_process_spider_input_without_errback(self):
         """
         (1.1) An exception from the process_spider_input chain should be caught by the
@@ -348,7 +348,7 @@ class TestSpiderMiddleware(TestCase):
         assert "Middleware: will raise IndexError" in str(log1)
         assert "Middleware: IndexError exception caught" in str(log1)
 
-    @defer.inlineCallbacks
+    @inlineCallbacks
     def test_process_spider_input_with_errback(self):
         """
         (1.2) An exception from the process_spider_input chain should not be caught by the
@@ -362,7 +362,7 @@ class TestSpiderMiddleware(TestCase):
         assert "{'from': 'callback'}" not in str(log1)
         assert "'item_scraped_count': 1" in str(log1)
 
-    @defer.inlineCallbacks
+    @inlineCallbacks
     def test_generator_callback(self):
         """
         (2) An exception from a spider callback (returning a generator) should
@@ -373,7 +373,7 @@ class TestSpiderMiddleware(TestCase):
         assert "Middleware: ImportError exception caught" in str(log2)
         assert "'item_scraped_count': 2" in str(log2)
 
-    @defer.inlineCallbacks
+    @inlineCallbacks
     def test_async_generator_callback(self):
         """
         Same as test_generator_callback but with an async callback.
@@ -382,7 +382,7 @@ class TestSpiderMiddleware(TestCase):
         assert "Middleware: ImportError exception caught" in str(log2)
         assert "'item_scraped_count': 2" in str(log2)
 
-    @defer.inlineCallbacks
+    @inlineCallbacks
     def test_generator_callback_right_after_callback(self):
         """
         (2.1) Special case of (2): Exceptions should be caught
@@ -392,7 +392,7 @@ class TestSpiderMiddleware(TestCase):
         assert "Middleware: ImportError exception caught" in str(log21)
         assert "'item_scraped_count': 2" in str(log21)
 
-    @defer.inlineCallbacks
+    @inlineCallbacks
     def test_not_a_generator_callback(self):
         """
         (3) An exception from a spider callback (returning a list) should
@@ -402,7 +402,7 @@ class TestSpiderMiddleware(TestCase):
         assert "Middleware: ZeroDivisionError exception caught" in str(log3)
         assert "item_scraped_count" not in str(log3)
 
-    @defer.inlineCallbacks
+    @inlineCallbacks
     def test_not_a_generator_callback_right_after_callback(self):
         """
         (3.1) Special case of (3): Exceptions should be caught
@@ -414,7 +414,7 @@ class TestSpiderMiddleware(TestCase):
         assert "Middleware: ZeroDivisionError exception caught" in str(log31)
         assert "item_scraped_count" not in str(log31)
 
-    @defer.inlineCallbacks
+    @inlineCallbacks
     def test_generator_output_chain(self):
         """
         (4) An exception from a middleware's process_spider_output method should be sent
@@ -461,7 +461,7 @@ class TestSpiderMiddleware(TestCase):
         assert str(item_recovered) in str(log4)
         assert "parse-second-item" not in str(log4)
 
-    @defer.inlineCallbacks
+    @inlineCallbacks
     def test_not_a_generator_output_chain(self):
         """
         (5) An exception from a middleware's process_spider_output method should be sent

--- a/tests/test_squeues_request.py
+++ b/tests/test_squeues_request.py
@@ -4,7 +4,6 @@ Queues that handle requests
 
 import shutil
 import tempfile
-import unittest
 
 import pytest
 import queuelib
@@ -46,7 +45,7 @@ class RequestQueueTestMixin:
 
     def test_one_element_with_peek(self):
         if not hasattr(queuelib.queue.FifoMemoryQueue, "peek"):
-            raise unittest.SkipTest("The queuelib queues do not define peek")
+            pytest.skip("The queuelib queues do not define peek")
         q = self.queue()
         assert len(q) == 0
         assert q.peek() is None
@@ -63,7 +62,7 @@ class RequestQueueTestMixin:
 
     def test_one_element_without_peek(self):
         if hasattr(queuelib.queue.FifoMemoryQueue, "peek"):
-            raise unittest.SkipTest("The queuelib queues define peek")
+            pytest.skip("The queuelib queues define peek")
         q = self.queue()
         assert len(q) == 0
         assert q.pop() is None
@@ -84,7 +83,7 @@ class RequestQueueTestMixin:
 class FifoQueueMixin(RequestQueueTestMixin):
     def test_fifo_with_peek(self):
         if not hasattr(queuelib.queue.FifoMemoryQueue, "peek"):
-            raise unittest.SkipTest("The queuelib queues do not define peek")
+            pytest.skip("The queuelib queues do not define peek")
         q = self.queue()
         assert len(q) == 0
         assert q.peek() is None
@@ -111,7 +110,7 @@ class FifoQueueMixin(RequestQueueTestMixin):
 
     def test_fifo_without_peek(self):
         if hasattr(queuelib.queue.FifoMemoryQueue, "peek"):
-            raise unittest.SkipTest("The queuelib queues do not define peek")
+            pytest.skip("The queuelib queues do not define peek")
         q = self.queue()
         assert len(q) == 0
         assert q.pop() is None
@@ -140,7 +139,7 @@ class FifoQueueMixin(RequestQueueTestMixin):
 class LifoQueueMixin(RequestQueueTestMixin):
     def test_lifo_with_peek(self):
         if not hasattr(queuelib.queue.FifoMemoryQueue, "peek"):
-            raise unittest.SkipTest("The queuelib queues do not define peek")
+            pytest.skip("The queuelib queues do not define peek")
         q = self.queue()
         assert len(q) == 0
         assert q.peek() is None
@@ -167,7 +166,7 @@ class LifoQueueMixin(RequestQueueTestMixin):
 
     def test_lifo_without_peek(self):
         if hasattr(queuelib.queue.FifoMemoryQueue, "peek"):
-            raise unittest.SkipTest("The queuelib queues do not define peek")
+            pytest.skip("The queuelib queues do not define peek")
         q = self.queue()
         assert len(q) == 0
         assert q.pop() is None

--- a/tests/test_utils_log.py
+++ b/tests/test_utils_log.py
@@ -4,7 +4,6 @@ import json
 import logging
 import re
 import sys
-import unittest
 from io import StringIO
 from typing import TYPE_CHECKING, Any
 
@@ -100,20 +99,18 @@ class TestLogCounterHandler:
         assert self.crawler.stats.get_value("log_count/INFO") is None
 
 
-class StreamLoggerTest(unittest.TestCase):
-    def setUp(self):
-        self.stdout = sys.stdout
+class TestStreamLogger:
+    def test_redirect(self):
         logger = logging.getLogger("test")
         logger.setLevel(logging.WARNING)
+        old_stdout = sys.stdout
         sys.stdout = StreamLogger(logger, logging.ERROR)
 
-    def tearDown(self):
-        sys.stdout = self.stdout
-
-    def test_redirect(self):
         with LogCapture() as log:
             print("test log msg")
         log.check(("test", "ERROR", "test log msg"))
+
+        sys.stdout = old_stdout
 
 
 @pytest.mark.parametrize(

--- a/tests/test_utils_signal.py
+++ b/tests/test_utils_signal.py
@@ -4,6 +4,7 @@ import pytest
 from pydispatch import dispatcher
 from testfixtures import LogCapture
 from twisted.internet import defer
+from twisted.internet.defer import inlineCallbacks
 from twisted.python.failure import Failure
 from twisted.trial import unittest
 
@@ -17,7 +18,7 @@ from scrapy.utils.test import get_from_asyncio_queue
 
 
 class TestSendCatchLog(unittest.TestCase):
-    @defer.inlineCallbacks
+    @inlineCallbacks
     def test_send_catch_log(self):
         test_signal = object()
         handlers_called = set()

--- a/tests/test_utils_trackref.py
+++ b/tests/test_utils_trackref.py
@@ -2,7 +2,7 @@ from io import StringIO
 from time import sleep, time
 from unittest import mock
 
-from twisted.trial.unittest import SkipTest
+import pytest
 
 from scrapy.utils import trackref
 
@@ -71,7 +71,7 @@ Foo                                 1   oldest: 0s ago\n\n"""
             sleep(0.01)
             o3_time = time()
         if o3_time <= o1_time:
-            raise SkipTest("time.time is not precise enough")
+            pytest.skip("time.time is not precise enough")
 
         o3 = Foo()  # noqa: F841
         assert trackref.get_oldest("Foo") is o1

--- a/tests/test_utils_url.py
+++ b/tests/test_utils_url.py
@@ -1,4 +1,3 @@
-import unittest
 import warnings
 
 import pytest
@@ -267,7 +266,7 @@ def create_guess_scheme_t(args):
 
 def create_skipped_scheme_t(args):
     def do_expected(self):
-        raise unittest.SkipTest(args[2])
+        pytest.skip(args[2])
 
     return do_expected
 


### PR DESCRIPTION
1. `@defer.inlineCallbacks` -> `@inlineCallbacks` (most of the PR changes)
2. Remaining `self.assertFailure()` -> `pytest.raises()`
3. Remaining `raise unittest.SkipTest()` -> `pytest.skip()`
4. One or two tests used `unittest` instead of `twisted.trial.unittest` so they could be migrated to pytest directly.