### PR TITLE
Increase the command timeout in test_short_timeout().

### DIFF
--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -495,7 +495,7 @@ class TestEngine(TestEngineBase):
         )
 
         try:
-            _, stderr = p.communicate(timeout=3)
+            _, stderr = p.communicate(timeout=15)
         except subprocess.TimeoutExpired:
             p.kill()
             p.communicate()


### PR DESCRIPTION
There is again some coverage-related slowdown on Python 3.12 and 3 seconds is sometimes not enough for the process to finish successfully, bump the timeout.