### PR TITLE
Reducing memory usage of SitemapSpider

### DIFF
--- a/scrapy/spiders/sitemap.py
+++ b/scrapy/spiders/sitemap.py
@@ -91,7 +91,7 @@ class SitemapSpider(Spider):
             # as this Iterable can be long lived
             # and they take much more memory than list of urls
             if s.type == "sitemapindex":
-                urls: list[str] = [
+                urls = [
                     loc
                     for loc in iterloc(it, self.sitemap_alternate_links)
                     if any(x.search(loc) for x in self._follow)
@@ -103,7 +103,7 @@ class SitemapSpider(Spider):
                 for loc in urls:
                     yield Request(loc, callback=self._parse_sitemap)
             elif s.type == "urlset":
-                urls: list[str] = list(iterloc(it, self.sitemap_alternate_links))
+                urls = list(iterloc(it, self.sitemap_alternate_links))
                 del s
                 del it
                 del body


### PR DESCRIPTION
The method `_parse_sitemap` used to return `Iterable`, which held a reference to the response data + parsed XML.

This commit changes the code, so the URLs from the sitemap are extracted immediately. And the reference to response data + parsed XML are freed, which saves a large amount of memory for sites with a large sitemap.

When I executed my crawler without this change, it used 2340 MB after five minutes. With the change, it used only 730 MB after five minutes. (The memory doesn't grow much from there.) I believe there is room for further improvement by saving the URLs to disk and loading them to memory only when needed and/or, in case of nested sitemaps, loading the next sitemap only when all the pages from the previous sitemap were crawled (but I am not sure how those optimizations could be implemented).

Resolves https://github.com/scrapy/scrapy/issues/3529