### PR TITLE
Migrate to pytest-twisted

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -56,7 +56,7 @@ def reactor_pytest(request) -> str:
 @pytest.fixture(autouse=True)
 def only_asyncio(request, reactor_pytest):
     if request.node.get_closest_marker("only_asyncio") and reactor_pytest != "asyncio":
-        pytest.skip("This test is only run without --reactor=default")
+        pytest.skip("This test is only run with --reactor=asyncio")
 
 
 @pytest.fixture(autouse=True)
@@ -65,7 +65,7 @@ def only_not_asyncio(request, reactor_pytest):
         request.node.get_closest_marker("only_not_asyncio")
         and reactor_pytest == "asyncio"
     ):
-        pytest.skip("This test is only run with --reactor=default")
+        pytest.skip("This test is only run without --reactor=asyncio")
 
 
 @pytest.fixture(autouse=True)

--- a/conftest.py
+++ b/conftest.py
@@ -48,18 +48,14 @@ if not H2_ENABLED:
     )
 
 
-@pytest.fixture(scope="class")
-def reactor_pytest(request):
-    if not request.cls:
-        # doctests
-        return None
-    request.cls.reactor_pytest = request.config.getoption("--reactor")
-    return request.cls.reactor_pytest
+@pytest.fixture(scope="session")
+def reactor_pytest(request) -> str:
+    return request.config.getoption("--reactor")
 
 
 @pytest.fixture(autouse=True)
 def only_asyncio(request, reactor_pytest):
-    if request.node.get_closest_marker("only_asyncio") and reactor_pytest == "default":
+    if request.node.get_closest_marker("only_asyncio") and reactor_pytest != "asyncio":
         pytest.skip("This test is only run without --reactor=default")
 
 
@@ -67,7 +63,7 @@ def only_asyncio(request, reactor_pytest):
 def only_not_asyncio(request, reactor_pytest):
     if (
         request.node.get_closest_marker("only_not_asyncio")
-        and reactor_pytest != "default"
+        and reactor_pytest == "asyncio"
     ):
         pytest.skip("This test is only run with --reactor=default")
 

--- a/conftest.py
+++ b/conftest.py
@@ -3,7 +3,6 @@ from pathlib import Path
 import pytest
 from twisted.web.http import H2_ENABLED
 
-from scrapy.utils.reactor import install_reactor
 from tests.keys import generate_keys
 
 
@@ -48,12 +47,12 @@ if not H2_ENABLED:
     )
 
 
-def pytest_addoption(parser):
-    parser.addoption(
-        "--reactor",
-        default="asyncio",
-        choices=["default", "asyncio"],
-    )
+# def pytest_addoption(parser):
+#     parser.addoption(
+#         "--reactor",
+#         default="asyncio",
+#         choices=["default", "asyncio"],
+#     )
 
 
 @pytest.fixture(scope="class")
@@ -116,12 +115,12 @@ def requires_boto3(request):
         pytest.skip("boto3 is not installed")
 
 
-def pytest_configure(config):
-    if config.getoption("--reactor") != "default":
-        install_reactor("twisted.internet.asyncioreactor.AsyncioSelectorReactor")
-    else:
-        # install the reactor explicitly
-        from twisted.internet import reactor  # noqa: F401
+# def pytest_configure(config):
+#     if config.getoption("--reactor") != "default":
+#         install_reactor("twisted.internet.asyncioreactor.AsyncioSelectorReactor")
+#     else:
+#         # install the reactor explicitly
+#         from twisted.internet import reactor
 
 
 # Generate localhost certificate files, needed by some tests

--- a/conftest.py
+++ b/conftest.py
@@ -3,6 +3,7 @@ from pathlib import Path
 import pytest
 from twisted.web.http import H2_ENABLED
 
+from scrapy.utils.reactor import set_asyncio_event_loop_policy
 from tests.keys import generate_keys
 
 
@@ -107,12 +108,11 @@ def requires_boto3(request):
         pytest.skip("boto3 is not installed")
 
 
-# def pytest_configure(config):
-#     if config.getoption("--reactor") != "default":
-#         install_reactor("twisted.internet.asyncioreactor.AsyncioSelectorReactor")
-#     else:
-#         # install the reactor explicitly
-#         from twisted.internet import reactor
+def pytest_configure(config):
+    if config.getoption("--reactor") == "asyncio":
+        # Needed on Windows to switch from proactor to selector for Twisted reactor compatibility.
+        # If we decide to run tests with both, we will need to add a new option and check it here.
+        set_asyncio_event_loop_policy()
 
 
 # Generate localhost certificate files, needed by some tests

--- a/conftest.py
+++ b/conftest.py
@@ -47,14 +47,6 @@ if not H2_ENABLED:
     )
 
 
-# def pytest_addoption(parser):
-#     parser.addoption(
-#         "--reactor",
-#         default="asyncio",
-#         choices=["default", "asyncio"],
-#     )
-
-
 @pytest.fixture(scope="class")
 def reactor_pytest(request):
     if not request.cls:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -218,6 +218,9 @@ disable = [
 ]
 
 [tool.pytest.ini_options]
+addopts = [
+    "--reactor=asyncio",
+]
 xfail_strict = true
 python_files = ["test_*.py", "test_*/__init__.py"]
 markers = [

--- a/scrapy/utils/reactor.py
+++ b/scrapy/utils/reactor.py
@@ -13,7 +13,7 @@ from scrapy.utils.misc import load_object
 from scrapy.utils.python import global_object_name
 
 if TYPE_CHECKING:
-    from asyncio import AbstractEventLoop, AbstractEventLoopPolicy
+    from asyncio import AbstractEventLoop
     from collections.abc import Callable
 
     from twisted.internet.protocol import ServerFactory
@@ -100,17 +100,12 @@ def set_asyncio_event_loop_policy() -> None:
     so we restrict their use to the absolutely essential case.
     This should only be used to install the reactor.
     """
-    _get_asyncio_event_loop_policy()
-
-
-def _get_asyncio_event_loop_policy() -> AbstractEventLoopPolicy:
     policy = asyncio.get_event_loop_policy()
     if sys.platform == "win32" and not isinstance(
         policy, asyncio.WindowsSelectorEventLoopPolicy
     ):
         policy = asyncio.WindowsSelectorEventLoopPolicy()
         asyncio.set_event_loop_policy(policy)
-    return policy
 
 
 def install_reactor(reactor_path: str, event_loop_path: str | None = None) -> None:

--- a/tests/test_addons.py
+++ b/tests/test_addons.py
@@ -3,7 +3,6 @@ from typing import Any
 from unittest.mock import patch
 
 from twisted.internet.defer import inlineCallbacks
-from twisted.trial import unittest
 
 from scrapy import Spider
 from scrapy.crawler import Crawler, CrawlerRunner
@@ -52,7 +51,7 @@ class TestAddon:
         assert settings["KEY3"] == "addon"
 
 
-class TestAddonManager(unittest.TestCase):
+class TestAddonManager:
     def test_load_settings(self):
         settings_dict = {
             "ADDONS": {"tests.test_addons.SimpleAddon": 0},

--- a/tests/test_closespider.py
+++ b/tests/test_closespider.py
@@ -1,5 +1,4 @@
 from twisted.internet.defer import inlineCallbacks
-from twisted.trial.unittest import TestCase
 
 from scrapy.utils.test import get_crawler
 from tests.mockserver import MockServer
@@ -12,14 +11,14 @@ from tests.spiders import (
 )
 
 
-class TestCloseSpider(TestCase):
+class TestCloseSpider:
     @classmethod
-    def setUpClass(cls):
+    def setup_class(cls):
         cls.mockserver = MockServer()
         cls.mockserver.__enter__()
 
     @classmethod
-    def tearDownClass(cls):
+    def teardown_class(cls):
         cls.mockserver.__exit__(None, None, None)
 
     @inlineCallbacks

--- a/tests/test_contracts.py
+++ b/tests/test_contracts.py
@@ -3,7 +3,6 @@ from unittest import TextTestResult
 import pytest
 from twisted.internet.defer import inlineCallbacks
 from twisted.python import failure
-from twisted.trial import unittest
 
 from scrapy import FormRequest
 from scrapy.contracts import Contract, ContractsManager
@@ -247,7 +246,7 @@ class InheritsDemoSpider(DemoSpider):
     name = "inherits_demo_spider"
 
 
-class TestContractsManager(unittest.TestCase):
+class TestContractsManager:
     contracts = [
         UrlContract,
         CallbackKeywordArgumentsContract,
@@ -259,7 +258,7 @@ class TestContractsManager(unittest.TestCase):
         CustomFailContract,
     ]
 
-    def setUp(self):
+    def setup_method(self):
         self.conman = ContractsManager(self.contracts)
         self.results = TextTestResult(stream=None, descriptions=False, verbosity=0)
 

--- a/tests/test_core_downloader.py
+++ b/tests/test_core_downloader.py
@@ -95,7 +95,7 @@ class TestContextFactoryBase:
 
 class TestContextFactory(TestContextFactoryBase):
     @deferred_f_from_coro_f
-    async def testPayload(self, server_url):
+    async def testPayload(self, server_url: str) -> None:
         s = "0123456789" * 10
         crawler = get_crawler()
         settings = Settings()
@@ -133,7 +133,7 @@ class TestContextFactoryTLSMethod(TestContextFactoryBase):
         assert body == to_bytes(s)
 
     @deferred_f_from_coro_f
-    async def test_setting_default(self, server_url):
+    async def test_setting_default(self, server_url: str) -> None:
         crawler = get_crawler()
         settings = Settings()
         client_context_factory = load_context_factory_from_settings(settings, crawler)
@@ -153,7 +153,7 @@ class TestContextFactoryTLSMethod(TestContextFactoryBase):
             load_context_factory_from_settings(settings, crawler)
 
     @deferred_f_from_coro_f
-    async def test_setting_explicit(self, server_url):
+    async def test_setting_explicit(self, server_url: str) -> None:
         crawler = get_crawler()
         settings = Settings({"DOWNLOADER_CLIENT_TLS_METHOD": "TLSv1.2"})
         client_context_factory = load_context_factory_from_settings(settings, crawler)
@@ -161,7 +161,7 @@ class TestContextFactoryTLSMethod(TestContextFactoryBase):
         await self._assert_factory_works(server_url, client_context_factory)
 
     @deferred_f_from_coro_f
-    async def test_direct_from_crawler(self, server_url):
+    async def test_direct_from_crawler(self, server_url: str) -> None:
         # the setting is ignored
         crawler = get_crawler(settings_dict={"DOWNLOADER_CLIENT_TLS_METHOD": "bad"})
         client_context_factory = build_from_crawler(ScrapyClientContextFactory, crawler)
@@ -169,7 +169,7 @@ class TestContextFactoryTLSMethod(TestContextFactoryBase):
         await self._assert_factory_works(server_url, client_context_factory)
 
     @deferred_f_from_coro_f
-    async def test_direct_init(self, server_url):
+    async def test_direct_init(self, server_url: str) -> None:
         client_context_factory = ScrapyClientContextFactory(OpenSSL.SSL.TLSv1_2_METHOD)
         assert client_context_factory._ssl_method == OpenSSL.SSL.TLSv1_2_METHOD
         await self._assert_factory_works(server_url, client_context_factory)

--- a/tests/test_core_downloader.py
+++ b/tests/test_core_downloader.py
@@ -1,16 +1,12 @@
 from __future__ import annotations
 
-import shutil
 import warnings
-from pathlib import Path
-from tempfile import mkdtemp
-from typing import Any, cast
+from typing import TYPE_CHECKING, Any, cast
 
 import OpenSSL.SSL
 import pytest
-from twisted.internet.defer import Deferred, inlineCallbacks
+from pytest_twisted import async_yield_fixture
 from twisted.protocols.policies import WrappingFactory
-from twisted.trial import unittest
 from twisted.web import server, static
 from twisted.web.client import Agent, BrowserLikePolicyForHTTPS, readBody
 from twisted.web.client import Response as TxResponse
@@ -29,6 +25,9 @@ from scrapy.utils.python import to_bytes
 from scrapy.utils.test import get_crawler
 from tests.mockserver import PayloadResource, ssl_context_factory
 
+if TYPE_CHECKING:
+    from twisted.internet.defer import Deferred
+
 
 class TestSlot:
     def test_repr(self):
@@ -36,8 +35,22 @@ class TestSlot:
         assert repr(slot) == "Slot(concurrency=8, delay=0.10, randomize_delay=True)"
 
 
-class TestContextFactoryBase(unittest.TestCase):
+class TestContextFactoryBase:
     context_factory = None
+
+    @async_yield_fixture
+    async def server_url(self, tmp_path):
+        (tmp_path / "file").write_bytes(b"0123456789")
+        r = static.File(str(tmp_path))
+        r.putChild(b"payload", PayloadResource())
+        site = server.Site(r, timeout=None)
+        wrapper = WrappingFactory(site)
+        port = self._listen(wrapper)
+        portno = port.getHost().port
+
+        yield f"https://127.0.0.1:{portno}/"
+
+        await port.stopListening()
 
     def _listen(self, site):
         from twisted.internet import reactor
@@ -48,24 +61,6 @@ class TestContextFactoryBase(unittest.TestCase):
             contextFactory=self.context_factory or ssl_context_factory(),
             interface="127.0.0.1",
         )
-
-    def getURL(self, path):
-        return f"https://127.0.0.1:{self.portno}/{path}"
-
-    def setUp(self):
-        self.tmpname = Path(mkdtemp())
-        (self.tmpname / "file").write_bytes(b"0123456789")
-        r = static.File(str(self.tmpname))
-        r.putChild(b"payload", PayloadResource())
-        self.site = server.Site(r, timeout=None)
-        self.wrapper = WrappingFactory(self.site)
-        self.port = self._listen(self.wrapper)
-        self.portno = self.port.getHost().port
-
-    @inlineCallbacks
-    def tearDown(self):
-        yield self.port.stopListening()
-        shutil.rmtree(self.tmpname)
 
     @staticmethod
     async def get_page(
@@ -100,13 +95,13 @@ class TestContextFactoryBase(unittest.TestCase):
 
 class TestContextFactory(TestContextFactoryBase):
     @deferred_f_from_coro_f
-    async def testPayload(self):
+    async def testPayload(self, server_url):
         s = "0123456789" * 10
         crawler = get_crawler()
         settings = Settings()
         client_context_factory = load_context_factory_from_settings(settings, crawler)
         body = await self.get_page(
-            self.getURL("payload"), client_context_factory, body=s
+            server_url + "payload", client_context_factory, body=s
         )
         assert body == to_bytes(s)
 
@@ -129,21 +124,21 @@ class TestContextFactory(TestContextFactoryBase):
 
 class TestContextFactoryTLSMethod(TestContextFactoryBase):
     async def _assert_factory_works(
-        self, client_context_factory: ScrapyClientContextFactory
+        self, server_url: str, client_context_factory: ScrapyClientContextFactory
     ) -> None:
         s = "0123456789" * 10
         body = await self.get_page(
-            self.getURL("payload"), client_context_factory, body=s
+            server_url + "payload", client_context_factory, body=s
         )
         assert body == to_bytes(s)
 
     @deferred_f_from_coro_f
-    async def test_setting_default(self):
+    async def test_setting_default(self, server_url):
         crawler = get_crawler()
         settings = Settings()
         client_context_factory = load_context_factory_from_settings(settings, crawler)
         assert client_context_factory._ssl_method == OpenSSL.SSL.SSLv23_METHOD
-        await self._assert_factory_works(client_context_factory)
+        await self._assert_factory_works(server_url, client_context_factory)
 
     def test_setting_none(self):
         crawler = get_crawler()
@@ -158,23 +153,23 @@ class TestContextFactoryTLSMethod(TestContextFactoryBase):
             load_context_factory_from_settings(settings, crawler)
 
     @deferred_f_from_coro_f
-    async def test_setting_explicit(self):
+    async def test_setting_explicit(self, server_url):
         crawler = get_crawler()
         settings = Settings({"DOWNLOADER_CLIENT_TLS_METHOD": "TLSv1.2"})
         client_context_factory = load_context_factory_from_settings(settings, crawler)
         assert client_context_factory._ssl_method == OpenSSL.SSL.TLSv1_2_METHOD
-        await self._assert_factory_works(client_context_factory)
+        await self._assert_factory_works(server_url, client_context_factory)
 
     @deferred_f_from_coro_f
-    async def test_direct_from_crawler(self):
+    async def test_direct_from_crawler(self, server_url):
         # the setting is ignored
         crawler = get_crawler(settings_dict={"DOWNLOADER_CLIENT_TLS_METHOD": "bad"})
         client_context_factory = build_from_crawler(ScrapyClientContextFactory, crawler)
         assert client_context_factory._ssl_method == OpenSSL.SSL.SSLv23_METHOD
-        await self._assert_factory_works(client_context_factory)
+        await self._assert_factory_works(server_url, client_context_factory)
 
     @deferred_f_from_coro_f
-    async def test_direct_init(self):
+    async def test_direct_init(self, server_url):
         client_context_factory = ScrapyClientContextFactory(OpenSSL.SSL.TLSv1_2_METHOD)
         assert client_context_factory._ssl_method == OpenSSL.SSL.TLSv1_2_METHOD
-        await self._assert_factory_works(client_context_factory)
+        await self._assert_factory_works(server_url, client_context_factory)

--- a/tests/test_crawl.py
+++ b/tests/test_crawl.py
@@ -12,7 +12,6 @@ from testfixtures import LogCapture
 from twisted.internet.defer import inlineCallbacks
 from twisted.internet.ssl import Certificate
 from twisted.python.failure import Failure
-from twisted.trial.unittest import TestCase
 
 from scrapy import Spider, signals
 from scrapy.crawler import CrawlerRunner
@@ -60,16 +59,16 @@ if TYPE_CHECKING:
     from scrapy.statscollectors import StatsCollector
 
 
-class TestCrawl(TestCase):
+class TestCrawl:
     mockserver: MockServer
 
     @classmethod
-    def setUpClass(cls):
+    def setup_class(cls):
         cls.mockserver = MockServer()
         cls.mockserver.__enter__()
 
     @classmethod
-    def tearDownClass(cls):
+    def teardown_class(cls):
         cls.mockserver.__exit__(None, None, None)
 
     @inlineCallbacks
@@ -427,16 +426,16 @@ with multiples lines
         assert "Got response 200" in str(log)
 
 
-class TestCrawlSpider(TestCase):
+class TestCrawlSpider:
     mockserver: MockServer
 
     @classmethod
-    def setUpClass(cls):
+    def setup_class(cls):
         cls.mockserver = MockServer()
         cls.mockserver.__enter__()
 
     @classmethod
-    def tearDownClass(cls):
+    def teardown_class(cls):
         cls.mockserver.__exit__(None, None, None)
 
     async def _run_spider(

--- a/tests/test_crawler.py
+++ b/tests/test_crawler.py
@@ -7,6 +7,7 @@ import subprocess
 import sys
 import warnings
 from abc import ABC, abstractmethod
+from collections.abc import Generator
 from pathlib import Path
 from typing import Any
 
@@ -647,7 +648,6 @@ class NoRequestsSpider(scrapy.Spider):
         yield
 
 
-@pytest.mark.usefixtures("reactor_pytest")
 class TestCrawlerRunnerHasSpider:
     @staticmethod
     def _runner():
@@ -699,8 +699,10 @@ class TestCrawlerRunnerHasSpider:
         assert runner.bootstrap_failed
 
     @inlineCallbacks
-    def test_crawler_runner_asyncio_enabled_true(self):
-        if self.reactor_pytest == "default":
+    def test_crawler_runner_asyncio_enabled_true(
+        self, reactor_pytest: str
+    ) -> Generator[Deferred[Any], Any, None]:
+        if reactor_pytest != "asyncio":
             runner = CrawlerRunner(
                 settings={
                     "TWISTED_REACTOR": "twisted.internet.asyncioreactor.AsyncioSelectorReactor",

--- a/tests/test_crawler.py
+++ b/tests/test_crawler.py
@@ -14,7 +14,6 @@ import pytest
 from packaging.version import parse as parse_version
 from pexpect.popen_spawn import PopenSpawn
 from twisted.internet.defer import Deferred, inlineCallbacks
-from twisted.trial import unittest
 from w3lib import __version__ as w3lib_version
 from zope.interface.exceptions import MultipleInvalid
 
@@ -48,7 +47,7 @@ def get_raw_crawler(spidercls=None, settings_dict=None):
     return Crawler(spidercls or DefaultSpider, settings)
 
 
-class TestBaseCrawler(unittest.TestCase):
+class TestBaseCrawler:
     def assertOptionIsDefault(self, settings, key):
         assert isinstance(settings, Settings)
         assert settings[key] == getattr(default_settings, key)
@@ -649,7 +648,7 @@ class NoRequestsSpider(scrapy.Spider):
 
 
 @pytest.mark.usefixtures("reactor_pytest")
-class TestCrawlerRunnerHasSpider(unittest.TestCase):
+class TestCrawlerRunnerHasSpider:
     @staticmethod
     def _runner():
         return CrawlerRunner(get_reactor_settings())
@@ -760,7 +759,7 @@ class ScriptRunnerMixin(ABC):
         return stderr.decode("utf-8")
 
 
-class TestCrawlerProcessSubprocessBase(ScriptRunnerMixin, unittest.TestCase):
+class TestCrawlerProcessSubprocessBase(ScriptRunnerMixin):
     """Common tests between CrawlerProcess and AsyncCrawlerProcess,
     with the same file names and expectations.
     """

--- a/tests/test_downloader_handler_twisted_http10.py
+++ b/tests/test_downloader_handler_twisted_http10.py
@@ -8,9 +8,12 @@ import pytest
 
 from scrapy.core.downloader.handlers.http10 import HTTP10DownloadHandler
 from scrapy.http import Request
-from scrapy.spiders import Spider
 from scrapy.utils.defer import deferred_f_from_coro_f
-from tests.test_downloader_handlers_http_base import TestHttpBase, TestHttpProxyBase
+from tests.test_downloader_handlers_http_base import (
+    TestHttpBase,
+    TestHttpProxyBase,
+    download_request,
+)
 
 if TYPE_CHECKING:
     from scrapy.core.downloader.handlers import DownloadHandlerProtocol
@@ -27,9 +30,11 @@ class TestHttp10(HTTP10DownloadHandlerMixin, TestHttpBase):
     """HTTP 1.0 test case"""
 
     @deferred_f_from_coro_f
-    async def test_protocol(self):
-        request = Request(self.getURL("host"), method="GET")
-        response = await self.download_request(request, Spider("foo"))
+    async def test_protocol(
+        self, server_port: int, download_handler: DownloadHandlerProtocol
+    ) -> None:
+        request = Request(self.getURL(server_port, "host"), method="GET")
+        response = await download_request(download_handler, request)
         assert response.protocol == "HTTP/1.0"
 
 

--- a/tests/test_downloader_handler_twisted_http2.py
+++ b/tests/test_downloader_handler_twisted_http2.py
@@ -72,7 +72,7 @@ class TestHttps2(H2DownloadHandlerMixin, TestHttps11Base):
         with mock.patch("scrapy.core.http2.stream.logger") as logger:
             request = Request(self.getURL(server_port, "largechunkedfile"))
 
-            def check(logger):
+            def check(logger: mock.Mock) -> None:
                 logger.error.assert_called_once_with(mock.ANY)
 
             with pytest.raises((defer.CancelledError, error.ConnectionAborted)):
@@ -83,7 +83,7 @@ class TestHttps2(H2DownloadHandlerMixin, TestHttps11Base):
             # As the error message is logged in the dataReceived callback, we
             # have to give a bit of time to the reactor to process the queue
             # after closing the connection.
-            d = defer.Deferred()
+            d: defer.Deferred[mock.Mock] = defer.Deferred()
             d.addCallback(check)
             reactor.callLater(0.1, d.callback, logger)
             await maybe_deferred_to_future(d)
@@ -96,13 +96,13 @@ class TestHttps2(H2DownloadHandlerMixin, TestHttps11Base):
         with pytest.raises(SchemeNotSupported):
             await download_request(download_handler, request)
 
-    def test_download_cause_data_loss(self) -> None:
+    def test_download_cause_data_loss(self) -> None:  # type: ignore[override]
         pytest.skip(self.HTTP2_DATALOSS_SKIP_REASON)
 
-    def test_download_allow_data_loss(self) -> None:
+    def test_download_allow_data_loss(self) -> None:  # type: ignore[override]
         pytest.skip(self.HTTP2_DATALOSS_SKIP_REASON)
 
-    def test_download_allow_data_loss_via_setting(self) -> None:
+    def test_download_allow_data_loss_via_setting(self) -> None:  # type: ignore[override]
         pytest.skip(self.HTTP2_DATALOSS_SKIP_REASON)
 
     @deferred_f_from_coro_f

--- a/tests/test_downloader_handler_twisted_http2.py
+++ b/tests/test_downloader_handler_twisted_http2.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING, Any
 from unittest import mock
 
 import pytest
+from pytest_twisted import async_yield_fixture
 from testfixtures import LogCapture
 from twisted.internet import defer, error
 from twisted.web import server
@@ -19,8 +20,6 @@ from scrapy.utils.defer import (
     deferred_f_from_coro_f,
     maybe_deferred_to_future,
 )
-from scrapy.utils.misc import build_from_crawler
-from scrapy.utils.test import get_crawler
 from tests.mockserver import ssl_context_factory
 from tests.test_downloader_handlers_http_base import (
     TestHttpMockServerBase,
@@ -31,9 +30,12 @@ from tests.test_downloader_handlers_http_base import (
     TestHttpsInvalidDNSPatternBase,
     TestHttpsWrongHostnameBase,
     UriResource,
+    download_request,
 )
 
 if TYPE_CHECKING:
+    from collections.abc import AsyncGenerator
+
     from scrapy.core.downloader.handlers import DownloadHandlerProtocol
 
 
@@ -55,24 +57,28 @@ class TestHttps2(H2DownloadHandlerMixin, TestHttps11Base):
     HTTP2_DATALOSS_SKIP_REASON = "Content-Length mismatch raises InvalidBodyLengthError"
 
     @deferred_f_from_coro_f
-    async def test_protocol(self):
-        request = Request(self.getURL("host"), method="GET")
-        response = await self.download_request(request, Spider("foo"))
+    async def test_protocol(
+        self, server_port: int, download_handler: DownloadHandlerProtocol
+    ) -> None:
+        request = Request(self.getURL(server_port, "host"), method="GET")
+        response = await download_request(download_handler, request)
         assert response.protocol == "h2"
 
     @deferred_f_from_coro_f
-    async def test_download_with_maxsize_very_large_file(self):
+    async def test_download_with_maxsize_very_large_file(
+        self, server_port: int, download_handler: DownloadHandlerProtocol
+    ) -> None:
         from twisted.internet import reactor
 
         with mock.patch("scrapy.core.http2.stream.logger") as logger:
-            request = Request(self.getURL("largechunkedfile"))
+            request = Request(self.getURL(server_port, "largechunkedfile"))
 
             def check(logger):
                 logger.error.assert_called_once_with(mock.ANY)
 
             with pytest.raises((defer.CancelledError, error.ConnectionAborted)):
-                await self.download_request(
-                    request, Spider("foo", download_maxsize=1500)
+                await download_request(
+                    download_handler, request, Spider("foo", download_maxsize=1500)
                 )
 
             # As the error message is logged in the dataReceived callback, we
@@ -84,55 +90,63 @@ class TestHttps2(H2DownloadHandlerMixin, TestHttps11Base):
             await maybe_deferred_to_future(d)
 
     @deferred_f_from_coro_f
-    async def test_unsupported_scheme(self):
+    async def test_unsupported_scheme(
+        self, download_handler: DownloadHandlerProtocol
+    ) -> None:
         request = Request("ftp://unsupported.scheme")
         with pytest.raises(SchemeNotSupported):
-            await self.download_request(request, Spider("foo"))
+            await download_request(download_handler, request)
 
-    async def _test_download_cause_data_loss(self, url: str) -> None:
+    def test_download_cause_data_loss(self) -> None:
         pytest.skip(self.HTTP2_DATALOSS_SKIP_REASON)
 
-    async def _test_download_allow_data_loss(self, url: str) -> None:
+    def test_download_allow_data_loss(self) -> None:
         pytest.skip(self.HTTP2_DATALOSS_SKIP_REASON)
 
-    async def _test_download_allow_data_loss_via_setting(self, url: str) -> None:
+    def test_download_allow_data_loss_via_setting(self) -> None:
         pytest.skip(self.HTTP2_DATALOSS_SKIP_REASON)
 
     @deferred_f_from_coro_f
-    async def test_concurrent_requests_same_domain(self):
-        spider = Spider("foo")
-
-        request1 = Request(self.getURL("file"))
-        response1 = await self.download_request(request1, spider)
+    async def test_concurrent_requests_same_domain(
+        self, server_port: int, download_handler: DownloadHandlerProtocol
+    ) -> None:
+        request1 = Request(self.getURL(server_port, "file"))
+        response1 = await download_request(download_handler, request1)
         assert response1.body == b"0123456789"
 
-        request2 = Request(self.getURL("echo"), method="POST")
-        response2 = await self.download_request(request2, spider)
+        request2 = Request(self.getURL(server_port, "echo"), method="POST")
+        response2 = await download_request(download_handler, request2)
         assert response2.headers["Content-Length"] == b"79"
 
     @pytest.mark.xfail(reason="https://github.com/python-hyper/h2/issues/1247")
     @deferred_f_from_coro_f
-    async def test_connect_request(self):
-        request = Request(self.getURL("file"), method="CONNECT")
-        response = await self.download_request(request, Spider("foo"))
+    async def test_connect_request(
+        self, server_port: int, download_handler: DownloadHandlerProtocol
+    ) -> None:
+        request = Request(self.getURL(server_port, "file"), method="CONNECT")
+        response = await download_request(download_handler, request)
         assert response.body == b""
 
     @deferred_f_from_coro_f
-    async def test_custom_content_length_good(self):
-        request = Request(self.getURL("contentlength"))
+    async def test_custom_content_length_good(
+        self, server_port: int, download_handler: DownloadHandlerProtocol
+    ) -> None:
+        request = Request(self.getURL(server_port, "contentlength"))
         custom_content_length = str(len(request.body))
         request.headers["Content-Length"] = custom_content_length
-        response = await self.download_request(request, Spider("foo"))
+        response = await download_request(download_handler, request)
         assert response.text == custom_content_length
 
     @deferred_f_from_coro_f
-    async def test_custom_content_length_bad(self):
-        request = Request(self.getURL("contentlength"))
+    async def test_custom_content_length_bad(
+        self, server_port: int, download_handler: DownloadHandlerProtocol
+    ) -> None:
+        request = Request(self.getURL(server_port, "contentlength"))
         actual_content_length = str(len(request.body))
         bad_content_length = str(len(request.body) + 1)
         request.headers["Content-Length"] = bad_content_length
         with LogCapture() as log:
-            response = await self.download_request(request, Spider("foo"))
+            response = await download_request(download_handler, request)
         assert response.text == actual_content_length
         log.check_present(
             (
@@ -145,12 +159,14 @@ class TestHttps2(H2DownloadHandlerMixin, TestHttps11Base):
         )
 
     @deferred_f_from_coro_f
-    async def test_duplicate_header(self):
-        request = Request(self.getURL("echo"))
+    async def test_duplicate_header(
+        self, server_port: int, download_handler: DownloadHandlerProtocol
+    ) -> None:
+        request = Request(self.getURL(server_port, "echo"))
         header, value1, value2 = "Custom-Header", "foo", "bar"
         request.headers.appendlist(header, value1)
         request.headers.appendlist(header, value2)
-        response = await self.download_request(request, Spider("foo"))
+        response = await download_request(download_handler, request)
         assert json.loads(response.text)["headers"][header] == [value1, value2]
 
 
@@ -190,33 +206,32 @@ class TestHttps2Proxy(H2DownloadHandlerMixin, TestHttpProxyBase):
     # only used for HTTPS tests
     keyfile = "keys/localhost.key"
     certfile = "keys/localhost.crt"
-
     scheme = "https"
-    host = "127.0.0.1"
-
     expected_http_proxy_request_body = b"/"
 
-    def setUp(self):
+    @async_yield_fixture
+    async def server_port(self) -> AsyncGenerator[int]:
         from twisted.internet import reactor
 
         site = server.Site(UriResource(), timeout=None)
-        self.port = reactor.listenSSL(
+        port = reactor.listenSSL(
             0,
             site,
             ssl_context_factory(self.keyfile, self.certfile),
             interface=self.host,
         )
-        self.portno = self.port.getHost().port
-        self.download_handler = build_from_crawler(
-            self.download_handler_cls, get_crawler()
-        )
 
-    def getURL(self, path):
-        return f"{self.scheme}://{self.host}:{self.portno}/{path}"
+        yield port.getHost().port
+
+        await port.stopListening()
 
     @deferred_f_from_coro_f
-    async def test_download_with_proxy_https_timeout(self):
+    async def test_download_with_proxy_https_timeout(
+        self, server_port: int, download_handler: DownloadHandlerProtocol
+    ) -> None:
         with pytest.raises(NotImplementedError):
             await maybe_deferred_to_future(
-                super().test_download_with_proxy_https_timeout()
+                super().test_download_with_proxy_https_timeout(
+                    server_port, download_handler
+                )
             )

--- a/tests/test_downloader_handlers.py
+++ b/tests/test_downloader_handlers.py
@@ -4,17 +4,15 @@ from __future__ import annotations
 
 import contextlib
 import os
-import shutil
 import sys
 from pathlib import Path
 from tempfile import mkdtemp, mkstemp
 from unittest import mock
 
 import pytest
+from pytest_twisted import async_yield_fixture
 from twisted.cred import checkers, credentials, portal
-from twisted.internet.defer import inlineCallbacks
 from twisted.protocols.ftp import FTPFactory, FTPRealm
-from twisted.trial import unittest
 from w3lib.url import path_to_file_uri
 
 from scrapy.core.downloader.handlers import DownloadHandlers
@@ -95,14 +93,14 @@ class TestLoad:
         assert "scheme" not in dh._notconfigured
 
 
-class TestFile(unittest.TestCase):
-    def setUp(self):
+class TestFile:
+    def setup_method(self):
         # add a special char to check that they are handled correctly
         self.fd, self.tmpname = mkstemp(suffix="^")
         Path(self.tmpname).write_text("0123456789", encoding="utf-8")
         self.download_handler = build_from_crawler(FileDownloadHandler, get_crawler())
 
-    def tearDown(self):
+    def teardown_method(self):
         os.close(self.fd)
         Path(self.tmpname).unlink()
 
@@ -307,7 +305,7 @@ class TestS3:
         )
 
 
-class TestFTPBase(unittest.TestCase):
+class TestFTPBase:
     username = "scrapy"
     password = "passwd"
     req_meta = {"ftp_user": username, "ftp_password": password}
@@ -318,127 +316,121 @@ class TestFTPBase(unittest.TestCase):
         ("html-file-without-extension", b"<!DOCTYPE html>\n<title>.</title>"),
     )
 
-    def setUp(self):
-        from twisted.internet import reactor
-
-        # setup dirs and test file
-        self.directory = Path(mkdtemp())
-        userdir = self.directory / self.username
+    def _create_files(self, root: Path) -> None:
+        userdir = root / self.username
         userdir.mkdir()
         for filename, content in self.test_files:
             (userdir / filename).write_bytes(content)
 
-        # setup server
-        realm = FTPRealm(
-            anonymousRoot=str(self.directory), userHome=str(self.directory)
-        )
+    def _get_factory(self, root: Path) -> FTPFactory:
+        realm = FTPRealm(anonymousRoot=str(root), userHome=str(root))
         p = portal.Portal(realm)
         users_checker = checkers.InMemoryUsernamePasswordDatabaseDontUse()
         users_checker.addUser(self.username, self.password)
         p.registerChecker(users_checker, credentials.IUsernamePassword)
-        self.factory = FTPFactory(portal=p)
-        self.port = reactor.listenTCP(0, self.factory, interface="127.0.0.1")
-        self.portNum = self.port.getHost().port
+        return FTPFactory(portal=p)
+
+    @async_yield_fixture
+    async def server_url(self, tmp_path):
+        from twisted.internet import reactor
+
+        self._create_files(tmp_path)
+        factory = self._get_factory(tmp_path)
+        port = reactor.listenTCP(0, factory, interface="127.0.0.1")
+        portno = port.getHost().port
+
+        yield f"https://127.0.0.1:{portno}/"
+
+        await port.stopListening()
+
+    @staticmethod
+    @pytest.fixture
+    def dh():
         crawler = get_crawler()
-        self.download_handler = build_from_crawler(FTPDownloadHandler, crawler)
+        dh = build_from_crawler(FTPDownloadHandler, crawler)
 
-    @inlineCallbacks
-    def tearDown(self):
-        yield self.port.stopListening()
-        shutil.rmtree(self.directory)
+        yield dh
 
-    async def download_request(self, request: Request) -> Response:
-        return await maybe_deferred_to_future(
-            self.download_handler.download_request(request, None)
-        )
+        dh.client.transport.loseConnection()
 
-    def _lose_connection(self):
-        self.download_handler.client.transport.loseConnection()
+    async def download_request(
+        self, dh: FTPDownloadHandler, request: Request
+    ) -> Response:
+        return await maybe_deferred_to_future(dh.download_request(request, None))
 
     @deferred_f_from_coro_f
-    async def test_ftp_download_success(self):
-        request = Request(
-            url=f"ftp://127.0.0.1:{self.portNum}/file.txt", meta=self.req_meta
-        )
-        try:
-            r = await self.download_request(request)
-            assert r.status == 200
-            assert r.body == b"I have the power!"
-            assert r.headers == {b"Local Filename": [b""], b"Size": [b"17"]}
-            assert r.protocol is None
-        finally:
-            self._lose_connection()
+    async def test_ftp_download_success(self, server_url, dh):
+        request = Request(url=server_url + "file.txt", meta=self.req_meta)
+        r = await self.download_request(dh, request)
+        assert r.status == 200
+        assert r.body == b"I have the power!"
+        assert r.headers == {b"Local Filename": [b""], b"Size": [b"17"]}
+        assert r.protocol is None
 
     @deferred_f_from_coro_f
-    async def test_ftp_download_path_with_spaces(self):
+    async def test_ftp_download_path_with_spaces(self, server_url, dh):
         request = Request(
-            url=f"ftp://127.0.0.1:{self.portNum}/file with spaces.txt",
+            url=server_url + "file with spaces.txt",
             meta=self.req_meta,
         )
-        try:
-            r = await self.download_request(request)
-            assert r.status == 200
-            assert r.body == b"Moooooooooo power!"
-            assert r.headers == {b"Local Filename": [b""], b"Size": [b"18"]}
-        finally:
-            self._lose_connection()
+        r = await self.download_request(dh, request)
+        assert r.status == 200
+        assert r.body == b"Moooooooooo power!"
+        assert r.headers == {b"Local Filename": [b""], b"Size": [b"18"]}
 
     @deferred_f_from_coro_f
-    async def test_ftp_download_nonexistent(self):
-        request = Request(
-            url=f"ftp://127.0.0.1:{self.portNum}/nonexistent.txt", meta=self.req_meta
-        )
-        try:
-            r = await self.download_request(request)
-            assert r.status == 404
-        finally:
-            self._lose_connection()
+    async def test_ftp_download_nonexistent(self, server_url, dh):
+        request = Request(url=server_url + "nonexistent.txt", meta=self.req_meta)
+        r = await self.download_request(dh, request)
+        assert r.status == 404
 
     @deferred_f_from_coro_f
-    async def test_ftp_local_filename(self):
+    async def test_ftp_local_filename(self, server_url, dh):
         f, local_fname = mkstemp()
         fname_bytes = to_bytes(local_fname)
         local_fname = Path(local_fname)
         os.close(f)
         meta = {"ftp_local_filename": fname_bytes}
         meta.update(self.req_meta)
-        request = Request(url=f"ftp://127.0.0.1:{self.portNum}/file.txt", meta=meta)
-        try:
-            r = await self.download_request(request)
-            assert r.body == fname_bytes
-            assert r.headers == {b"Local Filename": [fname_bytes], b"Size": [b"17"]}
-            assert local_fname.exists()
-            assert local_fname.read_bytes() == b"I have the power!"
-            local_fname.unlink()
-        finally:
-            self._lose_connection()
+        request = Request(url=server_url + "file.txt", meta=meta)
+        r = await self.download_request(dh, request)
+        assert r.body == fname_bytes
+        assert r.headers == {b"Local Filename": [fname_bytes], b"Size": [b"17"]}
+        assert local_fname.exists()
+        assert local_fname.read_bytes() == b"I have the power!"
+        local_fname.unlink()
 
-    async def _test_response_class(self, filename: str, response_class: type[Response]):
+    async def _test_response_class(
+        self,
+        server_url: str,
+        dh: FTPDownloadHandler,
+        filename: str,
+        response_class: type[Response],
+    ) -> None:
         f, local_fname = mkstemp()
         local_fname_path = Path(local_fname)
         os.close(f)
         meta = {}
         meta.update(self.req_meta)
-        request = Request(url=f"ftp://127.0.0.1:{self.portNum}/{filename}", meta=meta)
-        try:
-            r = await self.download_request(request)
-            assert type(r) is response_class  # pylint: disable=unidiomatic-typecheck
-            local_fname_path.unlink()
-        finally:
-            self._lose_connection()
+        request = Request(url=server_url + filename, meta=meta)
+        r = await self.download_request(dh, request)
+        assert type(r) is response_class  # pylint: disable=unidiomatic-typecheck
+        local_fname_path.unlink()
 
     @deferred_f_from_coro_f
-    async def test_response_class_from_url(self):
-        await self._test_response_class("file.txt", TextResponse)
+    async def test_response_class_from_url(self, server_url, dh):
+        await self._test_response_class(server_url, dh, "file.txt", TextResponse)
 
     @deferred_f_from_coro_f
-    async def test_response_class_from_body(self):
-        await self._test_response_class("html-file-without-extension", HtmlResponse)
+    async def test_response_class_from_body(self, server_url, dh):
+        await self._test_response_class(
+            server_url, dh, "html-file-without-extension", HtmlResponse
+        )
 
 
 class TestFTP(TestFTPBase):
     @deferred_f_from_coro_f
-    async def test_invalid_credentials(self):
+    async def test_invalid_credentials(self, server_url, dh):
         if self.reactor_pytest != "default" and sys.platform == "win32":
             pytest.skip(
                 "This test produces DirtyReactorAggregateError on Windows with asyncio"
@@ -447,45 +439,28 @@ class TestFTP(TestFTPBase):
 
         meta = dict(self.req_meta)
         meta.update({"ftp_password": "invalid"})
-        request = Request(url=f"ftp://127.0.0.1:{self.portNum}/file.txt", meta=meta)
-        try:
-            with pytest.raises(ConnectionLost):
-                await self.download_request(request)
-        finally:
-            self._lose_connection()
+        request = Request(url=server_url + "file.txt", meta=meta)
+        with pytest.raises(ConnectionLost):
+            await self.download_request(dh, request)
 
 
 class TestAnonymousFTP(TestFTPBase):
     username = "anonymous"
     req_meta = {}
 
-    def setUp(self):
-        from twisted.internet import reactor
-
-        # setup dir and test file
-        self.directory = Path(mkdtemp())
+    def _create_files(self, root: Path) -> None:
         for filename, content in self.test_files:
-            (self.directory / filename).write_bytes(content)
+            (root / filename).write_bytes(content)
 
-        # setup server for anonymous access
-        realm = FTPRealm(anonymousRoot=str(self.directory))
+    def _get_factory(self, tmp_path: Path) -> FTPFactory:
+        realm = FTPRealm(anonymousRoot=str(tmp_path))
         p = portal.Portal(realm)
         p.registerChecker(checkers.AllowAnonymousAccess(), credentials.IAnonymous)
-
-        self.factory = FTPFactory(portal=p, userAnonymous=self.username)
-        self.port = reactor.listenTCP(0, self.factory, interface="127.0.0.1")
-        self.portNum = self.port.getHost().port
-        crawler = get_crawler()
-        self.download_handler = build_from_crawler(FTPDownloadHandler, crawler)
-
-    @inlineCallbacks
-    def tearDown(self):
-        yield self.port.stopListening()
-        shutil.rmtree(self.directory)
+        return FTPFactory(portal=p, userAnonymous=self.username)
 
 
-class TestDataURI(unittest.TestCase):
-    def setUp(self):
+class TestDataURI:
+    def setup_method(self):
         crawler = get_crawler()
         self.download_handler = build_from_crawler(DataURIDownloadHandler, crawler)
         self.spider = Spider("foo")

--- a/tests/test_downloader_handlers.py
+++ b/tests/test_downloader_handlers.py
@@ -354,8 +354,10 @@ class TestFTPBase:
 
         yield dh
 
-        assert dh.client.transport
-        dh.client.transport.loseConnection()
+        # if the test was skipped, there will be no client attribute
+        if hasattr(dh, "client"):
+            assert dh.client.transport
+            dh.client.transport.loseConnection()
 
     async def download_request(
         self, dh: FTPDownloadHandler, request: Request

--- a/tests/test_downloader_handlers_http_base.py
+++ b/tests/test_downloader_handlers_http_base.py
@@ -246,9 +246,12 @@ class TestHttpBase(ABC):
 
     @deferred_f_from_coro_f
     async def test_timeout_download_from_spider_nodata_rcvd(
-        self, server_port: int, download_handler: DownloadHandlerProtocol
+        self,
+        server_port: int,
+        download_handler: DownloadHandlerProtocol,
+        reactor_pytest: str,
     ) -> None:
-        if self.reactor_pytest != "default" and sys.platform == "win32":
+        if reactor_pytest == "asyncio" and sys.platform == "win32":
             # https://twistedmatrix.com/trac/ticket/10279
             pytest.skip(
                 "This test produces DirtyReactorAggregateError on Windows with asyncio"
@@ -263,9 +266,12 @@ class TestHttpBase(ABC):
 
     @deferred_f_from_coro_f
     async def test_timeout_download_from_spider_server_hangs(
-        self, server_port: int, download_handler: DownloadHandlerProtocol
+        self,
+        server_port: int,
+        download_handler: DownloadHandlerProtocol,
+        reactor_pytest: str,
     ) -> None:
-        if self.reactor_pytest != "default" and sys.platform == "win32":
+        if reactor_pytest == "asyncio" and sys.platform == "win32":
             # https://twistedmatrix.com/trac/ticket/10279
             pytest.skip(
                 "This test produces DirtyReactorAggregateError on Windows with asyncio"

--- a/tests/test_downloadermiddleware.py
+++ b/tests/test_downloadermiddleware.py
@@ -247,7 +247,6 @@ class TestMiddlewareUsingDeferreds(TestManagerBase):
         assert not download_func.called
 
 
-@pytest.mark.usefixtures("reactor_pytest")
 class TestMiddlewareUsingCoro(TestManagerBase):
     """Middlewares using asyncio coroutines should work"""
 

--- a/tests/test_downloadermiddleware_robotstxt.py
+++ b/tests/test_downloadermiddleware_robotstxt.py
@@ -7,7 +7,6 @@ import pytest
 from twisted.internet import error
 from twisted.internet.defer import Deferred, maybeDeferred
 from twisted.python import failure
-from twisted.trial import unittest
 
 from scrapy.downloadermiddlewares.robotstxt import RobotsTxtMiddleware
 from scrapy.downloadermiddlewares.robotstxt import logger as mw_module_logger
@@ -22,13 +21,13 @@ if TYPE_CHECKING:
     from scrapy.crawler import Crawler
 
 
-class TestRobotsTxtMiddleware(unittest.TestCase):
-    def setUp(self):
+class TestRobotsTxtMiddleware:
+    def setup_method(self):
         self.crawler = mock.MagicMock()
         self.crawler.settings = Settings()
         self.crawler.engine.download = mock.MagicMock()
 
-    def tearDown(self):
+    def teardown_method(self):
         del self.crawler
 
     def test_robotstxt_settings(self):
@@ -249,8 +248,8 @@ Disallow: /some/randome/page.html
 
 @pytest.mark.skipif(not rerp_available(), reason="Rerp parser is not installed")
 class TestRobotsTxtMiddlewareWithRerp(TestRobotsTxtMiddleware):
-    def setUp(self):
-        super().setUp()
+    def setup_method(self):
+        super().setup_method()
         self.crawler.settings.set(
             "ROBOTSTXT_PARSER", "scrapy.robotstxt.RerpRobotParser"
         )

--- a/tests/test_downloaderslotssettings.py
+++ b/tests/test_downloaderslotssettings.py
@@ -1,7 +1,6 @@
 import time
 
 from twisted.internet.defer import inlineCallbacks
-from twisted.trial.unittest import TestCase
 
 from scrapy import Request
 from scrapy.core.downloader import Downloader, Slot
@@ -49,17 +48,17 @@ class DownloaderSlotsSettingsTestSpider(MetaSpider):
         self.times[slot].append(time.time())
 
 
-class TestCrawl(TestCase):
+class TestCrawl:
     @classmethod
-    def setUpClass(cls):
+    def setup_class(cls):
         cls.mockserver = MockServer()
         cls.mockserver.__enter__()
 
     @classmethod
-    def tearDownClass(cls):
+    def teardown_class(cls):
         cls.mockserver.__exit__(None, None, None)
 
-    def setUp(self):
+    def setup_method(self):
         self.runner = CrawlerRunner()
 
     @inlineCallbacks

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -27,7 +27,6 @@ from pydispatch import dispatcher
 from testfixtures import LogCapture
 from twisted.internet import defer
 from twisted.internet.defer import inlineCallbacks
-from twisted.trial import unittest
 from twisted.web import server, static, util
 
 from scrapy import signals
@@ -246,7 +245,7 @@ class CrawlerRun:
         self.signals_caught[sig] = signalargs
 
 
-class TestEngineBase(unittest.TestCase):
+class TestEngineBase:
     @staticmethod
     def _assert_visited_urls(run: CrawlerRun) -> None:
         must_be_visited = [

--- a/tests/test_engine_loop.py
+++ b/tests/test_engine_loop.py
@@ -6,7 +6,6 @@ from typing import TYPE_CHECKING
 
 from testfixtures import LogCapture
 from twisted.internet.defer import Deferred
-from twisted.trial.unittest import TestCase
 
 from scrapy import Request, Spider, signals
 from scrapy.utils.defer import deferred_f_from_coro_f, maybe_deferred_to_future
@@ -27,7 +26,7 @@ async def sleep(seconds: float = 0.001) -> None:
     await maybe_deferred_to_future(deferred)
 
 
-class TestMain(TestCase):
+class TestMain:
     @deferred_f_from_coro_f
     async def test_sleep(self):
         """Neither asynchronous sleeps on Spider.start() nor the equivalent on
@@ -120,16 +119,16 @@ class TestMain(TestCase):
         assert actual_urls == expected_urls, f"{actual_urls=} != {expected_urls=}"
 
 
-class TestRequestSendOrder(TestCase):
+class TestRequestSendOrder:
     seconds = 0.1  # increase if flaky
 
     @classmethod
-    def setUpClass(cls):
+    def setup_class(cls):
         cls.mockserver = MockServer()
         cls.mockserver.__enter__()
 
     @classmethod
-    def tearDownClass(cls):
+    def teardown_class(cls):
         cls.mockserver.__exit__(None, None, None)  # increase if flaky
 
     def request(self, num, response_seconds, download_slots, priority=0):

--- a/tests/test_extension_telnet.py
+++ b/tests/test_extension_telnet.py
@@ -2,13 +2,12 @@ import pytest
 from twisted.conch.telnet import ITelnetProtocol
 from twisted.cred import credentials
 from twisted.internet.defer import inlineCallbacks
-from twisted.trial import unittest
 
 from scrapy.extensions.telnet import TelnetConsole
 from scrapy.utils.test import get_crawler
 
 
-class TestTelnetExtension(unittest.TestCase):
+class TestTelnetExtension:
     def _get_console_and_portal(self, settings=None):
         crawler = get_crawler(settings_dict=settings)
         console = TelnetConsole(crawler)

--- a/tests/test_feedexport.py
+++ b/tests/test_feedexport.py
@@ -28,7 +28,6 @@ import pytest
 from testfixtures import LogCapture
 from twisted.internet import defer
 from twisted.internet.defer import inlineCallbacks
-from twisted.trial import unittest
 from w3lib.url import file_uri_to_path, path_to_file_uri
 from zope.interface import implementer
 from zope.interface.verify import verifyObject
@@ -161,7 +160,7 @@ class TestFileFeedStorage:
         assert storage.path == path
 
 
-class TestFTPFeedStorage(unittest.TestCase):
+class TestFTPFeedStorage:
     def get_test_spider(self, settings=None):
         class TestSpider(scrapy.Spider):
             name = "test_spider"
@@ -275,7 +274,7 @@ class TestBlockingFeedStorage:
 
 
 @pytest.mark.requires_boto3
-class TestS3FeedStorage(unittest.TestCase):
+class TestS3FeedStorage:
     def test_parse_credentials(self):
         aws_credentials = {
             "AWS_ACCESS_KEY_ID": "settings_key",
@@ -504,7 +503,7 @@ class TestS3FeedStorage(unittest.TestCase):
         assert "S3 does not support appending to files" in str(log)
 
 
-class TestGCSFeedStorage(unittest.TestCase):
+class TestGCSFeedStorage:
     def test_parse_settings(self):
         try:
             from google.cloud.storage import Client  # noqa: F401
@@ -658,7 +657,7 @@ class LogOnStoreFileStorage:
         file.close()
 
 
-class TestFeedExportBase(ABC, unittest.TestCase):
+class TestFeedExportBase(ABC):
     mockserver: MockServer
 
     class MyItem(scrapy.Item):
@@ -676,18 +675,18 @@ class TestFeedExportBase(ABC, unittest.TestCase):
         return Path(self.temp_dir, inter_dir, filename)
 
     @classmethod
-    def setUpClass(cls):
+    def setup_class(cls):
         cls.mockserver = MockServer()
         cls.mockserver.__enter__()
 
     @classmethod
-    def tearDownClass(cls):
+    def teardown_class(cls):
         cls.mockserver.__exit__(None, None, None)
 
-    def setUp(self):
+    def setup_method(self):
         self.temp_dir = tempfile.mkdtemp()
 
-    def tearDown(self):
+    def teardown_method(self):
         shutil.rmtree(self.temp_dir, ignore_errors=True)
 
     async def exported_data(

--- a/tests/test_feedexport.py
+++ b/tests/test_feedexport.py
@@ -734,7 +734,7 @@ class TestFeedExportBase(ABC):
         await self.assertExportedMarshal(items, rows, settings)
         await self.assertExportedMultiple(items, rows, settings)
 
-    async def assertExportedCsv(
+    async def assertExportedCsv(  # noqa: B027
         self,
         items: Iterable[Any],
         header: Iterable[str],
@@ -743,7 +743,7 @@ class TestFeedExportBase(ABC):
     ) -> None:
         pass
 
-    async def assertExportedJsonLines(
+    async def assertExportedJsonLines(  # noqa: B027
         self,
         items: Iterable[Any],
         rows: Iterable[dict[str, Any]],
@@ -751,7 +751,7 @@ class TestFeedExportBase(ABC):
     ) -> None:
         pass
 
-    async def assertExportedXml(
+    async def assertExportedXml(  # noqa: B027
         self,
         items: Iterable[Any],
         rows: Iterable[dict[str, Any]],
@@ -759,7 +759,7 @@ class TestFeedExportBase(ABC):
     ) -> None:
         pass
 
-    async def assertExportedMultiple(
+    async def assertExportedMultiple(  # noqa: B027
         self,
         items: Iterable[Any],
         rows: Iterable[dict[str, Any]],
@@ -767,7 +767,7 @@ class TestFeedExportBase(ABC):
     ) -> None:
         pass
 
-    async def assertExportedPickle(
+    async def assertExportedPickle(  # noqa: B027
         self,
         items: Iterable[Any],
         rows: Iterable[dict[str, Any]],
@@ -775,7 +775,7 @@ class TestFeedExportBase(ABC):
     ) -> None:
         pass
 
-    async def assertExportedMarshal(
+    async def assertExportedMarshal(  # noqa: B027
         self,
         items: Iterable[Any],
         rows: Iterable[dict[str, Any]],

--- a/tests/test_http2_client_protocol.py
+++ b/tests/test_http2_client_protocol.py
@@ -3,16 +3,15 @@ from __future__ import annotations
 import json
 import random
 import re
-import shutil
 import string
 from ipaddress import IPv4Address
 from pathlib import Path
-from tempfile import mkdtemp
 from typing import TYPE_CHECKING, Any, Callable
 from unittest import mock
 from urllib.parse import urlencode
 
 import pytest
+from pytest_twisted import async_yield_fixture
 from twisted.internet.defer import (
     CancelledError,
     Deferred,
@@ -22,7 +21,6 @@ from twisted.internet.defer import (
 from twisted.internet.endpoints import SSL4ClientEndpoint, SSL4ServerEndpoint
 from twisted.internet.error import TimeoutError
 from twisted.internet.ssl import Certificate, PrivateCertificate, optionsForClientTLS
-from twisted.trial.unittest import TestCase
 from twisted.web.client import URI, ResponseFailed
 from twisted.web.http import H2_ENABLED
 from twisted.web.http import Request as TxRequest
@@ -40,7 +38,9 @@ from scrapy.utils.defer import (
 from tests.mockserver import LeafResource, Status, ssl_context_factory
 
 if TYPE_CHECKING:
-    from collections.abc import Coroutine
+    from collections.abc import AsyncGenerator, Coroutine, Generator
+
+    from scrapy.core.http2.protocol import H2ClientProtocol
 
 
 def generate_random_string(size: int) -> str:
@@ -178,24 +178,24 @@ class RequestHeaders(LeafResource):
         return bytes(json.dumps(headers), "utf-8")
 
 
-def get_client_certificate(
-    key_file: Path, certificate_file: Path
-) -> PrivateCertificate:
-    pem = key_file.read_text(encoding="utf-8") + certificate_file.read_text(
-        encoding="utf-8"
-    )
-    return PrivateCertificate.loadPEM(pem)
+def make_request_dfd(client: H2ClientProtocol, request: Request) -> Deferred[Response]:
+    return client.request(request, DummySpider())
+
+
+async def make_request(client: H2ClientProtocol, request: Request) -> Response:
+    return await maybe_deferred_to_future(make_request_dfd(client, request))
 
 
 @pytest.mark.skipif(not H2_ENABLED, reason="HTTP/2 support in Twisted is not enabled")
-class TestHttps2ClientProtocol(TestCase):
+class TestHttps2ClientProtocol:
     scheme = "https"
+    host = "localhost"
     key_file = Path(__file__).parent / "keys" / "localhost.key"
     certificate_file = Path(__file__).parent / "keys" / "localhost.crt"
 
-    def _init_resource(self):
-        self.temp_directory = mkdtemp()
-        r = File(self.temp_directory)
+    @pytest.fixture
+    def site(self, tmp_path: Path) -> Site:
+        r = File(str(tmp_path))
         r.putChild(b"get-data-html-small", GetDataHtmlSmall())
         r.putChild(b"get-data-html-large", GetDataHtmlLarge())
 
@@ -208,72 +208,65 @@ class TestHttps2ClientProtocol(TestCase):
         r.putChild(b"query-params", QueryParams())
         r.putChild(b"timeout", TimeoutResponse())
         r.putChild(b"request-headers", RequestHeaders())
-        return r
+        return Site(r, timeout=None)
 
-    @inlineCallbacks
-    def setUp(self):
+    @async_yield_fixture
+    async def server_port(self, site: Site) -> AsyncGenerator[int]:
         from twisted.internet import reactor
 
-        # Initialize resource tree
-        root = self._init_resource()
-        self.site = Site(root, timeout=None)
-
-        # Start server for testing
-        self.hostname = "localhost"
         context_factory = ssl_context_factory(
             str(self.key_file), str(self.certificate_file)
         )
-
         server_endpoint = SSL4ServerEndpoint(
-            reactor, 0, context_factory, interface=self.hostname
+            reactor, 0, context_factory, interface=self.host
         )
-        self.server = yield server_endpoint.listen(self.site)
-        self.port_number = self.server.getHost().port
+        server = await server_endpoint.listen(site)
 
-        # Connect H2 client with server
-        self.client_certificate = get_client_certificate(
-            self.key_file, self.certificate_file
-        )
-        client_options = optionsForClientTLS(
-            hostname=self.hostname,
-            trustRoot=self.client_certificate,
-            acceptableProtocols=[b"h2"],
-        )
-        uri = URI.fromBytes(bytes(self.get_url("/"), "utf-8"))
+        yield server.getHost().port
 
-        self.conn_closed_deferred = Deferred()
+        await server.stopListening()
+
+    @pytest.fixture
+    def client_certificate(self) -> PrivateCertificate:
+        pem = self.key_file.read_text(
+            encoding="utf-8"
+        ) + self.certificate_file.read_text(encoding="utf-8")
+        return PrivateCertificate.loadPEM(pem)
+
+    @async_yield_fixture
+    async def client(
+        self, server_port: int, client_certificate: PrivateCertificate
+    ) -> AsyncGenerator[H2ClientProtocol]:
+        from twisted.internet import reactor
 
         from scrapy.core.http2.protocol import H2ClientFactory
 
-        h2_client_factory = H2ClientFactory(uri, Settings(), self.conn_closed_deferred)
-        client_endpoint = SSL4ClientEndpoint(
-            reactor, self.hostname, self.port_number, client_options
+        client_options = optionsForClientTLS(
+            hostname=self.host,
+            trustRoot=client_certificate,
+            acceptableProtocols=[b"h2"],
         )
-        self.client = yield client_endpoint.connect(h2_client_factory)
+        uri = URI.fromBytes(bytes(self.get_url(server_port, "/"), "utf-8"))
+        h2_client_factory = H2ClientFactory(uri, Settings(), Deferred())
+        client_endpoint = SSL4ClientEndpoint(
+            reactor, self.host, server_port, client_options
+        )
+        client = await client_endpoint.connect(h2_client_factory)
 
-    @inlineCallbacks
-    def tearDown(self):
-        if self.client.connected:
-            yield self.client.transport.loseConnection()
-            yield self.client.transport.abortConnection()
-        yield self.server.stopListening()
-        shutil.rmtree(self.temp_directory)
-        self.conn_closed_deferred = None
+        yield client
 
-    def get_url(self, path: str) -> str:
+        if client.connected:
+            client.transport.loseConnection()
+            client.transport.abortConnection()
+
+    def get_url(self, portno: int, path: str) -> str:
         """
         :param path: Should have / at the starting compulsorily if not empty
         :return: Complete url
         """
         assert len(path) > 0
         assert path[0] == "/" or path[0] == "&"
-        return f"{self.scheme}://{self.hostname}:{self.port_number}{path}"
-
-    async def make_request(self, request: Request) -> Response:
-        return await maybe_deferred_to_future(self.make_request_dfd(request))
-
-    def make_request_dfd(self, request: Request) -> Deferred[Response]:
-        return self.client.request(request, DummySpider())
+        return f"{self.scheme}://{self.host}:{portno}{path}"
 
     @staticmethod
     async def _check_repeat(
@@ -287,9 +280,13 @@ class TestHttps2ClientProtocol(TestCase):
         await maybe_deferred_to_future(DeferredList(d_list, fireOnOneErrback=True))
 
     async def _check_GET(
-        self, request: Request, expected_body: bytes, expected_status: int
+        self,
+        client: H2ClientProtocol,
+        request: Request,
+        expected_body: bytes,
+        expected_status: int,
     ) -> None:
-        response = await self.make_request(request)
+        response = await make_request(client, request)
         assert response.status == expected_status
         assert response.body == expected_body
         assert response.request == request
@@ -300,43 +297,62 @@ class TestHttps2ClientProtocol(TestCase):
         assert len(response.body) == content_length
 
     @deferred_f_from_coro_f
-    async def test_GET_small_body(self):
-        request = Request(self.get_url("/get-data-html-small"))
-        await self._check_GET(request, Data.HTML_SMALL, 200)
+    async def test_GET_small_body(
+        self, server_port: int, client: H2ClientProtocol
+    ) -> None:
+        request = Request(self.get_url(server_port, "/get-data-html-small"))
+        await self._check_GET(client, request, Data.HTML_SMALL, 200)
 
     @deferred_f_from_coro_f
-    async def test_GET_large_body(self):
-        request = Request(self.get_url("/get-data-html-large"))
-        await self._check_GET(request, Data.HTML_LARGE, 200)
+    async def test_GET_large_body(
+        self, server_port: int, client: H2ClientProtocol
+    ) -> None:
+        request = Request(self.get_url(server_port, "/get-data-html-large"))
+        await self._check_GET(client, request, Data.HTML_LARGE, 200)
 
     async def _check_GET_x10(
-        self, request: Request, expected_body: bytes, expected_status: int
+        self,
+        client: H2ClientProtocol,
+        request: Request,
+        expected_body: bytes,
+        expected_status: int,
     ) -> None:
         async def get_coro() -> None:
-            await self._check_GET(request, expected_body, expected_status)
+            await self._check_GET(client, request, expected_body, expected_status)
 
         await self._check_repeat(get_coro, 10)
 
     @deferred_f_from_coro_f
-    async def test_GET_small_body_x10(self):
+    async def test_GET_small_body_x10(
+        self, server_port: int, client: H2ClientProtocol
+    ) -> None:
         await self._check_GET_x10(
-            Request(self.get_url("/get-data-html-small")), Data.HTML_SMALL, 200
+            client,
+            Request(self.get_url(server_port, "/get-data-html-small")),
+            Data.HTML_SMALL,
+            200,
         )
 
     @deferred_f_from_coro_f
-    async def test_GET_large_body_x10(self):
+    async def test_GET_large_body_x10(
+        self, server_port: int, client: H2ClientProtocol
+    ) -> None:
         await self._check_GET_x10(
-            Request(self.get_url("/get-data-html-large")), Data.HTML_LARGE, 200
+            client,
+            Request(self.get_url(server_port, "/get-data-html-large")),
+            Data.HTML_LARGE,
+            200,
         )
 
+    @staticmethod
     async def _check_POST_json(
-        self,
+        client: H2ClientProtocol,
         request: Request,
         expected_request_body: dict[str, str],
         expected_extra_data: str,
         expected_status: int,
     ) -> None:
-        response = await self.make_request(request)
+        response = await make_request(client, request)
 
         assert response.status == expected_status
         assert response.request == request
@@ -369,22 +385,30 @@ class TestHttps2ClientProtocol(TestCase):
             assert request_headers[k_str] == str(v[0], "utf-8")
 
     @deferred_f_from_coro_f
-    async def test_POST_small_json(self):
+    async def test_POST_small_json(
+        self, server_port: int, client: H2ClientProtocol
+    ) -> None:
         request = JsonRequest(
-            url=self.get_url("/post-data-json-small"),
+            url=self.get_url(server_port, "/post-data-json-small"),
             method="POST",
             data=Data.JSON_SMALL,
         )
-        await self._check_POST_json(request, Data.JSON_SMALL, Data.EXTRA_SMALL, 200)
+        await self._check_POST_json(
+            client, request, Data.JSON_SMALL, Data.EXTRA_SMALL, 200
+        )
 
     @deferred_f_from_coro_f
-    async def test_POST_large_json(self):
+    async def test_POST_large_json(
+        self, server_port: int, client: H2ClientProtocol
+    ) -> None:
         request = JsonRequest(
-            url=self.get_url("/post-data-json-large"),
+            url=self.get_url(server_port, "/post-data-json-large"),
             method="POST",
             data=Data.JSON_LARGE,
         )
-        await self._check_POST_json(request, Data.JSON_LARGE, Data.EXTRA_LARGE, 200)
+        await self._check_POST_json(
+            client, request, Data.JSON_LARGE, Data.EXTRA_LARGE, 200
+        )
 
     async def _check_POST_json_x10(self, *args, **kwargs):
         async def get_coro() -> None:
@@ -393,48 +417,63 @@ class TestHttps2ClientProtocol(TestCase):
         await self._check_repeat(get_coro, 10)
 
     @deferred_f_from_coro_f
-    async def test_POST_small_json_x10(self):
+    async def test_POST_small_json_x10(
+        self, server_port: int, client: H2ClientProtocol
+    ) -> None:
         request = JsonRequest(
-            url=self.get_url("/post-data-json-small"),
+            url=self.get_url(server_port, "/post-data-json-small"),
             method="POST",
             data=Data.JSON_SMALL,
         )
-        await self._check_POST_json_x10(request, Data.JSON_SMALL, Data.EXTRA_SMALL, 200)
+        await self._check_POST_json_x10(
+            client, request, Data.JSON_SMALL, Data.EXTRA_SMALL, 200
+        )
 
     @deferred_f_from_coro_f
-    async def test_POST_large_json_x10(self):
+    async def test_POST_large_json_x10(
+        self, server_port: int, client: H2ClientProtocol
+    ) -> None:
         request = JsonRequest(
-            url=self.get_url("/post-data-json-large"),
+            url=self.get_url(server_port, "/post-data-json-large"),
             method="POST",
             data=Data.JSON_LARGE,
         )
-        await self._check_POST_json_x10(request, Data.JSON_LARGE, Data.EXTRA_LARGE, 200)
+        await self._check_POST_json_x10(
+            client, request, Data.JSON_LARGE, Data.EXTRA_LARGE, 200
+        )
 
     @inlineCallbacks
-    def test_invalid_negotiated_protocol(self):
+    def test_invalid_negotiated_protocol(
+        self, server_port: int, client: H2ClientProtocol
+    ) -> Generator[Deferred[Any], None, None]:
         with mock.patch(
             "scrapy.core.http2.protocol.PROTOCOL_NAME", return_value=b"not-h2"
         ):
-            request = Request(url=self.get_url("/status?n=200"))
+            request = Request(url=self.get_url(server_port, "/status?n=200"))
             with pytest.raises(ResponseFailed):
-                yield self.make_request_dfd(request)
+                yield make_request_dfd(client, request)
 
     @inlineCallbacks
-    def test_cancel_request(self):
-        request = Request(url=self.get_url("/get-data-html-large"))
-        d = self.make_request_dfd(request)
+    def test_cancel_request(
+        self, server_port: int, client: H2ClientProtocol
+    ) -> Generator[Deferred[Any], None, None]:
+        request = Request(url=self.get_url(server_port, "/get-data-html-large"))
+        d = make_request_dfd(client, request)
         d.cancel()
         response = yield d
         assert response.status == 499
         assert response.request == request
 
     @deferred_f_from_coro_f
-    async def test_download_maxsize_exceeded(self):
+    async def test_download_maxsize_exceeded(
+        self, server_port: int, client: H2ClientProtocol
+    ) -> None:
         request = Request(
-            url=self.get_url("/get-data-html-large"), meta={"download_maxsize": 1000}
+            url=self.get_url(server_port, "/get-data-html-large"),
+            meta={"download_maxsize": 1000},
         )
         with pytest.raises(CancelledError) as exc_info:
-            await self.make_request(request)
+            await make_request(client, request)
         error_pattern = re.compile(
             rf"Cancelling download of {request.url}: received response "
             rf"size \(\d*\) larger than download max size \(1000\)"
@@ -442,14 +481,16 @@ class TestHttps2ClientProtocol(TestCase):
         assert len(re.findall(error_pattern, str(exc_info.value))) == 1
 
     @inlineCallbacks
-    def test_received_dataloss_response(self):
+    def test_received_dataloss_response(
+        self, server_port: int, client: H2ClientProtocol
+    ) -> Generator[Deferred[Any], None, None]:
         """In case when value of Header Content-Length != len(Received Data)
         ProtocolError is raised"""
         from h2.exceptions import InvalidBodyLengthError
 
-        request = Request(url=self.get_url("/dataloss"))
+        request = Request(url=self.get_url(server_port, "/dataloss"))
         with pytest.raises(ResponseFailed) as exc_info:
-            yield self.make_request_dfd(request)
+            yield make_request_dfd(client, request)
         assert len(exc_info.value.reasons) > 0
         assert any(
             isinstance(error, InvalidBodyLengthError)
@@ -457,42 +498,62 @@ class TestHttps2ClientProtocol(TestCase):
         )
 
     @deferred_f_from_coro_f
-    async def test_missing_content_length_header(self):
-        request = Request(url=self.get_url("/no-content-length-header"))
-        response = await self.make_request(request)
+    async def test_missing_content_length_header(
+        self, server_port: int, client: H2ClientProtocol
+    ) -> None:
+        request = Request(url=self.get_url(server_port, "/no-content-length-header"))
+        response = await make_request(client, request)
         assert response.status == 200
         assert response.body == Data.NO_CONTENT_LENGTH
         assert response.request == request
         assert "Content-Length" not in response.headers
 
     async def _check_log_warnsize(
-        self, request: Request, warn_pattern: re.Pattern[str], expected_body: bytes
+        self,
+        client: H2ClientProtocol,
+        request: Request,
+        warn_pattern: re.Pattern[str],
+        expected_body: bytes,
+        caplog: pytest.LogCaptureFixture,
     ) -> None:
-        with self.assertLogs("scrapy.core.http2.stream", level="WARNING") as cm:
-            response = await self.make_request(request)
-            assert response.status == 200
-            assert response.request == request
-            assert response.body == expected_body
+        with caplog.at_level("WARNING", "scrapy.core.http2.stream"):
+            response = await make_request(client, request)
+        assert response.status == 200
+        assert response.request == request
+        assert response.body == expected_body
 
-            # Check the warning is raised only once for this request
-            assert sum(len(re.findall(warn_pattern, log)) for log in cm.output) == 1
+        # Check the warning is raised only once for this request
+        assert len(re.findall(warn_pattern, caplog.text)) == 1
 
     @deferred_f_from_coro_f
-    async def test_log_expected_warnsize(self):
+    async def test_log_expected_warnsize(
+        self,
+        server_port: int,
+        client: H2ClientProtocol,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
         request = Request(
-            url=self.get_url("/get-data-html-large"), meta={"download_warnsize": 1000}
+            url=self.get_url(server_port, "/get-data-html-large"),
+            meta={"download_warnsize": 1000},
         )
         warn_pattern = re.compile(
             rf"Expected response size \(\d*\) larger than "
             rf"download warn size \(1000\) in request {request}"
         )
 
-        await self._check_log_warnsize(request, warn_pattern, Data.HTML_LARGE)
+        await self._check_log_warnsize(
+            client, request, warn_pattern, Data.HTML_LARGE, caplog
+        )
 
     @deferred_f_from_coro_f
-    async def test_log_received_warnsize(self):
+    async def test_log_received_warnsize(
+        self,
+        server_port: int,
+        client: H2ClientProtocol,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
         request = Request(
-            url=self.get_url("/no-content-length-header"),
+            url=self.get_url(server_port, "/no-content-length-header"),
             meta={"download_warnsize": 10},
         )
         warn_pattern = re.compile(
@@ -500,23 +561,32 @@ class TestHttps2ClientProtocol(TestCase):
             rf"warn size \(10\) in request {request}"
         )
 
-        await self._check_log_warnsize(request, warn_pattern, Data.NO_CONTENT_LENGTH)
+        await self._check_log_warnsize(
+            client, request, warn_pattern, Data.NO_CONTENT_LENGTH, caplog
+        )
 
     @deferred_f_from_coro_f
-    async def test_max_concurrent_streams(self):
+    async def test_max_concurrent_streams(
+        self, server_port: int, client: H2ClientProtocol
+    ) -> None:
         """Send 500 requests at one to check if we can handle
         very large number of request.
         """
 
         async def get_coro() -> None:
             await self._check_GET(
-                Request(self.get_url("/get-data-html-small")), Data.HTML_SMALL, 200
+                client,
+                Request(self.get_url(server_port, "/get-data-html-small")),
+                Data.HTML_SMALL,
+                200,
             )
 
         await self._check_repeat(get_coro, 500)
 
     @inlineCallbacks
-    def test_inactive_stream(self):
+    def test_inactive_stream(
+        self, server_port: int, client: H2ClientProtocol
+    ) -> Generator[Deferred[Any], None, None]:
         """Here we send 110 requests considering the MAX_CONCURRENT_STREAMS
         by default is 100. After sending the first 100 requests we close the
         connection."""
@@ -533,38 +603,46 @@ class TestHttps2ClientProtocol(TestCase):
 
         # Send 100 request (we do not check the result)
         for _ in range(100):
-            d = self.make_request_dfd(Request(self.get_url("/get-data-html-small")))
+            d = make_request_dfd(
+                client, Request(self.get_url(server_port, "/get-data-html-small"))
+            )
             d.addBoth(lambda _: None)
             d_list.append(d)
 
         # Now send 10 extra request and save the response deferred in a list
         for _ in range(10):
-            d = self.make_request_dfd(Request(self.get_url("/get-data-html-small")))
+            d = make_request_dfd(
+                client, Request(self.get_url(server_port, "/get-data-html-small"))
+            )
             d.addCallback(lambda _: pytest.fail("This request should have failed"))
             d.addErrback(assert_inactive_stream)
             d_list.append(d)
 
         # Close the connection now to fire all the extra 10 requests errback
         # with InactiveStreamClosed
-        self.client.transport.loseConnection()
+        client.transport.loseConnection()
 
         yield DeferredList(d_list, consumeErrors=True, fireOnOneErrback=True)
 
     @deferred_f_from_coro_f
-    async def test_invalid_request_type(self):
+    async def test_invalid_request_type(self, client: H2ClientProtocol):
         with pytest.raises(TypeError):
-            await self.make_request("https://InvalidDataTypePassed.com")
+            await make_request(client, "https://InvalidDataTypePassed.com")
 
     @deferred_f_from_coro_f
-    async def test_query_parameters(self):
+    async def test_query_parameters(
+        self, server_port: int, client: H2ClientProtocol
+    ) -> None:
         params = {
             "a": generate_random_string(20),
             "b": generate_random_string(20),
             "c": generate_random_string(20),
             "d": generate_random_string(20),
         }
-        request = Request(self.get_url(f"/query-params?{urlencode(params)}"))
-        response = await self.make_request(request)
+        request = Request(
+            self.get_url(server_port, f"/query-params?{urlencode(params)}")
+        )
+        response = await make_request(client, request)
         content_encoding_header = response.headers[b"Content-Encoding"]
         assert content_encoding_header is not None
         content_encoding = str(content_encoding_header, "utf-8")
@@ -572,62 +650,78 @@ class TestHttps2ClientProtocol(TestCase):
         assert data == params
 
     @deferred_f_from_coro_f
-    async def test_status_codes(self):
+    async def test_status_codes(
+        self, server_port: int, client: H2ClientProtocol
+    ) -> None:
         for status in [200, 404]:
-            request = Request(self.get_url(f"/status?n={status}"))
-            response = await self.make_request(request)
+            request = Request(self.get_url(server_port, f"/status?n={status}"))
+            response = await make_request(client, request)
             assert response.status == status
 
     @deferred_f_from_coro_f
-    async def test_response_has_correct_certificate_ip_address(self):
-        request = Request(self.get_url("/status?n=200"))
-        response = await self.make_request(request)
+    async def test_response_has_correct_certificate_ip_address(
+        self,
+        server_port: int,
+        client: H2ClientProtocol,
+        client_certificate: PrivateCertificate,
+    ) -> None:
+        request = Request(self.get_url(server_port, "/status?n=200"))
+        response = await make_request(client, request)
         assert response.request == request
         assert isinstance(response.certificate, Certificate)
         assert response.certificate.original is not None
-        assert response.certificate.getIssuer() == self.client_certificate.getIssuer()
+        assert response.certificate.getIssuer() == client_certificate.getIssuer()
         assert response.certificate.getPublicKey().matches(
-            self.client_certificate.getPublicKey()
+            client_certificate.getPublicKey()
         )
         assert isinstance(response.ip_address, IPv4Address)
         assert str(response.ip_address) == "127.0.0.1"
 
-    async def _check_invalid_netloc(self, url: str) -> None:
+    @staticmethod
+    async def _check_invalid_netloc(client: H2ClientProtocol, url: str) -> None:
         from scrapy.core.http2.stream import InvalidHostname
 
         request = Request(url)
         with pytest.raises(InvalidHostname) as exc_info:
-            await self.make_request(request)
+            await make_request(client, request)
         error_msg = str(exc_info.value)
         assert "localhost" in error_msg
         assert "127.0.0.1" in error_msg
         assert str(request) in error_msg
 
     @deferred_f_from_coro_f
-    async def test_invalid_hostname(self):
-        await self._check_invalid_netloc("https://notlocalhost.notlocalhostdomain")
+    async def test_invalid_hostname(self, client: H2ClientProtocol) -> None:
+        await self._check_invalid_netloc(
+            client, "https://notlocalhost.notlocalhostdomain"
+        )
 
     @deferred_f_from_coro_f
-    async def test_invalid_host_port(self):
-        port = self.port_number + 1
-        await self._check_invalid_netloc(f"https://127.0.0.1:{port}")
+    async def test_invalid_host_port(
+        self, server_port: int, client: H2ClientProtocol
+    ) -> None:
+        port = server_port + 1
+        await self._check_invalid_netloc(client, f"https://127.0.0.1:{port}")
 
     @deferred_f_from_coro_f
-    async def test_connection_stays_with_invalid_requests(self):
-        await maybe_deferred_to_future(self.test_invalid_hostname())
-        await maybe_deferred_to_future(self.test_invalid_host_port())
-        await maybe_deferred_to_future(self.test_GET_small_body())
-        await maybe_deferred_to_future(self.test_POST_small_json())
+    async def test_connection_stays_with_invalid_requests(
+        self, server_port: int, client: H2ClientProtocol
+    ):
+        await maybe_deferred_to_future(self.test_invalid_hostname(client))
+        await maybe_deferred_to_future(self.test_invalid_host_port(server_port, client))
+        await maybe_deferred_to_future(self.test_GET_small_body(server_port, client))
+        await maybe_deferred_to_future(self.test_POST_small_json(server_port, client))
 
     @inlineCallbacks
-    def test_connection_timeout(self):
-        request = Request(self.get_url("/timeout"))
+    def test_connection_timeout(
+        self, server_port: int, client: H2ClientProtocol
+    ) -> Generator[Deferred[Any], None, None]:
+        request = Request(self.get_url(server_port, "/timeout"))
 
         # Update the timer to 1s to test connection timeout
-        self.client.setTimeout(1)
+        client.setTimeout(1)
 
         with pytest.raises(ResponseFailed) as exc_info:
-            yield self.make_request_dfd(request)
+            yield make_request_dfd(client, request)
 
         for err in exc_info.value.reasons:
             from scrapy.core.http2.protocol import H2ClientProtocol
@@ -642,12 +736,14 @@ class TestHttps2ClientProtocol(TestCase):
             pytest.fail("No TimeoutError raised.")
 
     @deferred_f_from_coro_f
-    async def test_request_headers_received(self):
+    async def test_request_headers_received(
+        self, server_port: int, client: H2ClientProtocol
+    ) -> None:
         request = Request(
-            self.get_url("/request-headers"),
+            self.get_url(server_port, "/request-headers"),
             headers={"header-1": "header value 1", "header-2": "header value 2"},
         )
-        response = await self.make_request(request)
+        response = await make_request(client, request)
         assert response.status == 200
         assert response.request == request
 

--- a/tests/test_http2_client_protocol.py
+++ b/tests/test_http2_client_protocol.py
@@ -445,7 +445,7 @@ class TestHttps2ClientProtocol:
     @inlineCallbacks
     def test_invalid_negotiated_protocol(
         self, server_port: int, client: H2ClientProtocol
-    ) -> Generator[Deferred[Any], None, None]:
+    ) -> Generator[Deferred[Any], Any, None]:
         with mock.patch(
             "scrapy.core.http2.protocol.PROTOCOL_NAME", return_value=b"not-h2"
         ):
@@ -456,7 +456,7 @@ class TestHttps2ClientProtocol:
     @inlineCallbacks
     def test_cancel_request(
         self, server_port: int, client: H2ClientProtocol
-    ) -> Generator[Deferred[Any], None, None]:
+    ) -> Generator[Deferred[Any], Any, None]:
         request = Request(url=self.get_url(server_port, "/get-data-html-large"))
         d = make_request_dfd(client, request)
         d.cancel()
@@ -483,7 +483,7 @@ class TestHttps2ClientProtocol:
     @inlineCallbacks
     def test_received_dataloss_response(
         self, server_port: int, client: H2ClientProtocol
-    ) -> Generator[Deferred[Any], None, None]:
+    ) -> Generator[Deferred[Any], Any, None]:
         """In case when value of Header Content-Length != len(Received Data)
         ProtocolError is raised"""
         from h2.exceptions import InvalidBodyLengthError  # noqa: PLC0415
@@ -586,7 +586,7 @@ class TestHttps2ClientProtocol:
     @inlineCallbacks
     def test_inactive_stream(
         self, server_port: int, client: H2ClientProtocol
-    ) -> Generator[Deferred[Any], None, None]:
+    ) -> Generator[Deferred[Any], Any, None]:
         """Here we send 110 requests considering the MAX_CONCURRENT_STREAMS
         by default is 100. After sending the first 100 requests we close the
         connection."""
@@ -715,7 +715,7 @@ class TestHttps2ClientProtocol:
     @inlineCallbacks
     def test_connection_timeout(
         self, server_port: int, client: H2ClientProtocol
-    ) -> Generator[Deferred[Any], None, None]:
+    ) -> Generator[Deferred[Any], Any, None]:
         request = Request(self.get_url(server_port, "/timeout"))
 
         # Update the timer to 1s to test connection timeout

--- a/tests/test_http_request.py
+++ b/tests/test_http_request.py
@@ -1466,12 +1466,6 @@ class TestJsonRequest(TestRequest):
         b"Accept": [b"application/json, text/javascript, */*; q=0.01"],
     }
 
-    def setup_method(self):
-        warnings.simplefilter("always")
-
-    def teardown_method(self):
-        warnings.resetwarnings()
-
     def test_data(self):
         r1 = self.request_class(url="http://www.example.com/")
         assert r1.body == b""

--- a/tests/test_logformatter.py
+++ b/tests/test_logformatter.py
@@ -4,7 +4,6 @@ import pytest
 from testfixtures import LogCapture
 from twisted.internet.defer import inlineCallbacks
 from twisted.python.failure import Failure
-from twisted.trial.unittest import TestCase
 
 from scrapy.exceptions import DropItem
 from scrapy.http import Request, Response
@@ -254,17 +253,17 @@ class DropSomeItemsPipeline:
         self.drop = True
 
 
-class TestShowOrSkipMessages(TestCase):
+class TestShowOrSkipMessages:
     @classmethod
-    def setUpClass(cls):
+    def setup_class(cls):
         cls.mockserver = MockServer()
         cls.mockserver.__enter__()
 
     @classmethod
-    def tearDownClass(cls):
+    def teardown_class(cls):
         cls.mockserver.__exit__(None, None, None)
 
-    def setUp(self):
+    def setup_method(self):
         self.base_settings = {
             "LOG_LEVEL": "DEBUG",
             "ITEM_PIPELINES": {

--- a/tests/test_pipeline_crawl.py
+++ b/tests/test_pipeline_crawl.py
@@ -8,7 +8,6 @@ from typing import TYPE_CHECKING, Any
 import pytest
 from testfixtures import LogCapture
 from twisted.internet.defer import inlineCallbacks
-from twisted.trial.unittest import TestCase
 from w3lib.url import add_or_replace_parameter
 
 from scrapy import Spider, signals
@@ -58,7 +57,7 @@ class RedirectedMediaDownloadSpider(MediaDownloadSpider):
         )
 
 
-class TestFileDownloadCrawl(TestCase):
+class TestFileDownloadCrawl:
     pipeline_class = "scrapy.pipelines.files.FilesPipeline"
     store_setting_key = "FILES_STORE"
     media_key = "files"
@@ -70,15 +69,15 @@ class TestFileDownloadCrawl(TestCase):
     }
 
     @classmethod
-    def setUpClass(cls):
+    def setup_class(cls):
         cls.mockserver = MockServer()
         cls.mockserver.__enter__()
 
     @classmethod
-    def tearDownClass(cls):
+    def teardown_class(cls):
         cls.mockserver.__exit__(None, None, None)
 
-    def setUp(self):
+    def setup_method(self):
         # prepare a directory for storing files
         self.tmpmediastore = Path(mkdtemp())
         self.settings = {
@@ -87,7 +86,7 @@ class TestFileDownloadCrawl(TestCase):
         }
         self.items = []
 
-    def tearDown(self):
+    def teardown_method(self):
         shutil.rmtree(self.tmpmediastore)
         self.items = []
 

--- a/tests/test_pipeline_files.py
+++ b/tests/test_pipeline_files.py
@@ -18,7 +18,6 @@ import attr
 import pytest
 from itemadapter import ItemAdapter
 from twisted.internet.defer import inlineCallbacks
-from twisted.trial import unittest
 
 from scrapy.http import Request, Response
 from scrapy.item import Field, Item
@@ -78,8 +77,8 @@ def get_ftp_content_and_delete(
     return b"".join(ftp_data)
 
 
-class TestFilesPipeline(unittest.TestCase):
-    def setUp(self):
+class TestFilesPipeline:
+    def setup_method(self):
         self.tempdir = mkdtemp()
         settings_dict = {"FILES_STORE": self.tempdir}
         crawler = get_crawler(spidercls=None, settings_dict=settings_dict)
@@ -87,7 +86,7 @@ class TestFilesPipeline(unittest.TestCase):
         self.pipeline.download_func = _mocked_download_func
         self.pipeline.open_spider(None)
 
-    def tearDown(self):
+    def teardown_method(self):
         rmtree(self.tempdir)
 
     def test_file_path(self):
@@ -541,7 +540,7 @@ class TestFilesPipelineCustomSettings:
 
 
 @pytest.mark.requires_botocore
-class TestS3FilesStore(unittest.TestCase):
+class TestS3FilesStore:
     @inlineCallbacks
     def test_persist(self):
         bucket = "mybucket"
@@ -618,7 +617,7 @@ class TestS3FilesStore(unittest.TestCase):
 @pytest.mark.skipif(
     "GCS_PROJECT_ID" not in os.environ, reason="GCS_PROJECT_ID not found"
 )
-class TestGCSFilesStore(unittest.TestCase):
+class TestGCSFilesStore:
     @inlineCallbacks
     def test_persist(self):
         uri = os.environ.get("GCS_TEST_FILE_URI")
@@ -670,7 +669,7 @@ class TestGCSFilesStore(unittest.TestCase):
             store.bucket.get_blob.assert_called_with(expected_blob_path)
 
 
-class TestFTPFileStore(unittest.TestCase):
+class TestFTPFileStore:
     @inlineCallbacks
     def test_persist(self):
         data = b"TestFTPFilesStore: \xe2\x98\x83"

--- a/tests/test_pipeline_media.py
+++ b/tests/test_pipeline_media.py
@@ -6,7 +6,6 @@ import pytest
 from testfixtures import LogCapture
 from twisted.internet.defer import Deferred, inlineCallbacks
 from twisted.python.failure import Failure
-from twisted.trial import unittest
 
 from scrapy import signals
 from scrapy.exceptions import ScrapyDeprecationWarning
@@ -43,11 +42,11 @@ class UserDefinedPipeline(MediaPipeline):
         return ""
 
 
-class TestBaseMediaPipeline(unittest.TestCase):
+class TestBaseMediaPipeline:
     pipeline_class = UserDefinedPipeline
     settings = None
 
-    def setUp(self):
+    def setup_method(self):
         spider_cls = Spider
         self.spider = spider_cls("media.com")
         crawler = get_crawler(spider_cls, self.settings)
@@ -57,7 +56,7 @@ class TestBaseMediaPipeline(unittest.TestCase):
         self.info = self.pipe.spiderinfo
         self.fingerprint = crawler.request_fingerprinter.fingerprint
 
-    def tearDown(self):
+    def teardown_method(self):
         for name, signal in vars(signals).items():
             if not name.startswith("_"):
                 disconnect_all(signal)
@@ -550,13 +549,13 @@ class MediaFailedFailurePipeline(MockedMediaPipeline):
         return failure  # deprecated
 
 
-class TestMediaFailedFailure(unittest.TestCase):
+class TestMediaFailedFailure:
     """Test that media_failed() can return a failure instead of raising."""
 
     pipeline_class = MediaFailedFailurePipeline
     settings = None
 
-    def setUp(self):
+    def setup_method(self):
         spider_cls = Spider
         self.spider = spider_cls("media.com")
         crawler = get_crawler(spider_cls, self.settings)
@@ -566,7 +565,7 @@ class TestMediaFailedFailure(unittest.TestCase):
         self.info = self.pipe.spiderinfo
         self.fingerprint = crawler.request_fingerprinter.fingerprint
 
-    def tearDown(self):
+    def teardown_method(self):
         for name, signal in vars(signals).items():
             if not name.startswith("_"):
                 disconnect_all(signal)

--- a/tests/test_pipelines.py
+++ b/tests/test_pipelines.py
@@ -2,7 +2,6 @@ import asyncio
 
 import pytest
 from twisted.internet.defer import Deferred, inlineCallbacks
-from twisted.trial import unittest
 
 from scrapy import Request, Spider, signals
 from scrapy.utils.defer import deferred_to_future, maybe_deferred_to_future
@@ -75,14 +74,14 @@ class ItemSpider(Spider):
         return {"field": 42}
 
 
-class TestPipeline(unittest.TestCase):
+class TestPipeline:
     @classmethod
-    def setUpClass(cls):
+    def setup_class(cls):
         cls.mockserver = MockServer()
         cls.mockserver.__enter__()
 
     @classmethod
-    def tearDownClass(cls):
+    def teardown_class(cls):
         cls.mockserver.__exit__(None, None, None)
 
     def _on_item_scraped(self, item):

--- a/tests/test_proxy_connect.py
+++ b/tests/test_proxy_connect.py
@@ -9,7 +9,6 @@ from urllib.parse import urlsplit, urlunsplit
 import pytest
 from testfixtures import LogCapture
 from twisted.internet.defer import inlineCallbacks
-from twisted.trial.unittest import TestCase
 
 from scrapy.http import Request
 from scrapy.utils.test import get_crawler
@@ -62,17 +61,17 @@ def _wrong_credentials(proxy_url):
     return urlunsplit(bad_auth_proxy)
 
 
-class TestProxyConnect(TestCase):
+class TestProxyConnect:
     @classmethod
-    def setUpClass(cls):
+    def setup_class(cls):
         cls.mockserver = MockServer()
         cls.mockserver.__enter__()
 
     @classmethod
-    def tearDownClass(cls):
+    def teardown_class(cls):
         cls.mockserver.__exit__(None, None, None)
 
-    def setUp(self):
+    def setup_method(self):
         try:
             import mitmproxy  # noqa: F401
         except ImportError:
@@ -85,7 +84,7 @@ class TestProxyConnect(TestCase):
         os.environ["https_proxy"] = proxy_url
         os.environ["http_proxy"] = proxy_url
 
-    def tearDown(self):
+    def teardown_method(self):
         self._proxy.stop()
         os.environ = self._oldenv
 

--- a/tests/test_request_attribute_binding.py
+++ b/tests/test_request_attribute_binding.py
@@ -1,6 +1,5 @@
 from testfixtures import LogCapture
 from twisted.internet.defer import inlineCallbacks
-from twisted.trial.unittest import TestCase
 
 from scrapy import Request, signals
 from scrapy.http.response import Response
@@ -56,14 +55,14 @@ class AlternativeCallbacksMiddleware:
         return response.replace(request=new_request)
 
 
-class TestCrawl(TestCase):
+class TestCrawl:
     @classmethod
-    def setUpClass(cls):
+    def setup_class(cls):
         cls.mockserver = MockServer()
         cls.mockserver.__enter__()
 
     @classmethod
-    def tearDownClass(cls):
+    def teardown_class(cls):
         cls.mockserver.__exit__(None, None, None)
 
     @inlineCallbacks

--- a/tests/test_request_cb_kwargs.py
+++ b/tests/test_request_cb_kwargs.py
@@ -1,6 +1,5 @@
 from testfixtures import LogCapture
 from twisted.internet.defer import inlineCallbacks
-from twisted.trial.unittest import TestCase
 
 from scrapy.http import Request
 from scrapy.utils.test import get_crawler
@@ -149,14 +148,14 @@ class KeywordArgumentsSpider(MockServerSpider):
         self.crawler.stats.inc_value("boolean_checks", 1)
 
 
-class TestCallbackKeywordArguments(TestCase):
+class TestCallbackKeywordArguments:
     @classmethod
-    def setUpClass(cls):
+    def setup_class(cls):
         cls.mockserver = MockServer()
         cls.mockserver.__enter__()
 
     @classmethod
-    def tearDownClass(cls):
+    def teardown_class(cls):
         cls.mockserver.__exit__(None, None, None)
 
     @inlineCallbacks

--- a/tests/test_request_left.py
+++ b/tests/test_request_left.py
@@ -1,5 +1,4 @@
 from twisted.internet.defer import inlineCallbacks
-from twisted.trial.unittest import TestCase
 
 from scrapy.signals import request_left_downloader
 from scrapy.spiders import Spider
@@ -24,14 +23,14 @@ class SignalCatcherSpider(Spider):
         self.caught_times += 1
 
 
-class TestCatching(TestCase):
+class TestCatching:
     @classmethod
-    def setUpClass(cls):
+    def setup_class(cls):
         cls.mockserver = MockServer()
         cls.mockserver.__enter__()
 
     @classmethod
-    def tearDownClass(cls):
+    def teardown_class(cls):
         cls.mockserver.__exit__(None, None, None)
 
     @inlineCallbacks

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -9,7 +9,6 @@ from typing import Any, NamedTuple
 
 import pytest
 from twisted.internet.defer import inlineCallbacks
-from twisted.trial.unittest import TestCase
 
 from scrapy.core.downloader import Downloader
 from scrapy.core.scheduler import BaseScheduler, Scheduler
@@ -353,8 +352,8 @@ class StartUrlsSpider(Spider):
         pass
 
 
-class TestIntegrationWithDownloaderAwareInMemory(TestCase):
-    def setUp(self):
+class TestIntegrationWithDownloaderAwareInMemory:
+    def setup_method(self):
         self.crawler = get_crawler(
             spidercls=StartUrlsSpider,
             settings_dict={
@@ -362,10 +361,6 @@ class TestIntegrationWithDownloaderAwareInMemory(TestCase):
                 "DUPEFILTER_CLASS": "scrapy.dupefilters.BaseDupeFilter",
             },
         )
-
-    @inlineCallbacks
-    def tearDown(self):
-        yield self.crawler.stop()
 
     @inlineCallbacks
     def test_integration_downloader_aware_priority_queue(self):

--- a/tests/test_scheduler_base.py
+++ b/tests/test_scheduler_base.py
@@ -6,7 +6,6 @@ import pytest
 from testfixtures import LogCapture
 from twisted.internet import defer
 from twisted.internet.defer import inlineCallbacks
-from twisted.trial.unittest import TestCase
 
 from scrapy.core.scheduler import BaseScheduler
 from scrapy.http import Request
@@ -115,8 +114,8 @@ class TestMinimalScheduler(InterfaceCheckMixin):
         assert not self.scheduler.has_pending_requests()
 
 
-class TestSimpleScheduler(TestCase, InterfaceCheckMixin):
-    def setUp(self):
+class TestSimpleScheduler(InterfaceCheckMixin):
+    def setup_method(self):
         self.scheduler = SimpleScheduler()
 
     @inlineCallbacks
@@ -145,7 +144,7 @@ class TestSimpleScheduler(TestCase, InterfaceCheckMixin):
         assert close_result == "close"
 
 
-class TestMinimalSchedulerCrawl(TestCase):
+class TestMinimalSchedulerCrawl:
     scheduler_cls = MinimalScheduler
 
     @inlineCallbacks

--- a/tests/test_signals.py
+++ b/tests/test_signals.py
@@ -1,6 +1,5 @@
 import pytest
 from twisted.internet.defer import inlineCallbacks
-from twisted.trial.unittest import TestCase
 
 from scrapy import Request, Spider, signals
 from scrapy.utils.defer import deferred_f_from_coro_f, maybe_deferred_to_future
@@ -21,7 +20,7 @@ class ItemSpider(Spider):
         return {"index": response.meta["index"]}
 
 
-class TestMain(TestCase):
+class TestMain:
     @deferred_f_from_coro_f
     async def test_scheduler_empty(self):
         crawler = get_crawler()
@@ -35,17 +34,17 @@ class TestMain(TestCase):
         assert len(calls) >= 1
 
 
-class TestMockServer(TestCase):
+class TestMockServer:
     @classmethod
-    def setUpClass(cls):
+    def setup_class(cls):
         cls.mockserver = MockServer()
         cls.mockserver.__enter__()
 
     @classmethod
-    def tearDownClass(cls):
+    def teardown_class(cls):
         cls.mockserver.__exit__(None, None, None)
 
-    def setUp(self):
+    def setup_method(self):
         self.items = []
 
     async def _on_item_scraped(self, item):

--- a/tests/test_spider.py
+++ b/tests/test_spider.py
@@ -37,12 +37,6 @@ from tests import get_testdata, tests_datadir
 class TestSpider:
     spider_class = Spider
 
-    def setup_method(self):
-        warnings.simplefilter("always")
-
-    def teardown_method(self):
-        warnings.resetwarnings()
-
     def test_base_spider(self):
         spider = self.spider_class("example.com")
         assert spider.name == "example.com"

--- a/tests/test_spider.py
+++ b/tests/test_spider.py
@@ -11,7 +11,6 @@ from unittest import mock
 import pytest
 from testfixtures import LogCapture
 from twisted.internet.defer import inlineCallbacks
-from twisted.trial import unittest
 from w3lib.url import safe_url_string
 
 from scrapy import signals
@@ -33,13 +32,13 @@ from scrapy.utils.test import get_crawler, get_reactor_settings
 from tests import get_testdata, tests_datadir
 
 
-class TestSpider(unittest.TestCase):
+class TestSpider:
     spider_class = Spider
 
-    def setUp(self):
+    def setup_method(self):
         warnings.simplefilter("always")
 
-    def tearDown(self):
+    def teardown_method(self):
         warnings.resetwarnings()
 
     def test_base_spider(self):

--- a/tests/test_spider_start.py
+++ b/tests/test_spider_start.py
@@ -6,7 +6,6 @@ from typing import Any
 
 import pytest
 from testfixtures import LogCapture
-from twisted.trial.unittest import TestCase
 
 from scrapy import Spider, signals
 from scrapy.exceptions import ScrapyDeprecationWarning
@@ -21,7 +20,7 @@ ITEM_A = {"id": "a"}
 ITEM_B = {"id": "b"}
 
 
-class TestMain(TestCase):
+class TestMain:
     async def _test_spider(
         self, spider: type[Spider], expected_items: list[Any] | None = None
     ) -> None:

--- a/tests/test_spidermiddleware.py
+++ b/tests/test_spidermiddleware.py
@@ -8,7 +8,6 @@ from unittest import mock
 import pytest
 from testfixtures import LogCapture
 from twisted.internet import defer
-from twisted.trial.unittest import TestCase
 
 from scrapy.core.spidermw import SpiderMiddlewareManager
 from scrapy.exceptions import _InvalidOutput
@@ -22,8 +21,8 @@ if TYPE_CHECKING:
     from twisted.python.failure import Failure
 
 
-class TestSpiderMiddleware(TestCase):
-    def setUp(self):
+class TestSpiderMiddleware:
+    def setup_method(self):
         self.request = Request("http://example.com/index.html")
         self.response = Response(self.request.url, request=self.request)
         self.crawler = get_crawler(Spider, {"SPIDER_MIDDLEWARES_BASE": {}})

--- a/tests/test_spidermiddleware_httperror.py
+++ b/tests/test_spidermiddleware_httperror.py
@@ -5,7 +5,6 @@ import logging
 import pytest
 from testfixtures import LogCapture
 from twisted.internet.defer import inlineCallbacks
-from twisted.trial.unittest import TestCase
 
 from scrapy.http import Request, Response
 from scrapy.settings import Settings
@@ -205,14 +204,14 @@ class TestHttpErrorMiddlewareHandleAll:
         mw.process_spider_input(res402, spider)
 
 
-class TestHttpErrorMiddlewareIntegrational(TestCase):
+class TestHttpErrorMiddlewareIntegrational:
     @classmethod
-    def setUpClass(cls):
+    def setup_class(cls):
         cls.mockserver = MockServer()
         cls.mockserver.__enter__()
 
     @classmethod
-    def tearDownClass(cls):
+    def teardown_class(cls):
         cls.mockserver.__exit__(None, None, None)
 
     @inlineCallbacks

--- a/tests/test_spidermiddleware_output_chain.py
+++ b/tests/test_spidermiddleware_output_chain.py
@@ -1,5 +1,4 @@
 from testfixtures import LogCapture
-from twisted.trial.unittest import TestCase
 
 from scrapy import Request, Spider
 from scrapy.utils.defer import deferred_f_from_coro_f, maybe_deferred_to_future
@@ -298,16 +297,16 @@ class NotGeneratorOutputChainSpider(Spider):
 
 
 # ================================================================================
-class TestSpiderMiddleware(TestCase):
+class TestSpiderMiddleware:
     mockserver: MockServer
 
     @classmethod
-    def setUpClass(cls):
+    def setup_class(cls):
         cls.mockserver = MockServer()
         cls.mockserver.__enter__()
 
     @classmethod
-    def tearDownClass(cls):
+    def teardown_class(cls):
         cls.mockserver.__exit__(None, None, None)
 
     async def crawl_log(self, spider: type[Spider]) -> LogCapture:

--- a/tests/test_spidermiddleware_process_start.py
+++ b/tests/test_spidermiddleware_process_start.py
@@ -2,7 +2,6 @@ import warnings
 from asyncio import sleep
 
 import pytest
-from twisted.trial.unittest import TestCase
 
 from scrapy import Spider, signals
 from scrapy.exceptions import ScrapyDeprecationWarning
@@ -106,7 +105,7 @@ class DeprecatedWrapSpiderMiddleware:
         yield ITEM_C
 
 
-class TestMain(TestCase):
+class TestMain:
     async def _test(self, spider_middlewares, spider_cls, expected_items):
         actual_items = []
 

--- a/tests/test_spidermiddleware_start.py
+++ b/tests/test_spidermiddleware_start.py
@@ -1,5 +1,3 @@
-from twisted.trial.unittest import TestCase
-
 from scrapy.http import Request
 from scrapy.spidermiddlewares.start import StartSpiderMiddleware
 from scrapy.spiders import Spider
@@ -8,7 +6,7 @@ from scrapy.utils.misc import build_from_crawler
 from scrapy.utils.test import get_crawler
 
 
-class TestMiddleware(TestCase):
+class TestMiddleware:
     @deferred_f_from_coro_f
     async def test_async(self):
         crawler = get_crawler(Spider)

--- a/tests/test_utils_asyncgen.py
+++ b/tests/test_utils_asyncgen.py
@@ -1,10 +1,8 @@
-from twisted.trial import unittest
-
 from scrapy.utils.asyncgen import as_async_generator, collect_asyncgen
 from scrapy.utils.defer import deferred_f_from_coro_f
 
 
-class TestAsyncgenUtils(unittest.TestCase):
+class TestAsyncgenUtils:
     @deferred_f_from_coro_f
     async def test_as_async_generator(self):
         ag = as_async_generator(range(42))

--- a/tests/test_utils_asyncio.py
+++ b/tests/test_utils_asyncio.py
@@ -7,7 +7,6 @@ from unittest import mock
 
 import pytest
 from twisted.internet.defer import Deferred
-from twisted.trial import unittest
 
 from scrapy.utils.asyncgen import as_async_generator
 from scrapy.utils.asyncio import (
@@ -29,7 +28,7 @@ class TestAsyncio:
 
 
 @pytest.mark.only_asyncio
-class TestParallelAsyncio(unittest.TestCase):
+class TestParallelAsyncio:
     """Test for scrapy.utils.asyncio.parallel_asyncio(), based on tests.test_utils_defer.TestParallelAsync."""
 
     CONCURRENT_ITEMS = 50

--- a/tests/test_utils_asyncio.py
+++ b/tests/test_utils_asyncio.py
@@ -20,11 +20,10 @@ if TYPE_CHECKING:
     from collections.abc import AsyncGenerator
 
 
-@pytest.mark.usefixtures("reactor_pytest")
 class TestAsyncio:
-    def test_is_asyncio_available(self):
+    def test_is_asyncio_available(self, reactor_pytest: str) -> None:
         # the result should depend only on the pytest --reactor argument
-        assert is_asyncio_available() == (self.reactor_pytest != "default")
+        assert is_asyncio_available() == (reactor_pytest == "asyncio")
 
 
 @pytest.mark.only_asyncio

--- a/tests/test_utils_defer.py
+++ b/tests/test_utils_defer.py
@@ -8,7 +8,6 @@ from typing import TYPE_CHECKING, Any
 import pytest
 from twisted.internet.defer import Deferred, inlineCallbacks, succeed
 from twisted.python.failure import Failure
-from twisted.trial import unittest
 
 from scrapy.utils.asyncgen import as_async_generator, collect_asyncgen
 from scrapy.utils.defer import (
@@ -29,7 +28,7 @@ if TYPE_CHECKING:
 
 
 @pytest.mark.filterwarnings("ignore::scrapy.exceptions.ScrapyDeprecationWarning")
-class TestMustbeDeferred(unittest.TestCase):
+class TestMustbeDeferred:
     @inlineCallbacks
     def test_success_function(self) -> Generator[Deferred[Any], Any, None]:
         steps: list[int] = []
@@ -87,7 +86,7 @@ def eb1(failure, arg1, arg2):
     return f"(eb1 {failure.value.__class__.__name__} {arg1} {arg2})"
 
 
-class TestDeferUtils(unittest.TestCase):
+class TestDeferUtils:
     @inlineCallbacks
     def test_process_chain(self):
         x = yield process_chain([cb1, cb2, cb3], "res", "v1", "v2")
@@ -131,7 +130,7 @@ class TestIterErrback:
         assert isinstance(errors[0].value, ZeroDivisionError)
 
 
-class TestAiterErrback(unittest.TestCase):
+class TestAiterErrback:
     @deferred_f_from_coro_f
     async def test_aiter_errback_good(self):
         async def itergood() -> AsyncGenerator[int, None]:
@@ -158,7 +157,7 @@ class TestAiterErrback(unittest.TestCase):
         assert isinstance(errors[0].value, ZeroDivisionError)
 
 
-class TestAsyncDefTestsuite(unittest.TestCase):
+class TestAsyncDefTestsuite:
     @deferred_f_from_coro_f
     async def test_deferred_f_from_coro_f(self):
         pass
@@ -173,7 +172,7 @@ class TestAsyncDefTestsuite(unittest.TestCase):
         raise RuntimeError("This is expected to be raised")
 
 
-class TestParallelAsync(unittest.TestCase):
+class TestParallelAsync:
     """This tests _AsyncCooperatorAdapter by testing parallel_async which is its only usage.
 
     parallel_async is called with the results of a callback (so an iterable of items, requests and None,
@@ -283,7 +282,7 @@ class TestParallelAsync(unittest.TestCase):
             assert max_parallel_count[0] <= self.CONCURRENT_ITEMS, max_parallel_count[0]
 
 
-class TestDeferredFromCoro(unittest.TestCase):
+class TestDeferredFromCoro:
     def test_deferred(self):
         d = Deferred()
         result = deferred_from_coro(d)
@@ -327,7 +326,7 @@ class TestDeferredFromCoro(unittest.TestCase):
         assert future_result == 42
 
 
-class TestDeferredFFromCoroF(unittest.TestCase):
+class TestDeferredFFromCoroF:
     @inlineCallbacks
     def _assert_result(
         self, c_f: Callable[[], Awaitable[int]]
@@ -364,7 +363,7 @@ class TestDeferredFFromCoroF(unittest.TestCase):
 
 
 @pytest.mark.only_asyncio
-class TestDeferredToFuture(unittest.TestCase):
+class TestDeferredToFuture:
     @deferred_f_from_coro_f
     async def test_deferred(self):
         d = Deferred()
@@ -399,7 +398,7 @@ class TestDeferredToFuture(unittest.TestCase):
 
 
 @pytest.mark.only_asyncio
-class TestMaybeDeferredToFutureAsyncio(unittest.TestCase):
+class TestMaybeDeferredToFutureAsyncio:
     @deferred_f_from_coro_f
     async def test_deferred(self):
         d = Deferred()

--- a/tests/test_utils_python.py
+++ b/tests/test_utils_python.py
@@ -7,7 +7,6 @@ import sys
 from typing import TYPE_CHECKING, TypeVar
 
 import pytest
-from twisted.trial import unittest
 
 from scrapy.utils.asyncgen import as_async_generator, collect_asyncgen
 from scrapy.utils.defer import aiter_errback, deferred_f_from_coro_f
@@ -41,7 +40,7 @@ def test_mutablechain():
     assert list(m) == list(range(2, 13))
 
 
-class TestMutableAsyncChain(unittest.TestCase):
+class TestMutableAsyncChain:
     @staticmethod
     async def g1():
         for i in range(3):

--- a/tests/test_utils_reactor.py
+++ b/tests/test_utils_reactor.py
@@ -2,7 +2,6 @@ import asyncio
 import warnings
 
 import pytest
-from twisted.trial.unittest import TestCase
 
 from scrapy.utils.defer import deferred_f_from_coro_f
 from scrapy.utils.reactor import (
@@ -14,7 +13,7 @@ from scrapy.utils.reactor import (
 
 
 @pytest.mark.usefixtures("reactor_pytest")
-class TestAsyncio(TestCase):
+class TestAsyncio:
     def test_is_asyncio_reactor_installed(self):
         # the result should depend only on the pytest --reactor argument
         assert is_asyncio_reactor_installed() == (self.reactor_pytest != "default")

--- a/tests/test_utils_reactor.py
+++ b/tests/test_utils_reactor.py
@@ -12,11 +12,10 @@ from scrapy.utils.reactor import (
 )
 
 
-@pytest.mark.usefixtures("reactor_pytest")
 class TestAsyncio:
-    def test_is_asyncio_reactor_installed(self):
+    def test_is_asyncio_reactor_installed(self, reactor_pytest: str) -> None:
         # the result should depend only on the pytest --reactor argument
-        assert is_asyncio_reactor_installed() == (self.reactor_pytest != "default")
+        assert is_asyncio_reactor_installed() == (reactor_pytest == "asyncio")
 
     def test_install_asyncio_reactor(self):
         from twisted.internet import reactor as original_reactor

--- a/tests/test_utils_signal.py
+++ b/tests/test_utils_signal.py
@@ -74,7 +74,6 @@ class TestSendCatchLogDeferred2(TestSendCatchLogDeferred):
         return d
 
 
-@pytest.mark.usefixtures("reactor_pytest")
 class TestSendCatchLogDeferredAsyncDef(TestSendCatchLogDeferred):
     async def ok_handler(self, arg, handlers_called):
         handlers_called.add(self.ok_handler)
@@ -108,7 +107,6 @@ class TestSendCatchLogAsync2(TestSendCatchLogAsync):
         return d
 
 
-@pytest.mark.usefixtures("reactor_pytest")
 class TestSendCatchLogAsyncAsyncDef(TestSendCatchLogAsync):
     async def ok_handler(self, arg, handlers_called):
         handlers_called.add(self.ok_handler)

--- a/tests/test_utils_signal.py
+++ b/tests/test_utils_signal.py
@@ -6,7 +6,6 @@ from testfixtures import LogCapture
 from twisted.internet import defer
 from twisted.internet.defer import inlineCallbacks
 from twisted.python.failure import Failure
-from twisted.trial import unittest
 
 from scrapy.utils.defer import deferred_from_coro
 from scrapy.utils.signal import (
@@ -17,7 +16,7 @@ from scrapy.utils.signal import (
 from scrapy.utils.test import get_from_asyncio_queue
 
 
-class TestSendCatchLog(unittest.TestCase):
+class TestSendCatchLog:
     @inlineCallbacks
     def test_send_catch_log(self):
         test_signal = object()

--- a/tests/test_webclient.py
+++ b/tests/test_webclient.py
@@ -1,22 +1,18 @@
 """
-from twisted.internet import defer
 Tests borrowed from the twisted.web.client tests.
 """
 
 from __future__ import annotations
 
-import shutil
-from pathlib import Path
-from tempfile import mkdtemp
 from urllib.parse import urlparse
 
 import OpenSSL.SSL
 import pytest
+from pytest_twisted import async_yield_fixture
 from twisted.internet import defer
 from twisted.internet.defer import inlineCallbacks
 from twisted.internet.testing import StringTransport
 from twisted.protocols.policies import WrappingFactory
-from twisted.trial import unittest
 from twisted.web import resource, server, static, util
 
 from scrapy.core.downloader import webclient as client
@@ -203,16 +199,16 @@ class EncodingResource(resource.Resource):
 
 
 @pytest.mark.filterwarnings("ignore::scrapy.exceptions.ScrapyDeprecationWarning")
-class TestWebClient(unittest.TestCase):
+class TestWebClient:
     def _listen(self, site):
         from twisted.internet import reactor
 
         return reactor.listenTCP(0, site, interface="127.0.0.1")
 
-    def setUp(self):
-        self.tmpname = Path(mkdtemp())
-        (self.tmpname / "file").write_bytes(b"0123456789")
-        r = static.File(str(self.tmpname))
+    @pytest.fixture
+    def wrapper(self, tmp_path):
+        (tmp_path / "file").write_bytes(b"0123456789")
+        r = static.File(str(tmp_path))
         r.putChild(b"redirect", util.Redirect(b"/file"))
         r.putChild(b"wait", ForeverTakingResource())
         r.putChild(b"error", ErrorResource())
@@ -221,45 +217,47 @@ class TestWebClient(unittest.TestCase):
         r.putChild(b"payload", PayloadResource())
         r.putChild(b"broken", BrokenDownloadResource())
         r.putChild(b"encoding", EncodingResource())
-        self.site = server.Site(r, timeout=None)
-        self.wrapper = WrappingFactory(self.site)
-        self.port = self._listen(self.wrapper)
-        self.portno = self.port.getHost().port
+        site = server.Site(r, timeout=None)
+        return WrappingFactory(site)
+
+    @async_yield_fixture
+    async def server_port(self, wrapper):
+        port = self._listen(wrapper)
+
+        yield port.getHost().port
+
+        await port.stopListening()
+
+    @pytest.fixture
+    def server_url(self, server_port):
+        return f"http://127.0.0.1:{server_port}/"
 
     @inlineCallbacks
-    def tearDown(self):
-        yield self.port.stopListening()
-        shutil.rmtree(self.tmpname)
-
-    def getURL(self, path):
-        return f"http://127.0.0.1:{self.portno}/{path}"
-
-    @inlineCallbacks
-    def testPayload(self):
+    def testPayload(self, server_url):
         s = "0123456789" * 10
-        body = yield getPage(self.getURL("payload"), body=s)
+        body = yield getPage(server_url + "payload", body=s)
         assert body == to_bytes(s)
 
     @inlineCallbacks
-    def testHostHeader(self):
+    def testHostHeader(self, server_port, server_url):
         # if we pass Host header explicitly, it should be used, otherwise
         # it should extract from url
-        body = yield getPage(self.getURL("host"))
-        assert body == to_bytes(f"127.0.0.1:{self.portno}")
-        body = yield getPage(self.getURL("host"), headers={"Host": "www.example.com"})
+        body = yield getPage(server_url + "host")
+        assert body == to_bytes(f"127.0.0.1:{server_port}")
+        body = yield getPage(server_url + "host", headers={"Host": "www.example.com"})
         assert body == to_bytes("www.example.com")
 
     @inlineCallbacks
-    def test_getPage(self):
+    def test_getPage(self, server_url):
         """
         L{client.getPage} returns a L{Deferred} which is called back with
         the body of the response if the default method B{GET} is used.
         """
-        body = yield getPage(self.getURL("file"))
+        body = yield getPage(server_url + "file")
         assert body == b"0123456789"
 
     @inlineCallbacks
-    def test_getPageHead(self):
+    def test_getPageHead(self, server_url):
         """
         L{client.getPage} returns a L{Deferred} which is called back with
         the empty string if the method is C{HEAD} and there is a successful
@@ -267,7 +265,7 @@ class TestWebClient(unittest.TestCase):
         """
 
         def _getPage(method):
-            return getPage(self.getURL("file"), method=method)
+            return getPage(server_url + "file", method=method)
 
         body = yield _getPage("head")
         assert body == b""
@@ -275,42 +273,42 @@ class TestWebClient(unittest.TestCase):
         assert body == b""
 
     @inlineCallbacks
-    def test_timeoutNotTriggering(self):
+    def test_timeoutNotTriggering(self, server_port, server_url):
         """
         When a non-zero timeout is passed to L{getPage} and the page is
         retrieved before the timeout period elapses, the L{Deferred} is
         called back with the contents of the page.
         """
-        body = yield getPage(self.getURL("host"), timeout=100)
-        assert body == to_bytes(f"127.0.0.1:{self.portno}")
+        body = yield getPage(server_url + "host", timeout=100)
+        assert body == to_bytes(f"127.0.0.1:{server_port}")
 
     @inlineCallbacks
-    def test_timeoutTriggering(self):
+    def test_timeoutTriggering(self, wrapper, server_url):
         """
         When a non-zero timeout is passed to L{getPage} and that many
         seconds elapse before the server responds to the request. the
         L{Deferred} is errbacked with a L{error.TimeoutError}.
         """
         with pytest.raises(defer.TimeoutError):
-            yield getPage(self.getURL("wait"), timeout=0.000001)
+            yield getPage(server_url + "wait", timeout=0.000001)
         # Clean up the server which is hanging around not doing
         # anything.
-        connected = list(self.wrapper.protocols.keys())
+        connected = list(wrapper.protocols.keys())
         # There might be nothing here if the server managed to already see
         # that the connection was lost.
         if connected:
             connected[0].transport.loseConnection()
 
     @inlineCallbacks
-    def testNotFound(self):
-        body = yield getPage(self.getURL("notsuchfile"))
+    def testNotFound(self, server_url):
+        body = yield getPage(server_url + "notsuchfile")
         assert b"404 - No Such Resource" in body
 
     @inlineCallbacks
-    def testFactoryInfo(self):
+    def testFactoryInfo(self, server_url):
         from twisted.internet import reactor
 
-        url = self.getURL("file")
+        url = server_url + "file"
         parsed = urlparse(url)
         factory = client.ScrapyHTTPClientFactory(Request(url))
         reactor.connectTCP(parsed.hostname, parsed.port, factory)
@@ -321,8 +319,8 @@ class TestWebClient(unittest.TestCase):
         assert factory.response_headers[b"content-length"] == b"10"
 
     @inlineCallbacks
-    def testRedirect(self):
-        body = yield getPage(self.getURL("redirect"))
+    def testRedirect(self, server_url):
+        body = yield getPage(server_url + "redirect")
         assert (
             body
             == b'\n<html>\n    <head>\n        <meta http-equiv="refresh" content="0;URL=/file">\n'
@@ -331,12 +329,12 @@ class TestWebClient(unittest.TestCase):
         )
 
     @inlineCallbacks
-    def test_encoding(self):
+    def test_encoding(self, server_url):
         """Test that non-standart body encoding matches
         Content-Encoding header"""
         original_body = b"\xd0\x81\xd1\x8e\xd0\xaf"
         response = yield getPage(
-            self.getURL("encoding"), body=original_body, response_transform=lambda r: r
+            server_url + "encoding", body=original_body, response_transform=lambda r: r
         )
         content_encoding = to_unicode(response.headers[b"Content-Encoding"])
         assert content_encoding == EncodingResource.out_encoding
@@ -346,9 +344,9 @@ class TestWebClient(unittest.TestCase):
 @pytest.mark.filterwarnings("ignore::scrapy.exceptions.ScrapyDeprecationWarning")
 class TestWebClientSSL(TestContextFactoryBase):
     @inlineCallbacks
-    def testPayload(self):
+    def testPayload(self, server_url):
         s = "0123456789" * 10
-        body = yield getPage(self.getURL("payload"), body=s)
+        body = yield getPage(server_url + "payload", body=s)
         assert body == to_bytes(s)
 
 
@@ -358,19 +356,19 @@ class TestWebClientCustomCiphersSSL(TestWebClientSSL):
     context_factory = ssl_context_factory(cipher_string=custom_ciphers)
 
     @inlineCallbacks
-    def testPayload(self):
+    def testPayload(self, server_url):
         s = "0123456789" * 10
         crawler = get_crawler(
             settings_dict={"DOWNLOADER_CLIENT_TLS_CIPHERS": self.custom_ciphers}
         )
         client_context_factory = build_from_crawler(ScrapyClientContextFactory, crawler)
         body = yield getPage(
-            self.getURL("payload"), body=s, contextFactory=client_context_factory
+            server_url + "payload", body=s, contextFactory=client_context_factory
         )
         assert body == to_bytes(s)
 
     @inlineCallbacks
-    def testPayloadDisabledCipher(self):
+    def testPayloadDisabledCipher(self, server_url):
         s = "0123456789" * 10
         crawler = get_crawler(
             settings_dict={
@@ -380,5 +378,5 @@ class TestWebClientCustomCiphersSSL(TestWebClientSSL):
         client_context_factory = build_from_crawler(ScrapyClientContextFactory, crawler)
         with pytest.raises(OpenSSL.SSL.Error):
             yield getPage(
-                self.getURL("payload"), body=s, contextFactory=client_context_factory
+                server_url + "payload", body=s, contextFactory=client_context_factory
             )

--- a/tox.ini
+++ b/tox.ini
@@ -40,7 +40,7 @@ passenv =
 #allow tox virtualenv to upgrade pip/wheel/setuptools
 download = true
 commands =
-    pytest --reactor=asyncio {posargs:--cov-config=pyproject.toml --cov=scrapy --cov-report= --cov-report=term-missing --cov-report=xml --junitxml=testenv.junit.xml -o junit_family=legacy --durations=10 docs scrapy tests --doctest-modules}
+    pytest {posargs:--cov-config=pyproject.toml --cov=scrapy --cov-report= --cov-report=term-missing --cov-report=xml --junitxml=testenv.junit.xml -o junit_family=legacy --durations=10 docs scrapy tests --doctest-modules}
 install_command =
     python -I -m pip install -ctests/upper-constraints.txt {opts} {packages}
 

--- a/tox.ini
+++ b/tox.ini
@@ -19,6 +19,7 @@ deps =
     pytest-xdist
     sybil >= 1.3.0  # https://github.com/cjw296/sybil/issues/20#issuecomment-605433422
     testfixtures
+    pytest-twisted >= 1.14.3
 
 [testenv]
 deps =
@@ -39,7 +40,7 @@ passenv =
 #allow tox virtualenv to upgrade pip/wheel/setuptools
 download = true
 commands =
-    pytest {posargs:--cov-config=pyproject.toml --cov=scrapy --cov-report= --cov-report=term-missing --cov-report=xml --junitxml=testenv.junit.xml -o junit_family=legacy --durations=10 docs scrapy tests --doctest-modules}
+    pytest --reactor=asyncio {posargs:--cov-config=pyproject.toml --cov=scrapy --cov-report= --cov-report=term-missing --cov-report=xml --junitxml=testenv.junit.xml -o junit_family=legacy --durations=10 docs scrapy tests --doctest-modules}
 install_command =
     python -I -m pip install -ctests/upper-constraints.txt {opts} {packages}
 


### PR DESCRIPTION
Fixes #6658 

- [x] Make --reactor=asyncio default even when run with simple pytest
- [x] Fix Windows (need a way to use the correct event loop)
- [x] Fix typing
- [x] Recheck and cleanup the changes
- [x] Check the coverage changes if any