### PR TITLE
Fix disabling middleware when referencing middleware by object (#6912)

### DIFF
--- a/scrapy/settings/__init__.py
+++ b/scrapy/settings/__init__.py
@@ -314,13 +314,18 @@ class BaseSettings(MutableMapping[_SettingsKeyT, Any]):
         compbs = BaseSettings()
         base_settings = self[name + "_BASE"]
         component_priority_dict = self[name]
-        for cls_path in tuple(base_settings):
-            for cls_or_path in tuple(component_priority_dict):
-                if load_object(cls_or_path) == load_object(cls_path):
-                    del base_settings[cls_path]
-                    break
+        if base_settings:
+            first_key = next(iter(base_settings))
+            if isinstance(first_key, str) and "." in first_key:
+                user_objects = {
+                    load_object(cls_or_path)
+                    for cls_or_path in tuple(component_priority_dict)
+                }
+                for cls_path in tuple(base_settings):
+                    if load_object(cls_path) in user_objects:
+                        del base_settings[cls_path]
         compbs.update(base_settings)
-        compbs.update(self[name])
+        compbs.update(component_priority_dict)
         return compbs
 
     def getpriority(self, name: _SettingsKeyT) -> int | None:

--- a/scrapy/settings/__init__.py
+++ b/scrapy/settings/__init__.py
@@ -314,10 +314,11 @@ class BaseSettings(MutableMapping[_SettingsKeyT, Any]):
         compbs = BaseSettings()
         base_settings = self[name + "_BASE"]
         component_priority_dict = self[name]
-        for cls in tuple(base_settings):
+        for cls_path in tuple(base_settings):
             for cls_or_path in tuple(component_priority_dict):
-                if load_object(cls_or_path) == load_object(cls):
-                    del base_settings[cls]
+                if load_object(cls_or_path) == load_object(cls_path):
+                    del base_settings[cls_path]
+                    break
         compbs.update(base_settings)
         compbs.update(self[name])
         return compbs

--- a/scrapy/settings/__init__.py
+++ b/scrapy/settings/__init__.py
@@ -312,7 +312,13 @@ class BaseSettings(MutableMapping[_SettingsKeyT, Any]):
         if not isinstance(name, str):
             raise ValueError(f"Base setting key must be a string, got {name}")
         compbs = BaseSettings()
-        compbs.update(self[name + "_BASE"])
+        base_settings = self[name + "_BASE"]
+        component_priority_dict = self[name]
+        for cls in tuple(base_settings):
+            for cls_or_path in tuple(component_priority_dict):
+                if load_object(cls_or_path) == load_object(cls):
+                    del base_settings[cls]
+        compbs.update(base_settings)
         compbs.update(self[name])
         return compbs
 

--- a/tests/test_settings/__init__.py
+++ b/tests/test_settings/__init__.py
@@ -402,6 +402,15 @@ class TestBaseSettings:
         assert frozencopy.frozen
         assert frozencopy is not self.settings
 
+    def test_getwithbase_class_object_replacement(self):
+        s = BaseSettings({
+            "TEST_BASE": BaseSettings({"tests.test_settings.Component1": 300}, "project"),
+            "TEST": BaseSettings({"tests.test_settings.Component2": 100}, "default"),
+        })
+        s["TEST"].set(Component1, None, "cmdline")
+        merged = s.getwithbase("TEST")
+        assert "tests.test_settings.Component1" not in merged
+
 
 class TestSettings:
     def setup_method(self):

--- a/tests/test_settings/__init__.py
+++ b/tests/test_settings/__init__.py
@@ -403,10 +403,16 @@ class TestBaseSettings:
         assert frozencopy is not self.settings
 
     def test_getwithbase_class_object_replacement(self):
-        s = BaseSettings({
-            "TEST_BASE": BaseSettings({"tests.test_settings.Component1": 300}, "project"),
-            "TEST": BaseSettings({"tests.test_settings.Component2": 100}, "default"),
-        })
+        s = BaseSettings(
+            {
+                "TEST_BASE": BaseSettings(
+                    {"tests.test_settings.Component1": 300}, "project"
+                ),
+                "TEST": BaseSettings(
+                    {"tests.test_settings.Component2": 100}, "default"
+                ),
+            }
+        )
         s["TEST"].set(Component1, None, "cmdline")
         merged = s.getwithbase("TEST")
         assert "tests.test_settings.Component1" not in merged


### PR DESCRIPTION
Fixes #6912

**Summary**
This PR fixes an issue where middleware cannot be disabled via settings when it is referenced by its callable object instead of a string path.

**What’s Done**
- Implements logic to drop base keys from `settings.getwithbase()` if they are defined by the user.
- This is achieved by comparing the user-specified keys with the base keys, using `load_object()`.
- Adds a test to ensure the expected behavior.

**Note**
- This fix causes the test `TestBaseSettings.test_getwithbase` (in `tests/test_settings/__init__.py`) to fail.
- The reason is that the test uses keys with integer data types, whereas the fix relies on `load_object()` for comparing base and user-defined (which can be class or path) keys.
- I explored alternative approaches but could not find another way to compare the user and base keys.

I’d appreciate feedback on whether this direction is acceptable or if there's another preferred way.


