### PR TITLE
Change default priority queue to DownloaderAwarePriorityQueue

### DIFF
--- a/docs/topics/broad-crawls.rst
+++ b/docs/topics/broad-crawls.rst
@@ -39,21 +39,6 @@ you need to keep in mind when using Scrapy for doing broad crawls, along with
 concrete suggestions of Scrapy settings to tune in order to achieve an
 efficient broad crawl.
 
-.. _broad-crawls-scheduler-priority-queue:
-
-Use the right :setting:`SCHEDULER_PRIORITY_QUEUE`
-=================================================
-
-Scrapy’s default scheduler priority queue is ``'scrapy.pqueues.ScrapyPriorityQueue'``.
-It works best during single-domain crawl. It does not work well with crawling
-many different domains in parallel
-
-To apply the recommended priority queue use:
-
-.. code-block:: python
-
-    SCHEDULER_PRIORITY_QUEUE = "scrapy.pqueues.DownloaderAwarePriorityQueue"
-
 .. _broad-crawls-concurrency:
 
 Increase concurrency

--- a/docs/topics/settings.rst
+++ b/docs/topics/settings.rst
@@ -1739,10 +1739,10 @@ Type of in-memory queue used by the scheduler. Other available type is:
 SCHEDULER_PRIORITY_QUEUE
 ------------------------
 
-Default: ``'scrapy.pqueues.ScrapyPriorityQueue'``
+Default: ``'scrapy.pqueues.DownloaderAwarePriorityQueue'``
 
 Type of priority queue used by the scheduler. Another available type is
-``scrapy.pqueues.DownloaderAwarePriorityQueue``.
+``scrapy.pqueues.ScrapyPriorityQueue``.
 ``scrapy.pqueues.DownloaderAwarePriorityQueue`` works better than
 ``scrapy.pqueues.ScrapyPriorityQueue`` when you crawl many different
 domains in parallel.

--- a/scrapy/pqueues.py
+++ b/scrapy/pqueues.py
@@ -336,6 +336,8 @@ class DownloaderAwarePriorityQueue:
 
     def push(self, request: Request) -> None:
         slot = self._downloader_interface.get_slot_key(request)
+        # Handle None slot by converting to string
+        slot = str(slot)
         if slot not in self.pqueues:
             self.pqueues[slot] = self.pqfactory(slot)
         queue = self.pqueues[slot]

--- a/scrapy/settings/default_settings.py
+++ b/scrapy/settings/default_settings.py
@@ -480,7 +480,7 @@ SCHEDULER = "scrapy.core.scheduler.Scheduler"
 SCHEDULER_DEBUG = False
 SCHEDULER_DISK_QUEUE = "scrapy.squeues.PickleLifoDiskQueue"
 SCHEDULER_MEMORY_QUEUE = "scrapy.squeues.LifoMemoryQueue"
-SCHEDULER_PRIORITY_QUEUE = "scrapy.pqueues.ScrapyPriorityQueue"
+SCHEDULER_PRIORITY_QUEUE = "scrapy.pqueues.DownloaderAwarePriorityQueue"
 SCHEDULER_START_DISK_QUEUE = "scrapy.squeues.PickleFifoDiskQueue"
 SCHEDULER_START_MEMORY_QUEUE = "scrapy.squeues.FifoMemoryQueue"
 

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -449,8 +449,25 @@ class TestEngine(TestEngineBase):
             )
 
     @inlineCallbacks
-    def test_start_already_running_exception(self):
-        e = ExecutionEngine(get_crawler(MySpider), lambda _: None)
+    def test_start_already_running_exception_with_default_priority_queue(self):
+        crawler = get_crawler(MySpider)
+        e = ExecutionEngine(crawler, lambda _: None)
+        crawler.engine = e
+        yield e.open_spider(MySpider())
+        e.start()
+        with pytest.raises(RuntimeError, match="Engine already running"):
+            yield e.start()
+        yield e.stop()
+
+    @inlineCallbacks
+    def test_start_already_running_exception_with_scrapy_priority_queue(self):
+        e = ExecutionEngine(
+            get_crawler(
+                MySpider,
+                {"SCHEDULER_PRIORITY_QUEUE": "scrapy.pqueues.ScrapyPriorityQueue"},
+            ),
+            lambda _: None,
+        )
         yield e.open_spider(MySpider())
         e.start()
         with pytest.raises(RuntimeError, match="Engine already running"):


### PR DESCRIPTION
Closes #6924 

This PR changes the default value of `SCHEDULER_PRIORITY_QUEUE` from `scrapy.pqueues.ScrapyPriorityQueue` to `scrapy.pqueues.DownloaderAwarePriorityQueue`. While implementing this change, two test failures appeared as side effects that required fixes.

The first issue occurred in `tests/test_engine.py::TestEngine::test_start_already_running_exception`. This test was using the ExecutionEngine API incorrectly by creating the engine externally and calling `open_spider()` directly, rather than using the standard `crawler.crawl()` flow. The bug occurs due to initialization timing: `ExecutionEngine.__init__()` is called but `crawler.engine` is not yet assigned, then `engine.open_spider()` is called which creates the scheduler, and the scheduler creates `DownloaderAwarePriorityQueue`. During `DownloaderAwarePriorityQueue.__init__()`, it creates `DownloaderInterface(crawler)`, which executes assert `crawler.engine` (still None at this point). The fix was simply adding `crawler.engine = e` in the test before calling `open_spider()`.

The second issue appeared in `tests/test_downloaderslotssettings.py::TestCrawl::test_delay`. This test deliberately creates requests with `meta={"download_slot": None}`, which works fine with `ScrapyPriorityQueue` since it ignores slots entirely. However, `DownloaderAwarePriorityQueue` organizes requests by slot and calls `_path_safe(slot)` where slot can be `None`, causing a `TypeError`. The difference is that `ScrapyPriorityQueue` uses `self.key + "/" + str(priority)` for internal queues, while `DownloaderAwarePriorityQueue` uses `self.key + "/" + _path_safe(slot)`. The fix was convert None slots to the string "None":

I'm not entirely certain this is the optimal approach for handling `None` slots. An alternative would be treating `None` as a fallback to the default hostname-based slot key rather than creating a literal "None" slot. I'd appreciate feedback on whether the current solution is acceptable or if a different approach would be preferred.