### PR TITLE
Fix setting ExecutionEngine._slot to None on close.

### DIFF
--- a/scrapy/core/engine.py
+++ b/scrapy/core/engine.py
@@ -530,10 +530,16 @@ class ExecutionEngine:
             )
         )
 
-        dfd.addBoth(lambda _: setattr(self, "slot", None))
+        def unassign_slot(_: Any) -> None:
+            self._slot = None
+
+        dfd.addBoth(unassign_slot)
         dfd.addErrback(log_failure("Error while unassigning slot"))
 
-        dfd.addBoth(lambda _: setattr(self, "spider", None))
+        def unassign_spider(_: Any) -> None:
+            self.spider = None
+
+        dfd.addBoth(unassign_spider)
         dfd.addErrback(log_failure("Error while unassigning spider"))
 
         dfd.addBoth(lambda _: self._spider_closed_callback(spider))

--- a/scrapy/core/engine.py
+++ b/scrapy/core/engine.py
@@ -266,10 +266,10 @@ class ExecutionEngine:
 
         See :ref:`start-requests-lazy` for an example.
         """
-        assert self._slot is not None  # typing
         assert self.scraper.slot is not None  # typing
         return (
             not self.running
+            or not self._slot
             or bool(self._slot.closing)
             or self.downloader.needs_backout()
             or self.scraper.slot.needs_backout()

--- a/tests/test_engine_loop.py
+++ b/tests/test_engine_loop.py
@@ -112,7 +112,7 @@ class TestMain(TestCase):
         with LogCapture(level=ERROR) as log:
             await maybe_deferred_to_future(crawler.crawl())
 
-        assert not log.records, f"{log.records=}"
+        assert not log.records
         finish_reason = crawler.stats.get_value("finish_reason")
         assert finish_reason == "shutdown", f"{finish_reason=}"
         expected_urls = []


### PR DESCRIPTION
When the attribute was renamed this code wasn't changed.

(the whole method needs refactoring but that's for later)