### PR TITLE
Fix: Raise exception when spider's start_requests returns a non-generator (#6859)

### DIFF
--- a/scrapy/exceptions.py
+++ b/scrapy/exceptions.py
@@ -88,3 +88,7 @@ class ScrapyDeprecationWarning(Warning):
 
 class ContractFail(AssertionError):
     """Error raised in case of a failing contract"""
+
+
+class ScrapyUsageError(UsageError):
+    """To indicate a usage error in Scrapy"""


### PR DESCRIPTION
### Fix for Issue #6859

This pull request resolves a usability issue in Scrapy where spiders could fail silently if `start_requests()` or `start()` return a non-generator (e.g., a list or a single `Request`).

---

### 🔧 Changes Made

- **`scrapy/core/spidermw.py`**
  - Added validation in `process_start()` to ensure `start_requests()` and `start()` return a generator.
  - Raises a `ScrapyUsageError` if the return value is not a generator.

- **`scrapy/exceptions.py`**
  - Introduced a new exception: `ScrapyUsageError`.

- **`tests/test_spidermiddleware.py`**
  - Added test cases to check that `ScrapyUsageError` is raised when a non-generator is returned.

---

### ✅ Benefits

- Prevents silent failure due to `return` being used instead of `yield`.
- Gives clear and early feedback to developers.
- Improves overall debugging experience.

---

### 📌 Related Issue

Fixes #6859
