### PR TITLE
Fixed the lambda "cell-var-from-loop" warning

### DIFF
--- a/scrapy/utils/signal.py
+++ b/scrapy/utils/signal.py
@@ -98,12 +98,10 @@ def send_catch_log_deferred(
         )
         d.addErrback(logerror, receiver)
         # TODO https://pylint.readthedocs.io/en/latest/user_guide/messages/warning/cell-var-from-loop.html
-        d2: Deferred[tuple[TypingAny, TypingAny]] = d.addBoth(
-            lambda result: (
-                receiver,  # pylint: disable=cell-var-from-loop  # noqa: B023
-                result,
-            )
-        )
+        def _make_result_tuple(res, recv=receiver):
+            return (recv, res)
+
+        d2: Deferred[tuple[TypingAny, TypingAny]] = d.addBoth(_make_result_tuple)
         dfds.append(d2)
 
     results = yield DeferredList(dfds)


### PR DESCRIPTION
replaced the lambda with a helper function _make_result_tuple that takes the result and the receiver as arguments, ensuring the receiver variable is correctly captured at each iteration

```bash
pytest tests/test_utils_signal.py -v
========================================================================== test session starts ===========================================================================
platform darwin -- Python 3.13.5, pytest-8.4.1, pluggy-1.6.0 -- /Library/Frameworks/Python.framework/Versions/3.13/bin/python3.13
cachedir: .pytest_cache
rootdir: /Users/spareair/Documents/scrapy
configfile: pyproject.toml
plugins: anyio-4.9.0, twisted-1.14.3
collected 10 items                                                                                                                                                       

tests/test_utils_signal.py::TestSendCatchLog::test_send_catch_log PASSED                                                                                           [ 10%]
tests/test_utils_signal.py::TestSendCatchLogDeferred::test_send_catch_log PASSED                                                                                   [ 20%]
tests/test_utils_signal.py::TestSendCatchLogDeferred2::test_send_catch_log PASSED                                                                                  [ 30%]
tests/test_utils_signal.py::TestSendCatchLogDeferredAsyncDef::test_send_catch_log PASSED                                                                           [ 40%]
tests/test_utils_signal.py::TestSendCatchLogDeferredAsyncio::test_send_catch_log PASSED                                                                            [ 50%]
tests/test_utils_signal.py::TestSendCatchLogAsync::test_send_catch_log PASSED                                                                                      [ 60%]
tests/test_utils_signal.py::TestSendCatchLogAsync2::test_send_catch_log PASSED                                                                                     [ 70%]
tests/test_utils_signal.py::TestSendCatchLogAsyncAsyncDef::test_send_catch_log PASSED                                                                              [ 80%]
tests/test_utils_signal.py::TestSendCatchLogAsyncAsyncio::test_send_catch_log PASSED                                                                               [ 90%]
tests/test_utils_signal.py::TestSendCatchLog2::test_error_logged_if_deferred_not_supported PASSED                                                                  [100%]

============================================================================ warnings summary ============================================================================
.:0
  :0: UserWarning: You do not have a working installation of the service_identity module: 'No module named 'service_identity''.  Please install it from <https://pypi.python.org/pypi/service_identity> and make sure all of its dependencies are satisfied.  Without the service_identity module, Twisted can perform only rudimentary TLS client hostname verification.  Many valid certificate/hostname mappings may be rejected.

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
===================================================================== 10 passed, 1 warning in 0.67s ======================================================================
```
The warning is about how my venv is setup. All tests passed.