### PR TITLE
Fix FilesPipeline for  not handling HTTP 201 Created responses (#1615)

### DIFF
--- a/scrapy/pipelines/files.py
+++ b/scrapy/pipelines/files.py
@@ -638,7 +638,31 @@ class FilesPipeline(MediaPipeline):
     ) -> FileInfo:
         referer = referer_str(request)
 
-        if response.status != 200:
+        # Enhanced handling for 201 Created responses
+        if response.status == 201:
+            if not response.body:
+                # If there's no body, check for Location header
+                location = response.headers.get(b"Location")
+                if location:
+                    new_url = location.decode()
+                    logger.debug(
+                        "File (201): no body, following Location header to %(new_url)s "
+                        "(referer: %(referer)s)",
+                        {"new_url": new_url, "referer": referer},
+                        extra={"spider": info.spider},
+                    )
+                    # Create new request to the Location URL
+                    new_request = request.replace(url=new_url, dont_filter=True)
+                    response = self._download_func(new_request, info.spider)
+                else:
+                    logger.warning(
+                        "File (201): no body and no Location header for %(request)s",
+                        {"request": request},
+                        extra={"spider": info.spider},
+                    )
+                    raise FileException("no-content-or-location")
+                    
+        if response.status not in (200, 201):
             logger.warning(
                 "File (code: %(status)s): Error downloading file from "
                 "%(request)s referred in <%(referer)s>",

--- a/tests/test_pipeline_files.py
+++ b/tests/test_pipeline_files.py
@@ -804,36 +804,36 @@ class TestBuildFromCrawler:
             assert pipe.store
             assert pipe._from_crawler_called
 
-    def test_media_downloaded_accepts_201_created(tmp_path):
-        # Define a simple spider class for testing
-        class DummySpider(Spider):
-            name = "dummy"
+def test_media_downloaded_accepts_201_created(tmp_path):
+    # Define a simple spider class for testing
+    class DummySpider(Spider):
+        name = "dummy"
 
-        # Define a simple pipeline that always saves to the same file name
-        class DummyPipeline(FilesPipeline):
-            def file_path(self, request, response=None, info=None, *, item=None):
-                return "201test.txt"
+    # Define a simple pipeline that always saves to the same file name
+    class DummyPipeline(FilesPipeline):
+        def file_path(self, request, response=None, info=None, *, item=None):
+            return "201test.txt"
 
-        # Create a crawler and pipeline instance
-        crawler = get_crawler(DummySpider)
-        pipeline = DummyPipeline(store_uri=str(tmp_path), crawler=crawler)
+    # Create a crawler and pipeline instance
+    crawler = get_crawler(DummySpider)
+    pipeline = DummyPipeline(store_uri=str(tmp_path), crawler=crawler)
 
-        # Create a request and a response with status 201 (Created)
-        request = Request(url="http://example.com/testfile.png")
-        response = Response(
-            url="http://example.com/testfile.png",
-            status=201,
-            body=b"fake image content",
-            request=request
-        )
+    # Create a request and a response with status 201 (Created)
+    request = Request(url="http://example.com/testfile.png")
+    response = Response(
+        url="http://example.com/testfile.png",
+        status=201,
+        body=b"fake image content",
+        request=request
+    )
 
-        # Get the spider info object
-        info = pipeline.spiderinfo(crawler.spider)
+    # Get the spider info object
+    info = pipeline.spiderinfo(crawler.spider)
 
-        # Call the media_downloaded method
-        result = pipeline.media_downloaded(response, request, info=info)
+    # Call the media_downloaded method
+    result = pipeline.media_downloaded(response, request, info=info)
 
-        # Check the results
-        assert result["status"] == "downloaded"
-        assert "checksum" in result
-        assert result["path"] == "201test.txt"
+    # Check the results
+    assert result["status"] == "downloaded"
+    assert "checksum" in result
+    assert result["path"] == "201test.txt"

--- a/tests/test_pipeline_files.py
+++ b/tests/test_pipeline_files.py
@@ -14,6 +14,7 @@ from tempfile import mkdtemp
 from typing import Any
 from unittest import mock
 from urllib.parse import urlparse
+from scrapy.spiders import Spider
 
 import attr
 import pytest
@@ -802,3 +803,37 @@ class TestBuildFromCrawler:
             assert len(w) == 0
             assert pipe.store
             assert pipe._from_crawler_called
+
+    def test_media_downloaded_accepts_201_created(tmp_path):
+        # Define a simple spider class for testing
+        class DummySpider(Spider):
+            name = "dummy"
+
+        # Define a simple pipeline that always saves to the same file name
+        class DummyPipeline(FilesPipeline):
+            def file_path(self, request, response=None, info=None, *, item=None):
+                return "201test.txt"
+
+        # Create a crawler and pipeline instance
+        crawler = get_crawler(DummySpider)
+        pipeline = DummyPipeline(store_uri=str(tmp_path), crawler=crawler)
+
+        # Create a request and a response with status 201 (Created)
+        request = Request(url="http://example.com/testfile.png")
+        response = Response(
+            url="http://example.com/testfile.png",
+            status=201,
+            body=b"fake image content",
+            request=request
+        )
+
+        # Get the spider info object
+        info = pipeline.spiderinfo(crawler.spider)
+
+        # Call the media_downloaded method
+        result = pipeline.media_downloaded(response, request, info=info)
+
+        # Check the results
+        assert result["status"] == "downloaded"
+        assert "checksum" in result
+        assert result["path"] == "201test.txt"


### PR DESCRIPTION
addresses issue #1615 by allowing the FilesPipeline to correctly handle HTTP 201 responses during file downloads

 Summary of Changes:
- Updated `media_downloaded` in `scrapy/pipelines/files.py` to accept both 200 and 201 status codes.
- Added support for checking the "Location" header if a 201 response returns without a body.
- Created a unit test (`test_media_downloaded_accepts_201_created`) under `tests/test_pipeline_files.py` to confirm correct behavior with 201 responses and file saving.


This ensures those valid downloads are saved correctly.

 Testing:
- Ran locally with tox -e and tox -- tests/test_pipeline_files.py and passed. 
Please let me know if anything doesn't work as expected or if any adjustments are needed.