### PR TITLE
Add type check in get_media_requests to enforce image / file urls as a list

### DIFF
--- a/scrapy/pipelines/files.py
+++ b/scrapy/pipelines/files.py
@@ -704,6 +704,10 @@ class FilesPipeline(MediaPipeline):
         self, item: Any, info: MediaPipeline.SpiderInfo
     ) -> list[Request]:
         urls = ItemAdapter(item).get(self.files_urls_field, [])
+        if not isinstance(urls, list):
+            raise TypeError(
+                f"{self.files_urls_field} must be a list of URLs, got {type(urls).__name__}. "
+            )
         return [Request(u, callback=NO_CALLBACK) for u in urls]
 
     def file_downloaded(

--- a/scrapy/pipelines/images.py
+++ b/scrapy/pipelines/images.py
@@ -241,6 +241,10 @@ class ImagesPipeline(FilesPipeline):
         self, item: Any, info: MediaPipeline.SpiderInfo
     ) -> list[Request]:
         urls = ItemAdapter(item).get(self.images_urls_field, [])
+        if not isinstance(urls, list):
+            raise TypeError(
+                f"{self.images_urls_field} must be a list of URLs, got {type(urls).__name__}. "
+            )
         return [Request(u, callback=NO_CALLBACK) for u in urls]
 
     def item_completed(

--- a/tests/test_pipeline_files.py
+++ b/tests/test_pipeline_files.py
@@ -261,13 +261,16 @@ class TestFilesPipeline:
         request = Request("http://example.com")
         assert file_path(request, item=item) == "full/path-to-store-file"
 
-    @pytest.mark.parametrize("bad_type", [
-        "http://example.com/file.pdf",
-        ("http://example.com/file.pdf",),
-        {"url": "http://example.com/file.pdf"},
-        123,
-        None,
-    ])
+    @pytest.mark.parametrize(
+        "bad_type",
+        [
+            "http://example.com/file.pdf",
+            ("http://example.com/file.pdf",),
+            {"url": "http://example.com/file.pdf"},
+            123,
+            None,
+        ],
+    )
     def test_rejects_non_list_file_urls(self, tmp_path, bad_type):
         pipeline = FilesPipeline.from_crawler(
             get_crawler(None, {"FILES_STORE": str(tmp_path)})

--- a/tests/test_pipeline_files.py
+++ b/tests/test_pipeline_files.py
@@ -257,7 +257,7 @@ class TestFilesPipeline:
         file_path = CustomFilesPipeline.from_crawler(
             get_crawler(None, {"FILES_STORE": self.tempdir})
         ).file_path
-        item = ItemWithFiles()
+        item = {"path": "path-to-store-file"}
         request = Request("http://example.com")
         assert file_path(request, item=item) == "full/path-to-store-file"
 

--- a/tests/test_pipeline_images.py
+++ b/tests/test_pipeline_images.py
@@ -209,6 +209,23 @@ class TestImagesPipeline:
         assert converted.mode == "RGB"
         assert converted.getcolors() == [(10000, (205, 230, 255))]
 
+    @pytest.mark.parametrize("bad_type", [
+        "http://example.com/file.jpg",
+        ("http://example.com/file.jpg",),
+        {"url": "http://example.com/file.jpg"},
+        123,
+        None,
+    ])
+    def test_rejects_non_list_image_urls(self, tmp_path, bad_type):
+        pipeline = ImagesPipeline.from_crawler(
+            get_crawler(None, {"IMAGES_STORE": str(tmp_path)})
+        )
+        item = ImagesPipelineTestItem()
+        item["image_urls"] = bad_type
+
+        with pytest.raises(TypeError, match="image_urls must be a list of URLs"):
+            list(pipeline.get_media_requests(item, None))
+
 
 class TestImagesPipelineFieldsMixin(ABC):
     @property

--- a/tests/test_pipeline_images.py
+++ b/tests/test_pipeline_images.py
@@ -209,13 +209,16 @@ class TestImagesPipeline:
         assert converted.mode == "RGB"
         assert converted.getcolors() == [(10000, (205, 230, 255))]
 
-    @pytest.mark.parametrize("bad_type", [
-        "http://example.com/file.jpg",
-        ("http://example.com/file.jpg",),
-        {"url": "http://example.com/file.jpg"},
-        123,
-        None,
-    ])
+    @pytest.mark.parametrize(
+        "bad_type",
+        [
+            "http://example.com/file.jpg",
+            ("http://example.com/file.jpg",),
+            {"url": "http://example.com/file.jpg"},
+            123,
+            None,
+        ],
+    )
     def test_rejects_non_list_image_urls(self, tmp_path, bad_type):
         pipeline = ImagesPipeline.from_crawler(
             get_crawler(None, {"IMAGES_STORE": str(tmp_path)})


### PR DESCRIPTION
**Raise TypeError if `images_urls_field` or `files_urls_field` value is not a list**

* Adds explicit type checking for both `images_urls_field` and `files_urls_field` to ensure they are lists.
* Provides clearer error messages to help users quickly identify and fix misconfigured items.
* Prevents silent bugs caused by accidentally passing a single string or other iterable types instead of a list.
* Adds comprehensive tests for `images_urls_field` and `files_urls_field` to validate the new type enforcement.
