### PR TITLE
Add ItemPipelineManager.process_item_async() and ensure_awaitable().

### DIFF
--- a/scrapy/core/downloader/middleware.py
+++ b/scrapy/core/downloader/middleware.py
@@ -50,7 +50,7 @@ class DownloaderMiddlewareManager(MiddlewareManager):
         if argument_is_required(download_func, "spider"):
             warnings.warn(
                 "The spider argument of download_func is deprecated"
-                " and will not be passed in the future Scrapy versions.",
+                " and will not be passed in future Scrapy versions.",
                 ScrapyDeprecationWarning,
                 stacklevel=2,
             )

--- a/scrapy/core/engine.py
+++ b/scrapy/core/engine.py
@@ -137,7 +137,7 @@ class ExecutionEngine:
             if self._downloader_fetch_needs_spider:
                 warnings.warn(
                     f"The fetch() method of {global_object_name(downloader_cls)} requires a spider argument,"
-                    f" this is deprecated and the argument will not be passed in the future Scrapy versions.",
+                    f" this is deprecated and the argument will not be passed in future Scrapy versions.",
                     ScrapyDeprecationWarning,
                     stacklevel=2,
                 )

--- a/scrapy/core/scraper.py
+++ b/scrapy/core/scraper.py
@@ -117,7 +117,7 @@ class Scraper:
         if not hasattr(self.itemproc, "process_item_async"):
             warnings.warn(
                 f"{global_object_name(itemproc_cls)} doesn't define a process_item_async() method,"
-                f" this is deprecated and the method will be required in the future Scrapy versions.",
+                f" this is deprecated and the method will be required in future Scrapy versions.",
                 ScrapyDeprecationWarning,
                 stacklevel=2,
             )
@@ -132,7 +132,7 @@ class Scraper:
         ):
             warnings.warn(
                 f"{global_object_name(itemproc_cls)} overrides process_item() but doesn't override process_item_async()."
-                f" This is deprecated. process_item() will be used, but in the future Scrapy versions process_item_async() will be used instead.",
+                f" This is deprecated. process_item() will be used, but in future Scrapy versions process_item_async() will be used instead.",
                 ScrapyDeprecationWarning,
                 stacklevel=2,
             )
@@ -148,7 +148,7 @@ class Scraper:
             if self._itemproc_needs_spider[method]:
                 warnings.warn(
                     f"The {method}() method of {global_object_name(itemproc_cls)} requires a spider argument,"
-                    f" this is deprecated and the argument will not be passed in the future Scrapy versions.",
+                    f" this is deprecated and the argument will not be passed in future Scrapy versions.",
                     ScrapyDeprecationWarning,
                     stacklevel=2,
                 )

--- a/scrapy/core/scraper.py
+++ b/scrapy/core/scraper.py
@@ -9,7 +9,7 @@ from collections import deque
 from collections.abc import AsyncIterator
 from typing import TYPE_CHECKING, Any, TypeVar, Union
 
-from twisted.internet.defer import Deferred, inlineCallbacks, maybeDeferred
+from twisted.internet.defer import Deferred, inlineCallbacks
 from twisted.python.failure import Failure
 
 from scrapy import Spider, signals
@@ -21,6 +21,7 @@ from scrapy.exceptions import (
     ScrapyDeprecationWarning,
 )
 from scrapy.http import Request, Response
+from scrapy.pipelines import ItemPipelineManager
 from scrapy.utils.asyncio import _parallel_asyncio, is_asyncio_available
 from scrapy.utils.defer import (
     _defer_sleep_async,
@@ -28,12 +29,13 @@ from scrapy.utils.defer import (
     aiter_errback,
     deferred_f_from_coro_f,
     deferred_from_coro,
+    ensure_awaitable,
     iter_errback,
     maybe_deferred_to_future,
     parallel,
     parallel_async,
 )
-from scrapy.utils.deprecate import argument_is_required
+from scrapy.utils.deprecate import argument_is_required, method_is_overridden
 from scrapy.utils.log import failure_to_exc_info, logformatter_adapter
 from scrapy.utils.misc import load_object, warn_on_generator_with_return_value
 from scrapy.utils.python import global_object_name
@@ -44,7 +46,6 @@ if TYPE_CHECKING:
 
     from scrapy.crawler import Crawler
     from scrapy.logformatter import LogFormatter
-    from scrapy.pipelines import ItemPipelineManager
     from scrapy.signalmanager import SignalManager
 
 
@@ -109,12 +110,38 @@ class Scraper:
             crawler.settings["ITEM_PROCESSOR"]
         )
         self.itemproc: ItemPipelineManager = itemproc_cls.from_crawler(crawler)
-        self._itemproc_needs_spider: dict[str, bool] = {}
-        for method in (
+        itemproc_methods = [
             "open_spider",
             "close_spider",
-            "process_item",
+        ]
+        if not hasattr(self.itemproc, "process_item_async"):
+            warnings.warn(
+                f"{global_object_name(itemproc_cls)} doesn't define a process_item_async() method,"
+                f" this is deprecated and the method will be required in the future Scrapy versions.",
+                ScrapyDeprecationWarning,
+                stacklevel=2,
+            )
+            itemproc_methods.append("process_item")
+            self._itemproc_has_process_async = False
+        elif (
+            issubclass(itemproc_cls, ItemPipelineManager)
+            and method_is_overridden(itemproc_cls, ItemPipelineManager, "process_item")
+            and not method_is_overridden(
+                itemproc_cls, ItemPipelineManager, "process_item_async"
+            )
         ):
+            warnings.warn(
+                f"{global_object_name(itemproc_cls)} overrides process_item() but doesn't override process_item_async()."
+                f" This is deprecated. process_item() will be used, but in the future Scrapy versions process_item_async() will be used instead.",
+                ScrapyDeprecationWarning,
+                stacklevel=2,
+            )
+            itemproc_methods.append("process_item")
+            self._itemproc_has_process_async = False
+        else:
+            self._itemproc_has_process_async = True
+        self._itemproc_needs_spider: dict[str, bool] = {}
+        for method in itemproc_methods:
             self._itemproc_needs_spider[method] = argument_is_required(
                 getattr(self.itemproc, method), "spider"
             )
@@ -125,6 +152,7 @@ class Scraper:
                     ScrapyDeprecationWarning,
                     stacklevel=2,
                 )
+
         self.concurrent_items: int = crawler.settings.getint("CONCURRENT_ITEMS")
         self.crawler: Crawler = crawler
         self.signals: SignalManager = crawler.signals
@@ -305,9 +333,7 @@ class Scraper:
                 output.raiseException()
             # else the errback returned actual output (like a callback),
             # which needs to be passed to iterate_spider_output()
-        return await maybe_deferred_to_future(
-            maybeDeferred(iterate_spider_output, output)
-        )
+        return await ensure_awaitable(iterate_spider_output(output))
 
     def handle_spider_error(
         self,
@@ -467,11 +493,14 @@ class Scraper:
         assert self.crawler.spider is not None  # typing
         self.slot.itemproc_size += 1
         try:
-            if self._itemproc_needs_spider["process_item"]:
-                d = self.itemproc.process_item(item, self.crawler.spider)
+            if self._itemproc_has_process_async:
+                output = await self.itemproc.process_item_async(item)
             else:
-                d = self.itemproc.process_item(item)
-            output = await maybe_deferred_to_future(d)
+                if self._itemproc_needs_spider["process_item"]:
+                    d = self.itemproc.process_item(item, self.crawler.spider)
+                else:
+                    d = self.itemproc.process_item(item)
+                output = await maybe_deferred_to_future(d)
         except DropItem as ex:
             logkws = self.logformatter.dropped(item, ex, response, self.crawler.spider)
             if logkws is not None:

--- a/scrapy/core/spidermw.py
+++ b/scrapy/core/spidermw.py
@@ -420,15 +420,13 @@ class SpiderMiddlewareManager(MiddlewareManager):
         self._check_deprecated_start_requests_use()
         if self._use_start_requests:
             sync_start = iter(self._spider.start_requests())
-            sync_start = await maybe_deferred_to_future(
-                self._process_chain("process_start_requests", sync_start, self._spider)
+            sync_start = await self._process_chain(
+                "process_start_requests", sync_start, self._spider
             )
             start: AsyncIterator[Any] = as_async_generator(sync_start)
         else:
             start = self._spider.start()
-            start = await maybe_deferred_to_future(
-                self._process_chain("process_start", start)
-            )
+            start = await self._process_chain("process_start", start)
         return start
 
     def _check_deprecated_start_requests_use(self):

--- a/scrapy/middleware.py
+++ b/scrapy/middleware.py
@@ -8,7 +8,7 @@ from collections import defaultdict, deque
 from typing import TYPE_CHECKING, Any, TypeVar, cast
 
 from scrapy.exceptions import NotConfigured, ScrapyDeprecationWarning
-from scrapy.utils.defer import process_chain, process_parallel
+from scrapy.utils.defer import _process_chain, process_parallel
 from scrapy.utils.misc import build_from_crawler, load_object
 from scrapy.utils.python import global_object_name
 
@@ -172,11 +172,11 @@ class MiddlewareManager(ABC):
         )
         return process_parallel(methods, obj, *args)
 
-    def _process_chain(self, methodname: str, obj: _T, *args: Any) -> Deferred[_T]:
+    async def _process_chain(self, methodname: str, obj: _T, *args: Any) -> _T:
         methods = cast(
             "Iterable[Callable[Concatenate[_T, _P], _T]]", self.methods[methodname]
         )
-        return process_chain(methods, obj, *args)
+        return await _process_chain(methods, obj, *args)
 
     def open_spider(self, spider: Spider | None = None) -> Deferred[list[None]]:
         if spider:

--- a/scrapy/pipelines/__init__.py
+++ b/scrapy/pipelines/__init__.py
@@ -6,11 +6,14 @@ See documentation in docs/item-pipeline.rst
 
 from __future__ import annotations
 
+import warnings
 from typing import TYPE_CHECKING, Any
 
+from scrapy.exceptions import ScrapyDeprecationWarning
 from scrapy.middleware import MiddlewareManager
 from scrapy.utils.conf import build_component_list
-from scrapy.utils.defer import deferred_f_from_coro_f
+from scrapy.utils.defer import deferred_from_coro
+from scrapy.utils.python import global_object_name
 
 if TYPE_CHECKING:
     from twisted.internet.defer import Deferred
@@ -29,12 +32,17 @@ class ItemPipelineManager(MiddlewareManager):
     def _add_middleware(self, pipe: Any) -> None:
         super()._add_middleware(pipe)
         if hasattr(pipe, "process_item"):
-            self.methods["process_item"].append(
-                deferred_f_from_coro_f(pipe.process_item)
-            )
+            self.methods["process_item"].append(pipe.process_item)
 
     def process_item(self, item: Any, spider: Spider | None = None) -> Deferred[Any]:
         if spider:
-            self._warn_spider_arg("process_item")
             self._set_compat_spider(spider)
-        return self._process_chain("process_item", item, self._spider)
+        warnings.warn(
+            f"{global_object_name(type(self))}.process_item() is deprecated, use process_item_async() instead.",
+            category=ScrapyDeprecationWarning,
+            stacklevel=2,
+        )
+        return deferred_from_coro(self.process_item_async(item))
+
+    async def process_item_async(self, item: Any) -> Any:
+        return await self._process_chain("process_item", item, self._spider)

--- a/scrapy/utils/deprecate.py
+++ b/scrapy/utils/deprecate.py
@@ -183,6 +183,8 @@ def method_is_overridden(subclass: type, base_class: type, method_name: str) -> 
     ...         pass
     >>> class Sub4(Sub2):
     ...     pass
+    >>> method_is_overridden(Base, Base, 'foo')
+    False
     >>> method_is_overridden(Sub1, Base, 'foo')
     False
     >>> method_is_overridden(Sub2, Base, 'foo')

--- a/tests/test_pipelines.py
+++ b/tests/test_pipelines.py
@@ -1,12 +1,13 @@
 import asyncio
 
 import pytest
-from twisted.internet.defer import Deferred, inlineCallbacks
+from twisted.internet.defer import Deferred, inlineCallbacks, succeed
 
 from scrapy import Request, Spider, signals
 from scrapy.exceptions import ScrapyDeprecationWarning
 from scrapy.pipelines import ItemPipelineManager
 from scrapy.utils.asyncio import call_later
+from scrapy.utils.conf import build_component_list
 from scrapy.utils.defer import (
     deferred_f_from_coro_f,
     deferred_to_future,
@@ -147,20 +148,48 @@ class TestCustomPipelineManager:
         itemproc = CustomPipelineManager.from_crawler(crawler)
         with pytest.warns(
             ScrapyDeprecationWarning,
-            match=r"Passing a spider argument to CustomPipelineManager.process_item\(\) is deprecated",
+            match=r"CustomPipelineManager.process_item\(\) is deprecated, use process_item_async\(\)",
         ):
             itemproc.process_item({}, crawler.spider)
 
     @deferred_f_from_coro_f
-    async def test_deprecated_spider_arg_integration(
-        self, mockserver: MockServer
-    ) -> None:
+    async def test_integration_recommended(self, mockserver: MockServer) -> None:
+        class CustomPipelineManager(ItemPipelineManager):
+            async def process_item_async(self, item):
+                return await super().process_item_async(item)
+
+        items = []
+
+        def _on_item_scraped(item):
+            assert isinstance(item, dict)
+            assert item.get("pipeline_passed")
+            items.append(item)
+
+        crawler = get_crawler(
+            ItemSpider,
+            {
+                "ITEM_PROCESSOR": CustomPipelineManager,
+                "ITEM_PIPELINES": {SimplePipeline: 1},
+            },
+        )
+        crawler.spider = crawler._create_spider()
+        crawler.signals.connect(_on_item_scraped, signals.item_scraped)
+        await maybe_deferred_to_future(crawler.crawl(mockserver=mockserver))
+
+        assert len(items) == 1
+
+    @deferred_f_from_coro_f
+    async def test_integration_no_async_subclass(self, mockserver: MockServer) -> None:
         class CustomPipelineManager(ItemPipelineManager):
             def open_spider(self, spider):  # pylint: disable=signature-differs
                 return super().open_spider(spider)
 
             def process_item(self, item, spider):  # pylint: disable=signature-differs
-                return super().process_item(item, spider)
+                with pytest.warns(
+                    ScrapyDeprecationWarning,
+                    match=r"CustomPipelineManager.process_item\(\) is deprecated, use process_item_async\(\)",
+                ):
+                    return super().process_item(item, spider)
 
         items = []
 
@@ -193,7 +222,73 @@ class TestCustomPipelineManager:
             ),
             pytest.warns(
                 ScrapyDeprecationWarning,
-                match=r"Passing a spider argument to CustomPipelineManager.process_item\(\) is deprecated",
+                match=r"CustomPipelineManager overrides process_item\(\) but doesn't override process_item_async\(\)",
+            ),
+        ):
+            await maybe_deferred_to_future(crawler.crawl(mockserver=mockserver))
+
+        assert len(items) == 1
+
+    @deferred_f_from_coro_f
+    async def test_integration_no_async_not_subclass(
+        self, mockserver: MockServer
+    ) -> None:
+        class CustomPipelineManager:
+            def __init__(self, crawler):
+                self.pipelines = [
+                    p()
+                    for p in build_component_list(
+                        crawler.settings.getwithbase("ITEM_PIPELINES")
+                    )
+                ]
+
+            @classmethod
+            def from_crawler(cls, crawler):
+                return cls(crawler)
+
+            def open_spider(self, spider):
+                return succeed(None)
+
+            def close_spider(self, spider):
+                return succeed(None)
+
+            def process_item(self, item, spider):
+                for pipeline in self.pipelines:
+                    item = pipeline.process_item(item, spider)
+                return succeed(item)
+
+        items = []
+
+        def _on_item_scraped(item):
+            assert isinstance(item, dict)
+            assert item.get("pipeline_passed")
+            items.append(item)
+
+        crawler = get_crawler(
+            ItemSpider,
+            {
+                "ITEM_PROCESSOR": CustomPipelineManager,
+                "ITEM_PIPELINES": {SimplePipeline: 1},
+            },
+        )
+        crawler.spider = crawler._create_spider()
+        crawler.signals.connect(_on_item_scraped, signals.item_scraped)
+        with (
+            pytest.warns(
+                ScrapyDeprecationWarning,
+                match=r"CustomPipelineManager doesn't define a process_item_async\(\) method",
+            ),
+            pytest.warns(
+                ScrapyDeprecationWarning,
+                match=r"The open_spider\(\) method of .+\.CustomPipelineManager requires a spider argument",
+            ),
+            pytest.warns(
+                ScrapyDeprecationWarning,
+                match=r"The close_spider\(\) method of .+\.CustomPipelineManager requires a spider argument",
+            ),
+            pytest.warns(
+                ScrapyDeprecationWarning,
+                match=r"The process_item\(\) method of .+\.CustomPipelineManager requires a spider argument",
             ),
         ):
             await maybe_deferred_to_future(crawler.crawl(mockserver=mockserver))


### PR DESCRIPTION
Maybe we should also deprecate `ITEM_PROCESSOR` values that aren't subclasses of `ItemPipelineManager` (considering how much code do you need in even a minimal `ITEM_PROCESSOR` if not subclassing that, it's unlikely that those implementations exist, but I'm not sure if the benefits to us from this deprecation are noticeable).