### PR TITLE
Fix getwithbase() to drop base keys when there is a setting value  (#6912)

### DIFF
--- a/tests/test_settings/__init__.py
+++ b/tests/test_settings/__init__.py
@@ -402,6 +402,21 @@ class TestBaseSettings:
         assert frozencopy.frozen
         assert frozencopy is not self.settings
 
+    def test_getwithbase_resolves_duplicate_keys(self):
+        settings = BaseSettings()
+        base_settings = BaseSettings({'builtins.dict': 500})
+        settings['TEST_BASE'] = base_settings
+ 
+        custom_settings = BaseSettings({dict: None})
+        settings['TEST'] = custom_settings
+        
+        result = settings.getwithbase('TEST')
+        result_dict = dict(result)
+        
+        assert 'builtins.dict' in result_dict
+        assert result_dict['builtins.dict'] is None
+        assert len(result_dict) == 1
+
 
 class TestSettings:
     def setup_method(self):


### PR DESCRIPTION
Resolves Issue #6912

Fixes code in Settings.getwithbase() to drop base keys when the setting value already has them. 
Logs a warning in getwithbase() when duplicate keys are detected (e.g., both "foo.Foo" and Foo present).
Test getwithbase() resolves duplicate keys when merging base and custom settings.