### PR TITLE
Add support for preserving lowercase headers via KEEP_LOWERCASE_HEADERS Flag

### DIFF
--- a/scrapy/http/headers.py
+++ b/scrapy/http/headers.py
@@ -27,8 +27,10 @@ class Headers(CaselessDict):
         self,
         seq: Mapping[AnyStr, Any] | Iterable[tuple[AnyStr, Any]] | None = None,
         encoding: str = "utf-8",
+        preserve_case: bool = False,
     ):
         self.encoding: str = encoding
+        self.preserve_case: bool = preserve_case
         super().__init__(seq)
 
     def update(  # type: ignore[override]
@@ -42,6 +44,8 @@ class Headers(CaselessDict):
 
     def normkey(self, key: AnyStr) -> bytes:  # type: ignore[override]
         """Normalize key to bytes"""
+        if self.preserve_case:
+            return self._tobytes(key)
         return self._tobytes(key.title())
 
     def normvalue(self, value: _RawValueT | Iterable[_RawValueT]) -> list[bytes]:

--- a/scrapy/http/request/__init__.py
+++ b/scrapy/http/request/__init__.py
@@ -191,7 +191,7 @@ class Request(object_ref):
         self.cookies: CookiesT = cookies or {}
         preserve_case = False
         if meta and isinstance(meta, dict):
-            preserve_case = meta.get("KEEP_LOWERCASE_HEADERS", False)
+            preserve_case = bool(meta.get("KEEP_LOWERCASE_HEADERS")) if meta else False
         self.headers: Headers = Headers(
             headers or {}, encoding=encoding, preserve_case=preserve_case
         )

--- a/scrapy/http/request/__init__.py
+++ b/scrapy/http/request/__init__.py
@@ -189,7 +189,9 @@ class Request(object_ref):
         self.errback: Callable[[Failure], Any] | None = errback
 
         self.cookies: CookiesT = cookies or {}
-        preserve_case = meta.get("KEEP_LOWERCASE_HEADERS")
+        preserve_case = False
+        if meta and isinstance(meta, dict):
+            preserve_case = meta.get("KEEP_LOWERCASE_HEADERS", False)
         self.headers: Headers = Headers(
             headers or {}, encoding=encoding, preserve_case=preserve_case
         )

--- a/scrapy/http/request/__init__.py
+++ b/scrapy/http/request/__init__.py
@@ -189,7 +189,10 @@ class Request(object_ref):
         self.errback: Callable[[Failure], Any] | None = errback
 
         self.cookies: CookiesT = cookies or {}
-        self.headers: Headers = Headers(headers or {}, encoding=encoding)
+        preserve_case = meta.get("KEEP_LOWERCASE_HEADERS")
+        self.headers: Headers = Headers(
+            headers or {}, encoding=encoding, preserve_case=preserve_case
+        )
 
         #: Whether this request may be filtered out by :ref:`components
         #: <topics-components>` that support filtering out requests (``False``,

--- a/tests/test_lowercase_headers.py
+++ b/tests/test_lowercase_headers.py
@@ -2,9 +2,13 @@ from twisted.trial import unittest as trial_unittest
 
 from scrapy import Request, Spider
 from scrapy.crawler import CrawlerRunner
+from scrapy.utils.log import configure_logging
 
 
 class LowercaseHeaderTests(trial_unittest.TestCase):
+    def setUp(self):
+        configure_logging({"LOG_LEVEL": "ERROR"})
+
     def test_lowercase_headers_preserved(self):
         class TestSpider(Spider):
             name = "lowercase_spider"
@@ -14,6 +18,7 @@ class LowercaseHeaderTests(trial_unittest.TestCase):
                     url="https://httpbin.org/headers",
                     headers={"x-my-lower-header": "test-value"},
                     callback=self.parse,
+                    meta={"KEEP_LOWERCASE_HEADERS": True},
                 )
 
             def parse(self, response):
@@ -22,7 +27,7 @@ class LowercaseHeaderTests(trial_unittest.TestCase):
                 assert headers[b"x-my-lower-header"] == [b"test-value"]
                 assert b"X-My-Lower-Header" not in headers
 
-        runner = CrawlerRunner(settings={"KEEP_LOWERCASE_HEADERS": True})
+        runner = CrawlerRunner()
         return runner.crawl(TestSpider)
 
     def test_default_header_casing(self):

--- a/tests/test_lowercase_headers.py
+++ b/tests/test_lowercase_headers.py
@@ -1,0 +1,46 @@
+from twisted.trial import unittest as trial_unittest
+
+from scrapy import Request, Spider
+from scrapy.crawler import CrawlerRunner
+
+
+class LowercaseHeaderTests(trial_unittest.TestCase):
+    def test_lowercase_headers_preserved(self):
+        class TestSpider(Spider):
+            name = "lowercase_spider"
+
+            def start_requests(self):
+                yield Request(
+                    url="https://httpbin.org/headers",
+                    headers={"x-my-lower-header": "test-value"},
+                    callback=self.parse,
+                )
+
+            def parse(self, response):
+                headers = response.request.headers
+                assert b"x-my-lower-header" in headers
+                assert headers[b"x-my-lower-header"] == [b"test-value"]
+                assert b"X-My-Lower-Header" not in headers
+
+        runner = CrawlerRunner(settings={"KEEP_LOWERCASE_HEADERS": True})
+        return runner.crawl(TestSpider)
+
+    def test_default_header_casing(self):
+        class TestSpider(Spider):
+            name = "default_header_spider"
+
+            def start_requests(self):
+                yield Request(
+                    url="https://httpbin.org/headers",
+                    headers={"x-my-lower-header": "test-value"},
+                    callback=self.parse,
+                )
+
+            def parse(self, response):
+                headers = response.request.headers
+                assert b"X-My-Lower-Header" in headers
+                assert headers[b"X-My-Lower-Header"] == [b"test-value"]
+                assert b"x-my-lower-header" not in headers
+
+        runner = CrawlerRunner()
+        return runner.crawl(TestSpider)


### PR DESCRIPTION
### Summary

This PR adds support for preserving lowercase headers in Scrapy requests using a new setting: `KEEP_LOWERCASE_HEADERS`.

### Changes

- Added support for lowercase headers in `Request.__init__` and `Headers` class.
- New Meta Flag `KEEP_LOWERCASE_HEADERS` to keep the header in lower case.
- Added tests to validate the behavior.

### Motivation

Sometime third-party services (e.g., Algolia, Elastic) require custom headers to be in lowercase. Scrapy by default normalizes headers by capitalizing them, which can cause certain requests to fail silently or behave unexpectedly. This often forces users to switch to `requests` or other libraries to handle such cases correctly.

By adding support for lowercase headers, this change allows developers to stay within the Scrapy ecosystem for all their HTTP needs.

### Tests

- Added `tests/test_lowercase_headers.py` with two test cases:
  - Headers are preserved when `KEEP_LOWERCASE_HEADERS` is True.
  - Headers are normalized when it's False (or not explicitly set).
  
- Example usage in a spider:
  ```python
  import scrapy

  class ExampleSpider(scrapy.Spider):
      name = "example"

      def start_requests(self):
          yield scrapy.Request(
              url="https://httpbin.org/headers",
              headers={"x-custom-lower": "demo"},
              meta={"KEEP_LOWERCASE_HEADERS": True},
              callback=self.parse
          )

      def parse(self, response):
          self.logger.info("Request Headers: %s", response.request.headers)
