### PR TITLE
Adding httpx-based downloader

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -2,3 +2,4 @@ sphinx==8.1.3
 sphinx-notfound-page==1.0.4
 sphinx-rtd-theme==3.0.2
 sphinx-rtd-dark-mode==1.3.0
+httpx>=0.24.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ dependencies = [
     "tldextract",
     "w3lib>=1.17.0",
     "zope.interface>=5.1.0",
+    "httpx>=0.24.0",
     # Platform-specific dependencies
     'PyDispatcher>=2.0.5; platform_python_implementation == "CPython"',
     'PyPyDispatcher>=2.1.0; platform_python_implementation == "PyPy"',

--- a/scrapy/core/downloader/handlers/http.py
+++ b/scrapy/core/downloader/handlers/http.py
@@ -2,8 +2,10 @@ from scrapy.core.downloader.handlers.http10 import HTTP10DownloadHandler
 from scrapy.core.downloader.handlers.http11 import (
     HTTP11DownloadHandler as HTTPDownloadHandler,
 )
+from scrapy.core.downloader.handlers.httpx import HTTPXDownloadHandler
 
 __all__ = [
     "HTTP10DownloadHandler",
     "HTTPDownloadHandler",
+    "HTTPXDownloadHandler",
 ]

--- a/scrapy/core/downloader/handlers/httpx.py
+++ b/scrapy/core/downloader/handlers/httpx.py
@@ -1,0 +1,42 @@
+from typing import Self
+import httpx
+from twisted.internet.defer import ensureDeferred
+
+from scrapy.crawler import Crawler
+from scrapy.http import HtmlResponse, JsonResponse, Response
+from scrapy.settings import BaseSettings
+
+
+class HTTPXDownloadHandler:
+    def __init__(self, settings: BaseSettings, crawler=None):
+        self.settings = settings
+
+    @classmethod
+    def from_crawler(cls, crawler: Crawler) -> Self:
+        return cls(crawler.settings, crawler)
+
+    def download_request(self, request, spider):
+        return ensureDeferred(self._download(request))
+
+    async def _download(self, request):
+        async with httpx.AsyncClient() as client:
+            resp = await client.request(
+                method=request.method,
+                url=str(request.url),
+                headers=request.headers.to_unicode_dict(),
+                content=request.body or None,
+                timeout=10,
+            )
+            content_type = resp.headers.get("content-type", "").lower()
+            response_cls = Response
+            if "text/html" in content_type:
+                response_cls = HtmlResponse
+            elif "application/json" in content_type or "json" in content_type:
+                response_cls = JsonResponse
+            return response_cls(
+                url=str(request.url),
+                status=resp.status_code,
+                headers=resp.headers,
+                body=resp.content,
+                request=request,
+            )

--- a/scrapy/settings/default_settings.py
+++ b/scrapy/settings/default_settings.py
@@ -531,8 +531,6 @@ URLLENGTH_LIMIT = 2083
 USER_AGENT = f"Scrapy/{import_module('scrapy').__version__} (+https://scrapy.org)"
 
 WARN_ON_GENERATOR_RETURN_VALUE = True
-
-
 def __getattr__(name: str):
     if name == "CONCURRENT_REQUESTS_PER_IP":
         import warnings  # noqa: PLC0415
@@ -547,3 +545,9 @@ def __getattr__(name: str):
         return 0
 
     raise AttributeError
+
+# To use the HTTPX-based download handler, uncomment and adjust the following:
+# DOWNLOAD_HANDLERS = {
+#     'http': 'scrapy.core.downloader.handlers.httpx.HTTPXDownloadHandler',
+#     'https': 'scrapy.core.downloader.handlers.httpx.HTTPXDownloadHandler',
+# }

--- a/tests/test_downloader_handler_httpx.py
+++ b/tests/test_downloader_handler_httpx.py
@@ -1,0 +1,55 @@
+"""Tests for scrapy.core.downloader.handlers.httpx.HTTPXDownloadHandler."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+# Running all pre-existing twisted HTTP download handler tests under HTTPX to avoid writing duplicate tests
+from tests.test_downloader_handler_twisted_http2 import TestHttps2, TestHttp2MockServer
+from tests.test_downloader_handler_twisted_http10 import TestHttp10, TestHttps10
+from tests.test_downloader_handler_twisted_http11 import TestHttp11, TestHttps11
+from tests.test_downloader_handlers_http_base import TestHttpMockServerBase
+
+if TYPE_CHECKING:
+    from scrapy.core.downloader.handlers import DownloadHandlerProtocol
+
+class TestHttps2x(TestHttps2):
+    @property
+    def download_handler_cls(self) -> type[DownloadHandlerProtocol]:
+        from scrapy.core.downloader.handlers.httpx import HTTPXDownloadHandler
+
+        return HTTPXDownloadHandler
+    
+
+
+
+class TestHttp11x(TestHttp11):
+    @property
+    def download_handler_cls(self) -> type[DownloadHandlerProtocol]:
+        from scrapy.core.downloader.handlers.httpx import HTTPXDownloadHandler
+
+        return HTTPXDownloadHandler
+
+
+class TestHttps11x(TestHttps11):
+    @property
+    def download_handler_cls(self) -> type[DownloadHandlerProtocol]:
+        from scrapy.core.downloader.handlers.httpx import HTTPXDownloadHandler
+
+        return HTTPXDownloadHandler
+
+
+class TestHttp10x(TestHttp10):
+    @property
+    def download_handler_cls(self) -> type[DownloadHandlerProtocol]:
+        from scrapy.core.downloader.handlers.httpx import HTTPXDownloadHandler
+
+        return HTTPXDownloadHandler
+
+
+class TestHttps10x(TestHttps10):
+    @property
+    def download_handler_cls(self) -> type[DownloadHandlerProtocol]:
+        from scrapy.core.downloader.handlers.httpx import HTTPXDownloadHandler
+
+        return HTTPXDownloadHandler

--- a/tests/upper-constraints.txt
+++ b/tests/upper-constraints.txt
@@ -15,3 +15,4 @@ service_identity>=17.0.0
 six>=1.14.0
 sybil>=2.0.0
 Twisted>=19.10.0
+httpx>=0.24.0


### PR DESCRIPTION
As per issue #6805, this PR implements a base for an httpx-based download handler. It's being submitted initially as a draft PR as this implementation currently lacks HTTPS support.

To add said support would most likely require either creating multiple download handlers (For example, Http11_X and Https11_X), or requiring parameters either in the download handler's constructor or in download_request(). The latter option would prevent the new handler from being a drop-in replacement for the previous twisted-based one

We tried to reuse the existing tests from the twisted handlers, but have been having issues making them work, though that is currently being addressed.