### PR TITLE
Handle exceptions in _start_request_processing(), cancel it on engine stop

### DIFF
--- a/scrapy/core/engine.py
+++ b/scrapy/core/engine.py
@@ -7,12 +7,13 @@ For more information see docs/topics/architecture.rst
 
 from __future__ import annotations
 
+import asyncio
 import logging
 from time import time
 from traceback import format_exc
 from typing import TYPE_CHECKING, Any, cast
 
-from twisted.internet.defer import Deferred, inlineCallbacks, succeed
+from twisted.internet.defer import CancelledError, Deferred, inlineCallbacks, succeed
 from twisted.python.failure import Failure
 
 from scrapy import signals
@@ -108,6 +109,8 @@ class ExecutionEngine:
         )
         self.start_time: float | None = None
         self._start: AsyncIterator[Any] | None = None
+        self._closewait: Deferred[None] | None = None
+        self._start_request_processing_dfd: Deferred[None] | None = None
         downloader_cls: type[Downloader] = load_object(self.settings["DOWNLOADER"])
         try:
             self.scheduler_cls: type[BaseScheduler] = self._get_scheduler_class(
@@ -139,9 +142,9 @@ class ExecutionEngine:
         self.start_time = time()
         await self.signals.send_catch_log_async(signal=signals.engine_started)
         self.running = True
-        self._closewait: Deferred[None] = Deferred()
+        self._closewait = Deferred()
         if _start_request_processing:
-            self._start_request_processing()
+            self._start_request_processing_dfd = self._start_request_processing()
         await maybe_deferred_to_future(self._closewait)
 
     def stop(self) -> Deferred[None]:
@@ -150,12 +153,16 @@ class ExecutionEngine:
         @deferred_f_from_coro_f
         async def _finish_stopping_engine(_: Any) -> None:
             await self.signals.send_catch_log_async(signal=signals.engine_stopped)
-            self._closewait.callback(None)
+            if self._closewait:
+                self._closewait.callback(None)
 
         if not self.running:
             raise RuntimeError("Engine not running")
 
         self.running = False
+        if self._start_request_processing_dfd is not None:
+            self._start_request_processing_dfd.cancel()
+            self._start_request_processing_dfd = None
         dfd = (
             self.close_spider(self.spider, reason="shutdown")
             if self.spider is not None
@@ -229,7 +236,12 @@ class ExecutionEngine:
                     # processed before continuing with the next iteration.
                     self._slot.nextcall.schedule()
                     await self._slot.nextcall.wait()
+        except (asyncio.exceptions.CancelledError, CancelledError):
+            # self.stop() has cancelled us, nothing to do
+            return
         except Exception:
+            # an error happened, log it and stop the engine
+            self._start_request_processing_dfd = None
             logger.error(
                 "Error while processing requests from start()",
                 exc_info=True,

--- a/scrapy/core/scraper.py
+++ b/scrapy/core/scraper.py
@@ -140,7 +140,6 @@ class Scraper:
 
     def _check_if_closing(self) -> None:
         assert self.slot is not None  # typing
-        assert self.crawler.spider
         if self.slot.closing and self.slot.is_idle():
             assert self.crawler.spider
             self.slot.closing.callback(self.crawler.spider)


### PR DESCRIPTION
Fixes #6784 by handling exceptions raised in code that is called from `ExecutionEngine._start_request_processing()` (the first commit). Additionally, fixes #6783 by cancelling that task from `ExecutionEngine.stop()` (the second commit; I'm not sure if it's possible to write a test for this, maybe only with `loop.set_exception_handler()`), hopefully there are no related code paths where `stop()` isn't called.

