### PR TITLE
[PoC] Reactorless tests.

### DIFF
--- a/.github/workflows/tests-ubuntu.yml
+++ b/.github/workflows/tests-ubuntu.yml
@@ -35,6 +35,9 @@ jobs:
         - python-version: "3.13"
           env:
             TOXENV: default-reactor
+        - python-version: "3.13"
+          env:
+            TOXENV: no-reactor
         - python-version: pypy3.10
           env:
             TOXENV: pypy3
@@ -49,6 +52,9 @@ jobs:
         - python-version: "3.9.21"
           env:
             TOXENV: default-reactor-pinned
+        - python-version: "3.9.21"
+          env:
+            TOXENV: no-reactor-pinned
         - python-version: pypy3.10
           env:
             TOXENV: pypy3-pinned

--- a/.github/workflows/tests-windows.yml
+++ b/.github/workflows/tests-windows.yml
@@ -35,6 +35,9 @@ jobs:
         - python-version: "3.13"
           env:
             TOXENV: default-reactor
+        - python-version: "3.13"
+          env:
+            TOXENV: no-reactor
 
         # pinned deps
         - python-version: "3.9.13"

--- a/docs/topics/asyncio.rst
+++ b/docs/topics/asyncio.rst
@@ -49,6 +49,7 @@ You can usually fix the issue by moving those offending module-level Twisted
 imports to the method or function definitions where they are used. For example,
 if you have something like:
 
+.. skip: next
 .. code-block:: python
 
     from twisted.internet import reactor

--- a/docs/topics/settings.rst
+++ b/docs/topics/settings.rst
@@ -2003,6 +2003,7 @@ reactor is installed.
 
 In order to use the reactor installed by Scrapy:
 
+.. skip: next
 .. code-block:: python
 
     import scrapy

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -226,6 +226,7 @@ python_files = ["test_*.py", "test_*/__init__.py"]
 markers = [
     "only_asyncio: marks tests as only enabled when --reactor=asyncio is passed",
     "only_not_asyncio: marks tests as only enabled when --reactor=asyncio is not passed",
+    "requires_reactor: marks tests that require a reactor",
     "requires_uvloop: marks tests as only enabled when uvloop is known to be working",
     "requires_botocore: marks tests that need botocore (but not boto3)",
     "requires_boto3: marks tests that need botocore and boto3",

--- a/scrapy/crawler.py
+++ b/scrapy/crawler.py
@@ -110,22 +110,23 @@ class Crawler:
             self,
         )
 
-        reactor_class: str = self.settings["TWISTED_REACTOR"]
-        event_loop: str = self.settings["ASYNCIO_EVENT_LOOP"]
-        if self._init_reactor:
-            # this needs to be done after the spider settings are merged,
-            # but before something imports twisted.internet.reactor
+        if self.settings.getbool("_USE_REACTOR"):
+            reactor_class: str = self.settings["TWISTED_REACTOR"]
+            event_loop: str = self.settings["ASYNCIO_EVENT_LOOP"]
+            if self._init_reactor:
+                # this needs to be done after the spider settings are merged,
+                # but before something imports twisted.internet.reactor
+                if reactor_class:
+                    install_reactor(reactor_class, event_loop)
+                else:
+                    from twisted.internet import reactor  # noqa: F401
             if reactor_class:
-                install_reactor(reactor_class, event_loop)
-            else:
-                from twisted.internet import reactor  # noqa: F401
-        if reactor_class:
-            verify_installed_reactor(reactor_class)
-            if is_asyncio_reactor_installed() and event_loop:
-                verify_installed_asyncio_event_loop(event_loop)
+                verify_installed_reactor(reactor_class)
+                if is_asyncio_reactor_installed() and event_loop:
+                    verify_installed_asyncio_event_loop(event_loop)
 
-        if self._init_reactor or reactor_class:
-            log_reactor_info()
+            if self._init_reactor or reactor_class:
+                log_reactor_info()
 
         self.extensions = ExtensionManager.from_crawler(self)
         self.settings.freeze()

--- a/scrapy/settings/default_settings.py
+++ b/scrapy/settings/default_settings.py
@@ -532,6 +532,8 @@ USER_AGENT = f"Scrapy/{import_module('scrapy').__version__} (+https://scrapy.org
 
 WARN_ON_GENERATOR_RETURN_VALUE = True
 
+_USE_REACTOR = True
+
 
 def __getattr__(name: str):
     if name == "CONCURRENT_REQUESTS_PER_IP":

--- a/scrapy/utils/asyncio.py
+++ b/scrapy/utils/asyncio.py
@@ -59,9 +59,18 @@ def is_asyncio_available() -> bool:
     objects.
     """
     if not is_reactor_installed():
-        raise RuntimeError(
-            "is_asyncio_available() called without an installed reactor."
-        )
+        # try:
+        #     asyncio.get_event_loop()
+        # except RuntimeError:
+        #     return False
+        # return True
+        try:
+            asyncio.get_running_loop()
+        except RuntimeError as ex:
+            raise RuntimeError(
+                "is_asyncio_available() called without an installed reactor or running asyncio event loop."
+            ) from ex
+        return True
 
     return is_asyncio_reactor_installed()
 

--- a/tests/test_addons.py
+++ b/tests/test_addons.py
@@ -2,13 +2,14 @@ import itertools
 from typing import Any
 from unittest.mock import patch
 
-from twisted.internet.defer import inlineCallbacks
+import pytest
 
 from scrapy import Spider
 from scrapy.crawler import Crawler, CrawlerRunner
 from scrapy.exceptions import NotConfigured
 from scrapy.settings import BaseSettings, Settings
 from scrapy.utils.test import get_crawler, get_reactor_settings
+from tests.utils.decorators import inlineCallbacks
 
 
 class SimpleAddon:
@@ -127,6 +128,7 @@ class TestAddonManager:
         crawler = runner.create_crawler(Spider)
         assert crawler.settings.getint("KEY") == 20
 
+    @pytest.mark.requires_reactor  # TODO use a different setting in the test
     def test_fallback_workflow(self):
         FALLBACK_SETTING = "MY_FALLBACK_DOWNLOAD_HANDLER"
 

--- a/tests/test_closespider.py
+++ b/tests/test_closespider.py
@@ -1,5 +1,3 @@
-from twisted.internet.defer import inlineCallbacks
-
 from scrapy.utils.test import get_crawler
 from tests.mockserver import MockServer
 from tests.spiders import (
@@ -9,6 +7,7 @@ from tests.spiders import (
     MaxItemsAndRequestsSpider,
     SlowSpider,
 )
+from tests.utils.decorators import inlineCallbacks
 
 
 class TestCloseSpider:

--- a/tests/test_contracts.py
+++ b/tests/test_contracts.py
@@ -1,7 +1,6 @@
 from unittest import TextTestResult
 
 import pytest
-from twisted.internet.defer import inlineCallbacks
 from twisted.python import failure
 
 from scrapy import FormRequest
@@ -19,6 +18,7 @@ from scrapy.spidermiddlewares.httperror import HttpError
 from scrapy.spiders import Spider
 from scrapy.utils.test import get_crawler
 from tests.mockserver import MockServer
+from tests.utils.decorators import inlineCallbacks
 
 
 class DemoItem(Item):

--- a/tests/test_core_downloader.py
+++ b/tests/test_core_downloader.py
@@ -18,11 +18,12 @@ from scrapy.core.downloader.contextfactory import (
 )
 from scrapy.core.downloader.handlers.http11 import _RequestBodyProducer
 from scrapy.settings import Settings
-from scrapy.utils.defer import deferred_f_from_coro_f, maybe_deferred_to_future
+from scrapy.utils.defer import maybe_deferred_to_future
 from scrapy.utils.misc import build_from_crawler
 from scrapy.utils.python import to_bytes
 from scrapy.utils.test import get_crawler
 from tests.mockserver import PayloadResource, ssl_context_factory
+from tests.utils.decorators import deferred_f_from_coro_f
 
 if TYPE_CHECKING:
     from twisted.internet.defer import Deferred

--- a/tests/test_crawl.py
+++ b/tests/test_crawl.py
@@ -9,7 +9,6 @@ from urllib.parse import urlencode, urlparse
 
 import pytest
 from testfixtures import LogCapture
-from twisted.internet.defer import inlineCallbacks
 from twisted.internet.ssl import Certificate
 from twisted.python.failure import Failure
 
@@ -18,7 +17,7 @@ from scrapy.crawler import CrawlerRunner
 from scrapy.exceptions import CloseSpider, StopDownload
 from scrapy.http import Request
 from scrapy.http.response import Response
-from scrapy.utils.defer import deferred_f_from_coro_f, maybe_deferred_to_future
+from scrapy.utils.defer import maybe_deferred_to_future
 from scrapy.utils.engine import format_engine_status, get_engine_status
 from scrapy.utils.python import to_unicode
 from scrapy.utils.test import get_crawler, get_reactor_settings
@@ -55,6 +54,7 @@ from tests.spiders import (
     StartGoodAndBadOutput,
     StartItemSpider,
 )
+from tests.utils.decorators import deferred_f_from_coro_f, inlineCallbacks
 
 if TYPE_CHECKING:
     from scrapy.statscollectors import StatsCollector

--- a/tests/test_crawler.py
+++ b/tests/test_crawler.py
@@ -14,7 +14,7 @@ from typing import Any
 import pytest
 from packaging.version import parse as parse_version
 from pexpect.popen_spawn import PopenSpawn
-from twisted.internet.defer import Deferred, inlineCallbacks
+from twisted.internet.defer import Deferred
 from w3lib import __version__ as w3lib_version
 from zope.interface.exceptions import MultipleInvalid
 
@@ -30,11 +30,12 @@ from scrapy.crawler import (
 from scrapy.exceptions import ScrapyDeprecationWarning
 from scrapy.extensions.throttle import AutoThrottle
 from scrapy.settings import Settings, default_settings
-from scrapy.utils.defer import deferred_f_from_coro_f, deferred_from_coro
+from scrapy.utils.defer import deferred_from_coro
 from scrapy.utils.log import configure_logging, get_scrapy_root_handler
 from scrapy.utils.spider import DefaultSpider
 from scrapy.utils.test import get_crawler, get_reactor_settings
 from tests.mockserver import MockServer, get_mockserver_env
+from tests.utils.decorators import deferred_f_from_coro_f, inlineCallbacks
 
 BASE_SETTINGS: dict[str, Any] = {}
 

--- a/tests/test_downloader_handler_twisted_http10.py
+++ b/tests/test_downloader_handler_twisted_http10.py
@@ -19,6 +19,9 @@ if TYPE_CHECKING:
     from scrapy.core.downloader.handlers import DownloadHandlerProtocol
 
 
+pytestmark = pytest.mark.requires_reactor
+
+
 class HTTP10DownloadHandlerMixin:
     @property
     def download_handler_cls(self) -> type[DownloadHandlerProtocol]:

--- a/tests/test_downloader_handler_twisted_http11.py
+++ b/tests/test_downloader_handler_twisted_http11.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
+import pytest
+
 from scrapy.core.downloader.handlers.http11 import HTTP11DownloadHandler
 from tests.test_downloader_handlers_http_base import (
     TestHttp11Base,
@@ -19,6 +21,9 @@ from tests.test_downloader_handlers_http_base import (
 
 if TYPE_CHECKING:
     from scrapy.core.downloader.handlers import DownloadHandlerProtocol
+
+
+pytestmark = pytest.mark.requires_reactor
 
 
 class HTTP11DownloadHandlerMixin:

--- a/tests/test_downloader_handler_twisted_http2.py
+++ b/tests/test_downloader_handler_twisted_http2.py
@@ -36,9 +36,12 @@ if TYPE_CHECKING:
     from scrapy.core.downloader.handlers import DownloadHandlerProtocol
 
 
-pytestmark = pytest.mark.skipif(
-    not H2_ENABLED, reason="HTTP/2 support in Twisted is not enabled"
-)
+pytestmark = [
+    pytest.mark.requires_reactor,
+    pytest.mark.skipif(
+        not H2_ENABLED, reason="HTTP/2 support in Twisted is not enabled"
+    ),
+]
 
 
 class H2DownloadHandlerMixin:

--- a/tests/test_downloader_handlers.py
+++ b/tests/test_downloader_handlers.py
@@ -24,11 +24,12 @@ from scrapy.exceptions import NotConfigured
 from scrapy.http import HtmlResponse, Request, Response
 from scrapy.http.response.text import TextResponse
 from scrapy.responsetypes import responsetypes
-from scrapy.utils.defer import deferred_f_from_coro_f, maybe_deferred_to_future
+from scrapy.utils.defer import maybe_deferred_to_future
 from scrapy.utils.misc import build_from_crawler
 from scrapy.utils.python import to_bytes
 from scrapy.utils.spider import DefaultSpider
 from scrapy.utils.test import get_crawler
+from tests.utils.decorators import deferred_f_from_coro_f
 
 if TYPE_CHECKING:
     from collections.abc import AsyncGenerator, Generator
@@ -305,6 +306,7 @@ class TestS3:
         )
 
 
+@pytest.mark.requires_reactor
 class TestFTPBase:
     username = "scrapy"
     password = "passwd"

--- a/tests/test_downloader_handlers_http_base.py
+++ b/tests/test_downloader_handlers_http_base.py
@@ -19,11 +19,7 @@ from twisted.web.http import _DataLoss
 
 from scrapy.http import Headers, HtmlResponse, Request, Response, TextResponse
 from scrapy.spiders import Spider
-from scrapy.utils.defer import (
-    deferred_f_from_coro_f,
-    deferred_from_coro,
-    maybe_deferred_to_future,
-)
+from scrapy.utils.defer import deferred_from_coro, maybe_deferred_to_future
 from scrapy.utils.misc import build_from_crawler
 from scrapy.utils.python import to_bytes
 from scrapy.utils.spider import DefaultSpider
@@ -39,6 +35,7 @@ from tests.mockserver import (
     ssl_context_factory,
 )
 from tests.spiders import SingleRequestSpider
+from tests.utils.decorators import deferred_f_from_coro_f
 
 if TYPE_CHECKING:
     from collections.abc import AsyncGenerator

--- a/tests/test_downloadermiddleware.py
+++ b/tests/test_downloadermiddleware.py
@@ -12,9 +12,10 @@ from scrapy.core.downloader.middleware import DownloaderMiddlewareManager
 from scrapy.exceptions import _InvalidOutput
 from scrapy.http import Request, Response
 from scrapy.spiders import Spider
-from scrapy.utils.defer import deferred_f_from_coro_f, maybe_deferred_to_future
+from scrapy.utils.defer import maybe_deferred_to_future
 from scrapy.utils.python import to_bytes
 from scrapy.utils.test import get_crawler, get_from_asyncio_queue
+from tests.utils.decorators import deferred_f_from_coro_f
 
 
 class TestManagerBase:

--- a/tests/test_downloadermiddleware_robotstxt.py
+++ b/tests/test_downloadermiddleware_robotstxt.py
@@ -14,8 +14,9 @@ from scrapy.exceptions import IgnoreRequest, NotConfigured
 from scrapy.http import Request, Response, TextResponse
 from scrapy.http.request import NO_CALLBACK
 from scrapy.settings import Settings
-from scrapy.utils.defer import deferred_f_from_coro_f, maybe_deferred_to_future
+from scrapy.utils.defer import maybe_deferred_to_future
 from tests.test_robotstxt_interface import rerp_available
+from tests.utils.decorators import deferred_f_from_coro_f
 
 if TYPE_CHECKING:
     from scrapy.crawler import Crawler

--- a/tests/test_downloaderslotssettings.py
+++ b/tests/test_downloaderslotssettings.py
@@ -1,6 +1,6 @@
 import time
 
-from twisted.internet.defer import inlineCallbacks
+import pytest
 
 from scrapy import Request
 from scrapy.core.downloader import Downloader, Slot
@@ -8,6 +8,7 @@ from scrapy.crawler import CrawlerRunner
 from scrapy.utils.test import get_crawler
 from tests.mockserver import MockServer
 from tests.spiders import MetaSpider
+from tests.utils.decorators import inlineCallbacks
 
 
 class DownloaderSlotsSettingsTestSpider(MetaSpider):
@@ -78,6 +79,7 @@ class TestCrawl:
         assert max(list(error_delta.values())) < tolerance
 
 
+@pytest.mark.requires_reactor  # needs a reactor or an event loop for Downloader._slot_gc_loop
 def test_params():
     params = {
         "concurrency": 1,

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -26,7 +26,6 @@ from itemadapter import ItemAdapter
 from pydispatch import dispatcher
 from testfixtures import LogCapture
 from twisted.internet import defer
-from twisted.internet.defer import inlineCallbacks
 from twisted.web import server, static, util
 
 from scrapy import signals
@@ -41,6 +40,7 @@ from scrapy.spiders import Spider
 from scrapy.utils.signal import disconnect_all
 from scrapy.utils.test import get_crawler
 from tests import get_testdata, tests_datadir
+from tests.utils.decorators import inlineCallbacks
 
 
 class MyItem(Item):
@@ -505,6 +505,7 @@ class TestEngine(TestEngineBase):
         assert "AssertionError" not in stderr_str, stderr_str
 
 
+@pytest.mark.requires_reactor  # needs a reactor or an event loop for Downloader._slot_gc_loop
 def test_request_scheduled_signal(caplog):
     class TestScheduler(BaseScheduler):
         def __init__(self):

--- a/tests/test_engine_loop.py
+++ b/tests/test_engine_loop.py
@@ -8,11 +8,12 @@ from testfixtures import LogCapture
 from twisted.internet.defer import Deferred
 
 from scrapy import Request, Spider, signals
-from scrapy.utils.defer import deferred_f_from_coro_f, maybe_deferred_to_future
+from scrapy.utils.defer import maybe_deferred_to_future
 from scrapy.utils.test import get_crawler
 
 from .mockserver import MockServer
 from .test_scheduler import MemoryScheduler
+from .utils.decorators import deferred_f_from_coro_f
 
 if TYPE_CHECKING:
     from scrapy.http import Response

--- a/tests/test_engine_stop_download_bytes.py
+++ b/tests/test_engine_stop_download_bytes.py
@@ -1,5 +1,4 @@
 from testfixtures import LogCapture
-from twisted.internet.defer import inlineCallbacks
 
 from scrapy.exceptions import StopDownload
 from tests.test_engine import (
@@ -10,6 +9,7 @@ from tests.test_engine import (
     MySpider,
     TestEngineBase,
 )
+from tests.utils.decorators import inlineCallbacks
 
 
 class BytesReceivedCrawlerRun(CrawlerRun):

--- a/tests/test_engine_stop_download_headers.py
+++ b/tests/test_engine_stop_download_headers.py
@@ -1,5 +1,4 @@
 from testfixtures import LogCapture
-from twisted.internet.defer import inlineCallbacks
 
 from scrapy.exceptions import StopDownload
 from tests.test_engine import (
@@ -10,6 +9,7 @@ from tests.test_engine import (
     MySpider,
     TestEngineBase,
 )
+from tests.utils.decorators import inlineCallbacks
 
 
 class HeadersReceivedCrawlerRun(CrawlerRun):

--- a/tests/test_extension_periodic_log.py
+++ b/tests/test_extension_periodic_log.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import datetime
 from typing import Any, Callable
 
+import pytest
+
 from scrapy.extensions.periodic_log import PeriodicLog
 from scrapy.utils.test import get_crawler
 
@@ -82,6 +84,7 @@ class TestPeriodicLog:
         assert extension({"PERIODIC_LOG_DELTA": True, "LOGSTATS_INTERVAL": 60})
         assert extension({"PERIODIC_LOG_DELTA": "True", "LOGSTATS_INTERVAL": 60})
 
+    @pytest.mark.requires_reactor  # needs a reactor or an event loop for PeriodicLog.task
     def test_log_delta(self):
         def emulate(settings=None):
             spider = MetaSpider()
@@ -139,6 +142,7 @@ class TestPeriodicLog:
             and ("downloader/" in k and "bytes" not in k),
         )
 
+    @pytest.mark.requires_reactor  # needs a reactor or an event loop for PeriodicLog.task
     def test_log_stats(self):
         def emulate(settings=None):
             spider = MetaSpider()

--- a/tests/test_extension_telnet.py
+++ b/tests/test_extension_telnet.py
@@ -1,10 +1,10 @@
 import pytest
 from twisted.conch.telnet import ITelnetProtocol
 from twisted.cred import credentials
-from twisted.internet.defer import inlineCallbacks
 
 from scrapy.extensions.telnet import TelnetConsole
 from scrapy.utils.test import get_crawler
+from tests.utils.decorators import inlineCallbacks
 
 
 class TestTelnetExtension:

--- a/tests/test_feedexport.py
+++ b/tests/test_feedexport.py
@@ -30,7 +30,6 @@ import pytest
 from packaging.version import Version
 from testfixtures import LogCapture
 from twisted.internet import defer
-from twisted.internet.defer import inlineCallbacks
 from w3lib.url import file_uri_to_path, path_to_file_uri
 from zope.interface import implementer
 from zope.interface.verify import verifyObject
@@ -51,11 +50,12 @@ from scrapy.extensions.feedexport import (
     StdoutFeedStorage,
 )
 from scrapy.settings import Settings
-from scrapy.utils.defer import deferred_f_from_coro_f, maybe_deferred_to_future
+from scrapy.utils.defer import maybe_deferred_to_future
 from scrapy.utils.python import to_unicode
 from scrapy.utils.test import get_crawler
 from tests.mockserver import MockFTPServer, MockServer
 from tests.spiders import ItemSpider
+from tests.utils.decorators import deferred_f_from_coro_f, inlineCallbacks
 
 if TYPE_CHECKING:
     from collections.abc import Iterable

--- a/tests/test_http2_client_protocol.py
+++ b/tests/test_http2_client_protocol.py
@@ -43,6 +43,14 @@ if TYPE_CHECKING:
     from scrapy.core.http2.protocol import H2ClientProtocol
 
 
+pytestmark = [
+    pytest.mark.requires_reactor,
+    pytest.mark.skipif(
+        not H2_ENABLED, reason="HTTP/2 support in Twisted is not enabled"
+    ),
+]
+
+
 def generate_random_string(size: int) -> str:
     return "".join(random.choices(string.ascii_uppercase + string.digits, k=size))
 
@@ -186,7 +194,6 @@ async def make_request(client: H2ClientProtocol, request: Request) -> Response:
     return await maybe_deferred_to_future(make_request_dfd(client, request))
 
 
-@pytest.mark.skipif(not H2_ENABLED, reason="HTTP/2 support in Twisted is not enabled")
 class TestHttps2ClientProtocol:
     scheme = "https"
     host = "localhost"

--- a/tests/test_logformatter.py
+++ b/tests/test_logformatter.py
@@ -2,7 +2,6 @@ import logging
 
 import pytest
 from testfixtures import LogCapture
-from twisted.internet.defer import inlineCallbacks
 from twisted.python.failure import Failure
 
 from scrapy.exceptions import DropItem
@@ -13,6 +12,7 @@ from scrapy.spiders import Spider
 from scrapy.utils.test import get_crawler
 from tests.mockserver import MockServer
 from tests.spiders import ItemSpider
+from tests.utils.decorators import inlineCallbacks
 
 
 class CustomItem(Item):

--- a/tests/test_logstats.py
+++ b/tests/test_logstats.py
@@ -16,6 +16,7 @@ class TestLogStats:
         self.stats.set_value("response_received_count", 4802)
         self.stats.set_value("item_scraped_count", 3201)
 
+    @pytest.mark.requires_reactor  # needs a reactor or an event loop for LogStats.task
     def test_stats_calculations(self):
         logstats = LogStats.from_crawler(self.crawler)
 

--- a/tests/test_mail.py
+++ b/tests/test_mail.py
@@ -1,12 +1,14 @@
 from email.charset import Charset
 from io import BytesIO
 
+import pytest
 from twisted.internet import defer
 from twisted.internet._sslverify import ClientTLSOptions
 
 from scrapy.mail import MailSender
 
 
+@pytest.mark.requires_reactor
 class TestMailSender:
     def test_send(self):
         mailsender = MailSender(debug=True)

--- a/tests/test_pipeline_crawl.py
+++ b/tests/test_pipeline_crawl.py
@@ -7,7 +7,6 @@ from typing import TYPE_CHECKING, Any
 
 import pytest
 from testfixtures import LogCapture
-from twisted.internet.defer import inlineCallbacks
 from w3lib.url import add_or_replace_parameter
 
 from scrapy import Spider, signals
@@ -15,6 +14,7 @@ from scrapy.utils.misc import load_object
 from scrapy.utils.test import get_crawler
 from tests.mockserver import MockServer
 from tests.spiders import SimpleSpider
+from tests.utils.decorators import inlineCallbacks
 
 if TYPE_CHECKING:
     from scrapy.crawler import Crawler

--- a/tests/test_pipeline_files.py
+++ b/tests/test_pipeline_files.py
@@ -18,7 +18,6 @@ from urllib.parse import urlparse
 import attr
 import pytest
 from itemadapter import ItemAdapter
-from twisted.internet.defer import inlineCallbacks
 
 from scrapy.http import Request, Response
 from scrapy.item import Field, Item
@@ -31,6 +30,7 @@ from scrapy.pipelines.files import (
 )
 from scrapy.utils.test import get_crawler
 from tests.mockserver import MockFTPServer
+from tests.utils.decorators import inlineCallbacks
 
 from .test_pipeline_media import _mocked_download_func
 

--- a/tests/test_pipeline_media.py
+++ b/tests/test_pipeline_media.py
@@ -4,7 +4,7 @@ import warnings
 
 import pytest
 from testfixtures import LogCapture
-from twisted.internet.defer import Deferred, inlineCallbacks
+from twisted.internet.defer import Deferred
 from twisted.python.failure import Failure
 
 from scrapy import signals
@@ -17,6 +17,7 @@ from scrapy.spiders import Spider
 from scrapy.utils.log import failure_to_exc_info
 from scrapy.utils.signal import disconnect_all
 from scrapy.utils.test import get_crawler
+from tests.utils.decorators import inlineCallbacks
 
 
 def _mocked_download_func(request, info):

--- a/tests/test_pipelines.py
+++ b/tests/test_pipelines.py
@@ -1,12 +1,13 @@
 import asyncio
 
 import pytest
-from twisted.internet.defer import Deferred, inlineCallbacks
+from twisted.internet.defer import Deferred
 
 from scrapy import Request, Spider, signals
 from scrapy.utils.defer import deferred_to_future, maybe_deferred_to_future
 from scrapy.utils.test import get_crawler, get_from_asyncio_queue
 from tests.mockserver import MockServer
+from tests.utils.decorators import inlineCallbacks
 
 
 class SimplePipeline:

--- a/tests/test_proxy_connect.py
+++ b/tests/test_proxy_connect.py
@@ -8,12 +8,12 @@ from urllib.parse import urlsplit, urlunsplit
 
 import pytest
 from testfixtures import LogCapture
-from twisted.internet.defer import inlineCallbacks
 
 from scrapy.http import Request
 from scrapy.utils.test import get_crawler
 from tests.mockserver import MockServer
 from tests.spiders import SimpleSpider, SingleRequestSpider
+from tests.utils.decorators import inlineCallbacks
 
 
 class MitmProxy:

--- a/tests/test_request_attribute_binding.py
+++ b/tests/test_request_attribute_binding.py
@@ -1,11 +1,11 @@
 from testfixtures import LogCapture
-from twisted.internet.defer import inlineCallbacks
 
 from scrapy import Request, signals
 from scrapy.http.response import Response
 from scrapy.utils.test import get_crawler
 from tests.mockserver import MockServer
 from tests.spiders import SingleRequestSpider
+from tests.utils.decorators import inlineCallbacks
 
 OVERRIDDEN_URL = "https://example.org"
 

--- a/tests/test_request_cb_kwargs.py
+++ b/tests/test_request_cb_kwargs.py
@@ -1,10 +1,10 @@
 from testfixtures import LogCapture
-from twisted.internet.defer import inlineCallbacks
 
 from scrapy.http import Request
 from scrapy.utils.test import get_crawler
 from tests.mockserver import MockServer
 from tests.spiders import MockServerSpider
+from tests.utils.decorators import inlineCallbacks
 
 
 class InjectArgumentsDownloaderMiddleware:

--- a/tests/test_request_left.py
+++ b/tests/test_request_left.py
@@ -1,9 +1,8 @@
-from twisted.internet.defer import inlineCallbacks
-
 from scrapy.signals import request_left_downloader
 from scrapy.spiders import Spider
 from scrapy.utils.test import get_crawler
 from tests.mockserver import MockServer
+from tests.utils.decorators import inlineCallbacks
 
 
 class SignalCatcherSpider(Spider):

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -8,7 +8,6 @@ from collections import deque
 from typing import Any, NamedTuple
 
 import pytest
-from twisted.internet.defer import inlineCallbacks
 
 from scrapy.core.downloader import Downloader
 from scrapy.core.scheduler import BaseScheduler, Scheduler
@@ -19,6 +18,7 @@ from scrapy.utils.httpobj import urlparse_cached
 from scrapy.utils.misc import load_object
 from scrapy.utils.test import get_crawler
 from tests.mockserver import MockServer
+from tests.utils.decorators import inlineCallbacks
 
 
 class MemoryScheduler(BaseScheduler):

--- a/tests/test_scheduler_base.py
+++ b/tests/test_scheduler_base.py
@@ -5,7 +5,6 @@ from urllib.parse import urljoin
 import pytest
 from testfixtures import LogCapture
 from twisted.internet import defer
-from twisted.internet.defer import inlineCallbacks
 
 from scrapy.core.scheduler import BaseScheduler
 from scrapy.http import Request
@@ -14,6 +13,7 @@ from scrapy.utils.httpobj import urlparse_cached
 from scrapy.utils.request import fingerprint
 from scrapy.utils.test import get_crawler
 from tests.mockserver import MockServer
+from tests.utils.decorators import inlineCallbacks
 
 PATHS = ["/a", "/b", "/c"]
 URLS = [urljoin("https://example.org", p) for p in PATHS]

--- a/tests/test_signals.py
+++ b/tests/test_signals.py
@@ -1,10 +1,10 @@
 import pytest
-from twisted.internet.defer import inlineCallbacks
 
 from scrapy import Request, Spider, signals
-from scrapy.utils.defer import deferred_f_from_coro_f, maybe_deferred_to_future
+from scrapy.utils.defer import maybe_deferred_to_future
 from scrapy.utils.test import get_crawler, get_from_asyncio_queue
 from tests.mockserver import MockServer
+from tests.utils.decorators import deferred_f_from_coro_f, inlineCallbacks
 
 
 class ItemSpider(Spider):

--- a/tests/test_spider.py
+++ b/tests/test_spider.py
@@ -12,7 +12,6 @@ from unittest import mock
 
 import pytest
 from testfixtures import LogCapture
-from twisted.internet.defer import inlineCallbacks
 from w3lib.url import safe_url_string
 
 from scrapy import signals
@@ -29,9 +28,10 @@ from scrapy.spiders import (
     XMLFeedSpider,
 )
 from scrapy.spiders.init import InitSpider
-from scrapy.utils.defer import deferred_f_from_coro_f, maybe_deferred_to_future
+from scrapy.utils.defer import maybe_deferred_to_future
 from scrapy.utils.test import get_crawler, get_reactor_settings
 from tests import get_testdata, tests_datadir
+from tests.utils.decorators import deferred_f_from_coro_f, inlineCallbacks
 
 
 class TestSpider:

--- a/tests/test_spider_start.py
+++ b/tests/test_spider_start.py
@@ -9,10 +9,11 @@ from testfixtures import LogCapture
 
 from scrapy import Spider, signals
 from scrapy.exceptions import ScrapyDeprecationWarning
-from scrapy.utils.defer import deferred_f_from_coro_f, maybe_deferred_to_future
+from scrapy.utils.defer import maybe_deferred_to_future
 from scrapy.utils.test import get_crawler
 
 from .utils import twisted_sleep
+from .utils.decorators import deferred_f_from_coro_f
 
 SLEEP_SECONDS = 0.1
 

--- a/tests/test_spidermiddleware.py
+++ b/tests/test_spidermiddleware.py
@@ -14,8 +14,9 @@ from scrapy.exceptions import _InvalidOutput
 from scrapy.http import Request, Response
 from scrapy.spiders import Spider
 from scrapy.utils.asyncgen import collect_asyncgen
-from scrapy.utils.defer import deferred_f_from_coro_f, maybe_deferred_to_future
+from scrapy.utils.defer import maybe_deferred_to_future
 from scrapy.utils.test import get_crawler
+from tests.utils.decorators import deferred_f_from_coro_f
 
 if TYPE_CHECKING:
     from twisted.python.failure import Failure

--- a/tests/test_spidermiddleware_httperror.py
+++ b/tests/test_spidermiddleware_httperror.py
@@ -4,7 +4,6 @@ import logging
 
 import pytest
 from testfixtures import LogCapture
-from twisted.internet.defer import inlineCallbacks
 
 from scrapy.http import Request, Response
 from scrapy.settings import Settings
@@ -13,6 +12,7 @@ from scrapy.spiders import Spider
 from scrapy.utils.test import get_crawler
 from tests.mockserver import MockServer
 from tests.spiders import MockServerSpider
+from tests.utils.decorators import inlineCallbacks
 
 
 class _HttpErrorSpider(MockServerSpider):

--- a/tests/test_spidermiddleware_output_chain.py
+++ b/tests/test_spidermiddleware_output_chain.py
@@ -1,9 +1,10 @@
 from testfixtures import LogCapture
 
 from scrapy import Request, Spider
-from scrapy.utils.defer import deferred_f_from_coro_f, maybe_deferred_to_future
+from scrapy.utils.defer import maybe_deferred_to_future
 from scrapy.utils.test import get_crawler
 from tests.mockserver import MockServer
+from tests.utils.decorators import deferred_f_from_coro_f
 
 
 class LogExceptionMiddleware:

--- a/tests/test_spidermiddleware_process_start.py
+++ b/tests/test_spidermiddleware_process_start.py
@@ -5,11 +5,12 @@ import pytest
 
 from scrapy import Spider, signals
 from scrapy.exceptions import ScrapyDeprecationWarning
-from scrapy.utils.defer import deferred_f_from_coro_f, maybe_deferred_to_future
+from scrapy.utils.defer import maybe_deferred_to_future
 from scrapy.utils.test import get_crawler
 from tests.test_spider_start import SLEEP_SECONDS
 
 from .utils import twisted_sleep
+from .utils.decorators import deferred_f_from_coro_f
 
 ITEM_A = {"id": "a"}
 ITEM_B = {"id": "b"}

--- a/tests/test_spidermiddleware_start.py
+++ b/tests/test_spidermiddleware_start.py
@@ -1,9 +1,9 @@
 from scrapy.http import Request
 from scrapy.spidermiddlewares.start import StartSpiderMiddleware
 from scrapy.spiders import Spider
-from scrapy.utils.defer import deferred_f_from_coro_f
 from scrapy.utils.misc import build_from_crawler
 from scrapy.utils.test import get_crawler
+from tests.utils.decorators import deferred_f_from_coro_f
 
 
 class TestMiddleware:

--- a/tests/test_utils_asyncgen.py
+++ b/tests/test_utils_asyncgen.py
@@ -1,5 +1,5 @@
 from scrapy.utils.asyncgen import as_async_generator, collect_asyncgen
-from scrapy.utils.defer import deferred_f_from_coro_f
+from tests.utils.decorators import deferred_f_from_coro_f
 
 
 class TestAsyncgenUtils:

--- a/tests/test_utils_asyncio.py
+++ b/tests/test_utils_asyncio.py
@@ -21,6 +21,7 @@ if TYPE_CHECKING:
 
 
 class TestAsyncio:
+    @pytest.mark.requires_reactor  # needs a reactor or an event loop for is_asyncio_available()
     def test_is_asyncio_available(self, reactor_pytest: str) -> None:
         # the result should depend only on the pytest --reactor argument
         assert is_asyncio_available() == (reactor_pytest == "asyncio")

--- a/tests/test_utils_defer.py
+++ b/tests/test_utils_defer.py
@@ -6,7 +6,7 @@ from asyncio import Future
 from typing import TYPE_CHECKING, Any
 
 import pytest
-from twisted.internet.defer import Deferred, inlineCallbacks, succeed
+from twisted.internet.defer import Deferred, succeed
 from twisted.python.failure import Failure
 
 from scrapy.utils.asyncgen import as_async_generator, collect_asyncgen
@@ -22,6 +22,7 @@ from scrapy.utils.defer import (
     process_chain,
     process_parallel,
 )
+from tests.utils.decorators import inlineCallbacks
 
 if TYPE_CHECKING:
     from collections.abc import AsyncGenerator, Awaitable, Callable, Generator
@@ -130,6 +131,7 @@ class TestIterErrback:
         assert isinstance(errors[0].value, ZeroDivisionError)
 
 
+@pytest.mark.requires_reactor
 class TestAiterErrback:
     @deferred_f_from_coro_f
     async def test_aiter_errback_good(self):
@@ -157,6 +159,7 @@ class TestAiterErrback:
         assert isinstance(errors[0].value, ZeroDivisionError)
 
 
+@pytest.mark.requires_reactor
 class TestAsyncDefTestsuite:
     @deferred_f_from_coro_f
     async def test_deferred_f_from_coro_f(self):
@@ -363,6 +366,7 @@ class TestDeferredFFromCoroF:
 
 
 @pytest.mark.only_asyncio
+@pytest.mark.requires_reactor
 class TestDeferredToFuture:
     @deferred_f_from_coro_f
     async def test_deferred(self):
@@ -398,6 +402,7 @@ class TestDeferredToFuture:
 
 
 @pytest.mark.only_asyncio
+@pytest.mark.requires_reactor
 class TestMaybeDeferredToFutureAsyncio:
     @deferred_f_from_coro_f
     async def test_deferred(self):
@@ -433,6 +438,7 @@ class TestMaybeDeferredToFutureAsyncio:
 
 
 @pytest.mark.only_not_asyncio
+@pytest.mark.requires_reactor  # needs a reactor or an event loop for is_asyncio_available()
 class TestMaybeDeferredToFutureNotAsyncio:
     def test_deferred(self):
         d = Deferred()

--- a/tests/test_utils_python.py
+++ b/tests/test_utils_python.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING, TypeVar
 import pytest
 
 from scrapy.utils.asyncgen import as_async_generator, collect_asyncgen
-from scrapy.utils.defer import aiter_errback, deferred_f_from_coro_f
+from scrapy.utils.defer import aiter_errback
 from scrapy.utils.python import (
     MutableAsyncChain,
     MutableChain,
@@ -21,6 +21,7 @@ from scrapy.utils.python import (
     to_unicode,
     without_none_values,
 )
+from tests.utils.decorators import deferred_f_from_coro_f
 
 if TYPE_CHECKING:
     from collections.abc import Iterable, Mapping

--- a/tests/test_utils_reactor.py
+++ b/tests/test_utils_reactor.py
@@ -3,20 +3,22 @@ import warnings
 
 import pytest
 
-from scrapy.utils.defer import deferred_f_from_coro_f
 from scrapy.utils.reactor import (
     _asyncio_reactor_path,
     install_reactor,
     is_asyncio_reactor_installed,
     set_asyncio_event_loop,
 )
+from tests.utils.decorators import deferred_f_from_coro_f
 
 
 class TestAsyncio:
+    @pytest.mark.requires_reactor
     def test_is_asyncio_reactor_installed(self, reactor_pytest: str) -> None:
         # the result should depend only on the pytest --reactor argument
         assert is_asyncio_reactor_installed() == (reactor_pytest == "asyncio")
 
+    @pytest.mark.requires_reactor
     def test_install_asyncio_reactor(self):
         from twisted.internet import reactor as original_reactor
 

--- a/tests/test_utils_signal.py
+++ b/tests/test_utils_signal.py
@@ -4,7 +4,6 @@ import pytest
 from pydispatch import dispatcher
 from testfixtures import LogCapture
 from twisted.internet import defer
-from twisted.internet.defer import inlineCallbacks
 from twisted.python.failure import Failure
 
 from scrapy.utils.defer import deferred_from_coro
@@ -14,6 +13,7 @@ from scrapy.utils.signal import (
     send_catch_log_deferred,
 )
 from scrapy.utils.test import get_from_asyncio_queue
+from tests.utils.decorators import inlineCallbacks
 
 
 class TestSendCatchLog:

--- a/tests/test_webclient.py
+++ b/tests/test_webclient.py
@@ -33,6 +33,8 @@ from tests.mockserver import (
 )
 from tests.test_core_downloader import TestContextFactoryBase
 
+pytestmark = pytest.mark.requires_reactor
+
 
 def getPage(url, contextFactory=None, response_transform=None, *args, **kwargs):
     """Adapted version of twisted.web.client.getPage"""

--- a/tests/utils/decorators.py
+++ b/tests/utils/decorators.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from functools import wraps
+from typing import TYPE_CHECKING, Any, TypeVar
+
+import pytest
+from twisted.internet.defer import Deferred
+from twisted.internet.defer import inlineCallbacks as inlineCallbacks_orig
+
+from scrapy.utils.defer import deferred_from_coro
+
+if TYPE_CHECKING:
+    from collections.abc import Awaitable, Callable, Generator
+
+    # typing.ParamSpec requires Python 3.10
+    from typing_extensions import ParamSpec
+
+    _P = ParamSpec("_P")
+
+_T = TypeVar("_T")
+
+
+def inlineCallbacks(
+    f: Callable[_P, Generator[Deferred[Any], Any, _T]],
+) -> Callable[_P, Deferred[_T]]:
+    @pytest.mark.requires_reactor
+    @wraps(f)
+    @inlineCallbacks_orig
+    def wrapper(
+        *args: _P.args, **kwargs: _P.kwargs
+    ) -> Generator[Deferred[Any], Any, _T]:
+        return f(*args, **kwargs)
+
+    return wrapper
+
+
+def deferred_f_from_coro_f(
+    coro_f: Callable[_P, Awaitable[_T]],
+) -> Callable[_P, Deferred[_T]]:
+    @pytest.mark.requires_reactor
+    @wraps(coro_f)
+    def f(*coro_args: _P.args, **coro_kwargs: _P.kwargs) -> Deferred[_T]:
+        return deferred_from_coro(coro_f(*coro_args, **coro_kwargs))
+
+    return f

--- a/tests/utils/reactorless.py
+++ b/tests/utils/reactorless.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+import sys
+from importlib.abc import MetaPathFinder
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+    from importlib.machinery import ModuleSpec
+    from types import ModuleType
+
+
+class ReactorImportHook(MetaPathFinder):
+    def find_spec(
+        self,
+        fullname: str,
+        path: Sequence[str] | None,
+        target: ModuleType | None = None,
+    ) -> ModuleSpec | None:
+        if fullname == "twisted.internet.reactor":
+            raise ImportError(
+                f"Import of {fullname} is forbidden in the reactorless mode, to avoid silent problems."
+            )
+        return None
+
+
+def install_reactor_import_hook() -> None:
+    sys.meta_path.insert(0, ReactorImportHook())

--- a/tox.ini
+++ b/tox.ini
@@ -177,10 +177,22 @@ commands = {[pinned]commands}
 commands =
     {[testenv]commands} --reactor=default
 
+[testenv:no-reactor]
+commands =
+    {[testenv]commands} -p no:twisted --reactor=none
+
 [testenv:default-reactor-pinned]
 basepython = {[pinned]basepython}
 deps = {[testenv:pinned]deps}
 commands = {[pinned]commands} --reactor=default
+install_command = {[pinned]install_command}
+setenv =
+    {[pinned]setenv}
+
+[testenv:no-reactor-pinned]
+basepython = {[pinned]basepython}
+deps = {[testenv:pinned]deps}
+commands = {[pinned]commands} -p no:twisted --reactor=none
 install_command = {[pinned]install_command}
 setenv =
     {[pinned]setenv}


### PR DESCRIPTION
This adds a new mode of running tests, one that disables pytest-twisted and enforces that there is no reactor. It doesn't use pytest-asyncio for now, instead skipping all async test functions.

This also necessarily changes the logic in `is_asyncio_available()` which may or may not be the way it will behave in proper reactorless-capable Scrapy.