### PR TITLE
Fix FileFeedStorage handling of Windows paths without file:// scheme

### DIFF
--- a/scrapy/extensions/feedexport.py
+++ b/scrapy/extensions/feedexport.py
@@ -185,7 +185,9 @@ class StdoutFeedStorage:
 @implementer(IFeedStorage)
 class FileFeedStorage:
     def __init__(self, uri: str, *, feed_options: dict[str, Any] | None = None):
-        self.path: str = file_uri_to_path(uri)
+        self.path: str = (
+            file_uri_to_path(uri) if uri.startswith("file://") else str(Path(uri))
+        )
         feed_options = feed_options or {}
         self.write_mode: OpenBinaryMode = (
             "wb" if feed_options.get("overwrite", False) else "ab"

--- a/scrapy/extensions/feedexport.py
+++ b/scrapy/extensions/feedexport.py
@@ -185,9 +185,7 @@ class StdoutFeedStorage:
 @implementer(IFeedStorage)
 class FileFeedStorage:
     def __init__(self, uri: str, *, feed_options: dict[str, Any] | None = None):
-        self.path: str = (
-            file_uri_to_path(uri) if uri.startswith("file://") else str(Path(uri))
-        )
+        self.path: str = file_uri_to_path(uri) if uri.startswith("file://") else uri
         feed_options = feed_options or {}
         self.write_mode: OpenBinaryMode = (
             "wb" if feed_options.get("overwrite", False) else "ab"

--- a/tests/test_feedexport.py
+++ b/tests/test_feedexport.py
@@ -155,11 +155,10 @@ class TestFileFeedStorage:
         finally:
             path.unlink()
 
-    def test_preserves_windows_path_without_file_scheme(self, tmp_path):
+    def test_preserves_windows_path_without_file_scheme(self):
         path = r"C:\Users\user\Desktop\test.txt"
-        expected_path = "C:\\Users\\user\\Desktop\\test.txt"
         storage = FileFeedStorage(path)
-        assert storage.path == expected_path
+        assert storage.path == path
 
 
 class TestFTPFeedStorage(unittest.TestCase):

--- a/tests/test_feedexport.py
+++ b/tests/test_feedexport.py
@@ -155,6 +155,12 @@ class TestFileFeedStorage:
         finally:
             path.unlink()
 
+    def test_preserves_windows_path_without_file_scheme(self, tmp_path):
+        path = r"C:\Users\user\Desktop\test.txt"
+        expected_path = "C:\\Users\\user\\Desktop\\test.txt"
+        storage = FileFeedStorage(path)
+        assert storage.path == expected_path
+
 
 class TestFTPFeedStorage(unittest.TestCase):
     def get_test_spider(self, settings=None):


### PR DESCRIPTION
## Description

This PR addresses an issue in the `FileFeedStorage` class where passing a Windows-style path without the `file://` URI scheme causes incorrect path resolution. Specifically, using a path like `C:/foo` was incorrectly processed by `w3lib.url.file_uri_to_path()`, which expects a proper URI. This led to malformed paths such as `\\foo`, causing files to be written relative to the spider's working directory instead of the intended absolute path.

The problematic code was:
```python
self.path = file_uri_to_path(uri)
```
which always called file_uri_to_path() regardless of whether uri was a valid URI or just a local path.

## Solution

The fix changes the initialization logic to only convert the path using file_uri_to_path() if the input string starts with the file:// scheme. Otherwise, the path is preserved as-is.

## Testing

- Added a new test test_preserves_windows_path_without_file_scheme that verifies Windows-style paths are preserved correctly when passed without the file:// scheme.
- Existing tests that use tmp_path cover writing and storing files, including relative and URI paths.
- The new test is sufficient to cover the issue because the root problem was path parsing, not file writing.

Fixes #6894 