### PR TITLE
Deprecate non-async counterparts of new async APIs.

### DIFF
--- a/scrapy/commands/shell.py
+++ b/scrapy/commands/shell.py
@@ -12,6 +12,7 @@ from typing import TYPE_CHECKING, Any
 from scrapy.commands import ScrapyCommand
 from scrapy.http import Request
 from scrapy.shell import Shell
+from scrapy.utils.defer import deferred_from_coro
 from scrapy.utils.spider import DefaultSpider, spidercls_for_request
 from scrapy.utils.url import guess_scheme
 
@@ -84,7 +85,7 @@ class Command(ScrapyCommand):
         crawler._apply_settings()
         # The Shell class needs a persistent engine in the crawler
         crawler.engine = crawler._create_engine()
-        crawler.engine.start(_start_request_processing=False)
+        deferred_from_coro(crawler.engine.start_async(_start_request_processing=False))
 
         self._start_crawler_thread()
 

--- a/scrapy/core/engine.py
+++ b/scrapy/core/engine.py
@@ -135,9 +135,14 @@ class ExecutionEngine:
         return scheduler_cls
 
     def start(self, _start_request_processing=True) -> Deferred[None]:
+        warnings.warn(
+            "ExecutionEngine.start() is deprecated, use start_async() instead",
+            ScrapyDeprecationWarning,
+            stacklevel=2,
+        )
         return deferred_from_coro(self.start_async(_start_request_processing))
 
-    async def start_async(self, _start_request_processing=True) -> None:
+    async def start_async(self, _start_request_processing: bool = True) -> None:
         if self.running:
             raise RuntimeError("Engine already running")
         self.start_time = time()
@@ -218,7 +223,9 @@ class ExecutionEngine:
             if isinstance(item_or_request, Request):
                 self.crawl(item_or_request)
             else:
-                self.scraper.start_itemproc(item_or_request, response=None)
+                deferred_from_coro(
+                    self.scraper.start_itemproc_async(item_or_request, response=None)
+                )
                 self._slot.nextcall.schedule()
 
     @deferred_f_from_coro_f
@@ -438,6 +445,11 @@ class ExecutionEngine:
             self._slot.nextcall.schedule()
 
     def open_spider(self, spider: Spider, close_if_idle: bool = True) -> Deferred[None]:
+        warnings.warn(
+            "ExecutionEngine.open_spider() is deprecated, use open_spider_async() instead",
+            ScrapyDeprecationWarning,
+            stacklevel=2,
+        )
         return deferred_from_coro(
             self.open_spider_async(spider, close_if_idle=close_if_idle)
         )

--- a/scrapy/core/scraper.py
+++ b/scrapy/core/scraper.py
@@ -314,12 +314,11 @@ class Scraper:
         spider: Spider | None = None,
     ) -> Deferred[None]:
         """Pass items/requests produced by a callback to ``_process_spidermw_output()`` in parallel."""
-        if spider is not None:
-            warnings.warn(
-                "Passing a 'spider' argument to Scraper.handle_spider_output() is deprecated.",
-                category=ScrapyDeprecationWarning,
-                stacklevel=2,
-            )
+        warnings.warn(
+            "Scraper.handle_spider_output() is deprecated, use handle_spider_output_async() instead",
+            ScrapyDeprecationWarning,
+            stacklevel=2,
+        )
         return deferred_from_coro(
             self.handle_spider_output_async(result, request, response)
         )
@@ -395,6 +394,11 @@ class Scraper:
         *response* is the source of the item data. If the item does not come
         from response data, e.g. it was hard-coded, set it to ``None``.
         """
+        warnings.warn(
+            "Scraper.start_itemproc() is deprecated, use start_itemproc_async() instead",
+            ScrapyDeprecationWarning,
+            stacklevel=2,
+        )
         return deferred_from_coro(self.start_itemproc_async(item, response=response))
 
     async def start_itemproc_async(

--- a/scrapy/core/spidermw.py
+++ b/scrapy/core/spidermw.py
@@ -367,6 +367,11 @@ class SpiderMiddlewareManager(MiddlewareManager):
         request: Request,
         spider: Spider,
     ) -> Deferred[MutableChain[_T] | MutableAsyncChain[_T]]:
+        warn(
+            "SpiderMiddlewareManager.scrape_response() is deprecated, use scrape_response_async() instead",
+            ScrapyDeprecationWarning,
+            stacklevel=2,
+        )
         return deferred_from_coro(
             self.scrape_response_async(scrape_func, response, request, spider)
         )

--- a/scrapy/crawler.py
+++ b/scrapy/crawler.py
@@ -159,8 +159,8 @@ class Crawler:
             self._apply_settings()
             self._update_root_log_handler()
             self.engine = self._create_engine()
-            yield self.engine.open_spider(self.spider)
-            yield self.engine.start()
+            yield deferred_from_coro(self.engine.open_spider_async(self.spider))
+            yield deferred_from_coro(self.engine.start_async())
         except Exception:
             self.crawling = False
             if self.engine is not None:

--- a/scrapy/shell.py
+++ b/scrapy/shell.py
@@ -25,7 +25,7 @@ from scrapy.spiders import Spider
 from scrapy.utils.conf import get_config
 from scrapy.utils.console import DEFAULT_PYTHON_SHELLS, start_python_console
 from scrapy.utils.datatypes import SequenceExclude
-from scrapy.utils.defer import deferred_f_from_coro_f, maybe_deferred_to_future
+from scrapy.utils.defer import deferred_f_from_coro_f
 from scrapy.utils.misc import load_object
 from scrapy.utils.reactor import is_asyncio_reactor_installed, set_asyncio_event_loop
 from scrapy.utils.response import open_in_browser
@@ -126,9 +126,7 @@ class Shell:
 
         self.crawler.spider = spider
         assert self.crawler.engine
-        await maybe_deferred_to_future(
-            self.crawler.engine.open_spider(spider, close_if_idle=False)
-        )
+        await self.crawler.engine.open_spider_async(spider, close_if_idle=False)
         self.crawler.engine._start_request_processing()
         self.spider = spider
 

--- a/tests/test_spidermiddleware.py
+++ b/tests/test_spidermiddleware.py
@@ -31,7 +31,7 @@ class TestSpiderMiddleware:
         self.mwman = SpiderMiddlewareManager.from_crawler(self.crawler)
 
     async def _scrape_response(self) -> Any:
-        """Execute spider mw manager's scrape_response method and return the result.
+        """Execute spider mw manager's scrape_response_async method and return the result.
         Raise exception in case of failure.
         """
 
@@ -41,10 +41,8 @@ class TestSpiderMiddleware:
             it = mock.MagicMock()
             return defer.succeed(it)
 
-        return await maybe_deferred_to_future(
-            self.mwman.scrape_response(
-                scrape_func, self.response, self.request, self.spider
-            )
+        return await self.mwman.scrape_response_async(
+            scrape_func, self.response, self.request, self.spider
         )
 
 


### PR DESCRIPTION
Deprecated:
* `ExecutionEngine.start()`
* `ExecutionEngine.open_spider()`
* `Scraper.handle_spider_output()`
* `Scraper.start_itemproc()`
* `SpiderMiddlewareManager.scrape_response()`

Kept:
* `Crawler.crawl()` and `Crawler.stop()` - the async counterparts need asyncio
* `SignalManager.send_catch_log_deferred()` and `scrapy.utils.signal.send_catch_log_deferred()` - makes more sense to deprecate together, but currently `scrapy.utils.signal.send_catch_log_async()` wraps `scrapy.utils.signal.send_catch_log_deferred()`, so it needs to be rewritten to a native implementation first to avoid multiple wrappers
* `Scraper.call_spider()` - needs refactoring of `SpiderMiddlewareManager` to use `call_spider_async()` there which may be easy but I don't think I've investigated it