### PR TITLE
docs: discourage using CrawlSpider in favor of Spider (#7025)

### DIFF
--- a/docs/topics/spiders.rst
+++ b/docs/topics/spiders.rst
@@ -427,11 +427,14 @@ CrawlSpider
 
 .. class:: CrawlSpider
 
-   This is the most commonly used spider for crawling regular websites, as it
-   provides a convenient mechanism for following links by defining a set of rules.
-   It may not be the best suited for your particular web sites or project, but
-   it's generic enough for several cases, so you can start from it and override it
-   as needed for more custom functionality, or just implement your own spider.
+    CrawlSpider provides a mechanism for crawling websites by following links
+    based on a set of rules. However, it is limited in flexibility and its control flow
+    can be confusing, especially when compared to a regular :class:`Spider`.
+
+    If you're starting a new project, or if you need extensibility or more control,
+    consider using a regular :class:`Spider` instead. CrawlSpider is only recommended for simple use cases
+    where you need basic link-following functionality without complex customization.
+
 
    Apart from the attributes inherited from Spider (that you must
    specify), this class supports a new attribute:


### PR DESCRIPTION
This pull request updates the documentation for CrawlSpider to recommend against using it for new projects.

The CrawlSpider class is limited in flexibility and has a control flow that is different from the standard Spider, which can lead to confusion and limitations when attempting to customize or extend its functionality.

Instead, we now encourage users to use the regular Spider class, which offers more flexibility and better extensibility for most use cases.

This change also highlights that CrawlSpider is best suited only for basic crawling tasks where minimal customization is needed.

Let me know if you'd like to adjust the description or need more information!