### PR TITLE
Narrow down TestEngine::test_short_timeout() expectations.

### DIFF
--- a/scrapy/core/engine.py
+++ b/scrapy/core/engine.py
@@ -135,6 +135,9 @@ class ExecutionEngine:
         await maybe_deferred_to_future(
             self.signals.send_catch_log_deferred(signal=signals.engine_started)
         )
+        if _start_request_processing and self.spider is None:
+            # require an opened spider when not run in scrapy shell
+            return
         self.running = True
         self._closewait = Deferred()
         if _start_request_processing:
@@ -541,5 +544,6 @@ class ExecutionEngine:
         dfd.addErrback(log_failure("Error while unassigning spider"))
 
         dfd.addBoth(lambda _: self._spider_closed_callback(spider))
+        dfd.addErrback(log_failure("Error running spider_closed_callback"))
 
         return dfd

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -509,7 +509,9 @@ class TestEngine(TestEngineBase):
         finally:
             timer.cancel()
 
-        assert b"Traceback" not in stderr, stderr
+        stderr_str = stderr.decode("utf-8")
+        assert "AttributeError" not in stderr_str
+        assert "AssertionError" not in stderr_str
 
 
 def test_request_scheduled_signal(caplog):

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -510,8 +510,8 @@ class TestEngine(TestEngineBase):
             timer.cancel()
 
         stderr_str = stderr.decode("utf-8")
-        assert "AttributeError" not in stderr_str
-        assert "AssertionError" not in stderr_str
+        assert "AttributeError" not in stderr_str, stderr_str
+        assert "AssertionError" not in stderr_str, stderr_str
 
 
 def test_request_scheduled_signal(caplog):

--- a/tests/test_engine_loop.py
+++ b/tests/test_engine_loop.py
@@ -112,7 +112,8 @@ class MainTestCase(TestCase):
         with LogCapture(level=ERROR) as log:
             await maybe_deferred_to_future(crawler.crawl())
 
-        assert not log.records
+        assert len(log.records) == 1
+        assert log.records[0].msg == "Error running spider_closed_callback"
         finish_reason = crawler.stats.get_value("finish_reason")
         assert finish_reason == "shutdown", f"{finish_reason=}"
         expected_urls = []


### PR DESCRIPTION
Fixes #6908

As it doesn't look like we can avoid the unhandled CancelledError, change the expectations to exceptions that could be raised when `self._slot` is unexpectedly None.

The test was added in #5440