### PR TITLE
Add basic initialization test for HTTPDownloadHandler (#6946)

### DIFF
--- a/tests/test_downloader_handlers.py
+++ b/tests/test_downloader_handlers.py
@@ -541,3 +541,10 @@ class TestDataURI:
         request = Request("data:,")
         response = await self.download_request(request)
         assert response.protocol is None
+
+    from scrapy.core.downloader.handlers.http import HTTPDownloadHandler
+    def test_http_handler_initialization():
+        crawler = get_crawler()
+        handler = HTTPDownloadHandler(crawler.settings)
+        assert handler is not None
+


### PR DESCRIPTION
This PR adds a simple unit test for HTTPDownloadHandler under tests/test_downloader_handlers.py to verify handler initialization.
Ensures the handler initializes without errors.
Complements issue [#6946](https://github.com/scrapy/scrapy/issues/6946) — adding more basic tests for HTTP download handlers.

Looking forward to feedback and happy to contribute more!