### PR TITLE
Deprecate various `spider` args in `MiddlewareManager` subclasses

### DIFF
--- a/scrapy/commands/parse.py
+++ b/scrapy/commands/parse.py
@@ -16,6 +16,7 @@ from scrapy.http import Request, Response
 from scrapy.utils import display
 from scrapy.utils.asyncgen import collect_asyncgen
 from scrapy.utils.defer import aiter_errback, deferred_from_coro
+from scrapy.utils.deprecate import argument_is_required
 from scrapy.utils.log import failure_to_exc_info
 from scrapy.utils.misc import arg_to_iter
 from scrapy.utils.spider import spidercls_for_request
@@ -284,8 +285,12 @@ class Command(BaseRunSpiderCommand):
         if opts.pipelines:
             assert self.pcrawler.engine
             itemproc = self.pcrawler.engine.scraper.itemproc
+            needs_spider = argument_is_required(itemproc.process_item, "spider")
             for item in items:
-                itemproc.process_item(item, spider)
+                if needs_spider:
+                    itemproc.process_item(item, spider)
+                else:
+                    itemproc.process_item(item)
         self.add_items(depth, items)
         self.add_requests(depth, requests)
 

--- a/scrapy/core/downloader/__init__.py
+++ b/scrapy/core/downloader/__init__.py
@@ -105,6 +105,7 @@ class Downloader:
     DOWNLOAD_SLOT = "download_slot"
 
     def __init__(self, crawler: Crawler):
+        self.crawler: Crawler = crawler
         self.settings: BaseSettings = crawler.settings
         self.signals: SignalManager = crawler.signals
         self.slots: dict[str, Slot] = {}
@@ -140,14 +141,17 @@ class Downloader:
     def needs_backout(self) -> bool:
         return len(self.active) >= self.total_concurrency
 
-    def _get_slot(self, request: Request, spider: Spider) -> tuple[str, Slot]:
+    def _get_slot(self, request: Request) -> tuple[str, Slot]:
         key = self.get_slot_key(request)
         if key not in self.slots:
+            assert self.crawler.spider
             slot_settings = self.per_slot_settings.get(key, {})
             conc = (
                 self.ip_concurrency if self.ip_concurrency else self.domain_concurrency
             )
-            conc, delay = _get_concurrency_delay(conc, spider, self.settings)
+            conc, delay = _get_concurrency_delay(
+                conc, self.crawler.spider, self.settings
+            )
             conc, delay = (
                 slot_settings.get("concurrency", conc),
                 slot_settings.get("delay", delay),
@@ -180,21 +184,23 @@ class Downloader:
     def _enqueue_request(
         self, request: Request, spider: Spider
     ) -> Generator[Deferred[Any], Any, Response]:
-        key, slot = self._get_slot(request, spider)
+        key, slot = self._get_slot(request)
         request.meta[self.DOWNLOAD_SLOT] = key
         slot.active.add(request)
         self.signals.send_catch_log(
-            signal=signals.request_reached_downloader, request=request, spider=spider
+            signal=signals.request_reached_downloader,
+            request=request,
+            spider=self.crawler.spider,
         )
         d: Deferred[Response] = Deferred()
         slot.queue.append((request, d))
-        self._process_queue(spider, slot)
+        self._process_queue(slot)
         try:
             return (yield d)
         finally:
             slot.active.remove(request)
 
-    def _process_queue(self, spider: Spider, slot: Slot) -> None:
+    def _process_queue(self, slot: Slot) -> None:
         if slot.latercall:
             # block processing until slot.latercall is called
             return
@@ -205,31 +211,31 @@ class Downloader:
         if delay:
             penalty = delay - now + slot.lastseen
             if penalty > 0:
-                slot.latercall = call_later(penalty, self._latercall, spider, slot)
+                slot.latercall = call_later(penalty, self._latercall, slot)
                 return
 
         # Process enqueued requests if there are free slots to transfer for this slot
         while slot.queue and slot.free_transfer_slots() > 0:
             slot.lastseen = now
             request, deferred = slot.queue.popleft()
-            dfd = deferred_from_coro(self._download(slot, request, spider))
+            dfd = deferred_from_coro(self._download(slot, request))
             dfd.chainDeferred(deferred)
             # prevent burst if inter-request delays were configured
             if delay:
-                self._process_queue(spider, slot)
+                self._process_queue(slot)
                 break
 
-    def _latercall(self, spider: Spider, slot: Slot) -> None:
+    def _latercall(self, slot: Slot) -> None:
         slot.latercall = None
-        self._process_queue(spider, slot)
+        self._process_queue(slot)
 
-    async def _download(self, slot: Slot, request: Request, spider: Spider) -> Response:
+    async def _download(self, slot: Slot, request: Request) -> Response:
         # The order is very important for the following logic. Do not change!
         slot.transferring.add(request)
         try:
             # 1. Download the response
             response: Response = await maybe_deferred_to_future(
-                self.handlers.download_request(request, spider)
+                self.handlers.download_request(request)
             )
             # 2. Notify response_downloaded listeners about the recent download
             # before querying queue for next request
@@ -237,7 +243,7 @@ class Downloader:
                 signal=signals.response_downloaded,
                 response=response,
                 request=request,
-                spider=spider,
+                spider=self.crawler.spider,
             )
             return response
         except Exception:
@@ -249,9 +255,11 @@ class Downloader:
             # following requests (perhaps those which came from the downloader
             # middleware itself)
             slot.transferring.remove(request)
-            self._process_queue(spider, slot)
+            self._process_queue(slot)
             self.signals.send_catch_log(
-                signal=signals.request_left_downloader, request=request, spider=spider
+                signal=signals.request_left_downloader,
+                request=request,
+                spider=self.crawler.spider,
             )
 
     def close(self) -> None:

--- a/scrapy/core/downloader/__init__.py
+++ b/scrapy/core/downloader/__init__.py
@@ -132,6 +132,12 @@ class Downloader:
     def fetch(
         self, request: Request, spider: Spider | None = None
     ) -> Generator[Deferred[Any], Any, Response | Request]:
+        if spider is not None:
+            warnings.warn(
+                "Passing a 'spider' argument to Downloader.fetch() is deprecated.",
+                category=ScrapyDeprecationWarning,
+                stacklevel=2,
+            )
         self.active.add(request)
         try:
             return (yield self.middleware.download(self._enqueue_request, request))

--- a/scrapy/core/downloader/__init__.py
+++ b/scrapy/core/downloader/__init__.py
@@ -129,13 +129,11 @@ class Downloader:
 
     @inlineCallbacks
     def fetch(
-        self, request: Request, spider: Spider
+        self, request: Request, spider: Spider | None = None
     ) -> Generator[Deferred[Any], Any, Response | Request]:
         self.active.add(request)
         try:
-            return (
-                yield self.middleware.download(self._enqueue_request, request, spider)
-            )
+            return (yield self.middleware.download(self._enqueue_request, request))
         finally:
             self.active.remove(request)
 

--- a/scrapy/core/downloader/__init__.py
+++ b/scrapy/core/downloader/__init__.py
@@ -182,7 +182,7 @@ class Downloader:
 
     @inlineCallbacks
     def _enqueue_request(
-        self, request: Request, spider: Spider
+        self, request: Request
     ) -> Generator[Deferred[Any], Any, Response]:
         key, slot = self._get_slot(request)
         request.meta[self.DOWNLOAD_SLOT] = key

--- a/scrapy/core/downloader/middleware.py
+++ b/scrapy/core/downloader/middleware.py
@@ -78,8 +78,7 @@ class DownloaderMiddlewareManager(MiddlewareManager):
                     return response
             if need_spider_arg:
                 return (yield download_func(request, self._spider))  # type: ignore[call-arg]
-            else:
-                return (yield download_func(request))
+            return (yield download_func(request))
 
         @inlineCallbacks
         def process_response(

--- a/scrapy/core/downloader/middleware.py
+++ b/scrapy/core/downloader/middleware.py
@@ -16,7 +16,7 @@ from scrapy.http import Request, Response
 from scrapy.middleware import MiddlewareManager
 from scrapy.utils.conf import build_component_list
 from scrapy.utils.defer import _defer_sleep, deferred_from_coro
-from scrapy.utils.python import get_func_args
+from scrapy.utils.deprecate import argument_is_required
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Generator
@@ -47,7 +47,7 @@ class DownloaderMiddlewareManager(MiddlewareManager):
         request: Request,
         spider: Spider | None = None,
     ) -> Generator[Deferred[Any], Any, Response | Request]:
-        if "spider" in get_func_args(download_func):
+        if argument_is_required(download_func, "spider"):
             warnings.warn(
                 "The spider argument of download_func is deprecated"
                 " and will not be passed in the future Scrapy versions.",

--- a/scrapy/core/engine.py
+++ b/scrapy/core/engine.py
@@ -467,7 +467,7 @@ class ExecutionEngine:
         self._start = await self.scraper.spidermw.process_start()
         if hasattr(scheduler, "open") and (d := scheduler.open(self.crawler.spider)):
             await maybe_deferred_to_future(d)
-        await maybe_deferred_to_future(self.scraper.open_spider(self.crawler.spider))
+        await maybe_deferred_to_future(self.scraper.open_spider())
         assert self.crawler.stats
         self.crawler.stats.open_spider(self.crawler.spider)
         await self.signals.send_catch_log_async(

--- a/scrapy/core/engine.py
+++ b/scrapy/core/engine.py
@@ -419,6 +419,7 @@ class ExecutionEngine:
 
         self._slot.add_request(request)
         try:
+            # we would like to drop the spider argument but self.downloader is pluggable
             result: Response | Request = yield self.downloader.fetch(
                 request, self.spider
             )
@@ -429,7 +430,6 @@ class ExecutionEngine:
             if isinstance(result, Response):
                 if result.request is None:
                     result.request = request
-                assert self.spider is not None
                 logkws = self.logformatter.crawled(result.request, result, self.spider)
                 if logkws is not None:
                     logger.log(
@@ -468,7 +468,7 @@ class ExecutionEngine:
         nextcall = CallLaterOnce(self._start_scheduled_requests)
         scheduler = build_from_crawler(self.scheduler_cls, self.crawler)
         self._slot = _Slot(close_if_idle, nextcall, scheduler)
-        self._start = await self.scraper.spidermw.process_start(spider)
+        self._start = await self.scraper.spidermw.process_start()
         if hasattr(scheduler, "open") and (d := scheduler.open(spider)):
             await maybe_deferred_to_future(d)
         await maybe_deferred_to_future(self.scraper.open_spider(spider))

--- a/scrapy/core/scraper.py
+++ b/scrapy/core/scraper.py
@@ -129,7 +129,7 @@ class Scraper:
             )
         await maybe_deferred_to_future(self.itemproc.open_spider(self.crawler.spider))
 
-    def close_spider(self, spider: Spider | None = None) -> Deferred[Spider]:
+    def close_spider(self, spider: Spider | None = None) -> Deferred[list[None]]:
         """Close the spider being scraped and release its resources"""
         if spider is not None:
             warnings.warn(
@@ -141,9 +141,9 @@ class Scraper:
         if self.slot is None:
             raise RuntimeError("Scraper slot not assigned")
         self.slot.closing = Deferred()
-        self.slot.closing.addCallback(self.itemproc.close_spider)
+        d = self.slot.closing.addCallback(self.itemproc.close_spider)
         self._check_if_closing()
-        return self.slot.closing
+        return d
 
     def is_idle(self) -> bool:
         """Return True if there isn't any more spiders to process"""

--- a/scrapy/core/spidermw.py
+++ b/scrapy/core/spidermw.py
@@ -33,6 +33,7 @@ from scrapy.utils.python import MutableAsyncChain, MutableChain, global_object_n
 if TYPE_CHECKING:
     from collections.abc import Generator
 
+    from scrapy.crawler import Crawler
     from scrapy.settings import BaseSettings
 
 
@@ -57,12 +58,12 @@ class SpiderMiddlewareManager(MiddlewareManager):
     def _get_mwlist_from_settings(cls, settings: BaseSettings) -> list[Any]:
         return build_component_list(settings.getwithbase("SPIDER_MIDDLEWARES"))
 
-    def __init__(self, *middlewares: Any) -> None:
+    def __init__(self, *middlewares: Any, crawler: Crawler | None = None) -> None:
         self._check_deprecated_process_start_requests_use(middlewares)
-        super().__init__(*middlewares)
+        super().__init__(*middlewares, crawler=crawler)
 
     def _check_deprecated_process_start_requests_use(
-        self, middlewares: tuple[Any]
+        self, middlewares: tuple[Any, ...]
     ) -> None:
         deprecated_middlewares = [
             middleware

--- a/scrapy/core/spidermw.py
+++ b/scrapy/core/spidermw.py
@@ -137,12 +137,11 @@ class SpiderMiddlewareManager(MiddlewareManager):
         scrape_func: ScrapeFunc[_T],
         response: Response,
         request: Request,
-        spider: Spider,
     ) -> Iterable[_T] | AsyncIterator[_T]:
         for method in self.methods["process_spider_input"]:
             method = cast("Callable", method)
             try:
-                result = method(response=response, spider=spider)
+                result = method(response=response, spider=self._spider)
                 if result is not None:
                     msg = (
                         f"{global_object_name(method)} must return None "
@@ -158,7 +157,6 @@ class SpiderMiddlewareManager(MiddlewareManager):
     def _evaluate_iterable(
         self,
         response: Response,
-        spider: Spider,
         iterable: Iterable[_T] | AsyncIterator[_T],
         exception_processor_index: int,
         recover_to: MutableChain[_T] | MutableAsyncChain[_T],
@@ -170,7 +168,7 @@ class SpiderMiddlewareManager(MiddlewareManager):
                 exception_result = cast(
                     "Union[Failure, MutableChain[_T]]",
                     self._process_spider_exception(
-                        response, spider, ex, exception_processor_index
+                        response, ex, exception_processor_index
                     ),
                 )
                 if isinstance(exception_result, Failure):
@@ -186,7 +184,7 @@ class SpiderMiddlewareManager(MiddlewareManager):
                 exception_result = cast(
                     "Union[Failure, MutableAsyncChain[_T]]",
                     self._process_spider_exception(
-                        response, spider, ex, exception_processor_index
+                        response, ex, exception_processor_index
                     ),
                 )
                 if isinstance(exception_result, Failure):
@@ -201,7 +199,6 @@ class SpiderMiddlewareManager(MiddlewareManager):
     def _process_spider_exception(
         self,
         response: Response,
-        spider: Spider,
         exception: Exception,
         start_index: int = 0,
     ) -> MutableChain[_T] | MutableAsyncChain[_T]:
@@ -215,14 +212,12 @@ class SpiderMiddlewareManager(MiddlewareManager):
             if method is None:
                 continue
             method = cast("Callable", method)
-            result = method(response=response, exception=exception, spider=spider)
+            result = method(response=response, exception=exception, spider=self._spider)
             if _isiterable(result):
                 # stop exception handling by handing control over to the
                 # process_spider_output chain if an iterable has been returned
                 dfd: Deferred[MutableChain[_T] | MutableAsyncChain[_T]] = (
-                    self._process_spider_output(
-                        response, spider, result, method_index + 1
-                    )
+                    self._process_spider_output(response, result, method_index + 1)
                 )
                 # _process_spider_output() returns a Deferred only because of downgrading so this can be
                 # simplified when downgrading is removed.
@@ -251,7 +246,6 @@ class SpiderMiddlewareManager(MiddlewareManager):
     def _process_spider_output(
         self,
         response: Response,
-        spider: Spider,
         result: Iterable[_T] | AsyncIterator[_T],
         start_index: int = 0,
     ) -> Generator[Deferred[Any], Any, MutableChain[_T] | MutableAsyncChain[_T]]:
@@ -304,19 +298,17 @@ class SpiderMiddlewareManager(MiddlewareManager):
                         )
                         recovered = MutableChain(recovered_collected)
                 # might fail directly if the output value is not a generator
-                result = method(response=response, result=result, spider=spider)
+                result = method(response=response, result=result, spider=self._spider)
             except Exception as ex:
                 exception_result: Failure | MutableChain[_T] | MutableAsyncChain[_T] = (
-                    self._process_spider_exception(
-                        response, spider, ex, method_index + 1
-                    )
+                    self._process_spider_exception(response, ex, method_index + 1)
                 )
                 if isinstance(exception_result, Failure):
                     raise
                 return exception_result
             if _isiterable(result):
                 result = self._evaluate_iterable(
-                    response, spider, result, method_index + 1, recovered
+                    response, result, method_index + 1, recovered
                 )
             else:
                 if iscoroutine(result):
@@ -340,7 +332,6 @@ class SpiderMiddlewareManager(MiddlewareManager):
     async def _process_callback_output(
         self,
         response: Response,
-        spider: Spider,
         result: Iterable[_T] | AsyncIterator[_T],
     ) -> MutableChain[_T] | MutableAsyncChain[_T]:
         recovered: MutableChain[_T] | MutableAsyncChain[_T]
@@ -348,11 +339,11 @@ class SpiderMiddlewareManager(MiddlewareManager):
             recovered = MutableAsyncChain()
         else:
             recovered = MutableChain()
-        result = self._evaluate_iterable(response, spider, result, 0, recovered)
+        result = self._evaluate_iterable(response, result, 0, recovered)
         result = await maybe_deferred_to_future(
             cast(
                 "Deferred[Iterable[_T] | AsyncIterator[_T]]",
-                self._process_spider_output(response, spider, result),
+                self._process_spider_output(response, result),
             )
         )
         if isinstance(result, AsyncIterator):
@@ -384,8 +375,9 @@ class SpiderMiddlewareManager(MiddlewareManager):
         ) -> Iterable[_T] | AsyncIterator[_T]:
             return await maybe_deferred_to_future(scrape_func(response, request))
 
+        self._set_compat_spider(spider)
         return deferred_from_coro(
-            self.scrape_response_async(scrape_func_wrapped, response, request, spider)
+            self.scrape_response_async(scrape_func_wrapped, response, request)
         )
 
     async def scrape_response_async(
@@ -393,46 +385,56 @@ class SpiderMiddlewareManager(MiddlewareManager):
         scrape_func: ScrapeFunc[_T],
         response: Response,
         request: Request,
-        spider: Spider,
     ) -> MutableChain[_T] | MutableAsyncChain[_T]:
+        if not self.crawler:
+            raise RuntimeError(
+                "scrape_response_async() called on a SpiderMiddlewareManager"
+                " instance created without a crawler."
+            )
+
         async def process_callback_output(
             result: Iterable[_T] | AsyncIterator[_T],
         ) -> MutableChain[_T] | MutableAsyncChain[_T]:
-            return await self._process_callback_output(response, spider, result)
+            return await self._process_callback_output(response, result)
 
         def process_spider_exception(
             exception: Exception,
         ) -> MutableChain[_T] | MutableAsyncChain[_T]:
-            return self._process_spider_exception(response, spider, exception)
+            return self._process_spider_exception(response, exception)
 
         try:
             it: Iterable[_T] | AsyncIterator[_T] = await self._process_spider_input(
-                scrape_func, response, request, spider
+                scrape_func, response, request
             )
             return await process_callback_output(it)
         except Exception as ex:
             await _defer_sleep_async()
             return process_spider_exception(ex)
 
-    async def process_start(self, spider: Spider) -> AsyncIterator[Any] | None:
-        self._check_deprecated_start_requests_use(spider)
+    async def process_start(
+        self, spider: Spider | None = None
+    ) -> AsyncIterator[Any] | None:
+        if spider:
+            self._warn_spider_arg("process_start")
+            self._set_compat_spider(spider)
+        self._check_deprecated_start_requests_use()
         if self._use_start_requests:
-            sync_start = iter(spider.start_requests())
+            sync_start = iter(self._spider.start_requests())
             sync_start = await maybe_deferred_to_future(
-                self._process_chain("process_start_requests", sync_start, spider)
+                self._process_chain("process_start_requests", sync_start, self._spider)
             )
             start: AsyncIterator[Any] = as_async_generator(sync_start)
         else:
-            start = spider.start()
+            start = self._spider.start()
             start = await maybe_deferred_to_future(
                 self._process_chain("process_start", start)
             )
         return start
 
-    def _check_deprecated_start_requests_use(self, spider: Spider):
+    def _check_deprecated_start_requests_use(self):
         start_requests_cls = None
         start_cls = None
-        spidercls = spider.__class__
+        spidercls = self._spider.__class__
         mro = spidercls.__mro__
 
         for cls in mro:

--- a/scrapy/crawler.py
+++ b/scrapy/crawler.py
@@ -159,7 +159,7 @@ class Crawler:
             self._apply_settings()
             self._update_root_log_handler()
             self.engine = self._create_engine()
-            yield deferred_from_coro(self.engine.open_spider_async(self.spider))
+            yield deferred_from_coro(self.engine.open_spider_async())
             yield deferred_from_coro(self.engine.start_async())
         except Exception:
             self.crawling = False
@@ -195,7 +195,7 @@ class Crawler:
             self._apply_settings()
             self._update_root_log_handler()
             self.engine = self._create_engine()
-            await self.engine.open_spider_async(self.spider)
+            await self.engine.open_spider_async()
             await self.engine.start_async()
         except Exception:
             self.crawling = False

--- a/scrapy/pipelines/__init__.py
+++ b/scrapy/pipelines/__init__.py
@@ -33,5 +33,8 @@ class ItemPipelineManager(MiddlewareManager):
                 deferred_f_from_coro_f(pipe.process_item)
             )
 
-    def process_item(self, item: Any, spider: Spider) -> Deferred[Any]:
-        return self._process_chain("process_item", item, spider)
+    def process_item(self, item: Any, spider: Spider | None = None) -> Deferred[Any]:
+        if spider:
+            self._warn_spider_arg("process_item")
+            self._set_compat_spider(spider)
+        return self._process_chain("process_item", item, self._spider)

--- a/scrapy/shell.py
+++ b/scrapy/shell.py
@@ -126,7 +126,7 @@ class Shell:
 
         self.crawler.spider = spider
         assert self.crawler.engine
-        await self.crawler.engine.open_spider_async(spider, close_if_idle=False)
+        await self.crawler.engine.open_spider_async(close_if_idle=False)
         self.crawler.engine._start_request_processing()
         self.spider = spider
 

--- a/scrapy/utils/deprecate.py
+++ b/scrapy/utils/deprecate.py
@@ -4,9 +4,13 @@ from __future__ import annotations
 
 import inspect
 import warnings
-from typing import Any, overload
+from typing import TYPE_CHECKING, Any, overload
 
 from scrapy.exceptions import ScrapyDeprecationWarning
+from scrapy.utils.python import get_func_args_dict
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 
 def attribute(obj: Any, oldattr: str, newattr: str, version: str = "0.12") -> None:
@@ -191,3 +195,25 @@ def method_is_overridden(subclass: type, base_class: type, method_name: str) -> 
     base_method = getattr(base_class, method_name)
     sub_method = getattr(subclass, method_name)
     return base_method.__code__ is not sub_method.__code__
+
+
+def argument_is_required(func: Callable[..., Any], arg_name: str) -> bool:
+    """
+    Check if a function argument is required (exists and doesn't have a default value).
+
+    .. versionadded:: VERSION
+
+    >>> def func(a, b=1, c=None):
+    ...     pass
+    >>> argument_is_required(func, 'a')
+    True
+    >>> argument_is_required(func, 'b')
+    False
+    >>> argument_is_required(func, 'c')
+    False
+    >>> argument_is_required(func, 'd')
+    False
+    """
+    args = get_func_args_dict(func)
+    param = args.get(arg_name)
+    return param is not None and param.default is inspect.Parameter.empty

--- a/tests/test_downloadermiddleware.py
+++ b/tests/test_downloadermiddleware.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 from contextlib import asynccontextmanager
 from gzip import BadGzipFile
+from typing import TYPE_CHECKING
 from unittest import mock
 
 import pytest
@@ -16,25 +17,27 @@ from scrapy.utils.defer import deferred_f_from_coro_f, maybe_deferred_to_future
 from scrapy.utils.python import to_bytes
 from scrapy.utils.test import get_crawler, get_from_asyncio_queue
 
+if TYPE_CHECKING:
+    from collections.abc import AsyncGenerator
+
 
 class TestManagerBase:
     settings_dict = None
 
     # should be a fixture but async fixtures that use Futures are problematic with pytest-twisted
     @asynccontextmanager
-    async def get_mwman_and_spider(self):
+    async def get_mwman(self) -> AsyncGenerator[DownloaderMiddlewareManager]:
         crawler = get_crawler(Spider, self.settings_dict)
-        spider = crawler._create_spider("foo")
+        crawler.spider = crawler._create_spider("foo")
         mwman = DownloaderMiddlewareManager.from_crawler(crawler)
         crawler.engine = crawler._create_engine()
-        await crawler.engine.open_spider_async(spider)
-        yield mwman, spider
-        await maybe_deferred_to_future(crawler.engine.close_spider(spider))
+        await crawler.engine.open_spider_async(crawler.spider)
+        yield mwman
+        await maybe_deferred_to_future(crawler.engine.close_spider(crawler.spider))
 
     @staticmethod
     async def _download(
         mwman: DownloaderMiddlewareManager,
-        spider: Spider,
         request: Request,
         response: Response | None = None,
     ) -> Response | Request:
@@ -48,9 +51,7 @@ class TestManagerBase:
         def download_func(request: Request, spider: Spider) -> Deferred[Response]:
             return succeed(response)
 
-        return await maybe_deferred_to_future(
-            mwman.download(download_func, request, spider)
-        )
+        return await maybe_deferred_to_future(mwman.download(download_func, request))
 
 
 class TestDefaults(TestManagerBase):
@@ -60,8 +61,8 @@ class TestDefaults(TestManagerBase):
     async def test_request_response(self):
         req = Request("http://example.com/index.html")
         resp = Response(req.url, status=200)
-        async with self.get_mwman_and_spider() as (mwman, spider):
-            ret = await self._download(mwman, spider, req, resp)
+        async with self.get_mwman() as mwman:
+            ret = await self._download(mwman, req, resp)
         assert isinstance(ret, Response), "Non-response returned"
 
     @deferred_f_from_coro_f
@@ -90,8 +91,8 @@ class TestDefaults(TestManagerBase):
                 "Location": "http://example.com/login",
             },
         )
-        async with self.get_mwman_and_spider() as (mwman, spider):
-            ret = await self._download(mwman, spider, req, resp)
+        async with self.get_mwman() as mwman:
+            ret = await self._download(mwman, req, resp)
         assert isinstance(ret, Request), f"Not redirected: {ret!r}"
         assert to_bytes(ret.url) == resp.headers["Location"], (
             "Not redirected to location header"
@@ -113,8 +114,8 @@ class TestDefaults(TestManagerBase):
             },
         )
         with pytest.raises(BadGzipFile):
-            async with self.get_mwman_and_spider() as (mwman, spider):
-                await self._download(mwman, spider, req, resp)
+            async with self.get_mwman() as mwman:
+                await self._download(mwman, req, resp)
 
 
 class TestResponseFromProcessRequest(TestManagerBase):
@@ -130,11 +131,9 @@ class TestResponseFromProcessRequest(TestManagerBase):
             def process_request(self, request, spider):
                 return resp
 
-        async with self.get_mwman_and_spider() as (mwman, spider):
+        async with self.get_mwman() as mwman:
             mwman._add_middleware(ResponseMiddleware())
-            result = await maybe_deferred_to_future(
-                mwman.download(download_func, req, spider)
-            )
+            result = await maybe_deferred_to_future(mwman.download(download_func, req))
         assert result is resp
         assert not download_func.called
 
@@ -160,11 +159,9 @@ class TestResponseFromProcessException(TestManagerBase):
                 calls.append("process_exception")
                 return resp
 
-        async with self.get_mwman_and_spider() as (mwman, spider):
+        async with self.get_mwman() as mwman:
             mwman._add_middleware(ResponseMiddleware())
-            result = await maybe_deferred_to_future(
-                mwman.download(download_func, req, spider)
-            )
+            result = await maybe_deferred_to_future(mwman.download(download_func, req))
         assert result is resp
         assert calls == [
             "process_exception",
@@ -182,10 +179,10 @@ class TestInvalidOutput(TestManagerBase):
             def process_request(self, request, spider):
                 return 1
 
-        async with self.get_mwman_and_spider() as (mwman, spider):
+        async with self.get_mwman() as mwman:
             mwman._add_middleware(InvalidProcessRequestMiddleware())
             with pytest.raises(_InvalidOutput):
-                await self._download(mwman, spider, req)
+                await self._download(mwman, req)
 
     @deferred_f_from_coro_f
     async def test_invalid_process_response(self):
@@ -196,10 +193,10 @@ class TestInvalidOutput(TestManagerBase):
             def process_response(self, request, response, spider):
                 return 1
 
-        async with self.get_mwman_and_spider() as (mwman, spider):
+        async with self.get_mwman() as mwman:
             mwman._add_middleware(InvalidProcessResponseMiddleware())
             with pytest.raises(_InvalidOutput):
-                await self._download(mwman, spider, req)
+                await self._download(mwman, req)
 
     @deferred_f_from_coro_f
     async def test_invalid_process_exception(self):
@@ -213,10 +210,10 @@ class TestInvalidOutput(TestManagerBase):
             def process_exception(self, request, exception, spider):
                 return 1
 
-        async with self.get_mwman_and_spider() as (mwman, spider):
+        async with self.get_mwman() as mwman:
             mwman._add_middleware(InvalidProcessExceptionMiddleware())
             with pytest.raises(_InvalidOutput):
-                await self._download(mwman, spider, req)
+                await self._download(mwman, req)
 
 
 class TestMiddlewareUsingDeferreds(TestManagerBase):
@@ -238,11 +235,9 @@ class TestMiddlewareUsingDeferreds(TestManagerBase):
                 d.callback(resp)
                 return d
 
-        async with self.get_mwman_and_spider() as (mwman, spider):
+        async with self.get_mwman() as mwman:
             mwman._add_middleware(DeferredMiddleware())
-            result = await maybe_deferred_to_future(
-                mwman.download(download_func, req, spider)
-            )
+            result = await maybe_deferred_to_future(mwman.download(download_func, req))
         assert result is resp
         assert not download_func.called
 
@@ -261,11 +256,9 @@ class TestMiddlewareUsingCoro(TestManagerBase):
                 await succeed(42)
                 return resp
 
-        async with self.get_mwman_and_spider() as (mwman, spider):
+        async with self.get_mwman() as mwman:
             mwman._add_middleware(CoroMiddleware())
-            result = await maybe_deferred_to_future(
-                mwman.download(download_func, req, spider)
-            )
+            result = await maybe_deferred_to_future(mwman.download(download_func, req))
         assert result is resp
         assert not download_func.called
 
@@ -281,10 +274,8 @@ class TestMiddlewareUsingCoro(TestManagerBase):
                 await asyncio.sleep(0.1)
                 return await get_from_asyncio_queue(resp)
 
-        async with self.get_mwman_and_spider() as (mwman, spider):
+        async with self.get_mwman() as mwman:
             mwman._add_middleware(CoroMiddleware())
-            result = await maybe_deferred_to_future(
-                mwman.download(download_func, req, spider)
-            )
+            result = await maybe_deferred_to_future(mwman.download(download_func, req))
         assert result is resp
         assert not download_func.called

--- a/tests/test_downloadermiddleware.py
+++ b/tests/test_downloadermiddleware.py
@@ -48,7 +48,7 @@ class TestManagerBase:
         if not response:
             response = Response(request.url)
 
-        def download_func(request: Request, spider: Spider) -> Deferred[Response]:
+        def download_func(request: Request) -> Deferred[Response]:
             return succeed(response)
 
         return await maybe_deferred_to_future(mwman.download(download_func, request))
@@ -147,7 +147,7 @@ class TestResponseFromProcessException(TestManagerBase):
         resp = Response("http://example.com/index.html")
         calls = []
 
-        def download_func(request, spider):
+        def download_func(request):
             raise ValueError("test")
 
         class ResponseMiddleware:

--- a/tests/test_downloadermiddleware.py
+++ b/tests/test_downloadermiddleware.py
@@ -31,7 +31,7 @@ class TestManagerBase:
         crawler.spider = crawler._create_spider("foo")
         mwman = DownloaderMiddlewareManager.from_crawler(crawler)
         crawler.engine = crawler._create_engine()
-        await crawler.engine.open_spider_async(crawler.spider)
+        await crawler.engine.open_spider_async()
         yield mwman
         await maybe_deferred_to_future(crawler.engine.close_spider(crawler.spider))
 

--- a/tests/test_downloaderslotssettings.py
+++ b/tests/test_downloaderslotssettings.py
@@ -5,6 +5,7 @@ from twisted.internet.defer import inlineCallbacks
 from scrapy import Request
 from scrapy.core.downloader import Downloader, Slot
 from scrapy.crawler import CrawlerRunner
+from scrapy.utils.spider import DefaultSpider
 from scrapy.utils.test import get_crawler
 from tests.mockserver.http import MockServer
 from tests.spiders import MetaSpider
@@ -89,11 +90,12 @@ def test_params():
             "example.com": params,
         },
     }
-    crawler = get_crawler(settings_dict=settings)
+    crawler = get_crawler(DefaultSpider, settings_dict=settings)
+    crawler.spider = crawler._create_spider()
     downloader = Downloader(crawler)
     downloader._slot_gc_loop.stop()  # Prevent an unclean reactor.
     request = Request("https://example.com")
-    _, actual = downloader._get_slot(request, spider=None)
+    _, actual = downloader._get_slot(request)
     expected = Slot(**params)
     for param in params:
         assert getattr(expected, param) == getattr(actual, param), (

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -441,7 +441,9 @@ class TestEngine(TestEngineBase):
 
     @inlineCallbacks
     def test_start_already_running_exception(self):
-        e = ExecutionEngine(get_crawler(DefaultSpider), lambda _: None)
+        crawler = get_crawler(DefaultSpider)
+        crawler.spider = crawler._create_spider()
+        e = ExecutionEngine(crawler, lambda _: None)
         yield deferred_from_coro(e.open_spider_async(DefaultSpider()))
         _schedule_coro(e.start_async())
         with pytest.raises(RuntimeError, match="Engine already running"):
@@ -451,7 +453,9 @@ class TestEngine(TestEngineBase):
     @pytest.mark.only_asyncio
     @deferred_f_from_coro_f
     async def test_start_already_running_exception_asyncio(self):
-        e = ExecutionEngine(get_crawler(DefaultSpider), lambda _: None)
+        crawler = get_crawler(DefaultSpider)
+        crawler.spider = crawler._create_spider()
+        e = ExecutionEngine(crawler, lambda _: None)
         await e.open_spider_async(DefaultSpider())
         with pytest.raises(RuntimeError, match="Engine already running"):
             await asyncio.gather(e.start_async(), e.start_async())
@@ -542,7 +546,6 @@ class TestEngineDownloadAsync:
     @deferred_f_from_coro_f
     async def test_download_async_redirect(self, engine):
         """Test async download with a redirect request."""
-        # Arrange
         original_request = Request("http://example.com")
         redirect_request = Request("http://example.com/redirect")
         final_response = Response("http://example.com/redirect", body=b"redirected")

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -541,7 +541,7 @@ class TestEngineDownloadAsync:
         assert result == response
         engine._slot.add_request.assert_called_once_with(request)
         engine._slot.remove_request.assert_called_once_with(request)
-        engine.downloader.fetch.assert_called_once_with(request, engine.spider)
+        engine.downloader.fetch.assert_called_once_with(request)
 
     @deferred_f_from_coro_f
     async def test_download_async_redirect(self, engine):

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -444,7 +444,7 @@ class TestEngine(TestEngineBase):
         crawler = get_crawler(DefaultSpider)
         crawler.spider = crawler._create_spider()
         e = ExecutionEngine(crawler, lambda _: None)
-        yield deferred_from_coro(e.open_spider_async(DefaultSpider()))
+        yield deferred_from_coro(e.open_spider_async())
         _schedule_coro(e.start_async())
         with pytest.raises(RuntimeError, match="Engine already running"):
             yield deferred_from_coro(e.start_async())
@@ -456,7 +456,7 @@ class TestEngine(TestEngineBase):
         crawler = get_crawler(DefaultSpider)
         crawler.spider = crawler._create_spider()
         e = ExecutionEngine(crawler, lambda _: None)
-        await e.open_spider_async(DefaultSpider())
+        await e.open_spider_async()
         with pytest.raises(RuntimeError, match="Engine already running"):
             await asyncio.gather(e.start_async(), e.start_async())
         await deferred_to_future(e.stop())

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -1,6 +1,16 @@
-from scrapy.exceptions import NotConfigured
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from scrapy import Spider
+from scrapy.exceptions import NotConfigured, ScrapyDeprecationWarning
 from scrapy.middleware import MiddlewareManager
 from scrapy.utils.test import get_crawler
+
+if TYPE_CHECKING:
+    from scrapy.crawler import Crawler
 
 
 class M1:
@@ -51,27 +61,46 @@ class MyMiddlewareManager(MiddlewareManager):
             self.methods["process"].append(mw.process)
 
 
-class TestMiddlewareManager:
-    def test_init(self):
-        m1, m2, m3 = M1(), M2(), M3()
+@pytest.fixture
+def crawler() -> Crawler:
+    return get_crawler(Spider)
+
+
+def test_init(crawler: Crawler) -> None:
+    m1, m2, m3 = M1(), M2(), M3()
+    mwman = MyMiddlewareManager(m1, m2, m3, crawler=crawler)
+    assert list(mwman.methods["open_spider"]) == [m1.open_spider, m2.open_spider]
+    assert list(mwman.methods["close_spider"]) == [m2.close_spider, m1.close_spider]
+    assert list(mwman.methods["process"]) == [m1.process, m3.process]
+    assert mwman.crawler == crawler
+
+
+def test_methods(crawler: Crawler) -> None:
+    mwman = MyMiddlewareManager(M1(), M2(), M3(), crawler=crawler)
+    assert [x.__self__.__class__ for x in mwman.methods["open_spider"]] == [M1, M2]  # type: ignore[union-attr]
+    assert [x.__self__.__class__ for x in mwman.methods["close_spider"]] == [M2, M1]  # type: ignore[union-attr]
+    assert [x.__self__.__class__ for x in mwman.methods["process"]] == [M1, M3]  # type: ignore[union-attr]
+
+
+def test_enabled(crawler: Crawler) -> None:
+    m1, m2, m3 = M1(), M2(), M3()
+    mwman = MyMiddlewareManager(m1, m2, m3, crawler=crawler)
+    assert mwman.middlewares == (m1, m2, m3)
+
+
+def test_enabled_from_settings(crawler: Crawler) -> None:
+    crawler = get_crawler()
+    mwman = MyMiddlewareManager.from_crawler(crawler)
+    classes = [x.__class__ for x in mwman.middlewares]
+    assert classes == [M1, M3]
+    assert mwman.crawler == crawler
+
+
+def test_no_crawler() -> None:
+    m1, m2, m3 = M1(), M2(), M3()
+    with pytest.warns(
+        ScrapyDeprecationWarning, match="was called without the crawler argument"
+    ):
         mwman = MyMiddlewareManager(m1, m2, m3)
-        assert list(mwman.methods["open_spider"]) == [m1.open_spider, m2.open_spider]
-        assert list(mwman.methods["close_spider"]) == [m2.close_spider, m1.close_spider]
-        assert list(mwman.methods["process"]) == [m1.process, m3.process]
-
-    def test_methods(self):
-        mwman = MyMiddlewareManager(M1(), M2(), M3())
-        assert [x.__self__.__class__ for x in mwman.methods["open_spider"]] == [M1, M2]
-        assert [x.__self__.__class__ for x in mwman.methods["close_spider"]] == [M2, M1]
-        assert [x.__self__.__class__ for x in mwman.methods["process"]] == [M1, M3]
-
-    def test_enabled(self):
-        m1, m2, m3 = M1(), M2(), M3()
-        mwman = MyMiddlewareManager(m1, m2, m3)
-        assert mwman.middlewares == (m1, m2, m3)
-
-    def test_enabled_from_settings(self):
-        crawler = get_crawler()
-        mwman = MyMiddlewareManager.from_crawler(crawler)
-        classes = [x.__class__ for x in mwman.middlewares]
-        assert classes == [M1, M3]
+    assert mwman.middlewares == (m1, m2, m3)
+    assert mwman.crawler is None

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -7,6 +7,7 @@ import pytest
 from scrapy import Spider
 from scrapy.exceptions import NotConfigured, ScrapyDeprecationWarning
 from scrapy.middleware import MiddlewareManager
+from scrapy.utils.spider import DefaultSpider
 from scrapy.utils.test import get_crawler
 
 if TYPE_CHECKING:
@@ -104,3 +105,73 @@ def test_no_crawler() -> None:
         mwman = MyMiddlewareManager(m1, m2, m3)
     assert mwman.middlewares == (m1, m2, m3)
     assert mwman.crawler is None
+
+
+def test_deprecated_spider_arg_no_crawler_spider(crawler: Crawler) -> None:
+    """Crawler is provided, but doesn't have a spider. The instance passed to the method is
+    ignored and raises a warning."""
+    mwman = MyMiddlewareManager(crawler=crawler)
+    with (
+        pytest.warns(
+            ScrapyDeprecationWarning,
+            match=r"Passing a spider argument to MyMiddlewareManager.open_spider\(\) is deprecated",
+        ),
+        pytest.raises(
+            ValueError,
+            match="MyMiddlewareManager needs to access self.crawler.spider but it is None",
+        ),
+    ):
+        mwman.open_spider(DefaultSpider())
+
+
+def test_deprecated_spider_arg_with_crawler(crawler: Crawler) -> None:
+    """Crawler is provided and has a spider, works. The instance passed to the method is ignored,
+    even if mismatched, but raises a warning."""
+    mwman = MyMiddlewareManager(crawler=crawler)
+    crawler.spider = crawler._create_spider("foo")
+    with pytest.warns(
+        ScrapyDeprecationWarning,
+        match=r"Passing a spider argument to MyMiddlewareManager.open_spider\(\) is deprecated",
+    ):
+        mwman.open_spider(DefaultSpider())
+    with pytest.warns(
+        ScrapyDeprecationWarning,
+        match=r"Passing a spider argument to MyMiddlewareManager.close_spider\(\) is deprecated",
+    ):
+        mwman.close_spider(DefaultSpider())
+
+
+def test_deprecated_spider_arg_without_crawler() -> None:
+    """The first instance passed to the method is used, with a warning. Mismatched ones raise an error."""
+    with pytest.warns(
+        ScrapyDeprecationWarning,
+        match="was called without the crawler argument",
+    ):
+        mwman = MyMiddlewareManager()
+    with pytest.warns(
+        ScrapyDeprecationWarning,
+        match=r"Passing a spider argument to MyMiddlewareManager.open_spider\(\) is deprecated",
+    ):
+        mwman.open_spider(DefaultSpider())
+    with (
+        pytest.warns(
+            ScrapyDeprecationWarning,
+            match=r"Passing a spider argument to MyMiddlewareManager.close_spider\(\) is deprecated",
+        ),
+        pytest.raises(RuntimeError, match="Different instances of Spider were passed"),
+    ):
+        mwman.close_spider(DefaultSpider())
+
+
+def test_no_spider_arg_without_crawler() -> None:
+    """If no crawler and no spider arg, raise an error."""
+    with pytest.warns(
+        ScrapyDeprecationWarning,
+        match="was called without the crawler argument",
+    ):
+        mwman = MyMiddlewareManager()
+    with pytest.raises(
+        ValueError,
+        match="has no known Spider instance",
+    ):
+        mwman.open_spider()

--- a/tests/test_spidermiddleware.py
+++ b/tests/test_spidermiddleware.py
@@ -21,6 +21,8 @@ from scrapy.utils.test import get_crawler
 if TYPE_CHECKING:
     from twisted.python.failure import Failure
 
+    from scrapy.crawler import Crawler
+
 
 class TestSpiderMiddleware:
     def setup_method(self):
@@ -404,8 +406,12 @@ class UniversalMiddlewareBothAsync:
 
 class TestUniversalMiddlewareManager:
     @pytest.fixture
-    def mwman(self) -> SpiderMiddlewareManager:
-        return SpiderMiddlewareManager()
+    def crawler(self) -> Crawler:
+        return get_crawler(Spider)
+
+    @pytest.fixture
+    def mwman(self, crawler: Crawler) -> SpiderMiddlewareManager:
+        return SpiderMiddlewareManager.from_crawler(crawler)
 
     def test_simple_mw(self, mwman: SpiderMiddlewareManager) -> None:
         mw = ProcessSpiderOutputSimpleMiddleware()

--- a/tests/test_spidermiddleware.py
+++ b/tests/test_spidermiddleware.py
@@ -29,7 +29,7 @@ class TestSpiderMiddleware:
         self.request = Request("http://example.com/index.html")
         self.response = Response(self.request.url, request=self.request)
         self.crawler = get_crawler(Spider, {"SPIDER_MIDDLEWARES_BASE": {}})
-        self.spider = self.crawler._create_spider("foo")
+        self.crawler.spider = self.crawler._create_spider("foo")
         self.mwman = SpiderMiddlewareManager.from_crawler(self.crawler)
 
     async def _scrape_response(self) -> Any:
@@ -44,7 +44,7 @@ class TestSpiderMiddleware:
             return defer.succeed(it)
 
         return await self.mwman.scrape_response_async(
-            scrape_func, self.response, self.request, self.spider
+            scrape_func, self.response, self.request
         )
 
 
@@ -148,10 +148,10 @@ class TestBaseAsyncSpiderMiddleware(TestSpiderMiddleware):
         self.crawler = get_crawler(
             Spider, {"SPIDER_MIDDLEWARES_BASE": {}, "SPIDER_MIDDLEWARES": setting}
         )
-        self.spider = self.crawler._create_spider("foo")
+        self.crawler.spider = self.crawler._create_spider("foo")
         self.mwman = SpiderMiddlewareManager.from_crawler(self.crawler)
         return await self.mwman.scrape_response_async(
-            self._scrape_func, self.response, self.request, self.spider
+            self._scrape_func, self.response, self.request
         )
 
     async def _test_simple_base(
@@ -369,9 +369,9 @@ class TestProcessStartSimple(TestBaseAsyncSpiderMiddleware):
         self.crawler = get_crawler(
             TestSpider, {"SPIDER_MIDDLEWARES_BASE": {}, "SPIDER_MIDDLEWARES": setting}
         )
-        self.spider = self.crawler._create_spider()
+        self.crawler.spider = self.crawler._create_spider()
         self.mwman = SpiderMiddlewareManager.from_crawler(self.crawler)
-        return await self.mwman.process_start(self.spider)
+        return await self.mwman.process_start()
 
     @deferred_f_from_coro_f
     async def test_simple(self):
@@ -481,10 +481,10 @@ class TestBuiltinMiddlewareSimple(TestBaseAsyncSpiderMiddleware):
     ) -> Any:
         setting = self._construct_mw_setting(*mw_classes, start_index=start_index)
         self.crawler = get_crawler(Spider, {"SPIDER_MIDDLEWARES": setting})
-        self.spider = self.crawler._create_spider("foo")
+        self.crawler.spider = self.crawler._create_spider("foo")
         self.mwman = SpiderMiddlewareManager.from_crawler(self.crawler)
         return await self.mwman.scrape_response_async(
-            self._scrape_func, self.response, self.request, self.spider
+            self._scrape_func, self.response, self.request
         )
 
     @deferred_f_from_coro_f

--- a/tests/test_utils_python.py
+++ b/tests/test_utils_python.py
@@ -236,7 +236,7 @@ def test_get_func_args():
     assert get_func_args(partial_f2) == ["a", "c"]
     assert get_func_args(partial_f3) == ["c"]
     assert get_func_args(cal) == ["a", "b", "c"]
-    assert get_func_args(object) == []
+    assert get_func_args(object) == []  # pylint: disable=use-implicit-booleaness-not-comparison
     assert get_func_args(str.split, stripself=True) == ["sep", "maxsplit"]
     assert get_func_args(" ".join, stripself=True) == ["iterable"]
 


### PR DESCRIPTION
Part of #6927

Instantiating `MiddlewareManager` subclasses without a crawler is now deprecated. While it's still possible there is a `self._spider` property that returns `self.crawler.spider` or an internal value set from the first method call with a deprecates `spider` arg passed.

The spider argument is deprecated and ignored in the following methods of `MiddlewareManager` subclasses:

* `DownloaderMiddlewareManager.download()`
* `SpiderMiddlewareManager.process_start()`
* `SpiderMiddlewareManager.scrape_response_async()` (not deprecated but removed right away as it's a new method)
* `ItemPipelineManager.process_item()`
* `open_spider()` and `close_spider()` of all but `ItemPipelineManager` because that one is pluggable

And in the following methods of other classes:

* `Downloader.fetch()` and several private methods
* `DownloadHandlers.download_request()`
* `ExecutionEngine.open_spider_async()` (not deprecated but removed)
* `Scraper.open_spider()`

Following methods are customizable so the arg is passed to the call only if needed:

* `process_item()` of `ITEM_PROCESSOR` (`ItemPipelineManager.process_item()` by default)
* `fetch()` of `DOWNLOADER` (`Downloader.fetch()` by default)
* `download_func` passed to `SpiderMiddlewareManager` (`Downloader._enqueue_request()` by default)

To detect this, `scrapy.utils.python.get_func_args_dict()` and `scrapy.utils.deprecate.argument_is_required()` functions are added.

For this PR:
- [ ] Try to fix special handling of `ItemPipelineManager` in the base `{open,close}_spider()`
- [ ] Check whether adding `{open,close}_spider_async()` to `MiddlewareManager` makes more sense here or separately

User impact should be zero for normal workflows that don't call internals and don't replace `DOWNLOADER` and `ITEM_PROCESSOR`.