### PR TITLE
Fix #6876: Raise TypeError instead of assert in getdictorlist()

### DIFF
--- a/scrapy/settings/__init__.py
+++ b/scrapy/settings/__init__.py
@@ -282,13 +282,15 @@ class BaseSettings(MutableMapping[_SettingsKeyT, Any]):
         if isinstance(value, str):
             try:
                 value_loaded = json.loads(value)
-                assert isinstance(value_loaded, (dict, list))
+                if not isinstance(value_loaded, (dict, list)):
+                    raise ValueError(f"Expected a dict or a list, got {type(value_loaded)}.")
                 return value_loaded
             except ValueError:
                 return value.split(",")
         if isinstance(value, tuple):
             return list(value)
-        assert isinstance(value, (dict, list))
+        if not isinstance(value, (dict, list)):
+            raise ValueError(f"Expected a dict or a list, got {type(value)}.")
         return copy.deepcopy(value)
 
     def getwithbase(self, name: _SettingsKeyT) -> BaseSettings:


### PR DESCRIPTION
This pull request fixes #6876 by replacing 'assert' statements in 'getdictorlist()' with proper 'TypeError' exceptions.  

Using 'assert' for validation is unreliable and can be disabled with 'python -O'.  
Raising 'TypeError' makes the code more robust and clear when invalid input is provided.


- Replaced:
assert isinstance(value, (dict, list))

- With:
if not isinstance(value, (dict, list)):
    raise TypeError(f"Expected a dict or a list, got {type(value)}.")