### PR TITLE
Deprecate spider args of middlewares and pipelines.

### DIFF
--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -349,7 +349,7 @@ method for this purpose. For example:
 
 
     class MultiplyItemsMiddleware:
-        def process_spider_output(self, response, result, spider):
+        def process_spider_output(self, response, result):
             for item_or_request in result:
                 if isinstance(item_or_request, Request):
                     continue

--- a/docs/news.rst
+++ b/docs/news.rst
@@ -48,7 +48,7 @@ Backward-incompatible changes
     handling ``open_spider()`` and ``close_spider()`` component methods. As
     this code was only used for pipelines it was moved into
     :class:`scrapy.pipelines.ItemPipelineManager`. This change should only
-    affect custom subclasses of :class:`scrapy.middleware.~MiddlewareManager`.
+    affect custom subclasses of :class:`~scrapy.middleware.MiddlewareManager`.
     The following code was moved:
 
     - ``scrapy.middleware.MiddlewareManager.open_spider()``

--- a/docs/news.rst
+++ b/docs/news.rst
@@ -44,6 +44,20 @@ Backward-incompatible changes
 
         - :meth:`~scrapy.spidermiddlewares.referer.ReferrerPolicy.referrer`
 
+-   :class:`scrapy.middleware.MiddlewareManager` no longer includes code for
+    handling ``open_spider()`` and ``close_spider()`` component methods. As
+    this code was only used for pipelines it was moved into
+    :class:`scrapy.pipelines.ItemPipelineManager`. This change should only
+    affect custom subclasses of :class:`scrapy.middleware.~MiddlewareManager`.
+    The following code was moved:
+
+    - ``scrapy.middleware.MiddlewareManager.open_spider()``
+
+    - ``scrapy.middleware.MiddlewareManager.close_spider()``
+
+    - Code in ``scrapy.middleware.MiddlewareManager._add_middleware()`` that
+      processes ``open_spider()`` and ``close_spider()`` component methods.
+
 
 .. _release-2.13.3:
 

--- a/docs/topics/coroutines.rst
+++ b/docs/topics/coroutines.rst
@@ -191,7 +191,7 @@ shorter and cleaner:
             adapter["field"] = data
             return item
 
-        def process_item(self, item, spider):
+        def process_item(self, item):
             adapter = ItemAdapter(item)
             dfd = db.get_some_data(adapter["id"])
             dfd.addCallback(self._update_item, item)
@@ -205,7 +205,7 @@ becomes:
 
 
     class DbPipeline:
-        async def process_item(self, item, spider):
+        async def process_item(self, item):
             adapter = ItemAdapter(item)
             adapter["field"] = await db.get_some_data(adapter["id"])
             return item
@@ -421,12 +421,12 @@ For example:
 .. code-block:: python
 
     class UniversalSpiderMiddleware:
-        def process_spider_output(self, response, result, spider):
+        def process_spider_output(self, response, result):
             for r in result:
                 # ... do something with r
                 yield r
 
-        async def process_spider_output_async(self, response, result, spider):
+        async def process_spider_output_async(self, response, result):
             async for r in result:
                 # ... do something with r
                 yield r

--- a/docs/topics/exporters.rst
+++ b/docs/topics/exporters.rst
@@ -67,7 +67,7 @@ value of one of their fields:
                 self.year_to_exporter[year] = (exporter, xml_file)
             return self.year_to_exporter[year][0]
 
-        def process_item(self, item, spider):
+        def process_item(self, item):
             exporter = self._exporter_for_item(item)
             exporter.export_item(item)
             return item

--- a/docs/topics/item-pipeline.rst
+++ b/docs/topics/item-pipeline.rst
@@ -26,7 +26,7 @@ Writing your own item pipeline
 Each item pipeline is a :ref:`component <topics-components>` that must
 implement the following method:
 
-.. method:: process_item(self, item, spider)
+.. method:: process_item(self, item)
 
    This method is called for every item pipeline component.
 
@@ -42,24 +42,15 @@ implement the following method:
    :param item: the scraped item
    :type item: :ref:`item object <item-types>`
 
-   :param spider: the spider which scraped the item
-   :type spider: :class:`~scrapy.Spider` object
-
 Additionally, they may also implement the following methods:
 
-.. method:: open_spider(self, spider)
+.. method:: open_spider(self)
 
    This method is called when the spider is opened.
 
-   :param spider: the spider which was opened
-   :type spider: :class:`~scrapy.Spider` object
-
-.. method:: close_spider(self, spider)
+.. method:: close_spider(self)
 
    This method is called when the spider is closed.
-
-   :param spider: the spider which was closed
-   :type spider: :class:`~scrapy.Spider` object
 
 
 Item pipeline example
@@ -82,7 +73,7 @@ contain a price:
     class PricePipeline:
         vat_factor = 1.15
 
-        def process_item(self, item, spider):
+        def process_item(self, item):
             adapter = ItemAdapter(item)
             if adapter.get("price"):
                 if adapter.get("price_excludes_vat"):
@@ -107,13 +98,13 @@ format:
 
 
    class JsonWriterPipeline:
-       def open_spider(self, spider):
+       def open_spider(self):
            self.file = open("items.jsonl", "w")
 
-       def close_spider(self, spider):
+       def close_spider(self):
            self.file.close()
 
-       def process_item(self, item, spider):
+       def process_item(self, item):
            line = json.dumps(ItemAdapter(item).asdict()) + "\n"
            self.file.write(line)
            return item
@@ -153,14 +144,14 @@ The main point of this example is to show how to :ref:`get the crawler
                 mongo_db=crawler.settings.get("MONGO_DATABASE", "items"),
             )
 
-        def open_spider(self, spider):
+        def open_spider(self):
             self.client = pymongo.MongoClient(self.mongo_uri)
             self.db = self.client[self.mongo_db]
 
-        def close_spider(self, spider):
+        def close_spider(self):
             self.client.close()
 
-        def process_item(self, item, spider):
+        def process_item(self, item):
             self.db[self.collection_name].insert_one(ItemAdapter(item).asdict())
             return item
 
@@ -198,12 +189,19 @@ item.
 
         SPLASH_URL = "http://localhost:8050/render.png?url={}"
 
-        async def process_item(self, item, spider):
+        def __init__(crawler):
+            self.crawler = crawler
+
+        @classmethod
+        def from_crawler(cls, crawler):
+            return cls(crawler)
+
+        async def process_item(self, item):
             adapter = ItemAdapter(item)
             encoded_item_url = quote(adapter["url"])
             screenshot_url = self.SPLASH_URL.format(encoded_item_url)
             request = scrapy.Request(screenshot_url, callback=NO_CALLBACK)
-            response = await spider.crawler.engine.download_async(request)
+            response = await self.crawler.engine.download_async(request)
 
             if response.status != 200:
                 # Error happened, return item.
@@ -238,7 +236,7 @@ returns multiples items with the same id:
         def __init__(self):
             self.ids_seen = set()
 
-        def process_item(self, item, spider):
+        def process_item(self, item):
             adapter = ItemAdapter(item)
             if adapter["id"] in self.ids_seen:
                 raise DropItem(f"Item ID already seen: {adapter['id']}")

--- a/docs/topics/settings.rst
+++ b/docs/topics/settings.rst
@@ -554,7 +554,7 @@ When writing an item pipeline, you can force a different log level by setting
 
 
    class MyPipeline:
-       def process_item(self, item, spider):
+       def process_item(self, item):
            if not item.get("price"):
                raise DropItem("Missing price data", log_level="INFO")
            return item

--- a/docs/topics/spider-middleware.rst
+++ b/docs/topics/spider-middleware.rst
@@ -94,7 +94,7 @@ one or more of these methods:
             def process_start_requests(self, start, spider):
                 yield from start
 
-    .. method:: process_spider_input(response, spider)
+    .. method:: process_spider_input(response)
 
         This method is called for each response that goes through the spider
         middleware and into the spider, for processing.
@@ -116,11 +116,7 @@ one or more of these methods:
         :param response: the response being processed
         :type response: :class:`~scrapy.http.Response` object
 
-        :param spider: the spider for which this response is intended
-        :type spider: :class:`~scrapy.Spider` object
-
-
-    .. method:: process_spider_output(response, result, spider)
+    .. method:: process_spider_output(response, result)
 
         This method is called with the results returned from the Spider, after
         it has processed the response.
@@ -149,10 +145,7 @@ one or more of these methods:
         :type result: an iterable of :class:`~scrapy.Request` objects and
           :ref:`item objects <topics-items>`
 
-        :param spider: the spider whose result is being processed
-        :type spider: :class:`~scrapy.Spider` object
-
-    .. method:: process_spider_output_async(response, result, spider)
+    .. method:: process_spider_output_async(response, result)
         :async:
 
         .. versionadded:: 2.7
@@ -161,7 +154,7 @@ one or more of these methods:
         which will be called instead of :meth:`process_spider_output` if
         ``result`` is an :term:`asynchronous iterable`.
 
-    .. method:: process_spider_exception(response, exception, spider)
+    .. method:: process_spider_exception(response, exception)
 
         This method is called when a spider or :meth:`process_spider_output`
         method (from a previous spider middleware) raises an exception.
@@ -186,8 +179,6 @@ one or more of these methods:
         :param exception: the exception raised
         :type exception: :exc:`Exception` object
 
-        :param spider: the spider which raised the exception
-        :type spider: :class:`~scrapy.Spider` object
 
 Base class for custom spider middlewares
 ----------------------------------------

--- a/scrapy/core/spidermw.py
+++ b/scrapy/core/spidermw.py
@@ -117,8 +117,6 @@ class SpiderMiddlewareManager(MiddlewareManager):
             )
 
     def _add_middleware(self, mw: Any) -> None:
-        super()._add_middleware(mw)
-
         if hasattr(mw, "process_spider_input"):
             self.methods["process_spider_input"].append(mw.process_spider_input)
             self._check_mw_method_spider_arg(mw.process_spider_input)

--- a/scrapy/core/spidermw.py
+++ b/scrapy/core/spidermw.py
@@ -446,7 +446,7 @@ class SpiderMiddlewareManager(MiddlewareManager):
         if self._use_start_requests:
             sync_start = iter(self._spider.start_requests())
             sync_start = await self._process_chain(
-                "process_start_requests", sync_start, self._spider
+                "process_start_requests", sync_start, always_add_spider=True
             )
             start: AsyncIterator[Any] = as_async_generator(sync_start)
         else:

--- a/scrapy/core/spidermw.py
+++ b/scrapy/core/spidermw.py
@@ -118,8 +118,11 @@ class SpiderMiddlewareManager(MiddlewareManager):
 
     def _add_middleware(self, mw: Any) -> None:
         super()._add_middleware(mw)
+
         if hasattr(mw, "process_spider_input"):
             self.methods["process_spider_input"].append(mw.process_spider_input)
+            self._check_mw_method_spider_arg(mw.process_spider_input)
+
         if self._use_start_requests:
             if hasattr(mw, "process_start_requests"):
                 self.methods["process_start_requests"].appendleft(
@@ -127,10 +130,19 @@ class SpiderMiddlewareManager(MiddlewareManager):
                 )
         elif hasattr(mw, "process_start"):
             self.methods["process_start"].appendleft(mw.process_start)
+
         process_spider_output = self._get_async_method_pair(mw, "process_spider_output")
         self.methods["process_spider_output"].appendleft(process_spider_output)
+        if callable(process_spider_output):
+            self._check_mw_method_spider_arg(process_spider_output)
+        elif isinstance(process_spider_output, tuple):
+            for m in process_spider_output:
+                self._check_mw_method_spider_arg(m)
+
         process_spider_exception = getattr(mw, "process_spider_exception", None)
         self.methods["process_spider_exception"].appendleft(process_spider_exception)
+        if process_spider_exception is not None:
+            self._check_mw_method_spider_arg(process_spider_exception)
 
     async def _process_spider_input(
         self,
@@ -141,7 +153,10 @@ class SpiderMiddlewareManager(MiddlewareManager):
         for method in self.methods["process_spider_input"]:
             method = cast("Callable", method)
             try:
-                result = method(response=response, spider=self._spider)
+                if method in self._mw_methods_requiring_spider:
+                    result = method(response=response, spider=self._spider)
+                else:
+                    result = method(response=response)
                 if result is not None:
                     msg = (
                         f"{global_object_name(method)} must return None "
@@ -212,7 +227,12 @@ class SpiderMiddlewareManager(MiddlewareManager):
             if method is None:
                 continue
             method = cast("Callable", method)
-            result = method(response=response, exception=exception, spider=self._spider)
+            if method in self._mw_methods_requiring_spider:
+                result = method(
+                    response=response, exception=exception, spider=self._spider
+                )
+            else:
+                result = method(response=response, exception=exception)
             if _isiterable(result):
                 # stop exception handling by handing control over to the
                 # process_spider_output chain if an iterable has been returned
@@ -298,7 +318,12 @@ class SpiderMiddlewareManager(MiddlewareManager):
                         )
                         recovered = MutableChain(recovered_collected)
                 # might fail directly if the output value is not a generator
-                result = method(response=response, result=result, spider=self._spider)
+                if method in self._mw_methods_requiring_spider:
+                    result = method(
+                        response=response, result=result, spider=self._spider
+                    )
+                else:
+                    result = method(response=response, result=result)
             except Exception as ex:
                 exception_result: Failure | MutableChain[_T] | MutableAsyncChain[_T] = (
                     self._process_spider_exception(response, ex, method_index + 1)

--- a/scrapy/middleware.py
+++ b/scrapy/middleware.py
@@ -194,13 +194,17 @@ class MiddlewareManager(ABC):
                 obj = await ensure_awaitable(method(obj, *args))
         return obj
 
-    def open_spider(self, spider: Spider | None = None) -> Deferred[list[None]]:
+    def open_spider(
+        self, spider: Spider | None = None
+    ) -> Deferred[list[None]]:  # pragma: no cover
         raise NotImplementedError(
             "MiddlewareManager.open_spider() is no longer implemented"
             " and will be removed in a future Scrapy version."
         )
 
-    def close_spider(self, spider: Spider | None = None) -> Deferred[list[None]]:
+    def close_spider(
+        self, spider: Spider | None = None
+    ) -> Deferred[list[None]]:  # pragma: no cover
         raise NotImplementedError(
             "MiddlewareManager.close_spider() is no longer implemented"
             " and will be removed in a future Scrapy version."

--- a/scrapy/middleware.py
+++ b/scrapy/middleware.py
@@ -8,7 +8,7 @@ from collections import defaultdict, deque
 from typing import TYPE_CHECKING, Any, TypeVar, cast
 
 from scrapy.exceptions import NotConfigured, ScrapyDeprecationWarning
-from scrapy.utils.defer import ensure_awaitable, process_parallel
+from scrapy.utils.defer import ensure_awaitable
 from scrapy.utils.deprecate import argument_is_required
 from scrapy.utils.misc import build_from_crawler, load_object
 from scrapy.utils.python import global_object_name
@@ -32,7 +32,6 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 _T = TypeVar("_T")
-_T2 = TypeVar("_T2")
 
 
 class MiddlewareManager(ABC):
@@ -160,11 +159,8 @@ class MiddlewareManager(ABC):
         )
         return cls(*middlewares, crawler=crawler)
 
-    def _add_middleware(self, mw: Any) -> None:
-        if hasattr(mw, "open_spider"):
-            self.methods["open_spider"].append(mw.open_spider)
-        if hasattr(mw, "close_spider"):
-            self.methods["close_spider"].appendleft(mw.close_spider)
+    def _add_middleware(self, mw: Any) -> None:  # noqa: B027
+        pass
 
     def _check_mw_method_spider_arg(self, method: Callable) -> None:
         if argument_is_required(method, "spider"):
@@ -177,14 +173,6 @@ class MiddlewareManager(ABC):
                 stacklevel=2,
             )
             self._mw_methods_requiring_spider.add(method)
-
-    def _process_parallel(
-        self, methodname: str, obj: _T, *args: Any
-    ) -> Deferred[list[_T2]]:
-        methods = cast(
-            "Iterable[Callable[Concatenate[_T, _P], _T2]]", self.methods[methodname]
-        )
-        return process_parallel(methods, obj, *args)
 
     async def _process_chain(
         self,
@@ -207,13 +195,13 @@ class MiddlewareManager(ABC):
         return obj
 
     def open_spider(self, spider: Spider | None = None) -> Deferred[list[None]]:
-        if spider:
-            self._warn_spider_arg("open_spider")
-            self._set_compat_spider(spider)
-        return self._process_parallel("open_spider", self._spider)
+        raise NotImplementedError(
+            "MiddlewareManager.open_spider() is no longer implemented"
+            " and will be removed in a future Scrapy version."
+        )
 
     def close_spider(self, spider: Spider | None = None) -> Deferred[list[None]]:
-        if spider:
-            self._warn_spider_arg("close_spider")
-            self._set_compat_spider(spider)
-        return self._process_parallel("close_spider", self._spider)
+        raise NotImplementedError(
+            "MiddlewareManager.close_spider() is no longer implemented"
+            " and will be removed in a future Scrapy version."
+        )

--- a/scrapy/middleware.py
+++ b/scrapy/middleware.py
@@ -201,7 +201,7 @@ class MiddlewareManager(ABC):
             if always_add_spider or (
                 add_spider and method in self._mw_methods_requiring_spider
             ):
-                obj = await ensure_awaitable(method(obj, *args, self._spider))
+                obj = await ensure_awaitable(method(obj, *(*args, self._spider)))
             else:
                 obj = await ensure_awaitable(method(obj, *args))
         return obj

--- a/scrapy/pipelines/__init__.py
+++ b/scrapy/pipelines/__init__.py
@@ -7,16 +7,20 @@ See documentation in docs/item-pipeline.rst
 from __future__ import annotations
 
 import warnings
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Callable, cast
+
+from twisted.internet.defer import Deferred, DeferredList
 
 from scrapy.exceptions import ScrapyDeprecationWarning
 from scrapy.middleware import MiddlewareManager
 from scrapy.utils.conf import build_component_list
-from scrapy.utils.defer import deferred_from_coro
+from scrapy.utils.defer import deferred_from_coro, maybeDeferred_coro
 from scrapy.utils.python import global_object_name
 
 if TYPE_CHECKING:
-    from twisted.internet.defer import Deferred
+    from collections.abc import Iterable
+
+    from twisted.python.failure import Failure
 
     from scrapy import Spider
     from scrapy.settings import Settings
@@ -30,7 +34,12 @@ class ItemPipelineManager(MiddlewareManager):
         return build_component_list(settings.getwithbase("ITEM_PIPELINES"))
 
     def _add_middleware(self, pipe: Any) -> None:
-        super()._add_middleware(pipe)
+        if hasattr(pipe, "open_spider"):
+            self.methods["open_spider"].append(pipe.open_spider)
+            self._check_mw_method_spider_arg(pipe.open_spider)
+        if hasattr(pipe, "close_spider"):
+            self.methods["close_spider"].appendleft(pipe.close_spider)
+            self._check_mw_method_spider_arg(pipe.close_spider)
         if hasattr(pipe, "process_item"):
             self.methods["process_item"].append(pipe.process_item)
             self._check_mw_method_spider_arg(pipe.process_item)
@@ -47,3 +56,37 @@ class ItemPipelineManager(MiddlewareManager):
 
     async def process_item_async(self, item: Any) -> Any:
         return await self._process_chain("process_item", item, add_spider=True)
+
+    def _process_parallel(
+        self, methodname: str, add_spider: bool = False
+    ) -> Deferred[list[None]]:
+        methods = cast("Iterable[Callable[..., None]]", self.methods[methodname])
+
+        def get_dfd(method: Callable[..., None]) -> Deferred[None]:
+            if add_spider and method in self._mw_methods_requiring_spider:
+                return maybeDeferred_coro(method, self._spider)
+            return maybeDeferred_coro(method)
+
+        dfds = [get_dfd(m) for m in methods]
+        d: Deferred[list[tuple[bool, None]]] = DeferredList(
+            dfds, fireOnOneErrback=True, consumeErrors=True
+        )
+        d2: Deferred[list[None]] = d.addCallback(lambda r: [x[1] for x in r])
+
+        def eb(failure: Failure) -> Failure:
+            return failure.value.subFailure
+
+        d2.addErrback(eb)
+        return d2
+
+    def open_spider(self, spider: Spider | None = None) -> Deferred[list[None]]:
+        if spider:
+            self._warn_spider_arg("open_spider")
+            self._set_compat_spider(spider)
+        return self._process_parallel("open_spider", add_spider=True)
+
+    def close_spider(self, spider: Spider | None = None) -> Deferred[list[None]]:
+        if spider:
+            self._warn_spider_arg("close_spider")
+            self._set_compat_spider(spider)
+        return self._process_parallel("close_spider", add_spider=True)

--- a/scrapy/pipelines/__init__.py
+++ b/scrapy/pipelines/__init__.py
@@ -57,13 +57,11 @@ class ItemPipelineManager(MiddlewareManager):
     async def process_item_async(self, item: Any) -> Any:
         return await self._process_chain("process_item", item, add_spider=True)
 
-    def _process_parallel(
-        self, methodname: str, add_spider: bool = False
-    ) -> Deferred[list[None]]:
+    def _process_parallel(self, methodname: str) -> Deferred[list[None]]:
         methods = cast("Iterable[Callable[..., None]]", self.methods[methodname])
 
         def get_dfd(method: Callable[..., None]) -> Deferred[None]:
-            if add_spider and method in self._mw_methods_requiring_spider:
+            if method in self._mw_methods_requiring_spider:
                 return maybeDeferred_coro(method, self._spider)
             return maybeDeferred_coro(method)
 
@@ -83,10 +81,10 @@ class ItemPipelineManager(MiddlewareManager):
         if spider:
             self._warn_spider_arg("open_spider")
             self._set_compat_spider(spider)
-        return self._process_parallel("open_spider", add_spider=True)
+        return self._process_parallel("open_spider")
 
     def close_spider(self, spider: Spider | None = None) -> Deferred[list[None]]:
         if spider:
             self._warn_spider_arg("close_spider")
             self._set_compat_spider(spider)
-        return self._process_parallel("close_spider", add_spider=True)
+        return self._process_parallel("close_spider")

--- a/scrapy/pipelines/__init__.py
+++ b/scrapy/pipelines/__init__.py
@@ -33,6 +33,7 @@ class ItemPipelineManager(MiddlewareManager):
         super()._add_middleware(pipe)
         if hasattr(pipe, "process_item"):
             self.methods["process_item"].append(pipe.process_item)
+            self._check_mw_method_spider_arg(pipe.process_item)
 
     def process_item(self, item: Any, spider: Spider | None = None) -> Deferred[Any]:
         if spider:
@@ -45,4 +46,4 @@ class ItemPipelineManager(MiddlewareManager):
         return deferred_from_coro(self.process_item_async(item))
 
     async def process_item_async(self, item: Any) -> Any:
-        return await self._process_chain("process_item", item, self._spider)
+        return await self._process_chain("process_item", item, add_spider=True)

--- a/scrapy/pipelines/media.py
+++ b/scrapy/pipelines/media.py
@@ -165,8 +165,16 @@ class MediaPipeline(ABC):
             pipe._finish_init(crawler)
         return pipe
 
-    def open_spider(self, spider: Spider) -> None:
-        self.spiderinfo = self.SpiderInfo(spider)
+    def open_spider(self, spider: Spider | None = None) -> None:
+        if spider is not None:
+            warnings.warn(
+                "Passing a spider argument to MediaPipeline.open_spider()"
+                " is deprecated and the passed value is ignored.",
+                ScrapyDeprecationWarning,
+                stacklevel=2,
+            )
+        assert self.crawler.spider
+        self.spiderinfo = self.SpiderInfo(self.crawler.spider)
 
     def process_item(
         self, item: Any, spider: Spider | None = None

--- a/scrapy/pipelines/media.py
+++ b/scrapy/pipelines/media.py
@@ -166,7 +166,7 @@ class MediaPipeline(ABC):
         return pipe
 
     def open_spider(self, spider: Spider | None = None) -> None:
-        if spider is not None:
+        if spider is not None:  # pragma: no cover
             warnings.warn(
                 "Passing a spider argument to MediaPipeline.open_spider()"
                 " is deprecated and the passed value is ignored.",
@@ -179,7 +179,7 @@ class MediaPipeline(ABC):
     def process_item(
         self, item: Any, spider: Spider | None = None
     ) -> Deferred[list[FileInfoOrError]]:
-        if spider is not None:
+        if spider is not None:  # pragma: no cover
             warnings.warn(
                 "Passing a spider argument to MediaPipeline.process_item()"
                 " is deprecated and the passed value is ignored.",

--- a/scrapy/pipelines/media.py
+++ b/scrapy/pipelines/media.py
@@ -169,8 +169,15 @@ class MediaPipeline(ABC):
         self.spiderinfo = self.SpiderInfo(spider)
 
     def process_item(
-        self, item: Any, spider: Spider
+        self, item: Any, spider: Spider | None = None
     ) -> Deferred[list[FileInfoOrError]]:
+        if spider is not None:
+            warnings.warn(
+                "Passing a spider argument to MediaPipeline.process_item()"
+                " is deprecated and the passed value is ignored.",
+                ScrapyDeprecationWarning,
+                stacklevel=2,
+            )
         info = self.spiderinfo
         requests = arg_to_iter(self.get_media_requests(item, info))
         dlist = [self._process_request(r, info, item) for r in requests]

--- a/scrapy/spidermiddlewares/base.py
+++ b/scrapy/spidermiddlewares/base.py
@@ -57,7 +57,7 @@ class BaseSpiderMiddleware:
     def process_spider_output(
         self, response: Response, result: Iterable[Any], spider: Spider | None = None
     ) -> Iterable[Any]:
-        if spider is not None:
+        if spider is not None:  # pragma: no cover
             warnings.warn(
                 "Passing a spider argument to BaseSpiderMiddleware.process_spider_output()"
                 " is deprecated and the passed value is ignored.",
@@ -74,7 +74,7 @@ class BaseSpiderMiddleware:
         result: AsyncIterator[Any],
         spider: Spider | None = None,
     ) -> AsyncIterator[Any]:
-        if spider is not None:
+        if spider is not None:  # pragma: no cover
             warnings.warn(
                 "Passing a spider argument to BaseSpiderMiddleware.process_spider_output_async()"
                 " is deprecated and the passed value is ignored.",

--- a/scrapy/spidermiddlewares/base.py
+++ b/scrapy/spidermiddlewares/base.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
+import warnings
 from typing import TYPE_CHECKING, Any
 
 from scrapy import Request, Spider
+from scrapy.exceptions import ScrapyDeprecationWarning
 
 if TYPE_CHECKING:
     from collections.abc import AsyncIterator, Iterable
@@ -53,15 +55,32 @@ class BaseSpiderMiddleware:
                 yield o
 
     def process_spider_output(
-        self, response: Response, result: Iterable[Any], spider: Spider
+        self, response: Response, result: Iterable[Any], spider: Spider | None = None
     ) -> Iterable[Any]:
+        if spider is not None:
+            warnings.warn(
+                "Passing a spider argument to BaseSpiderMiddleware.process_spider_output()"
+                " is deprecated and the passed value is ignored.",
+                ScrapyDeprecationWarning,
+                stacklevel=2,
+            )
         for o in result:
             if (o := self._get_processed(o, response)) is not None:
                 yield o
 
     async def process_spider_output_async(
-        self, response: Response, result: AsyncIterator[Any], spider: Spider
+        self,
+        response: Response,
+        result: AsyncIterator[Any],
+        spider: Spider | None = None,
     ) -> AsyncIterator[Any]:
+        if spider is not None:
+            warnings.warn(
+                "Passing a spider argument to BaseSpiderMiddleware.process_spider_output_async()"
+                " is deprecated and the passed value is ignored.",
+                ScrapyDeprecationWarning,
+                stacklevel=2,
+            )
         async for o in result:
             if (o := self._get_processed(o, response)) is not None:
                 yield o

--- a/scrapy/spidermiddlewares/depth.py
+++ b/scrapy/spidermiddlewares/depth.py
@@ -7,8 +7,10 @@ See documentation in docs/topics/spider-middleware.rst
 from __future__ import annotations
 
 import logging
+import warnings
 from typing import TYPE_CHECKING, Any
 
+from scrapy.exceptions import ScrapyDeprecationWarning
 from scrapy.spidermiddlewares.base import BaseSpiderMiddleware
 
 if TYPE_CHECKING:
@@ -53,24 +55,43 @@ class DepthMiddleware(BaseSpiderMiddleware):
         return o
 
     def process_spider_output(
-        self, response: Response, result: Iterable[Any], spider: Spider
+        self, response: Response, result: Iterable[Any], spider: Spider | None = None
     ) -> Iterable[Any]:
-        self._init_depth(response, spider)
-        yield from super().process_spider_output(response, result, spider)
+        if spider is not None:
+            warnings.warn(
+                "Passing a spider argument to DepthMiddleware.process_spider_output()"
+                " is deprecated and the passed value is ignored.",
+                ScrapyDeprecationWarning,
+                stacklevel=2,
+            )
+        self._init_depth(response)
+        yield from super().process_spider_output(response, result)
 
     async def process_spider_output_async(
-        self, response: Response, result: AsyncIterator[Any], spider: Spider
+        self,
+        response: Response,
+        result: AsyncIterator[Any],
+        spider: Spider | None = None,
     ) -> AsyncIterator[Any]:
-        self._init_depth(response, spider)
-        async for o in super().process_spider_output_async(response, result, spider):
+        if spider is not None:
+            warnings.warn(
+                "Passing a spider argument to DepthMiddleware.process_spider_output_async()"
+                " is deprecated and the passed value is ignored.",
+                ScrapyDeprecationWarning,
+                stacklevel=2,
+            )
+        self._init_depth(response)
+        async for o in super().process_spider_output_async(response, result):
             yield o
 
-    def _init_depth(self, response: Response, spider: Spider) -> None:
+    def _init_depth(self, response: Response) -> None:
         # base case (depth=0)
         if "depth" not in response.meta:
             response.meta["depth"] = 0
             if self.verbose_stats:
-                self.stats.inc_value("request_depth_count/0", spider=spider)
+                self.stats.inc_value(
+                    "request_depth_count/0", spider=self.crawler.spider
+                )
 
     def get_processed_request(
         self, request: Request, response: Response | None

--- a/scrapy/spidermiddlewares/depth.py
+++ b/scrapy/spidermiddlewares/depth.py
@@ -57,7 +57,7 @@ class DepthMiddleware(BaseSpiderMiddleware):
     def process_spider_output(
         self, response: Response, result: Iterable[Any], spider: Spider | None = None
     ) -> Iterable[Any]:
-        if spider is not None:
+        if spider is not None:  # pragma: no cover
             warnings.warn(
                 "Passing a spider argument to DepthMiddleware.process_spider_output()"
                 " is deprecated and the passed value is ignored.",
@@ -73,7 +73,7 @@ class DepthMiddleware(BaseSpiderMiddleware):
         result: AsyncIterator[Any],
         spider: Spider | None = None,
     ) -> AsyncIterator[Any]:
-        if spider is not None:
+        if spider is not None:  # pragma: no cover
             warnings.warn(
                 "Passing a spider argument to DepthMiddleware.process_spider_output_async()"
                 " is deprecated and the passed value is ignored.",

--- a/scrapy/spidermiddlewares/httperror.py
+++ b/scrapy/spidermiddlewares/httperror.py
@@ -53,7 +53,7 @@ class HttpErrorMiddleware:
     def process_spider_input(
         self, response: Response, spider: Spider | None = None
     ) -> None:
-        if spider is not None:
+        if spider is not None:  # pragma: no cover
             warnings.warn(
                 "Passing a spider argument to HttpErrorMiddleware.process_spider_input()"
                 " is deprecated and the passed value is ignored.",
@@ -82,7 +82,7 @@ class HttpErrorMiddleware:
     def process_spider_exception(
         self, response: Response, exception: Exception, spider: Spider | None = None
     ) -> Iterable[Any] | None:
-        if spider is not None:
+        if spider is not None:  # pragma: no cover
             warnings.warn(
                 "Passing a spider argument to HttpErrorMiddleware.process_spider_exception()"
                 " is deprecated and the passed value is ignored.",

--- a/scrapy/spidermiddlewares/httperror.py
+++ b/scrapy/spidermiddlewares/httperror.py
@@ -7,9 +7,10 @@ See documentation in docs/topics/spider-middleware.rst
 from __future__ import annotations
 
 import logging
+import warnings
 from typing import TYPE_CHECKING, Any
 
-from scrapy.exceptions import IgnoreRequest
+from scrapy.exceptions import IgnoreRequest, ScrapyDeprecationWarning
 
 if TYPE_CHECKING:
     from collections.abc import Iterable
@@ -35,9 +36,7 @@ class HttpError(IgnoreRequest):
 
 
 class HttpErrorMiddleware:
-    @classmethod
-    def from_crawler(cls, crawler: Crawler) -> Self:
-        return cls(crawler.settings)
+    crawler: Crawler
 
     def __init__(self, settings: BaseSettings):
         self.handle_httpstatus_all: bool = settings.getbool("HTTPERROR_ALLOW_ALL")
@@ -45,7 +44,22 @@ class HttpErrorMiddleware:
             "HTTPERROR_ALLOWED_CODES"
         )
 
-    def process_spider_input(self, response: Response, spider: Spider) -> None:
+    @classmethod
+    def from_crawler(cls, crawler: Crawler) -> Self:
+        o = cls(crawler.settings)
+        o.crawler = crawler
+        return o
+
+    def process_spider_input(
+        self, response: Response, spider: Spider | None = None
+    ) -> None:
+        if spider is not None:
+            warnings.warn(
+                "Passing a spider argument to HttpErrorMiddleware.process_spider_input()"
+                " is deprecated and the passed value is ignored.",
+                ScrapyDeprecationWarning,
+                stacklevel=2,
+            )
         if 200 <= response.status < 300:  # common case
             return
         meta = response.meta
@@ -57,25 +71,34 @@ class HttpErrorMiddleware:
             return
         else:
             allowed_statuses = getattr(
-                spider, "handle_httpstatus_list", self.handle_httpstatus_list
+                self.crawler.spider,
+                "handle_httpstatus_list",
+                self.handle_httpstatus_list,
             )
         if response.status in allowed_statuses:
             return
         raise HttpError(response, "Ignoring non-200 response")
 
     def process_spider_exception(
-        self, response: Response, exception: Exception, spider: Spider
+        self, response: Response, exception: Exception, spider: Spider | None = None
     ) -> Iterable[Any] | None:
+        if spider is not None:
+            warnings.warn(
+                "Passing a spider argument to HttpErrorMiddleware.process_spider_exception()"
+                " is deprecated and the passed value is ignored.",
+                ScrapyDeprecationWarning,
+                stacklevel=2,
+            )
         if isinstance(exception, HttpError):
-            assert spider.crawler.stats
-            spider.crawler.stats.inc_value("httperror/response_ignored_count")
-            spider.crawler.stats.inc_value(
+            assert self.crawler.stats
+            self.crawler.stats.inc_value("httperror/response_ignored_count")
+            self.crawler.stats.inc_value(
                 f"httperror/response_ignored_status_count/{response.status}"
             )
             logger.info(
                 "Ignoring response %(response)r: HTTP status code is not handled or not allowed",
                 {"response": response},
-                extra={"spider": spider},
+                extra={"spider": self.crawler.spider},
             )
             return []
         return None

--- a/scrapy/utils/defer.py
+++ b/scrapy/utils/defer.py
@@ -346,6 +346,11 @@ def process_parallel(
     """Return a Deferred with the output of all successful calls to the given
     callbacks
     """
+    warnings.warn(
+        "process_parallel() is deprecated.",
+        category=ScrapyDeprecationWarning,
+        stacklevel=2,
+    )
     dfds = [succeed(input).addCallback(x, *a, **kw) for x in callbacks]
     d: Deferred[list[tuple[bool, _T2]]] = DeferredList(
         dfds, fireOnOneErrback=True, consumeErrors=True

--- a/scrapy/utils/defer.py
+++ b/scrapy/utils/defer.py
@@ -312,19 +312,6 @@ def process_chain(
     return d
 
 
-async def _process_chain(
-    callables: Iterable[Callable[Concatenate[_T, _P], _T | Awaitable[_T]]],
-    input_: _T,
-    *a: _P.args,
-    **kw: _P.kwargs,
-) -> _T:
-    """Chain the given (potentialy asynchronous) callables."""
-    result = input_
-    for callable_ in callables:
-        result = await ensure_awaitable(callable_(result, *a, **kw))
-    return result
-
-
 def process_chain_both(
     callbacks: Iterable[Callable[Concatenate[_T, _P], Any]],
     errbacks: Iterable[Callable[Concatenate[Failure, _P], Any]],

--- a/scrapy/utils/defer.py
+++ b/scrapy/utils/defer.py
@@ -342,7 +342,7 @@ def process_parallel(
     input: _T,  # noqa: A002
     *a: _P.args,
     **kw: _P.kwargs,
-) -> Deferred[list[_T2]]:
+) -> Deferred[list[_T2]]:  # pragma: no cover
     """Return a Deferred with the output of all successful calls to the given
     callbacks
     """

--- a/tests/AsyncCrawlerProcess/asyncio_deferred_signal.py
+++ b/tests/AsyncCrawlerProcess/asyncio_deferred_signal.py
@@ -16,7 +16,7 @@ class UppercasePipeline:
     def open_spider(self, spider):
         return deferred_from_coro(self._open_spider(spider))
 
-    def process_item(self, item, spider):
+    def process_item(self, item):
         return {"url": item["url"].upper()}
 
 

--- a/tests/CrawlerProcess/asyncio_deferred_signal.py
+++ b/tests/CrawlerProcess/asyncio_deferred_signal.py
@@ -16,7 +16,7 @@ class UppercasePipeline:
     def open_spider(self, spider):
         return deferred_from_coro(self._open_spider(spider))
 
-    def process_item(self, item, spider):
+    def process_item(self, item):
         return {"url": item["url"].upper()}
 
 

--- a/tests/pipelines.py
+++ b/tests/pipelines.py
@@ -4,7 +4,7 @@ Some pipelines used for testing
 
 
 class ZeroDivisionErrorPipeline:
-    def open_spider(self, spider):
+    def open_spider(self):
         1 / 0
 
     def process_item(self, item):

--- a/tests/pipelines.py
+++ b/tests/pipelines.py
@@ -7,10 +7,10 @@ class ZeroDivisionErrorPipeline:
     def open_spider(self, spider):
         1 / 0
 
-    def process_item(self, item, spider):
+    def process_item(self, item):
         return item
 
 
 class ProcessWithZeroDivisionErrorPipeline:
-    def process_item(self, item, spider):
+    def process_item(self, item):
         1 / 0

--- a/tests/test_cmdline_crawl_with_pipeline/test_spider/pipelines.py
+++ b/tests/test_cmdline_crawl_with_pipeline/test_spider/pipelines.py
@@ -2,7 +2,7 @@ class TestSpiderPipeline:
     def open_spider(self, spider):
         pass
 
-    def process_item(self, item, spider):
+    def process_item(self, item):
         return item
 
 
@@ -10,5 +10,5 @@ class TestSpiderExceptionPipeline:
     def open_spider(self, spider):
         raise RuntimeError("exception")
 
-    def process_item(self, item, spider):
+    def process_item(self, item):
         return item

--- a/tests/test_command_parse.py
+++ b/tests/test_command_parse.py
@@ -153,7 +153,7 @@ import logging
 class MyPipeline:
     component_name = 'my_pipeline'
 
-    def process_item(self, item, spider):
+    def process_item(self, item):
         logging.info('It Works!')
         return item
 """,

--- a/tests/test_logformatter.py
+++ b/tests/test_logformatter.py
@@ -246,7 +246,7 @@ class SkipMessagesLogFormatter(LogFormatter):
 class DropSomeItemsPipeline:
     drop = True
 
-    def process_item(self, item, spider):
+    def process_item(self, item):
         if self.drop:
             self.drop = False
             raise DropItem("Ignoring item")

--- a/tests/test_pipeline_files.py
+++ b/tests/test_pipeline_files.py
@@ -29,6 +29,7 @@ from scrapy.pipelines.files import (
     GCSFilesStore,
     S3FilesStore,
 )
+from scrapy.utils.spider import DefaultSpider
 from scrapy.utils.test import get_crawler
 from tests.mockserver.ftp import MockFTPServer
 
@@ -78,10 +79,11 @@ class TestFilesPipeline:
     def setup_method(self):
         self.tempdir = mkdtemp()
         settings_dict = {"FILES_STORE": self.tempdir}
-        crawler = get_crawler(spidercls=None, settings_dict=settings_dict)
+        crawler = get_crawler(DefaultSpider, settings_dict=settings_dict)
+        crawler.spider = crawler._create_spider()
         self.pipeline = FilesPipeline.from_crawler(crawler)
         self.pipeline.download_func = _mocked_download_func
-        self.pipeline.open_spider(None)
+        self.pipeline.open_spider()
 
     def teardown_method(self):
         rmtree(self.tempdir)

--- a/tests/test_pipeline_media.py
+++ b/tests/test_pipeline_media.py
@@ -13,10 +13,10 @@ from scrapy.http import Request, Response
 from scrapy.http.request import NO_CALLBACK
 from scrapy.pipelines.files import FileException
 from scrapy.pipelines.media import MediaPipeline
-from scrapy.spiders import Spider
 from scrapy.utils.asyncio import call_later
 from scrapy.utils.log import failure_to_exc_info
 from scrapy.utils.signal import disconnect_all
+from scrapy.utils.spider import DefaultSpider
 from scrapy.utils.test import get_crawler
 
 
@@ -48,12 +48,11 @@ class TestBaseMediaPipeline:
     settings = None
 
     def setup_method(self):
-        spider_cls = Spider
-        spider = spider_cls("media.com")
-        crawler = get_crawler(spider_cls, self.settings)
+        crawler = get_crawler(DefaultSpider, self.settings)
+        crawler.spider = crawler._create_spider()
         self.pipe = self.pipeline_class.from_crawler(crawler)
         self.pipe.download_func = _mocked_download_func
-        self.pipe.open_spider(spider)
+        self.pipe.open_spider()
         self.info = self.pipe.spiderinfo
         self.fingerprint = crawler.request_fingerprinter.fingerprint
 
@@ -555,12 +554,11 @@ class TestMediaFailedFailure:
     settings = None
 
     def setup_method(self):
-        spider_cls = Spider
-        spider = spider_cls("media.com")
-        crawler = get_crawler(spider_cls, self.settings)
+        crawler = get_crawler(DefaultSpider, self.settings)
+        crawler.spider = crawler._create_spider()
         self.pipe = self.pipeline_class.from_crawler(crawler)
         self.pipe.download_func = _mocked_download_func
-        self.pipe.open_spider(spider)
+        self.pipe.open_spider()
         self.info = self.pipe.spiderinfo
         self.fingerprint = crawler.request_fingerprinter.fingerprint
 

--- a/tests/test_pipeline_media.py
+++ b/tests/test_pipeline_media.py
@@ -49,11 +49,11 @@ class TestBaseMediaPipeline:
 
     def setup_method(self):
         spider_cls = Spider
-        self.spider = spider_cls("media.com")
+        spider = spider_cls("media.com")
         crawler = get_crawler(spider_cls, self.settings)
         self.pipe = self.pipeline_class.from_crawler(crawler)
         self.pipe.download_func = _mocked_download_func
-        self.pipe.open_spider(self.spider)
+        self.pipe.open_spider(spider)
         self.info = self.pipe.spiderinfo
         self.fingerprint = crawler.request_fingerprinter.fingerprint
 
@@ -162,7 +162,7 @@ class TestBaseMediaPipeline:
     @inlineCallbacks
     def test_default_process_item(self):
         item = {"name": "name"}
-        new_item = yield self.pipe.process_item(item, self.spider)
+        new_item = yield self.pipe.process_item(item)
         assert new_item is item
 
 
@@ -216,7 +216,7 @@ class TestMediaPipeline(TestBaseMediaPipeline):
             errback=self._errback,
         )
         item = {"requests": req}
-        new_item = yield self.pipe.process_item(item, self.spider)
+        new_item = yield self.pipe.process_item(item)
         assert new_item["results"] == [(True, {})]
         assert self.pipe._mockcalled == [
             "get_media_requests",
@@ -236,7 +236,7 @@ class TestMediaPipeline(TestBaseMediaPipeline):
             errback=self._errback,
         )
         item = {"requests": req}
-        new_item = yield self.pipe.process_item(item, self.spider)
+        new_item = yield self.pipe.process_item(item)
         assert len(new_item["results"]) == 1
         assert new_item["results"][0][0] is False
         assert isinstance(new_item["results"][0][1], Failure)
@@ -258,7 +258,7 @@ class TestMediaPipeline(TestBaseMediaPipeline):
         fail = Failure(exc)
         req2 = Request("http://url2", meta={"response": fail})
         item = {"requests": [req1, req2]}
-        new_item = yield self.pipe.process_item(item, self.spider)
+        new_item = yield self.pipe.process_item(item)
         assert len(new_item["results"]) == 2
         assert new_item["results"][0] == (True, {})
         assert new_item["results"][1][0] is False
@@ -281,7 +281,7 @@ class TestMediaPipeline(TestBaseMediaPipeline):
         # returns single Request (without callback)
         req = Request("http://url")
         item = {"requests": req}  # pass a single item
-        new_item = yield self.pipe.process_item(item, self.spider)
+        new_item = yield self.pipe.process_item(item)
         assert new_item is item
         assert self.fingerprint(req) in self.info.downloaded
 
@@ -289,7 +289,7 @@ class TestMediaPipeline(TestBaseMediaPipeline):
         req1 = Request("http://url1")
         req2 = Request("http://url2")
         item = {"requests": iter([req1, req2])}
-        new_item = yield self.pipe.process_item(item, self.spider)
+        new_item = yield self.pipe.process_item(item)
         assert new_item is item
         assert self.fingerprint(req1) in self.info.downloaded
         assert self.fingerprint(req2) in self.info.downloaded
@@ -299,7 +299,7 @@ class TestMediaPipeline(TestBaseMediaPipeline):
         rsp1 = Response("http://url1")
         req1 = Request("http://url1", meta={"response": rsp1})
         item = {"requests": req1}
-        new_item = yield self.pipe.process_item(item, self.spider)
+        new_item = yield self.pipe.process_item(item)
         assert new_item is item
         assert new_item["results"] == [(True, {})]
 
@@ -308,7 +308,7 @@ class TestMediaPipeline(TestBaseMediaPipeline):
             req1.url, meta={"response": Response("http://donot.download.me")}
         )
         item = {"requests": req2}
-        new_item = yield self.pipe.process_item(item, self.spider)
+        new_item = yield self.pipe.process_item(item)
         assert new_item is item
         assert self.fingerprint(req1) == self.fingerprint(req2)
         assert new_item["results"] == [(True, {})]
@@ -321,7 +321,7 @@ class TestMediaPipeline(TestBaseMediaPipeline):
             req1.url, meta={"response": Response("http://donot.download.me")}
         )
         item = {"requests": [req1, req2]}
-        new_item = yield self.pipe.process_item(item, self.spider)
+        new_item = yield self.pipe.process_item(item)
         assert new_item is item
         assert new_item["results"] == [(True, {}), (True, {})]
 
@@ -348,14 +348,14 @@ class TestMediaPipeline(TestBaseMediaPipeline):
         req1 = Request("http://url", meta={"response": rsp1_func})
         req2 = Request(req1.url, meta={"response": rsp2_func})
         item = {"requests": [req1, req2]}
-        new_item = yield self.pipe.process_item(item, self.spider)
+        new_item = yield self.pipe.process_item(item)
         assert new_item["results"] == [(True, {}), (True, {})]
 
     @inlineCallbacks
     def test_use_media_to_download_result(self):
         req = Request("http://url", meta={"result": "ITSME"})
         item = {"requests": req}
-        new_item = yield self.pipe.process_item(item, self.spider)
+        new_item = yield self.pipe.process_item(item)
         assert new_item["results"] == [(True, "ITSME")]
         assert self.pipe._mockcalled == [
             "get_media_requests",
@@ -556,11 +556,11 @@ class TestMediaFailedFailure:
 
     def setup_method(self):
         spider_cls = Spider
-        self.spider = spider_cls("media.com")
+        spider = spider_cls("media.com")
         crawler = get_crawler(spider_cls, self.settings)
         self.pipe = self.pipeline_class.from_crawler(crawler)
         self.pipe.download_func = _mocked_download_func
-        self.pipe.open_spider(self.spider)
+        self.pipe.open_spider(spider)
         self.info = self.pipe.spiderinfo
         self.fingerprint = crawler.request_fingerprinter.fingerprint
 
@@ -587,7 +587,7 @@ class TestMediaFailedFailure:
         with pytest.warns(
             ScrapyDeprecationWarning, match="media_failed returned a Failure instance"
         ):
-            new_item = yield self.pipe.process_item(item, self.spider)
+            new_item = yield self.pipe.process_item(item)
         assert len(new_item["results"]) == 1
         assert new_item["results"][0][0] is False
         assert isinstance(new_item["results"][0][1], Failure)

--- a/tests/test_pipelines.py
+++ b/tests/test_pipelines.py
@@ -25,8 +25,11 @@ class SimplePipeline:
         return item
 
 
-class DeprecatedOpenSpiderArgPipeline:
+class DeprecatedSpiderArgPipeline:
     def open_spider(self, spider):
+        pass
+
+    def close_spider(self, spider):
         pass
 
 
@@ -326,11 +329,17 @@ class TestMiddlewareManagerSpider:
         """Crawler is provided, but doesn't have a spider. The instance passed to the method is
         ignored and raises a warning."""
         mwman = ItemPipelineManager(crawler=crawler)
-        with pytest.warns(
-            ScrapyDeprecationWarning,
-            match=r"DeprecatedOpenSpiderArgPipeline.open_spider\(\) requires a spider argument",
+        with (
+            pytest.warns(
+                ScrapyDeprecationWarning,
+                match=r"DeprecatedSpiderArgPipeline.open_spider\(\) requires a spider argument",
+            ),
+            pytest.warns(
+                ScrapyDeprecationWarning,
+                match=r"DeprecatedSpiderArgPipeline.close_spider\(\) requires a spider argument",
+            ),
         ):
-            mwman._add_middleware(DeprecatedOpenSpiderArgPipeline)
+            mwman._add_middleware(DeprecatedSpiderArgPipeline)
         with (
             pytest.warns(
                 ScrapyDeprecationWarning,
@@ -342,6 +351,17 @@ class TestMiddlewareManagerSpider:
             ),
         ):
             mwman.open_spider(DefaultSpider())
+        with (
+            pytest.warns(
+                ScrapyDeprecationWarning,
+                match=r"Passing a spider argument to ItemPipelineManager.close_spider\(\) is deprecated",
+            ),
+            pytest.raises(
+                ValueError,
+                match="ItemPipelineManager needs to access self.crawler.spider but it is None",
+            ),
+        ):
+            mwman.close_spider(DefaultSpider())
 
     def test_deprecated_spider_arg_with_crawler(self, crawler: Crawler) -> None:
         """Crawler is provided and has a spider, works. The instance passed to the method is ignored,
@@ -389,11 +409,17 @@ class TestMiddlewareManagerSpider:
             match="was called without the crawler argument",
         ):
             mwman = ItemPipelineManager()
-        with pytest.warns(
-            ScrapyDeprecationWarning,
-            match=r"DeprecatedOpenSpiderArgPipeline.open_spider\(\) requires a spider argument",
+        with (
+            pytest.warns(
+                ScrapyDeprecationWarning,
+                match=r"DeprecatedSpiderArgPipeline.open_spider\(\) requires a spider argument",
+            ),
+            pytest.warns(
+                ScrapyDeprecationWarning,
+                match=r"DeprecatedSpiderArgPipeline.close_spider\(\) requires a spider argument",
+            ),
         ):
-            mwman._add_middleware(DeprecatedOpenSpiderArgPipeline)
+            mwman._add_middleware(DeprecatedSpiderArgPipeline)
         with (
             pytest.raises(
                 ValueError,

--- a/tests/test_pipelines.py
+++ b/tests/test_pipelines.py
@@ -190,6 +190,9 @@ class TestCustomPipelineManager:
             def open_spider(self, spider):  # pylint: disable=signature-differs
                 return super().open_spider(spider)
 
+            def close_spider(self, spider):  # pylint: disable=signature-differs
+                return super().close_spider(spider)
+
             def process_item(self, item, spider):  # pylint: disable=signature-differs
                 with pytest.warns(
                     ScrapyDeprecationWarning,
@@ -220,11 +223,19 @@ class TestCustomPipelineManager:
             ),
             pytest.warns(
                 ScrapyDeprecationWarning,
+                match=r"The close_spider\(\) method of .+\.CustomPipelineManager requires a spider argument",
+            ),
+            pytest.warns(
+                ScrapyDeprecationWarning,
                 match=r"The process_item\(\) method of .+\.CustomPipelineManager requires a spider argument",
             ),
             pytest.warns(
                 ScrapyDeprecationWarning,
                 match=r"Passing a spider argument to CustomPipelineManager.open_spider\(\) is deprecated",
+            ),
+            pytest.warns(
+                ScrapyDeprecationWarning,
+                match=r"Passing a spider argument to CustomPipelineManager.close_spider\(\) is deprecated",
             ),
             pytest.warns(
                 ScrapyDeprecationWarning,

--- a/tests/test_pipelines.py
+++ b/tests/test_pipelines.py
@@ -339,7 +339,7 @@ class TestMiddlewareManagerSpider:
                 match=r"DeprecatedSpiderArgPipeline.close_spider\(\) requires a spider argument",
             ),
         ):
-            mwman._add_middleware(DeprecatedSpiderArgPipeline)
+            mwman._add_middleware(DeprecatedSpiderArgPipeline())
         with (
             pytest.warns(
                 ScrapyDeprecationWarning,
@@ -386,6 +386,17 @@ class TestMiddlewareManagerSpider:
             match="was called without the crawler argument",
         ):
             mwman = ItemPipelineManager()
+        with (
+            pytest.warns(
+                ScrapyDeprecationWarning,
+                match=r"DeprecatedSpiderArgPipeline.open_spider\(\) requires a spider argument",
+            ),
+            pytest.warns(
+                ScrapyDeprecationWarning,
+                match=r"DeprecatedSpiderArgPipeline.close_spider\(\) requires a spider argument",
+            ),
+        ):
+            mwman._add_middleware(DeprecatedSpiderArgPipeline())
         with pytest.warns(
             ScrapyDeprecationWarning,
             match=r"Passing a spider argument to ItemPipelineManager.open_spider\(\) is deprecated",
@@ -401,6 +412,7 @@ class TestMiddlewareManagerSpider:
             ),
         ):
             mwman.close_spider(DefaultSpider())
+        mwman.close_spider()
 
     def test_no_spider_arg_without_crawler(self) -> None:
         """If no crawler and no spider arg, raise an error."""
@@ -419,7 +431,7 @@ class TestMiddlewareManagerSpider:
                 match=r"DeprecatedSpiderArgPipeline.close_spider\(\) requires a spider argument",
             ),
         ):
-            mwman._add_middleware(DeprecatedSpiderArgPipeline)
+            mwman._add_middleware(DeprecatedSpiderArgPipeline())
         with (
             pytest.raises(
                 ValueError,

--- a/tests/test_pipelines.py
+++ b/tests/test_pipelines.py
@@ -19,7 +19,7 @@ from tests.mockserver.http import MockServer
 
 
 class SimplePipeline:
-    def process_item(self, item, spider):
+    def process_item(self, item):
         item["pipeline_passed"] = True
         return item
 
@@ -29,7 +29,7 @@ class DeferredPipeline:
         item["pipeline_passed"] = True
         return item
 
-    def process_item(self, item, spider):
+    def process_item(self, item):
         d = Deferred()
         d.addCallback(self.cb)
         d.callback(item)
@@ -37,7 +37,7 @@ class DeferredPipeline:
 
 
 class AsyncDefPipeline:
-    async def process_item(self, item, spider):
+    async def process_item(self, item):
         d = Deferred()
         call_later(0, d.callback, None)
         await maybe_deferred_to_future(d)
@@ -46,7 +46,7 @@ class AsyncDefPipeline:
 
 
 class AsyncDefAsyncioPipeline:
-    async def process_item(self, item, spider):
+    async def process_item(self, item):
         d = Deferred()
         loop = asyncio.get_event_loop()
         loop.call_later(0, d.callback, None)
@@ -57,7 +57,7 @@ class AsyncDefAsyncioPipeline:
 
 
 class AsyncDefNotAsyncioPipeline:
-    async def process_item(self, item, spider):
+    async def process_item(self, item):
         d1 = Deferred()
         from twisted.internet import reactor
 
@@ -254,7 +254,7 @@ class TestCustomPipelineManager:
 
             def process_item(self, item, spider):
                 for pipeline in self.pipelines:
-                    item = pipeline.process_item(item, spider)
+                    item = pipeline.process_item(item)
                 return succeed(item)
 
         items = []

--- a/tests/test_request_cb_kwargs.py
+++ b/tests/test_request_cb_kwargs.py
@@ -33,12 +33,12 @@ class InjectArgumentsSpiderMiddleware:
                 request.cb_kwargs["from_process_start"] = True
             yield request
 
-    def process_spider_input(self, response, spider):
+    def process_spider_input(self, response):
         request = response.request
         if request.callback.__name__ == "parse_spider_mw":
             request.cb_kwargs["from_process_spider_input"] = True
 
-    def process_spider_output(self, response, result, spider):
+    def process_spider_output(self, response, result):
         for element in result:
             if (
                 isinstance(element, Request)

--- a/tests/test_settings/__init__.py
+++ b/tests/test_settings/__init__.py
@@ -451,7 +451,7 @@ class TestSettings:
 
     def test_passing_objects_as_values(self):
         class TestPipeline:
-            def process_item(self, i, s):
+            def process_item(self, i):
                 return i
 
         settings = Settings(
@@ -471,7 +471,7 @@ class TestSettings:
         assert priority == 800
         assert mypipeline == TestPipeline
         assert isinstance(mypipeline(), TestPipeline)
-        assert mypipeline().process_item("item", None) == "item"
+        assert mypipeline().process_item("item") == "item"
 
         myhandler = settings.getdict("DOWNLOAD_HANDLERS").pop("ftp")
         assert myhandler == FileDownloadHandler

--- a/tests/test_spidermiddleware.py
+++ b/tests/test_spidermiddleware.py
@@ -54,7 +54,7 @@ class TestProcessSpiderInputInvalidOutput(TestSpiderMiddleware):
     @deferred_f_from_coro_f
     async def test_invalid_process_spider_input(self):
         class InvalidProcessSpiderInputMiddleware:
-            def process_spider_input(self, response, spider):
+            def process_spider_input(self, response):
                 return 1
 
         self.mwman._add_middleware(InvalidProcessSpiderInputMiddleware())
@@ -68,7 +68,7 @@ class TestProcessSpiderOutputInvalidOutput(TestSpiderMiddleware):
     @deferred_f_from_coro_f
     async def test_invalid_process_spider_output(self):
         class InvalidProcessSpiderOutputMiddleware:
-            def process_spider_output(self, response, result, spider):
+            def process_spider_output(self, response, result):
                 return 1
 
         self.mwman._add_middleware(InvalidProcessSpiderOutputMiddleware())
@@ -82,11 +82,11 @@ class TestProcessSpiderExceptionInvalidOutput(TestSpiderMiddleware):
     @deferred_f_from_coro_f
     async def test_invalid_process_spider_exception(self):
         class InvalidProcessSpiderOutputExceptionMiddleware:
-            def process_spider_exception(self, response, exception, spider):
+            def process_spider_exception(self, response, exception):
                 return 1
 
         class RaiseExceptionProcessSpiderOutputMiddleware:
-            def process_spider_output(self, response, result, spider):
+            def process_spider_output(self, response, result):
                 raise RuntimeError
 
         self.mwman._add_middleware(InvalidProcessSpiderOutputExceptionMiddleware())
@@ -101,11 +101,11 @@ class TestProcessSpiderExceptionReRaise(TestSpiderMiddleware):
     @deferred_f_from_coro_f
     async def test_process_spider_exception_return_none(self):
         class ProcessSpiderExceptionReturnNoneMiddleware:
-            def process_spider_exception(self, response, exception, spider):
+            def process_spider_exception(self, response, exception):
                 return None
 
         class RaiseExceptionProcessSpiderOutputMiddleware:
-            def process_spider_output(self, response, result, spider):
+            def process_spider_output(self, response, result):
                 1 / 0
 
         self.mwman._add_middleware(ProcessSpiderExceptionReturnNoneMiddleware())
@@ -191,34 +191,34 @@ class TestBaseAsyncSpiderMiddleware(TestSpiderMiddleware):
 
 
 class ProcessSpiderOutputSimpleMiddleware:
-    def process_spider_output(self, response, result, spider):
+    def process_spider_output(self, response, result):
         yield from result
 
 
 class ProcessSpiderOutputAsyncGenMiddleware:
-    async def process_spider_output(self, response, result, spider):
+    async def process_spider_output(self, response, result):
         async for r in result:
             yield r
 
 
 class ProcessSpiderOutputUniversalMiddleware:
-    def process_spider_output(self, response, result, spider):
+    def process_spider_output(self, response, result):
         yield from result
 
-    async def process_spider_output_async(self, response, result, spider):
+    async def process_spider_output_async(self, response, result):
         async for r in result:
             yield r
 
 
 class ProcessSpiderExceptionSimpleIterableMiddleware:
-    def process_spider_exception(self, response, exception, spider):
+    def process_spider_exception(self, response, exception):
         yield {"foo": 1}
         yield {"foo": 2}
         yield {"foo": 3}
 
 
 class ProcessSpiderExceptionAsyncIteratorMiddleware:
-    async def process_spider_exception(self, response, exception, spider):
+    async def process_spider_exception(self, response, exception):
         yield {"foo": 1}
         d = defer.Deferred()
         call_later(0, d.callback, None)
@@ -315,12 +315,12 @@ class TestProcessSpiderOutputAsyncGen(TestProcessSpiderOutputSimple):
 
 
 class ProcessSpiderOutputNonIterableMiddleware:
-    def process_spider_output(self, response, result, spider):
+    def process_spider_output(self, response, result):
         return
 
 
 class ProcessSpiderOutputCoroutineMiddleware:
-    async def process_spider_output(self, response, result, spider):
+    async def process_spider_output(self, response, result):
         return result
 
 
@@ -384,23 +384,23 @@ class TestProcessStartSimple(TestBaseAsyncSpiderMiddleware):
 
 
 class UniversalMiddlewareNoSync:
-    async def process_spider_output_async(self, response, result, spider):
+    async def process_spider_output_async(self, response, result):
         yield
 
 
 class UniversalMiddlewareBothSync:
-    def process_spider_output(self, response, result, spider):
+    def process_spider_output(self, response, result):
         yield
 
-    def process_spider_output_async(self, response, result, spider):
+    def process_spider_output_async(self, response, result):
         yield
 
 
 class UniversalMiddlewareBothAsync:
-    async def process_spider_output(self, response, result, spider):
+    async def process_spider_output(self, response, result):
         yield
 
-    async def process_spider_output_async(self, response, result, spider):
+    async def process_spider_output_async(self, response, result):
         yield
 
 

--- a/tests/test_spidermiddleware_depth.py
+++ b/tests/test_spidermiddleware_depth.py
@@ -22,12 +22,6 @@ def crawler() -> Crawler:
 
 
 @pytest.fixture
-def spider(crawler: Crawler) -> Spider:
-    crawler.spider = crawler._create_spider("scrapytest.org")
-    return crawler.spider
-
-
-@pytest.fixture
 def stats(crawler: Crawler) -> Generator[StatsCollector]:
     assert crawler.stats is not None
     crawler.stats.open_spider()
@@ -42,9 +36,7 @@ def mw(crawler: Crawler) -> DepthMiddleware:
     return DepthMiddleware.from_crawler(crawler)
 
 
-def test_process_spider_output(
-    mw: DepthMiddleware, stats: StatsCollector, spider: Spider
-) -> None:
+def test_process_spider_output(mw: DepthMiddleware, stats: StatsCollector) -> None:
     req = Request("http://scrapytest.org")
     resp = Response("http://scrapytest.org")
     resp.request = req

--- a/tests/test_spidermiddleware_depth.py
+++ b/tests/test_spidermiddleware_depth.py
@@ -50,7 +50,7 @@ def test_process_spider_output(
     resp.request = req
     result = [Request("http://scrapytest.org")]
 
-    out = list(mw.process_spider_output(resp, result, spider))
+    out = list(mw.process_spider_output(resp, result))
     assert out == result
 
     rdc = stats.get_value("request_depth_count/1", spider=spider)
@@ -58,7 +58,7 @@ def test_process_spider_output(
 
     req.meta["depth"] = 1
 
-    out2 = list(mw.process_spider_output(resp, result, spider))
+    out2 = list(mw.process_spider_output(resp, result))
     assert not out2
 
     rdm = stats.get_value("request_depth_max", spider=spider)

--- a/tests/test_spidermiddleware_referer.py
+++ b/tests/test_spidermiddleware_referer.py
@@ -61,11 +61,11 @@ class TestRefererMiddleware:
     def get_response(self, origin: str) -> Response:
         return Response(origin, headers=self.resp_headers)
 
-    def test(self, mw: RefererMiddleware, spider: Spider) -> None:
+    def test(self, mw: RefererMiddleware) -> None:
         for origin, target, referrer in self.scenarii:
             response = self.get_response(origin)
             request = self.get_request(target)
-            out = list(mw.process_spider_output(response, [request], spider))
+            out = list(mw.process_spider_output(response, [request]))
             assert out[0].headers.get("Referer") == referrer
 
 
@@ -1036,7 +1036,7 @@ class TestReferrerOnRedirect(TestRefererMiddleware):
             response = self.get_response(parent)
             request = self.get_request(target)
 
-            out = list(referrermw.process_spider_output(response, [request], spider))
+            out = list(referrermw.process_spider_output(response, [request]))
             assert out[0].headers.get("Referer") == init_referrer
 
             for status, url in redirections:

--- a/tests/test_spidermiddleware_urllength.py
+++ b/tests/test_spidermiddleware_urllength.py
@@ -43,12 +43,12 @@ def mw(crawler: Crawler) -> UrlLengthMiddleware:
     return UrlLengthMiddleware.from_crawler(crawler)
 
 
-def process_spider_output(mw: UrlLengthMiddleware, spider: Spider) -> list[Request]:
-    return list(mw.process_spider_output(response, reqs, spider))
+def process_spider_output(mw: UrlLengthMiddleware) -> list[Request]:
+    return list(mw.process_spider_output(response, reqs))
 
 
-def test_middleware_works(mw: UrlLengthMiddleware, spider: Spider) -> None:
-    assert process_spider_output(mw, spider) == [short_url_req]
+def test_middleware_works(mw: UrlLengthMiddleware) -> None:
+    assert process_spider_output(mw) == [short_url_req]
 
 
 def test_logging(
@@ -58,7 +58,7 @@ def test_logging(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     with caplog.at_level(INFO):
-        process_spider_output(mw, spider)
+        process_spider_output(mw)
     ric = stats.get_value("urllength/request_ignored_count", spider=spider)
     assert ric == 1
     assert f"Ignoring link (url length > {maxlength})" in caplog.text

--- a/tests/test_spidermiddleware_urllength.py
+++ b/tests/test_spidermiddleware_urllength.py
@@ -28,11 +28,6 @@ def crawler() -> Crawler:
 
 
 @pytest.fixture
-def spider(crawler: Crawler) -> Spider:
-    return crawler._create_spider("foo")
-
-
-@pytest.fixture
 def stats(crawler: Crawler) -> StatsCollector:
     assert crawler.stats is not None
     return crawler.stats
@@ -52,10 +47,7 @@ def test_middleware_works(mw: UrlLengthMiddleware) -> None:
 
 
 def test_logging(
-    stats: StatsCollector,
-    mw: UrlLengthMiddleware,
-    spider: Spider,
-    caplog: pytest.LogCaptureFixture,
+    stats: StatsCollector, mw: UrlLengthMiddleware, caplog: pytest.LogCaptureFixture
 ) -> None:
     with caplog.at_level(INFO):
         process_spider_output(mw)

--- a/tests/test_utils_defer.py
+++ b/tests/test_utils_defer.py
@@ -18,7 +18,6 @@ from scrapy.utils.defer import (
     maybe_deferred_to_future,
     mustbe_deferred,
     parallel_async,
-    process_parallel,
 )
 
 if TYPE_CHECKING:
@@ -82,18 +81,6 @@ def cb_fail(value, arg1, arg2):
 
 def eb1(failure, arg1, arg2):
     return f"(eb1 {failure.value.__class__.__name__} {arg1} {arg2})"
-
-
-class TestDeferUtils:
-    @inlineCallbacks
-    def test_process_parallel(self):
-        x = yield process_parallel([cb1, cb2, cb3], "res", "v1", "v2")
-        assert x == ["(cb1 res v1 v2)", "(cb2 res v1 v2)", "(cb3 res v1 v2)"]
-
-    @inlineCallbacks
-    def test_process_parallel_failure(self):
-        with pytest.raises(TypeError):
-            yield process_parallel([cb1, cb_fail, cb3], "res", "v1", "v2")
 
 
 class TestIterErrback:

--- a/tests/test_utils_defer.py
+++ b/tests/test_utils_defer.py
@@ -10,7 +10,6 @@ from twisted.internet.defer import Deferred, inlineCallbacks, succeed
 
 from scrapy.utils.asyncgen import as_async_generator, collect_asyncgen
 from scrapy.utils.defer import (
-    _process_chain,
     aiter_errback,
     deferred_f_from_coro_f,
     deferred_from_coro,
@@ -86,14 +85,6 @@ def eb1(failure, arg1, arg2):
 
 
 class TestDeferUtils:
-    @deferred_f_from_coro_f
-    async def test_process_chain(self):
-        x = await _process_chain([cb1, cb2, cb3], "res", "v1", "v2")
-        assert x == "(cb3 (cb2 (cb1 res v1 v2) v1 v2) v1 v2)"
-
-        with pytest.raises(TypeError):
-            await _process_chain([cb1, cb_fail, cb3], "res", "v1", "v2")
-
     @inlineCallbacks
     def test_process_parallel(self):
         x = yield process_parallel([cb1, cb2, cb3], "res", "v1", "v2")


### PR DESCRIPTION
Partial fix for #6927 

- [x] docs
- [x] tests
~~- [ ] downloader middlewares~~
- [x] pipelines
- [x] `{open,close}_spider()`

Downloader middlewares need more changes as there are more of them so will be done separately.