### PR TITLE
Update sphinx and sphinx-notfound-page in requirements.txt

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,4 @@
-sphinx==8.1.3
-sphinx-notfound-page==1.0.4
+sphinx==8.2.3
+sphinx-notfound-page==1.1.0
 sphinx-rtd-theme==3.0.2
 sphinx-rtd-dark-mode==1.3.0


### PR DESCRIPTION
- Updated sphinx to 8.2.3
- Updated sphinx-notfound-page to 1.1.0

This change keeps the documentation dependencies up-to-date with the latest stable releases.