### PR TITLE
Replace assert statements with ValueError in getdictorlist()

### DIFF
--- a/scrapy/settings/__init__.py
+++ b/scrapy/settings/__init__.py
@@ -282,13 +282,19 @@ class BaseSettings(MutableMapping[_SettingsKeyT, Any]):
         if isinstance(value, str):
             try:
                 value_loaded = json.loads(value)
-                assert isinstance(value_loaded, (dict, list))
+                if not isinstance(value_loaded, (dict, list)):
+                    raise ValueError(
+                        f"JSON-loaded setting value must be a dict or list, got {type(value_loaded).__name__}"
+                    )
                 return value_loaded
-            except ValueError:
+            except json.JSONDecodeError:
                 return value.split(",")
         if isinstance(value, tuple):
             return list(value)
-        assert isinstance(value, (dict, list))
+        if not isinstance(value, (dict, list)):
+            raise ValueError(
+                f"Setting value must be a dict, list, or tuple, got {type(value).__name__}"
+            )
         return copy.deepcopy(value)
 
     def getwithbase(self, name: _SettingsKeyT) -> BaseSettings:

--- a/tests/test_settings/__init__.py
+++ b/tests/test_settings/__init__.py
@@ -398,6 +398,83 @@ class TestBaseSettings:
         assert frozencopy.frozen
         assert frozencopy is not self.settings
 
+    def test_getdictorlist_with_dict(self):
+        """Test getdictorlist with a dict value."""
+        test_dict = {"key": "value", "key2": "value2"}
+        self.settings.set("TEST_DICT", test_dict)
+        result = self.settings.getdictorlist("TEST_DICT")
+        assert result == test_dict
+        assert result is not test_dict  # Should be a copy
+
+    def test_getdictorlist_with_list(self):
+        """Test getdictorlist with a list value."""
+        test_list = ["item1", "item2", "item3"]
+        self.settings.set("TEST_LIST", test_list)
+        result = self.settings.getdictorlist("TEST_LIST")
+        assert result == test_list
+        assert result is not test_list  # Should be a copy
+
+    def test_getdictorlist_with_tuple(self):
+        """Test getdictorlist with a tuple value."""
+        test_tuple = ("item1", "item2", "item3")
+        self.settings.set("TEST_TUPLE", test_tuple)
+        result = self.settings.getdictorlist("TEST_TUPLE")
+        assert result == ["item1", "item2", "item3"]
+        assert isinstance(result, list)
+
+    def test_getdictorlist_with_json_string_dict(self):
+        """Test getdictorlist with a JSON string representing a dict."""
+        json_string = '{"key": "value", "key2": "value2"}'
+        self.settings.set("TEST_JSON_DICT", json_string)
+        result = self.settings.getdictorlist("TEST_JSON_DICT")
+        assert result == {"key": "value", "key2": "value2"}
+
+    def test_getdictorlist_with_json_string_list(self):
+        """Test getdictorlist with a JSON string representing a list."""
+        json_string = '["item1", "item2", "item3"]'
+        self.settings.set("TEST_JSON_LIST", json_string)
+        result = self.settings.getdictorlist("TEST_JSON_LIST")
+        assert result == ["item1", "item2", "item3"]
+
+    def test_getdictorlist_with_comma_separated_string(self):
+        """Test getdictorlist with a comma-separated string."""
+        csv_string = "item1,item2,item3"
+        self.settings.set("TEST_CSV", csv_string)
+        result = self.settings.getdictorlist("TEST_CSV")
+        assert result == ["item1", "item2", "item3"]
+
+    def test_getdictorlist_with_none_value(self):
+        """Test getdictorlist with None value returns empty dict."""
+        self.settings.set("TEST_NONE", None)
+        result = self.settings.getdictorlist("TEST_NONE")
+        assert result == {}
+
+    def test_getdictorlist_with_default(self):
+        """Test getdictorlist with default value when setting doesn't exist."""
+        default_value = {"default": "value"}
+        result = self.settings.getdictorlist("NONEXISTENT_SETTING", default_value)
+        assert result == default_value
+
+    def test_getdictorlist_invalid_json_string_raises_valueerror(self):
+        """Test that getdictorlist raises ValueError for JSON strings that don't parse to dict/list."""
+        # JSON string that parses to a string (not dict or list)
+        json_string = '"just_a_string"'
+        self.settings.set("TEST_INVALID_JSON", json_string)
+        with pytest.raises(
+            ValueError, match="JSON-loaded setting value must be a dict or list"
+        ):
+            self.settings.getdictorlist("TEST_INVALID_JSON")
+
+    def test_getdictorlist_invalid_type_raises_valueerror(self):
+        """Test that getdictorlist raises ValueError for invalid data types."""
+        # Set a value that's not dict, list, tuple, or string
+        invalid_value = 12345
+        self.settings.set("TEST_INVALID_TYPE", invalid_value)
+        with pytest.raises(
+            ValueError, match="Setting value must be a dict, list, or tuple"
+        ):
+            self.settings.getdictorlist("TEST_INVALID_TYPE")
+
 
 class TestSettings:
     def setup_method(self):
@@ -522,9 +599,9 @@ def test_add_to_list(before, name, item, after):
     settings.add_to_list(name, item)
     expected_priority = settings.getpriority(name) or 0
     expected_settings = BaseSettings(after, priority=expected_priority)
-    assert settings == expected_settings, (
-        f"{settings[name]=} != {expected_settings[name]=}"
-    )
+    assert (
+        settings == expected_settings
+    ), f"{settings[name]=} != {expected_settings[name]=}"
     assert settings.getpriority(name) == expected_settings.getpriority(name)
 
 
@@ -553,9 +630,9 @@ def test_remove_from_list(before, name, item, after):
     settings.remove_from_list(name, item)
     expected_priority = settings.getpriority(name) or 0
     expected_settings = BaseSettings(after, priority=expected_priority)
-    assert settings == expected_settings, (
-        f"{settings[name]=} != {expected_settings[name]=}"
-    )
+    assert (
+        settings == expected_settings
+    ), f"{settings[name]=} != {expected_settings[name]=}"
     assert settings.getpriority(name) == expected_settings.getpriority(name)
 
 
@@ -941,9 +1018,9 @@ def test_set_in_component_priority_dict(before, name, cls, priority, after):
     settings.set_in_component_priority_dict(name, cls, priority)
     expected_settings = BaseSettings(after, priority=expected_priority)
     assert settings == expected_settings
-    assert settings.getpriority(name) == expected_settings.getpriority(name), (
-        f"{settings.getpriority(name)=} != {expected_settings.getpriority(name)=}"
-    )
+    assert settings.getpriority(name) == expected_settings.getpriority(
+        name
+    ), f"{settings.getpriority(name)=} != {expected_settings.getpriority(name)=}"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Description

This PR replaces non-typing assert statements in `BaseSettings.getdictorlist()` method with proper `ValueError` exceptions for better error handling.

## Changes

- **Line 285**: Replace `assert isinstance(value_loaded, (dict, list))` with proper ValueError
- **Line 291**: Replace `assert isinstance(value, (dict, list))` with proper ValueError  
- **Improved error handling**: Use `json.JSONDecodeError` instead of `ValueError` for JSON parsing failures
- **Comprehensive tests**: Added 10 new test cases covering all code paths and error conditions

## Rationale

Assert statements should not be used for user input validation as they can be disabled with the `-O` flag and provide poor error messages. Using proper exceptions ensures:

1. Better error messages for users
2. Consistent behavior regardless of Python optimization flags
3. Proper exception handling in calling code

## Test Coverage

Added comprehensive tests for:
- ✅ Valid dict/list inputs
- ✅ Tuple conversion to list
- ✅ JSON string parsing (dict and list)
- ✅ Comma-separated string fallback
- ✅ None values and defaults
- ✅ Error cases with descriptive messages

## Verification

```bash
# Run specific tests
python -m pytest tests/test_settings/ -k "getdictorlist" -v

# Run all settings tests
python -m pytest tests/test_settings/ -x
```

All tests pass with no regressions.

Fixes #6876