### PR TITLE
RAG use case with Embeddings LiteLLM Pipeline and S3 Vectors Storage

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -117,6 +117,18 @@ def requires_boto3(request):
         pytest.skip("boto3 is not installed")
 
 
+@pytest.fixture(autouse=True)
+def requires_litellm(request):
+    if not request.node.get_closest_marker("requires_litellm"):
+        return
+    try:
+        import litellm  # noqa: PLC0415
+
+        del litellm
+    except ImportError:
+        pytest.skip("litellm is not installed")
+
+
 def pytest_configure(config):
     if config.getoption("--reactor") == "asyncio":
         # Needed on Windows to switch from proactor to selector for Twisted reactor compatibility.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -229,6 +229,7 @@ markers = [
     "requires_uvloop: marks tests as only enabled when uvloop is known to be working",
     "requires_botocore: marks tests that need botocore (but not boto3)",
     "requires_boto3: marks tests that need botocore and boto3",
+    "requires_litellm: marks tests that need litellm package",
 ]
 filterwarnings = [
     "ignore::DeprecationWarning:twisted.web.static"

--- a/scrapy/extensions/feedexport.py
+++ b/scrapy/extensions/feedexport.py
@@ -7,6 +7,7 @@ See documentation in docs/topics/feed-exports.rst
 from __future__ import annotations
 
 import contextlib
+import json
 import logging
 import re
 import sys
@@ -323,6 +324,87 @@ class GCSFeedStorage(BlockingFeedStorage):
         bucket = client.get_bucket(self.bucket_name)
         blob = bucket.blob(self.blob_name)
         blob.upload_from_file(file, predefined_acl=self.acl)
+
+
+class S3VectorsFeedStorage(BlockingFeedStorage):
+    """
+    Store on Amazon S3 Vectors using Pinecone schema.
+    File input is jsonl-pinecone (id, values, metadata).
+    """
+
+    def __init__(
+        self,
+        uri: str,
+        *,
+        feed_options: dict[str, Any] | None = None,
+        region_name: str | None = None,
+    ):
+        try:
+            import boto3  # noqa: PLC0415
+        except ImportError as exc:
+            raise NotConfigured("missing boto3 library") from exc
+
+        u = urlparse(uri)
+        if not u.hostname:
+            raise NotConfigured(
+                f"invalid S3 vectors URI: missing bucket name in '{uri}'"
+            )
+        index_path = u.path.lstrip("/")
+        if not index_path:
+            raise NotConfigured(
+                f"invalid S3 vectors URI: missing index name in '{uri}'"
+            )
+        if not region_name:
+            raise NotConfigured(
+                "S3 Vectors requires a region to be specified. "
+                "Set AWS_REGION_NAME in settings or pass region_name parameter."
+            )
+
+        self.region_name: str = region_name
+        self.index: str = index_path
+        self.bucket: str = u.hostname
+        # S3 Vectors type stubs available in mypy-boto3-s3vectors, but not in base boto3-stubs
+        self.client = boto3.client("s3vectors", region_name=region_name)  # type: ignore[call-overload]
+
+    @classmethod
+    def from_crawler(
+        cls,
+        crawler: Crawler,
+        uri: str,
+        *,
+        feed_options: dict[str, Any] | None = None,
+    ) -> S3VectorsFeedStorage:
+        return cls(
+            uri,
+            feed_options=feed_options,
+            region_name=crawler.settings.get("AWS_REGION_NAME"),
+        )
+
+    def _store_in_thread(self, file: IO[bytes]) -> None:
+        file.seek(0)
+        vectors = [
+            parsed for raw in file if (parsed := self._parse_line(raw)) is not None
+        ]
+        if vectors:
+            self.client.put_vectors(
+                vectorBucketName=self.bucket,
+                indexName=self.index,
+                vectors=vectors,
+            )
+        file.close()
+
+    def _parse_line(self, raw: bytes) -> dict[str, Any] | None:
+        if not raw or not raw.strip():
+            return None
+        line = raw.decode("utf-8")
+        rec = json.loads(line)
+        return {
+            "key": rec["id"],
+            "data": {"float32": rec["values"]},
+            # Metadata automatically becomes filterable in S3 Vectors by default
+            # Supports queries like: {"source": "file.pdf"}, {"year": {"$gte": 2020}}
+            "metadata": rec.get("metadata", {}),
+        }
 
 
 class FTPFeedStorage(BlockingFeedStorage):

--- a/scrapy/pipelines/embeddings.py
+++ b/scrapy/pipelines/embeddings.py
@@ -1,0 +1,109 @@
+"""
+Embeddings Pipeline
+
+Adds vector embeddings to scraped items.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any
+
+from itemadapter import ItemAdapter
+
+from scrapy.exceptions import NotConfigured
+
+# Optional dependency
+try:
+    import litellm
+except ImportError:
+    litellm = None
+
+if TYPE_CHECKING:
+    # typing.Self requires Python 3.11
+    from typing_extensions import Self
+
+    from scrapy import Spider
+    from scrapy.crawler import Crawler
+
+logger = logging.getLogger(__name__)
+
+
+class EmbeddingsLiteLLMPipeline:
+    """Add vector embeddings to Pinecone-formatted items using LiteLLM.
+
+    Input item format:
+        {
+            'id': 'unique_id',
+            'page_content': 'text to embed',
+            'metadata': {'source': 'file.pdf', ...}
+        }
+
+    Output item format:
+        {
+            'id': 'unique_id',
+            'values': [0.1, 0.2, 0.3, ...],      # Created by pipeline
+            'metadata': {
+                'page_content': 'text to embed', # Moved by pipeline
+                'source': 'file.pdf',
+                ...
+            }
+        }
+
+    Settings:
+        LITELLM_API_KEY: API key for the embedding provider (required)
+        LITELLM_EMBEDDING_MODEL: Model to use (default: openai's "text-embedding-3-small")
+    """
+
+    def __init__(
+        self,
+        api_key: str | None = None,
+        model: str = "text-embedding-3-small",
+    ):
+        if not api_key:
+            raise NotConfigured("LITELLM_API_KEY setting is required")
+        if litellm is None:
+            raise NotConfigured("litellm package not installed")
+
+        litellm.api_key = api_key
+        self.model = model
+
+    @classmethod
+    def from_crawler(cls, crawler: Crawler) -> Self:
+        settings = crawler.settings
+        return cls(
+            api_key=settings.get("LITELLM_API_KEY"),
+            model=settings.get("LITELLM_EMBEDDING_MODEL", "text-embedding-3-small"),
+        )
+
+    def process_item(self, item: Any, spider: Spider) -> Any:
+        adapter = ItemAdapter(item)
+
+        page_content = adapter.get("page_content")
+        if not page_content or not isinstance(page_content, str):
+            logger.debug(
+                f"Skipping item - invalid page_content: {page_content!r} "
+                f"({type(page_content).__name__})",
+                extra={"spider": spider},
+            )
+            return item
+
+        response = litellm.embedding(
+            model=self.model, input=page_content, num_retries=3
+        )
+        embedding = response["data"][0]["embedding"]
+
+        adapter["id"] = str(adapter["id"])
+        adapter["values"] = embedding
+        adapter["metadata"] = {
+            **adapter.get("metadata", {}),
+            "page_content": page_content,
+        }
+        del adapter["page_content"]
+
+        logger.debug(
+            f"Added embedding vector (length={len(embedding)}) "
+            f"to item {adapter.get('id', 'unknown')} via {self.model}",
+            extra={"spider": spider},
+        )
+        return item

--- a/scrapy/settings/default_settings.py
+++ b/scrapy/settings/default_settings.py
@@ -333,6 +333,7 @@ FEED_EXPORTERS_BASE = {
     "xml": "scrapy.exporters.XmlItemExporter",
     "marshal": "scrapy.exporters.MarshalItemExporter",
     "pickle": "scrapy.exporters.PickleItemExporter",
+    "jsonl-pinecone": "scrapy.exporters.JsonLinesItemExporter",
 }
 FEED_FORMAT = "jsonlines"
 FEED_STORE_EMPTY = True
@@ -345,6 +346,11 @@ FEED_STORAGES_BASE = {
     "s3": "scrapy.extensions.feedexport.S3FeedStorage",
     "stdout": "scrapy.extensions.feedexport.StdoutFeedStorage",
 }
+
+# Embeddings pipeline settings (LiteLLM)
+# LITELLM_API_KEY = "your-api-key-here"
+# LITELLM_EMBEDDING_MODEL = "text-embedding-3-small"
+
 FEED_STORAGE_FTP_ACTIVE = False
 FEED_STORAGE_GCS_ACL = ""
 FEED_STORAGE_S3_ACL = ""

--- a/tests/test_feedexport.py
+++ b/tests/test_feedexport.py
@@ -48,6 +48,7 @@ from scrapy.extensions.feedexport import (
     GCSFeedStorage,
     IFeedStorage,
     S3FeedStorage,
+    S3VectorsFeedStorage,
     StdoutFeedStorage,
 )
 from scrapy.settings import Settings
@@ -505,6 +506,56 @@ class TestS3FeedStorage:
                 feed_options={"overwrite": False},
             )
         assert "S3 does not support appending to files" in str(log)
+
+
+@pytest.mark.requires_boto3
+class TestS3VectorsFeedStorage:
+    def test_parse_credentials(self):
+        settings = {"AWS_REGION_NAME": "us-west-2"}
+        crawler = get_crawler(settings_dict=settings)
+
+        storage = S3VectorsFeedStorage.from_crawler(
+            crawler, "s3-vectors://bucket/index"
+        )
+        assert storage.region_name == "us-west-2"
+        assert storage.bucket == "bucket"
+        assert storage.index == "index"
+
+    def test_store(self):
+        storage = S3VectorsFeedStorage(
+            "s3-vectors://bucket/index", region_name="us-east-1"
+        )
+        verifyObject(IFeedStorage, storage)
+        storage.client = mock.MagicMock()
+
+        # Create test JSONL data with multiple records and empty line
+        test_data = (
+            b'{"id": "doc1", "values": [0.1, 0.2], "metadata": {"source": "test"}}\n'
+            b"\n"  # Empty line should be filtered out
+            b'{"id": "doc2", "values": [0.3, 0.4], "metadata": {"source": "file.pdf", "page": 5}}\n'
+            b'{"id": "doc3", "values": [0.5, 0.6]}\n'  # No metadata
+        )
+        test_file = BytesIO(test_data)
+        storage._store_in_thread(test_file)
+
+        # Verify put_vectors was called with correct parameters
+        storage.client.put_vectors.assert_called_once_with(
+            vectorBucketName="bucket",
+            indexName="index",
+            vectors=[
+                {
+                    "key": "doc1",
+                    "data": {"float32": [0.1, 0.2]},
+                    "metadata": {"source": "test"},
+                },
+                {
+                    "key": "doc2",
+                    "data": {"float32": [0.3, 0.4]},
+                    "metadata": {"source": "file.pdf", "page": 5},
+                },
+                {"key": "doc3", "data": {"float32": [0.5, 0.6]}, "metadata": {}},
+            ],
+        )
 
 
 class TestGCSFeedStorage:

--- a/tests/test_pipeline_embeddings.py
+++ b/tests/test_pipeline_embeddings.py
@@ -1,0 +1,89 @@
+"""Tests for the Embeddings LiteLLM pipeline."""
+
+from __future__ import annotations
+
+import pytest
+
+from scrapy.pipelines.embeddings import EmbeddingsLiteLLMPipeline
+from scrapy.utils.test import get_crawler
+
+
+@pytest.fixture
+def pipeline(monkeypatch):
+    def mock_embedding(*args, **kwargs):
+        return {
+            "data": [{"embedding": [0.1, 0.2, 0.3]}],
+            "model": "text-embedding-3-small",
+            "object": "list",
+            "usage": {"prompt_tokens": 5, "total_tokens": 5},
+        }
+
+    mock_litellm_obj = type(
+        "MockLiteLLM", (), {"api_key": None, "embedding": mock_embedding}
+    )
+    monkeypatch.setattr("scrapy.pipelines.embeddings.litellm", mock_litellm_obj)
+    return EmbeddingsLiteLLMPipeline(api_key="test-key")
+
+
+@pytest.mark.requires_litellm
+class TestEmbeddingsLiteLLMPipeline:
+    def test_from_crawler_with_default_settings(self, pipeline):
+        settings = {"LITELLM_API_KEY": "test-api-key"}
+        crawler = get_crawler(None, settings)
+        pipeline = EmbeddingsLiteLLMPipeline.from_crawler(crawler)
+        assert pipeline.model == "text-embedding-3-small"
+
+    def test_from_crawler_with_custom_settings(self, pipeline):
+        settings = {
+            "LITELLM_API_KEY": "test-api-key",
+            "LITELLM_EMBEDDING_MODEL": "cohere/embed-english-v3.0",
+        }
+        crawler = get_crawler(None, settings)
+        pipeline = EmbeddingsLiteLLMPipeline.from_crawler(crawler)
+        assert pipeline.model == "cohere/embed-english-v3.0"
+
+    def test_process_item(self, pipeline):
+        item = {
+            "id": "123",
+            "page_content": "Hello world",
+            "metadata": {"title": "Test Item", "source": "test.pdf"},
+            "url": "https://example.com",  # Extra field - should be ignored
+            "timestamp": "2024-01-01",  # Extra field - should be ignored
+        }
+        result = pipeline.process_item(item, None)
+
+        # Verify Pinecone format
+        assert result["id"] == "123"
+        assert result["values"] == [0.1, 0.2, 0.3]
+        assert result["metadata"]["page_content"] == "Hello world"
+        assert result["metadata"]["title"] == "Test Item"
+        assert result["metadata"]["source"] == "test.pdf"
+
+        # Extra fields should be preserved (JsonLines exporter handles final format)
+        assert result["url"] == "https://example.com"
+        assert result["timestamp"] == "2024-01-01"
+
+    @pytest.mark.parametrize(
+        ("item", "description"),
+        [
+            ({"id": "123", "metadata": {"title": "Test"}}, "missing page_content"),
+            (
+                {"id": "123", "page_content": "", "metadata": {"title": "Test"}},
+                "empty page_content",
+            ),
+            (
+                {"id": "123", "page_content": None, "metadata": {"title": "Test"}},
+                "None page_content",
+            ),
+            (
+                {"id": "123", "page_content": 12345, "metadata": {"title": "Test"}},
+                "invalid type page_content",
+            ),
+        ],
+    )
+    def test_skip_invalid_items(self, pipeline, item, description):
+        original_item = item.copy()
+        result = pipeline.process_item(item, None)
+
+        assert "values" not in result, f"Should skip item with {description}"
+        assert result == original_item, f"Item should be unchanged with {description}"

--- a/tox.ini
+++ b/tox.ini
@@ -145,6 +145,7 @@ deps =
     Twisted[http2]
     boto3
     bpython  # optional for shell wrapper tests
+    litellm>=1.55.0  # optional for embeddings pipeline
     brotli; implementation_name != "pypy"  # optional for HTTP compress downloader middleware tests
     brotlicffi; implementation_name == "pypy"  # optional for HTTP compress downloader middleware tests
     google-cloud-storage


### PR DESCRIPTION
Proposal for RAG use cases:
- Add Pipeline that takes scraped page and embeds it using LiteLLM, thus supporting various embedding models
- Add [S3 Vectors](https://aws.amazon.com/s3/features/vectors/) storage feed
- Add `jsonl-pinecone` format (id, values, metadata) as a simple format+schema to simplify how embedding pipeline and vector storage are built / used