### PR TITLE
Deprecate spider attribute overrides, add warnings (scrapy#6988)

### DIFF
--- a/scrapy/core/downloader/__init__.py
+++ b/scrapy/core/downloader/__init__.py
@@ -93,9 +93,23 @@ def _get_concurrency_delay(
 ) -> tuple[int, float]:
     delay: float = settings.getfloat("DOWNLOAD_DELAY")
     if hasattr(spider, "download_delay"):
+        warnings.warn(
+            "The 'download_delay' spider attribute is deprecated. "
+            "Use Spider.custom_settings or Spider.update_settings() instead. "
+            "The corresponding setting name is 'DOWNLOAD_DELAY'.",
+            category=ScrapyDeprecationWarning,
+            stacklevel=2,
+        )
         delay = spider.download_delay
 
     if hasattr(spider, "max_concurrent_requests"):
+        warnings.warn(
+            "The 'max_concurrent_requests' spider attribute is deprecated. "
+            "Use Spider.custom_settings or Spider.update_settings() instead. "
+            "The corresponding setting name is 'CONCURRENT_REQUESTS'.",
+            category=ScrapyDeprecationWarning,
+            stacklevel=2,
+        )
         concurrency = spider.max_concurrent_requests
 
     return concurrency, delay

--- a/scrapy/downloadermiddlewares/httpcompression.py
+++ b/scrapy/downloadermiddlewares/httpcompression.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
+import warnings
 from itertools import chain
 from logging import getLogger
 from typing import TYPE_CHECKING, Any
 
 from scrapy import Request, Spider, signals
-from scrapy.exceptions import IgnoreRequest, NotConfigured
+from scrapy.exceptions import IgnoreRequest, NotConfigured, ScrapyDeprecationWarning
 from scrapy.http import Response, TextResponse
 from scrapy.responsetypes import responsetypes
 from scrapy.utils._compression import (
@@ -74,8 +75,22 @@ class HttpCompressionMiddleware:
 
     def open_spider(self, spider: Spider) -> None:
         if hasattr(spider, "download_maxsize"):
+            warnings.warn(
+                "The 'download_maxsize' spider attribute is deprecated. "
+                "Use Spider.custom_settings or Spider.update_settings() instead. "
+                "The corresponding setting name is 'DOWNLOAD_MAXSIZE'.",
+                category=ScrapyDeprecationWarning,
+                stacklevel=2,
+            )
             self._max_size = spider.download_maxsize
         if hasattr(spider, "download_warnsize"):
+            warnings.warn(
+                "The 'download_warnsize' spider attribute is deprecated. "
+                "Use Spider.custom_settings or Spider.update_settings() instead. "
+                "The corresponding setting name is 'DOWNLOAD_WARNSIZE'.",
+                category=ScrapyDeprecationWarning,
+                stacklevel=2,
+            )
             self._warn_size = spider.download_warnsize
 
     def process_request(


### PR DESCRIPTION
Deprecate spider attributes in favor of custom_settings/update_settings()

Add deprecation warnings for the following spider attributes that were
used to override project-level settings before Scrapy 1.0:

- download_delay -> DOWNLOAD_DELAY
- download_maxsize -> DOWNLOAD_MAXSIZE  
- download_warnsize -> DOWNLOAD_WARNSIZE
- max_concurrent_requests -> CONCURRENT_REQUESTS

Each warning includes guidance to use Spider.custom_settings or
Spider.update_settings() instead, along with the corresponding
setting name.

Closes #6988