### PR TITLE
feat(settings): Change default SCHEDULER_PRIORITY_QUEUE to Downloader…

### DIFF
--- a/docs/topics/settings.rst
+++ b/docs/topics/settings.rst
@@ -1739,14 +1739,13 @@ Type of in-memory queue used by the scheduler. Other available type is:
 SCHEDULER_PRIORITY_QUEUE
 ------------------------
 
-Default: ``'scrapy.pqueues.ScrapyPriorityQueue'``
+Default: ``'scrapy.pqueues.DownloaderAwarePriorityQueue'``
 
-Type of priority queue used by the scheduler. Another available type is
-``scrapy.pqueues.DownloaderAwarePriorityQueue``.
-``scrapy.pqueues.DownloaderAwarePriorityQueue`` works better than
-``scrapy.pqueues.ScrapyPriorityQueue`` when you crawl many different
-domains in parallel.
+The priority queue class used by the scheduler. 
 
+Available implementations:
+- ``scrapy.pqueues.DownloaderAwarePriorityQueue`` (default): Better for crawling many different domains in parallel
+- ``scrapy.pqueues.ScrapyPriorityQueue``: Legacy implementation
 
 .. setting:: SCHEDULER_START_DISK_QUEUE
 

--- a/scrapy/settings/default_settings.py
+++ b/scrapy/settings/default_settings.py
@@ -480,7 +480,7 @@ SCHEDULER = "scrapy.core.scheduler.Scheduler"
 SCHEDULER_DEBUG = False
 SCHEDULER_DISK_QUEUE = "scrapy.squeues.PickleLifoDiskQueue"
 SCHEDULER_MEMORY_QUEUE = "scrapy.squeues.LifoMemoryQueue"
-SCHEDULER_PRIORITY_QUEUE = "scrapy.pqueues.ScrapyPriorityQueue"
+SCHEDULER_PRIORITY_QUEUE = 'scrapy.pqueues.DownloaderAwarePriorityQueue'
 SCHEDULER_START_DISK_QUEUE = "scrapy.squeues.PickleFifoDiskQueue"
 SCHEDULER_START_MEMORY_QUEUE = "scrapy.squeues.FifoMemoryQueue"
 


### PR DESCRIPTION
## Description
Changes default `SCHEDULER_PRIORITY_QUEUE` to `DownloaderAwarePriorityQueue` (closes #6924).

Depends on #6921 (merged) where the new queue was implemented.

## Changes
- Updated `SCHEDULER_PRIORITY_QUEUE` default in `default_settings.py`
- Updated documentation in `docs/topics/settings.rst`

## Verification
- Ran tests with `pytest`
- Confirmed backward compatibility

## Testing
- Ran priority queue tests (`test_pqueues.py`) - 11 passed, 2 skipped
- Verified with `scrapy bench` (manual testing)