### PR TITLE
Add `.venv` to `.gitignore` to prevent accidental commits

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ docs/build
 *egg-info
 .tox
 venv
+.venv
 build
 dist
 .idea


### PR DESCRIPTION
As discussed in #6898, this small PR adds .venv/ to the .gitignore file.

While venv/ was already ignored, .venv/ is a common convention, especially when using:

```bash
python -m venv .venv
```

and it's easy to forget to exclude it manually. This small change helps prevent contributors from accidentally committing local virtual environments, which can be large and unnecessary in version control.

This should also make it easier for new contributors to set up their development environment without having to modify .gitignore themselves.