### PR TITLE
Remove transitive dependency Automat

### DIFF
--- a/tests/upper-constraints.txt
+++ b/tests/upper-constraints.txt
@@ -1,7 +1,6 @@
 # Request the latest known version or newer of some dependencies to prevent the
 # pip dependency resolver from spending too much time backtracking.
 attrs>=20.2.0
-Automat>=0.8.0
 botocore>=1.20.30
 itemadapter>=0.1.1
 itemloaders>=1.0.3


### PR DESCRIPTION
As part of our ongoing research on Python dependency management we noticed a potential improvement in your project’s dependency management.

Specifically, the transitive dependency `Automat` is specified as a requirement in the `tests/upper-constraints.txt` file, when in reality it is not needed. That can also be the case for other dependencies.

This PR removes it from `tests/upper-constraints.txt` to let pip manage it automatically, which helps keeping the dependency list clean. The [pip documentation](https://pip.pypa.io/en/stable/topics/dependency-resolution/#audit-your-top-level-requirements) also encourages auditing your top-level requirements and removing unused or transitive ones to simplify the dependency graph and minimize the risk of version conflicts.

Hope this is helpful!

Best regards