### PR TITLE
fix: replace non-typing asserts in getdictorlist with explicit TypeError

### DIFF
--- a/scrapy/settings/__init__.py
+++ b/scrapy/settings/__init__.py
@@ -293,15 +293,21 @@ class BaseSettings(MutableMapping[_SettingsKeyT, Any]):
         if isinstance(value, str):
             try:
                 value_loaded = json.loads(value)
-                assert isinstance(value_loaded, (dict, list))
+                if not isinstance(value_loaded, (dict, list)):
+                    raise TypeError(
+                        f"Expected JSON string to decode to dict or list, got {type(value_loaded).__name__}"
+                    )
                 return value_loaded
             except ValueError:
                 return value.split(",")
         if isinstance(value, tuple):
             return list(value)
-        assert isinstance(value, (dict, list))
+        if not isinstance(value, (dict, list)):
+            raise TypeError(
+                f"Expected dict or list, got {type(value).__name__}"
+            )
         return copy.deepcopy(value)
-
+    
     def getwithbase(self, name: _SettingsKeyT) -> BaseSettings:
         """Get a composition of a dictionary-like setting and its `_BASE`
         counterpart.


### PR DESCRIPTION
### Summary
Replaced the use of bare `assert` statements in `getdictorlist()` with explicit `TypeError` exceptions.

### Why
- Bare asserts can be disabled with Python optimizations (`-O` flag).
- Explicit exceptions ensure type checking is always enforced.

### Changes
- Added explicit `TypeError` when the loaded value is not a dict or list.
- Added explicit `TypeError` when the final value is not a dict or list.

### Testing
Verified locally with a custom test script:
- Dict, list, JSON string, tuple → returned as expected.
- Invalid type (int) → raised `TypeError` with descriptive message.

Fixes #6876
