### PR TITLE
Remove the deprecated sphinx-hoverxref

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -26,7 +26,6 @@ author = "Scrapy developers"
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
 
 extensions = [
-    "hoverxref.extension",
     "notfound.extension",
     "scrapydocs",
     "sphinx.ext.autodoc",
@@ -157,22 +156,5 @@ intersphinx_mapping = {
 }
 intersphinx_disabled_reftypes: Sequence[str] = []
 
-
-# -- Options for sphinx-hoverxref extension ----------------------------------
-# https://sphinx-hoverxref.readthedocs.io/en/latest/configuration.html
-
-hoverxref_auto_ref = True
-hoverxref_role_types = {
-    "class": "tooltip",
-    "command": "tooltip",
-    "confval": "tooltip",
-    "hoverxref": "tooltip",
-    "mod": "tooltip",
-    "ref": "tooltip",
-    "reqmeta": "tooltip",
-    "setting": "tooltip",
-    "signal": "tooltip",
-}
-hoverxref_roles = ["command", "reqmeta", "setting", "signal"]
-
+# -- Other options ------------------------------------------------------------
 default_dark_mode = False

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,4 @@
 sphinx==8.1.3
-sphinx-hoverxref==1.4.2
 sphinx-notfound-page==1.0.4
 sphinx-rtd-theme==3.0.2
 sphinx-rtd-dark-mode==1.3.0


### PR DESCRIPTION
Fixes #6786 

> This extension has been deprecated. ([ref](https://github.com/readthedocs/sphinx-hoverxref/blob/main/README.rst))