### PR TITLE
Deprecate mustbe_deferred() and defer_*().

### DIFF
--- a/scrapy/core/downloader/middleware.py
+++ b/scrapy/core/downloader/middleware.py
@@ -15,7 +15,7 @@ from scrapy.exceptions import _InvalidOutput
 from scrapy.http import Request, Response
 from scrapy.middleware import MiddlewareManager
 from scrapy.utils.conf import build_component_list
-from scrapy.utils.defer import deferred_from_coro, mustbe_deferred
+from scrapy.utils.defer import _defer_sleep, deferred_from_coro
 
 if TYPE_CHECKING:
     from collections.abc import Generator
@@ -110,8 +110,9 @@ class DownloaderMiddlewareManager(MiddlewareManager):
             raise exception
 
         try:
-            result: Response | Request = yield mustbe_deferred(process_request, request)
+            result: Response | Request = yield process_request(request)
         except Exception as ex:
+            yield _defer_sleep()
             # either returns a request or response (which we pass to process_response())
             # or reraises the exception
             result = yield process_exception(ex)

--- a/scrapy/core/scraper.py
+++ b/scrapy/core/scraper.py
@@ -23,7 +23,7 @@ from scrapy.exceptions import (
 from scrapy.http import Request, Response
 from scrapy.utils.asyncio import _parallel_asyncio, is_asyncio_available
 from scrapy.utils.defer import (
-    _defer_sleep,
+    _defer_sleep_async,
     aiter_errback,
     deferred_f_from_coro_f,
     deferred_from_coro,
@@ -236,7 +236,7 @@ class Scraper:
         self, result: Response | Failure, request: Request
     ) -> Iterable[Any] | AsyncIterator[Any]:
         """Call the request callback or errback with the response or failure."""
-        await maybe_deferred_to_future(_defer_sleep())
+        await _defer_sleep_async()
         assert self.crawler.spider
         if isinstance(result, Response):
             if getattr(result, "request", None) is None:

--- a/scrapy/pipelines/files.py
+++ b/scrapy/pipelines/files.py
@@ -562,7 +562,7 @@ class FilesPipeline(MediaPipeline):
 
     def media_to_download(
         self, request: Request, info: MediaPipeline.SpiderInfo, *, item: Any = None
-    ) -> Deferred[FileInfo | None]:
+    ) -> Deferred[FileInfo | None] | None:
         def _onsuccess(result: StatInfo) -> FileInfo | None:
             if not result:
                 return None  # returning None force download

--- a/tests/test_spidermiddleware.py
+++ b/tests/test_spidermiddleware.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from collections.abc import AsyncIterator, Iterable
 from inspect import isasyncgen
-from typing import Any
+from typing import TYPE_CHECKING, Any
 from unittest import mock
 
 import pytest
@@ -18,6 +18,9 @@ from scrapy.utils.asyncgen import collect_asyncgen
 from scrapy.utils.defer import deferred_f_from_coro_f, maybe_deferred_to_future
 from scrapy.utils.test import get_crawler
 
+if TYPE_CHECKING:
+    from twisted.python.failure import Failure
+
 
 class TestSpiderMiddleware(TestCase):
     def setUp(self):
@@ -31,7 +34,13 @@ class TestSpiderMiddleware(TestCase):
         """Execute spider mw manager's scrape_response method and return the result.
         Raise exception in case of failure.
         """
-        scrape_func = mock.MagicMock()
+
+        def scrape_func(
+            response: Response | Failure, request: Request
+        ) -> defer.Deferred[Iterable[Any]]:
+            it = mock.MagicMock()
+            return defer.succeed(it)
+
         return await maybe_deferred_to_future(
             self.mwman.scrape_response(
                 scrape_func, self.response, self.request, self.spider
@@ -122,10 +131,15 @@ class TestBaseAsyncSpiderMiddleware(TestSpiderMiddleware):
             start_index = 10
         return {i: c for c, i in enumerate(mw_classes, start=start_index)}
 
-    def _scrape_func(self, *args, **kwargs):
+    def _callback(self) -> Any:
         yield {"foo": 1}
         yield {"foo": 2}
         yield {"foo": 3}
+
+    def _scrape_func(
+        self, response: Response | Failure, request: Request
+    ) -> defer.Deferred[Iterable[Any] | AsyncIterator[Any]]:
+        return defer.succeed(self._callback())
 
     async def _get_middleware_result(
         self, *mw_classes: type[Any], start_index: int | None = None
@@ -272,8 +286,8 @@ class TestProcessSpiderOutputSimple(TestBaseAsyncSpiderMiddleware):
 class TestProcessSpiderOutputAsyncGen(TestProcessSpiderOutputSimple):
     """process_spider_output tests for async generator callbacks"""
 
-    async def _scrape_func(self, *args, **kwargs):
-        for item in super()._scrape_func():
+    async def _callback(self) -> Any:
+        for item in super()._callback():
             yield item
 
     @deferred_f_from_coro_f
@@ -503,8 +517,8 @@ class TestBuiltinMiddlewareSimple(TestBaseAsyncSpiderMiddleware):
 
 
 class TestBuiltinMiddlewareAsyncGen(TestBuiltinMiddlewareSimple):
-    async def _scrape_func(self, *args, **kwargs):
-        for item in super()._scrape_func():
+    async def _callback(self) -> Any:
+        for item in super()._callback():
             yield item
 
     @deferred_f_from_coro_f
@@ -546,7 +560,7 @@ class TestProcessSpiderException(TestBaseAsyncSpiderMiddleware):
     MW_EXC_SIMPLE = ProcessSpiderExceptionSimpleIterableMiddleware
     MW_EXC_ASYNCGEN = ProcessSpiderExceptionAsyncIteratorMiddleware
 
-    def _scrape_func(self, *args, **kwargs):
+    def _callback(self) -> Any:
         1 / 0
 
     async def _test_asyncgen_nodowngrade(self, *mw_classes: type[Any]) -> None:

--- a/tests/test_utils_defer.py
+++ b/tests/test_utils_defer.py
@@ -28,6 +28,7 @@ if TYPE_CHECKING:
     from collections.abc import AsyncGenerator, Awaitable, Callable, Generator
 
 
+@pytest.mark.filterwarnings("ignore::scrapy.exceptions.ScrapyDeprecationWarning")
 class TestMustbeDeferred(unittest.TestCase):
     @inlineCallbacks
     def test_success_function(self) -> Generator[Deferred[Any], Any, None]:


### PR DESCRIPTION
`mustbe_deferred()` calls the wrapped function and 
1. if got a Deferred returns that one directly 
2. if got an exception sleeps for `_DEFER_DELAY` and propagates it
3. if got a normal result sleeps for `_DEFER_DELAY` and returns it.

Thus if we know that the wrapped function always returns a Deferred we add a sleep to the `except` block (it looks like all calls outside `MediaPipeline` are like this) and if we know that the wrapped function can return a normal result we wrap it into a `maybeDeferred()` and add a sleep before calling it (this is only in `MediaPipeline`). I think if `MediaPipeline.media_to_download()` returns a Deferred there is one more sleep than before the change, which I'm fine with. 

Note that all of these sleeps seem to be added empirically and doing more of them shouldn't hurt anything except maybe some performance and doing less of them may be fine or increase some blocking/deadlocking chance (as brefiely mentioned in https://www.youtube.com/watch?v=6hiXhNaWTTk).