### PR TITLE
Raise NotConfigured when FILES_STORE or IMAGES_STORE is None or empty

### DIFF
--- a/scrapy/pipelines/files.py
+++ b/scrapy/pipelines/files.py
@@ -516,6 +516,16 @@ class FilesPipeline(MediaPipeline):
     def _from_settings(cls, settings: Settings, crawler: Crawler | None) -> Self:
         cls._update_stores(settings)
         store_uri = settings["FILES_STORE"]
+        if store_uri is None or (
+            isinstance(store_uri, str) and store_uri.strip() == ""
+        ):
+            setting_name = (
+                "IMAGES_STORE" if cls.__name__ == "ImagesPipeline" else "FILES_STORE"
+            )
+            raise NotConfigured(
+                f"{setting_name} setting must be set to a valid path (not None or empty) "
+                f"to enable {cls.__name__}."
+            )
         if "crawler" in get_func_args(cls.__init__):
             o = cls(store_uri, crawler=crawler)
         else:


### PR DESCRIPTION
## Summary

This PR fixes an issue where the absence of the `FILES_STORE` or `IMAGES_STORE` settings results in a "None" directory being used, instead of raising a proper error.

## Problem

The current behavior converts `None` to the string `"None"` via `_to_string()`, which then passes the `if not store_uri` check and leads to unexpected folder creation named `"None"`.

## Fix

This change ensures that the setting is explicitly checked for `None` before `_to_string()` is applied, and raises a `NotConfigured` exception with a clear message if the setting is missing.

https://github.com/scrapy/scrapy/issues/6964

