### PR TITLE
Deprecate the spider arg of downloader middleware methods.

### DIFF
--- a/docs/topics/downloader-middleware.rst
+++ b/docs/topics/downloader-middleware.rst
@@ -70,7 +70,7 @@ defines one or more of these methods:
 
    .. note::  Any of the downloader middleware methods may also return a deferred.
 
-   .. method:: process_request(request, spider)
+   .. method:: process_request(request)
 
       This method is called for each request that goes through the download
       middleware.
@@ -102,10 +102,7 @@ defines one or more of these methods:
       :param request: the request being processed
       :type request: :class:`~scrapy.Request` object
 
-      :param spider: the spider for which this request is intended
-      :type spider: :class:`~scrapy.Spider` object
-
-   .. method:: process_response(request, response, spider)
+   .. method:: process_response(request, response)
 
       :meth:`process_response` should either: return a :class:`~scrapy.http.Response`
       object, return a :class:`~scrapy.Request` object or
@@ -129,10 +126,7 @@ defines one or more of these methods:
       :param response: the response being processed
       :type response: :class:`~scrapy.http.Response` object
 
-      :param spider: the spider for which this response is intended
-      :type spider: :class:`~scrapy.Spider` object
-
-   .. method:: process_exception(request, exception, spider)
+   .. method:: process_exception(request, exception)
 
       Scrapy calls :meth:`process_exception` when a download handler
       or a :meth:`process_request` (from a downloader middleware) raises an
@@ -159,9 +153,6 @@ defines one or more of these methods:
 
       :param exception: the raised exception
       :type exception: an ``Exception`` object
-
-      :param spider: the spider for which this request is intended
-      :type spider: :class:`~scrapy.Spider` object
 
 .. _topics-downloader-middleware-ref:
 

--- a/scrapy/downloadermiddlewares/defaultheaders.py
+++ b/scrapy/downloadermiddlewares/defaultheaders.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from scrapy.utils.decorators import _warn_spider_arg
 from scrapy.utils.python import without_none_values
 
 if TYPE_CHECKING:
@@ -30,8 +31,9 @@ class DefaultHeadersMiddleware:
         headers = without_none_values(crawler.settings["DEFAULT_REQUEST_HEADERS"])
         return cls(headers.items())
 
+    @_warn_spider_arg
     def process_request(
-        self, request: Request, spider: Spider
+        self, request: Request, spider: Spider | None = None
     ) -> Request | Response | None:
         for k, v in self._headers:
             request.headers.setdefault(k, v)

--- a/scrapy/downloadermiddlewares/downloadtimeout.py
+++ b/scrapy/downloadermiddlewares/downloadtimeout.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from scrapy import Request, Spider, signals
+from scrapy.utils.decorators import _warn_spider_arg
 
 if TYPE_CHECKING:
     # typing.Self requires Python 3.11
@@ -31,8 +32,9 @@ class DownloadTimeoutMiddleware:
     def spider_opened(self, spider: Spider) -> None:
         self._timeout = getattr(spider, "download_timeout", self._timeout)
 
+    @_warn_spider_arg
     def process_request(
-        self, request: Request, spider: Spider
+        self, request: Request, spider: Spider | None = None
     ) -> Request | Response | None:
         if self._timeout:
             request.meta.setdefault("download_timeout", self._timeout)

--- a/scrapy/downloadermiddlewares/httpauth.py
+++ b/scrapy/downloadermiddlewares/httpauth.py
@@ -11,6 +11,7 @@ from typing import TYPE_CHECKING
 from w3lib.http import basic_auth_header
 
 from scrapy import Request, Spider, signals
+from scrapy.utils.decorators import _warn_spider_arg
 from scrapy.utils.url import url_is_from_any_domain
 
 if TYPE_CHECKING:
@@ -38,8 +39,9 @@ class HttpAuthMiddleware:
             self.auth = basic_auth_header(usr, pwd)
             self.domain = spider.http_auth_domain  # type: ignore[attr-defined]
 
+    @_warn_spider_arg
     def process_request(
-        self, request: Request, spider: Spider
+        self, request: Request, spider: Spider | None = None
     ) -> Request | Response | None:
         auth = getattr(self, "auth", None)
         if (

--- a/scrapy/downloadermiddlewares/httpcompression.py
+++ b/scrapy/downloadermiddlewares/httpcompression.py
@@ -15,6 +15,7 @@ from scrapy.utils._compression import (
     _unbrotli,
     _unzstd,
 )
+from scrapy.utils.decorators import _warn_spider_arg
 from scrapy.utils.gz import gunzip
 
 if TYPE_CHECKING:
@@ -93,14 +94,16 @@ class HttpCompressionMiddleware:
             )
             self._warn_size = spider.download_warnsize
 
+    @_warn_spider_arg
     def process_request(
-        self, request: Request, spider: Spider
+        self, request: Request, spider: Spider | None = None
     ) -> Request | Response | None:
         request.headers.setdefault("Accept-Encoding", b", ".join(ACCEPTED_ENCODINGS))
         return None
 
+    @_warn_spider_arg
     def process_response(
-        self, request: Request, response: Response, spider: Spider
+        self, request: Request, response: Response, spider: Spider | None = None
     ) -> Request | Response:
         if request.method == "HEAD":
             return response

--- a/scrapy/downloadermiddlewares/httpproxy.py
+++ b/scrapy/downloadermiddlewares/httpproxy.py
@@ -10,6 +10,7 @@ from urllib.request import (  # type: ignore[attr-defined]
 )
 
 from scrapy.exceptions import NotConfigured
+from scrapy.utils.decorators import _warn_spider_arg
 from scrapy.utils.httpobj import urlparse_cached
 from scrapy.utils.python import to_bytes
 
@@ -55,8 +56,9 @@ class HttpProxyMiddleware:
 
         return creds, proxy_url
 
+    @_warn_spider_arg
     def process_request(
-        self, request: Request, spider: Spider
+        self, request: Request, spider: Spider | None = None
     ) -> Request | Response | None:
         creds, proxy_url, scheme = None, None, None
         if "proxy" in request.meta:

--- a/scrapy/downloadermiddlewares/offsite.py
+++ b/scrapy/downloadermiddlewares/offsite.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING
 
 from scrapy import Request, Spider, signals
 from scrapy.exceptions import IgnoreRequest
+from scrapy.utils.decorators import _warn_spider_arg
 from scrapy.utils.httpobj import urlparse_cached
 
 if TYPE_CHECKING:
@@ -21,29 +22,34 @@ logger = logging.getLogger(__name__)
 
 
 class OffsiteMiddleware:
+    crawler: Crawler
+
+    def __init__(self, stats: StatsCollector):
+        self.stats = stats
+        self.domains_seen: set[str] = set()
+
     @classmethod
     def from_crawler(cls, crawler: Crawler) -> Self:
         assert crawler.stats
         o = cls(crawler.stats)
         crawler.signals.connect(o.spider_opened, signal=signals.spider_opened)
         crawler.signals.connect(o.request_scheduled, signal=signals.request_scheduled)
+        o.crawler = crawler
         return o
-
-    def __init__(self, stats: StatsCollector):
-        self.stats = stats
-        self.domains_seen: set[str] = set()
 
     def spider_opened(self, spider: Spider) -> None:
         self.host_regex: re.Pattern[str] = self.get_host_regex(spider)
 
     def request_scheduled(self, request: Request, spider: Spider) -> None:
-        self.process_request(request, spider)
+        self.process_request(request)
 
-    def process_request(self, request: Request, spider: Spider) -> None:
+    @_warn_spider_arg
+    def process_request(self, request: Request, spider: Spider | None = None) -> None:
+        assert self.crawler.spider
         if (
             request.dont_filter
             or request.meta.get("allow_offsite")
-            or self.should_follow(request, spider)
+            or self.should_follow(request, self.crawler.spider)
         ):
             return
         domain = urlparse_cached(request).hostname
@@ -52,7 +58,7 @@ class OffsiteMiddleware:
             logger.debug(
                 "Filtered offsite request to %(domain)r: %(request)s",
                 {"domain": domain, "request": request},
-                extra={"spider": spider},
+                extra={"spider": self.crawler.spider},
             )
             self.stats.inc_value("offsite/domains")
         self.stats.inc_value("offsite/filtered")

--- a/scrapy/downloadermiddlewares/redirect.py
+++ b/scrapy/downloadermiddlewares/redirect.py
@@ -8,6 +8,7 @@ from w3lib.url import safe_url_string
 
 from scrapy.exceptions import IgnoreRequest, NotConfigured
 from scrapy.http import HtmlResponse, Response
+from scrapy.utils.decorators import _warn_spider_arg
 from scrapy.utils.httpobj import urlparse_cached
 from scrapy.utils.response import get_meta_refresh
 
@@ -79,6 +80,7 @@ def _build_redirect_request(
 
 
 class BaseRedirectMiddleware:
+    crawler: Crawler
     enabled_setting: str = "REDIRECT_ENABLED"
 
     def __init__(self, settings: BaseSettings):
@@ -90,11 +92,11 @@ class BaseRedirectMiddleware:
 
     @classmethod
     def from_crawler(cls, crawler: Crawler) -> Self:
-        return cls(crawler.settings)
+        o = cls(crawler.settings)
+        o.crawler = crawler
+        return o
 
-    def _redirect(
-        self, redirected: Request, request: Request, spider: Spider, reason: Any
-    ) -> Request:
+    def _redirect(self, redirected: Request, request: Request, reason: Any) -> Request:
         ttl = request.meta.setdefault("redirect_ttl", self.max_redirect_times)
         redirects = request.meta.get("redirect_times", 0) + 1
 
@@ -114,13 +116,13 @@ class BaseRedirectMiddleware:
             logger.debug(
                 "Redirecting (%(reason)s) to %(redirected)s from %(request)s",
                 {"reason": reason, "redirected": redirected, "request": request},
-                extra={"spider": spider},
+                extra={"spider": self.crawler.spider},
             )
             return redirected
         logger.debug(
             "Discarding %(request)s: max redirections reached",
             {"request": request},
-            extra={"spider": spider},
+            extra={"spider": self.crawler.spider},
         )
         raise IgnoreRequest("max redirections reached")
 
@@ -144,12 +146,14 @@ class RedirectMiddleware(BaseRedirectMiddleware):
     and meta-refresh html tag.
     """
 
+    @_warn_spider_arg
     def process_response(
-        self, request: Request, response: Response, spider: Spider
+        self, request: Request, response: Response, spider: Spider | None = None
     ) -> Request | Response:
         if (
             request.meta.get("dont_redirect", False)
-            or response.status in getattr(spider, "handle_httpstatus_list", [])
+            or response.status
+            in getattr(self.crawler.spider, "handle_httpstatus_list", [])
             or response.status in request.meta.get("handle_httpstatus_list", [])
             or request.meta.get("handle_httpstatus_all", False)
         ):
@@ -171,10 +175,10 @@ class RedirectMiddleware(BaseRedirectMiddleware):
             return response
 
         if response.status in (301, 307, 308) or request.method == "HEAD":
-            return self._redirect(redirected, request, spider, response.status)
+            return self._redirect(redirected, request, response.status)
 
         redirected = self._redirect_request_using_get(request, redirected_url)
-        return self._redirect(redirected, request, spider, response.status)
+        return self._redirect(redirected, request, response.status)
 
 
 class MetaRefreshMiddleware(BaseRedirectMiddleware):
@@ -185,8 +189,9 @@ class MetaRefreshMiddleware(BaseRedirectMiddleware):
         self._ignore_tags: list[str] = settings.getlist("METAREFRESH_IGNORE_TAGS")
         self._maxdelay: int = settings.getint("METAREFRESH_MAXDELAY")
 
+    @_warn_spider_arg
     def process_response(
-        self, request: Request, response: Response, spider: Spider
+        self, request: Request, response: Response, spider: Spider | None = None
     ) -> Request | Response:
         if (
             request.meta.get("dont_redirect", False)
@@ -203,5 +208,5 @@ class MetaRefreshMiddleware(BaseRedirectMiddleware):
         if urlparse_cached(redirected).scheme not in {"http", "https"}:
             return response
         if cast("float", interval) < self._maxdelay:
-            return self._redirect(redirected, request, spider, "meta refresh")
+            return self._redirect(redirected, request, "meta refresh")
         return response

--- a/scrapy/downloadermiddlewares/retry.py
+++ b/scrapy/downloadermiddlewares/retry.py
@@ -16,6 +16,7 @@ from logging import Logger, getLogger
 from typing import TYPE_CHECKING
 
 from scrapy.exceptions import NotConfigured
+from scrapy.utils.decorators import _warn_spider_arg
 from scrapy.utils.misc import load_object
 from scrapy.utils.python import global_object_name
 from scrapy.utils.response import response_status_message
@@ -123,6 +124,8 @@ def get_retry_request(
 
 
 class RetryMiddleware:
+    crawler: Crawler
+
     def __init__(self, settings: BaseSettings):
         if not settings.getbool("RETRY_ENABLED"):
             raise NotConfigured
@@ -136,39 +139,41 @@ class RetryMiddleware:
 
     @classmethod
     def from_crawler(cls, crawler: Crawler) -> Self:
-        return cls(crawler.settings)
+        o = cls(crawler.settings)
+        o.crawler = crawler
+        return o
 
+    @_warn_spider_arg
     def process_response(
-        self, request: Request, response: Response, spider: Spider
+        self, request: Request, response: Response, spider: Spider | None = None
     ) -> Request | Response:
         if request.meta.get("dont_retry", False):
             return response
         if response.status in self.retry_http_codes:
             reason = response_status_message(response.status)
-            return self._retry(request, reason, spider) or response
+            return self._retry(request, reason) or response
         return response
 
+    @_warn_spider_arg
     def process_exception(
-        self, request: Request, exception: Exception, spider: Spider
+        self, request: Request, exception: Exception, spider: Spider | None = None
     ) -> Request | Response | None:
         if isinstance(exception, self.exceptions_to_retry) and not request.meta.get(
             "dont_retry", False
         ):
-            return self._retry(request, exception, spider)
+            return self._retry(request, exception)
         return None
 
     def _retry(
-        self,
-        request: Request,
-        reason: str | Exception | type[Exception],
-        spider: Spider,
+        self, request: Request, reason: str | Exception | type[Exception]
     ) -> Request | None:
         max_retry_times = request.meta.get("max_retry_times", self.max_retry_times)
         priority_adjust = request.meta.get("priority_adjust", self.priority_adjust)
+        assert self.crawler.spider
         return get_retry_request(
             request,
             reason=reason,
-            spider=spider,
+            spider=self.crawler.spider,
             max_retry_times=max_retry_times,
             priority_adjust=priority_adjust,
         )

--- a/scrapy/downloadermiddlewares/stats.py
+++ b/scrapy/downloadermiddlewares/stats.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING
 from twisted.web import http
 
 from scrapy.exceptions import NotConfigured
+from scrapy.utils.decorators import _warn_spider_arg
 from scrapy.utils.python import global_object_name, to_bytes
 from scrapy.utils.request import request_httprepr
 
@@ -45,8 +46,9 @@ class DownloaderStats:
         assert crawler.stats
         return cls(crawler.stats)
 
+    @_warn_spider_arg
     def process_request(
-        self, request: Request, spider: Spider
+        self, request: Request, spider: Spider | None = None
     ) -> Request | Response | None:
         self.stats.inc_value("downloader/request_count")
         self.stats.inc_value(f"downloader/request_method_count/{request.method}")
@@ -54,8 +56,9 @@ class DownloaderStats:
         self.stats.inc_value("downloader/request_bytes", reqlen)
         return None
 
+    @_warn_spider_arg
     def process_response(
-        self, request: Request, response: Response, spider: Spider
+        self, request: Request, response: Response, spider: Spider | None = None
     ) -> Request | Response:
         self.stats.inc_value("downloader/response_count")
         self.stats.inc_value(f"downloader/response_status_count/{response.status}")
@@ -69,8 +72,9 @@ class DownloaderStats:
         self.stats.inc_value("downloader/response_bytes", reslen)
         return response
 
+    @_warn_spider_arg
     def process_exception(
-        self, request: Request, exception: Exception, spider: Spider
+        self, request: Request, exception: Exception, spider: Spider | None = None
     ) -> Request | Response | None:
         ex_class = global_object_name(exception.__class__)
         self.stats.inc_value("downloader/exception_count")

--- a/scrapy/downloadermiddlewares/useragent.py
+++ b/scrapy/downloadermiddlewares/useragent.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from scrapy import Request, Spider, signals
+from scrapy.utils.decorators import _warn_spider_arg
 
 if TYPE_CHECKING:
     # typing.Self requires Python 3.11
@@ -29,8 +30,9 @@ class UserAgentMiddleware:
     def spider_opened(self, spider: Spider) -> None:
         self.user_agent = getattr(spider, "user_agent", self.user_agent)
 
+    @_warn_spider_arg
     def process_request(
-        self, request: Request, spider: Spider
+        self, request: Request, spider: Spider | None = None
     ) -> Request | Response | None:
         if self.user_agent:
             request.headers.setdefault(b"User-Agent", self.user_agent)

--- a/tests/test_downloadermiddleware.py
+++ b/tests/test_downloadermiddleware.py
@@ -128,7 +128,7 @@ class TestResponseFromProcessRequest(TestManagerBase):
         download_func = mock.MagicMock()
 
         class ResponseMiddleware:
-            def process_request(self, request, spider):
+            def process_request(self, request):
                 return resp
 
         async with self.get_mwman() as mwman:
@@ -151,11 +151,11 @@ class TestResponseFromProcessException(TestManagerBase):
             raise ValueError("test")
 
         class ResponseMiddleware:
-            def process_response(self, request, response, spider):
+            def process_response(self, request, response):
                 calls.append("process_response")
                 return resp
 
-            def process_exception(self, request, exception, spider):
+            def process_exception(self, request, exception):
                 calls.append("process_exception")
                 return resp
 
@@ -176,7 +176,7 @@ class TestInvalidOutput(TestManagerBase):
         req = Request("http://example.com/index.html")
 
         class InvalidProcessRequestMiddleware:
-            def process_request(self, request, spider):
+            def process_request(self, request):
                 return 1
 
         async with self.get_mwman() as mwman:
@@ -190,7 +190,7 @@ class TestInvalidOutput(TestManagerBase):
         req = Request("http://example.com/index.html")
 
         class InvalidProcessResponseMiddleware:
-            def process_response(self, request, response, spider):
+            def process_response(self, request, response):
                 return 1
 
         async with self.get_mwman() as mwman:
@@ -204,10 +204,10 @@ class TestInvalidOutput(TestManagerBase):
         req = Request("http://example.com/index.html")
 
         class InvalidProcessExceptionMiddleware:
-            def process_request(self, request, spider):
+            def process_request(self, request):
                 raise RuntimeError
 
-            def process_exception(self, request, exception, spider):
+            def process_exception(self, request, exception):
                 return 1
 
         async with self.get_mwman() as mwman:
@@ -229,7 +229,7 @@ class TestMiddlewareUsingDeferreds(TestManagerBase):
             def cb(self, result):
                 return result
 
-            def process_request(self, request, spider):
+            def process_request(self, request):
                 d = Deferred()
                 d.addCallback(self.cb)
                 d.callback(resp)
@@ -252,7 +252,7 @@ class TestMiddlewareUsingCoro(TestManagerBase):
         download_func = mock.MagicMock()
 
         class CoroMiddleware:
-            async def process_request(self, request, spider):
+            async def process_request(self, request):
                 await succeed(42)
                 return resp
 
@@ -270,7 +270,7 @@ class TestMiddlewareUsingCoro(TestManagerBase):
         download_func = mock.MagicMock()
 
         class CoroMiddleware:
-            async def process_request(self, request, spider):
+            async def process_request(self, request):
                 await asyncio.sleep(0.1)
                 return await get_from_asyncio_queue(resp)
 

--- a/tests/test_downloadermiddleware_defaultheaders.py
+++ b/tests/test_downloadermiddleware_defaultheaders.py
@@ -6,28 +6,27 @@ from scrapy.utils.test import get_crawler
 
 
 class TestDefaultHeadersMiddleware:
-    def get_defaults_spider_mw(self):
+    def get_defaults_mw(self):
         crawler = get_crawler(Spider)
-        spider = crawler._create_spider("foo")
         defaults = {
             to_bytes(k): [to_bytes(v)]
             for k, v in crawler.settings.get("DEFAULT_REQUEST_HEADERS").items()
         }
-        return defaults, spider, DefaultHeadersMiddleware.from_crawler(crawler)
+        return defaults, DefaultHeadersMiddleware.from_crawler(crawler)
 
     def test_process_request(self):
-        defaults, spider, mw = self.get_defaults_spider_mw()
+        defaults, mw = self.get_defaults_mw()
         req = Request("http://www.scrapytest.org")
-        mw.process_request(req, spider)
+        mw.process_request(req)
         assert req.headers == defaults
 
     def test_update_headers(self):
-        defaults, spider, mw = self.get_defaults_spider_mw()
+        defaults, mw = self.get_defaults_mw()
         headers = {"Accept-Language": ["es"], "Test-Header": ["test"]}
         bytes_headers = {b"Accept-Language": [b"es"], b"Test-Header": [b"test"]}
         req = Request("http://www.scrapytest.org", headers=headers)
         assert req.headers == bytes_headers
 
-        mw.process_request(req, spider)
+        mw.process_request(req)
         defaults.update(bytes_headers)
         assert req.headers == defaults

--- a/tests/test_downloadermiddleware_downloadtimeout.py
+++ b/tests/test_downloadermiddleware_downloadtimeout.py
@@ -14,20 +14,20 @@ class TestDownloadTimeoutMiddleware:
     def test_default_download_timeout(self):
         req, spider, mw = self.get_request_spider_mw()
         mw.spider_opened(spider)
-        assert mw.process_request(req, spider) is None
+        assert mw.process_request(req) is None
         assert req.meta.get("download_timeout") == 180
 
     def test_string_download_timeout(self):
         req, spider, mw = self.get_request_spider_mw({"DOWNLOAD_TIMEOUT": "20.1"})
         mw.spider_opened(spider)
-        assert mw.process_request(req, spider) is None
+        assert mw.process_request(req) is None
         assert req.meta.get("download_timeout") == 20.1
 
     def test_spider_has_download_timeout(self):
         req, spider, mw = self.get_request_spider_mw()
         spider.download_timeout = 2
         mw.spider_opened(spider)
-        assert mw.process_request(req, spider) is None
+        assert mw.process_request(req) is None
         assert req.meta.get("download_timeout") == 2
 
     def test_request_has_download_timeout(self):
@@ -35,5 +35,5 @@ class TestDownloadTimeoutMiddleware:
         spider.download_timeout = 2
         mw.spider_opened(spider)
         req.meta["download_timeout"] = 1
-        assert mw.process_request(req, spider) is None
+        assert mw.process_request(req) is None
         assert req.meta.get("download_timeout") == 1

--- a/tests/test_downloadermiddleware_httpauth.py
+++ b/tests/test_downloadermiddleware_httpauth.py
@@ -36,48 +36,48 @@ class TestHttpAuthMiddlewareLegacy:
 class TestHttpAuthMiddleware:
     def setup_method(self):
         self.mw = HttpAuthMiddleware()
-        self.spider = DomainSpider("foo")
-        self.mw.spider_opened(self.spider)
+        spider = DomainSpider("foo")
+        self.mw.spider_opened(spider)
 
     def teardown_method(self):
         del self.mw
 
     def test_no_auth(self):
         req = Request("http://example-noauth.com/")
-        assert self.mw.process_request(req, self.spider) is None
+        assert self.mw.process_request(req) is None
         assert "Authorization" not in req.headers
 
     def test_auth_domain(self):
         req = Request("http://example.com/")
-        assert self.mw.process_request(req, self.spider) is None
+        assert self.mw.process_request(req) is None
         assert req.headers["Authorization"] == basic_auth_header("foo", "bar")
 
     def test_auth_subdomain(self):
         req = Request("http://foo.example.com/")
-        assert self.mw.process_request(req, self.spider) is None
+        assert self.mw.process_request(req) is None
         assert req.headers["Authorization"] == basic_auth_header("foo", "bar")
 
     def test_auth_already_set(self):
         req = Request("http://example.com/", headers={"Authorization": "Digest 123"})
-        assert self.mw.process_request(req, self.spider) is None
+        assert self.mw.process_request(req) is None
         assert req.headers["Authorization"] == b"Digest 123"
 
 
 class TestHttpAuthAnyMiddleware:
     def setup_method(self):
         self.mw = HttpAuthMiddleware()
-        self.spider = AnyDomainSpider("foo")
-        self.mw.spider_opened(self.spider)
+        spider = AnyDomainSpider("foo")
+        self.mw.spider_opened(spider)
 
     def teardown_method(self):
         del self.mw
 
     def test_auth(self):
         req = Request("http://example.com/")
-        assert self.mw.process_request(req, self.spider) is None
+        assert self.mw.process_request(req) is None
         assert req.headers["Authorization"] == basic_auth_header("foo", "bar")
 
     def test_auth_already_set(self):
         req = Request("http://example.com/", headers={"Authorization": "Digest 123"})
-        assert self.mw.process_request(req, self.spider) is None
+        assert self.mw.process_request(req) is None
         assert req.headers["Authorization"] == b"Digest 123"

--- a/tests/test_downloadermiddleware_httpcache.py
+++ b/tests/test_downloadermiddleware_httpcache.py
@@ -1,28 +1,36 @@
+from __future__ import annotations
+
 import email.utils
 import shutil
 import tempfile
 import time
 from contextlib import contextmanager
+from typing import TYPE_CHECKING, Any
 
 import pytest
 
 from scrapy.downloadermiddlewares.httpcache import HttpCacheMiddleware
 from scrapy.exceptions import IgnoreRequest
 from scrapy.http import HtmlResponse, Request, Response
-from scrapy.settings import Settings
 from scrapy.spiders import Spider
 from scrapy.utils.test import get_crawler
+
+if TYPE_CHECKING:
+    from collections.abc import Generator
+
+    from scrapy.crawler import Crawler
 
 
 class TestBase:
     """Base class with common setup and helper methods."""
 
+    policy_class: str
+    storage_class: str
+
     def setup_method(self):
         self.yesterday = email.utils.formatdate(time.time() - 86400)
         self.today = email.utils.formatdate()
         self.tomorrow = email.utils.formatdate(time.time() + 86400)
-        self.crawler = get_crawler(Spider)
-        self.spider = self.crawler._create_spider("example.com")
         self.tmpdir = tempfile.mkdtemp()
         self.request = Request("http://www.example.com", headers={"User-Agent": "test"})
         self.response = Response(
@@ -31,13 +39,11 @@ class TestBase:
             body=b"test body",
             status=202,
         )
-        self.crawler.stats.open_spider()
 
     def teardown_method(self):
-        self.crawler.stats.close_spider()
         shutil.rmtree(self.tmpdir)
 
-    def _get_settings(self, **new_settings):
+    def _get_settings(self, **new_settings: Any) -> dict[str, Any]:
         settings = {
             "HTTPCACHE_ENABLED": True,
             "HTTPCACHE_DIR": self.tmpdir,
@@ -47,27 +53,35 @@ class TestBase:
             "HTTPCACHE_STORAGE": self.storage_class,
         }
         settings.update(new_settings)
-        return Settings(settings)
+        return settings
 
     @contextmanager
-    def _storage(self, **new_settings):
-        with self._middleware(**new_settings) as mw:
-            yield mw.storage
-
-    @contextmanager
-    def _policy(self, **new_settings):
-        with self._middleware(**new_settings) as mw:
-            yield mw.policy
-
-    @contextmanager
-    def _middleware(self, **new_settings):
+    def _get_crawler(self, **new_settings: Any) -> Generator[Crawler]:
         settings = self._get_settings(**new_settings)
-        mw = HttpCacheMiddleware(settings, self.crawler.stats)
-        mw.spider_opened(self.spider)
+        crawler = get_crawler(Spider, settings)
+        crawler.spider = crawler._create_spider("example.com")
+        assert crawler.stats
+        crawler.stats.open_spider()
         try:
-            yield mw
+            yield crawler
         finally:
-            mw.spider_closed(self.spider)
+            crawler.stats.close_spider()
+
+    @contextmanager
+    def _storage(self, **new_settings: Any):
+        with self._middleware(**new_settings) as mw:
+            yield mw.storage, mw.crawler
+
+    @contextmanager
+    def _middleware(self, **new_settings: Any) -> Generator[HttpCacheMiddleware]:
+        with self._get_crawler(**new_settings) as crawler:
+            assert crawler.spider
+            mw = HttpCacheMiddleware.from_crawler(crawler)
+            mw.spider_opened(crawler.spider)
+            try:
+                yield mw
+            finally:
+                mw.spider_closed(crawler.spider)
 
     def assertEqualResponse(self, response1, response2):
         assert response1.url == response2.url
@@ -94,37 +108,37 @@ class StorageTestMixin:
     """Mixin containing storage-specific test methods."""
 
     def test_storage(self):
-        with self._storage() as storage:
+        with self._storage() as (storage, crawler):
             request2 = self.request.copy()
-            assert storage.retrieve_response(self.spider, request2) is None
+            assert storage.retrieve_response(crawler.spider, request2) is None
 
-            storage.store_response(self.spider, self.request, self.response)
-            response2 = storage.retrieve_response(self.spider, request2)
+            storage.store_response(crawler.spider, self.request, self.response)
+            response2 = storage.retrieve_response(crawler.spider, request2)
             assert isinstance(response2, HtmlResponse)  # content-type header
             self.assertEqualResponse(self.response, response2)
 
             time.sleep(2)  # wait for cache to expire
-            assert storage.retrieve_response(self.spider, request2) is None
+            assert storage.retrieve_response(crawler.spider, request2) is None
 
     def test_storage_never_expire(self):
-        with self._storage(HTTPCACHE_EXPIRATION_SECS=0) as storage:
-            assert storage.retrieve_response(self.spider, self.request) is None
-            storage.store_response(self.spider, self.request, self.response)
+        with self._storage(HTTPCACHE_EXPIRATION_SECS=0) as (storage, crawler):
+            assert storage.retrieve_response(crawler.spider, self.request) is None
+            storage.store_response(crawler.spider, self.request, self.response)
             time.sleep(0.5)  # give the chance to expire
-            assert storage.retrieve_response(self.spider, self.request)
+            assert storage.retrieve_response(crawler.spider, self.request)
 
     def test_storage_no_content_type_header(self):
         """Test that the response body is used to get the right response class
         even if there is no Content-Type header"""
-        with self._storage() as storage:
-            assert storage.retrieve_response(self.spider, self.request) is None
+        with self._storage() as (storage, crawler):
+            assert storage.retrieve_response(crawler.spider, self.request) is None
             response = Response(
                 "http://www.example.com",
                 body=b"<!DOCTYPE html>\n<title>.</title>",
                 status=202,
             )
-            storage.store_response(self.spider, self.request, response)
-            cached_response = storage.retrieve_response(self.spider, self.request)
+            storage.store_response(crawler.spider, self.request, response)
+            cached_response = storage.retrieve_response(crawler.spider, self.request)
             assert isinstance(cached_response, HtmlResponse)
             self.assertEqualResponse(response, cached_response)
 
@@ -135,15 +149,15 @@ class PolicyTestMixin:
     def test_dont_cache(self):
         with self._middleware() as mw:
             self.request.meta["dont_cache"] = True
-            mw.process_response(self.request, self.response, self.spider)
-            assert mw.storage.retrieve_response(self.spider, self.request) is None
+            mw.process_response(self.request, self.response)
+            assert mw.storage.retrieve_response(mw.crawler.spider, self.request) is None
 
         with self._middleware() as mw:
             self.request.meta["dont_cache"] = False
-            mw.process_response(self.request, self.response, self.spider)
+            mw.process_response(self.request, self.response)
             if mw.policy.should_cache_response(self.response, self.request):
                 assert isinstance(
-                    mw.storage.retrieve_response(self.spider, self.request),
+                    mw.storage.retrieve_response(mw.crawler.spider, self.request),
                     self.response.__class__,
                 )
 
@@ -153,9 +167,9 @@ class DummyPolicyTestMixin(PolicyTestMixin):
 
     def test_middleware(self):
         with self._middleware() as mw:
-            assert mw.process_request(self.request, self.spider) is None
-            mw.process_response(self.request, self.response, self.spider)
-            response = mw.process_request(self.request, self.spider)
+            assert mw.process_request(self.request) is None
+            mw.process_response(self.request, self.response)
+            response = mw.process_request(self.request)
             assert isinstance(response, HtmlResponse)
             self.assertEqualResponse(self.response, response)
             assert "cached" in response.flags
@@ -164,9 +178,9 @@ class DummyPolicyTestMixin(PolicyTestMixin):
         with self._middleware() as mw:
             req = Request("http://host.com/path")
             res = Response("http://host2.net/test.html")
-            assert mw.process_request(req, self.spider) is None
-            mw.process_response(req, res, self.spider)
-            cached = mw.process_request(req, self.spider)
+            assert mw.process_request(req) is None
+            mw.process_response(req, res)
+            cached = mw.process_request(req)
             assert isinstance(cached, Response)
             self.assertEqualResponse(res, cached)
             assert "cached" in cached.flags
@@ -174,9 +188,9 @@ class DummyPolicyTestMixin(PolicyTestMixin):
     def test_middleware_ignore_missing(self):
         with self._middleware(HTTPCACHE_IGNORE_MISSING=True) as mw:
             with pytest.raises(IgnoreRequest):
-                mw.process_request(self.request, self.spider)
-            mw.process_response(self.request, self.response, self.spider)
-            response = mw.process_request(self.request, self.spider)
+                mw.process_request(self.request)
+            mw.process_response(self.request, self.response)
+            response = mw.process_request(self.request)
             assert isinstance(response, HtmlResponse)
             self.assertEqualResponse(self.response, response)
             assert "cached" in response.flags
@@ -185,10 +199,10 @@ class DummyPolicyTestMixin(PolicyTestMixin):
         # http responses are cached by default
         req, res = Request("http://test.com/"), Response("http://test.com/")
         with self._middleware() as mw:
-            assert mw.process_request(req, self.spider) is None
-            mw.process_response(req, res, self.spider)
+            assert mw.process_request(req) is None
+            mw.process_response(req, res)
 
-            cached = mw.process_request(req, self.spider)
+            cached = mw.process_request(req)
             assert isinstance(cached, Response), type(cached)
             self.assertEqualResponse(res, cached)
             assert "cached" in cached.flags
@@ -196,19 +210,19 @@ class DummyPolicyTestMixin(PolicyTestMixin):
         # file response is not cached by default
         req, res = Request("file:///tmp/t.txt"), Response("file:///tmp/t.txt")
         with self._middleware() as mw:
-            assert mw.process_request(req, self.spider) is None
-            mw.process_response(req, res, self.spider)
+            assert mw.process_request(req) is None
+            mw.process_response(req, res)
 
-            assert mw.storage.retrieve_response(self.spider, req) is None
-            assert mw.process_request(req, self.spider) is None
+            assert mw.storage.retrieve_response(mw.crawler.spider, req) is None
+            assert mw.process_request(req) is None
 
         # s3 scheme response is cached by default
         req, res = Request("s3://bucket/key"), Response("http://bucket/key")
         with self._middleware() as mw:
-            assert mw.process_request(req, self.spider) is None
-            mw.process_response(req, res, self.spider)
+            assert mw.process_request(req) is None
+            mw.process_response(req, res)
 
-            cached = mw.process_request(req, self.spider)
+            cached = mw.process_request(req)
             assert isinstance(cached, Response), type(cached)
             self.assertEqualResponse(res, cached)
             assert "cached" in cached.flags
@@ -216,25 +230,25 @@ class DummyPolicyTestMixin(PolicyTestMixin):
         # ignore s3 scheme
         req, res = Request("s3://bucket/key2"), Response("http://bucket/key2")
         with self._middleware(HTTPCACHE_IGNORE_SCHEMES=["s3"]) as mw:
-            assert mw.process_request(req, self.spider) is None
-            mw.process_response(req, res, self.spider)
+            assert mw.process_request(req) is None
+            mw.process_response(req, res)
 
-            assert mw.storage.retrieve_response(self.spider, req) is None
-            assert mw.process_request(req, self.spider) is None
+            assert mw.storage.retrieve_response(mw.crawler.spider, req) is None
+            assert mw.process_request(req) is None
 
     def test_middleware_ignore_http_codes(self):
         # test response is not cached
         with self._middleware(HTTPCACHE_IGNORE_HTTP_CODES=[202]) as mw:
-            assert mw.process_request(self.request, self.spider) is None
-            mw.process_response(self.request, self.response, self.spider)
+            assert mw.process_request(self.request) is None
+            mw.process_response(self.request, self.response)
 
-            assert mw.storage.retrieve_response(self.spider, self.request) is None
-            assert mw.process_request(self.request, self.spider) is None
+            assert mw.storage.retrieve_response(mw.crawler.spider, self.request) is None
+            assert mw.process_request(self.request) is None
 
         # test response is cached
         with self._middleware(HTTPCACHE_IGNORE_HTTP_CODES=[203]) as mw:
-            mw.process_response(self.request, self.response, self.spider)
-            response = mw.process_request(self.request, self.spider)
+            mw.process_response(self.request, self.response)
+            response = mw.process_request(self.request)
             assert isinstance(response, HtmlResponse)
             self.assertEqualResponse(self.response, response)
             assert "cached" in response.flags
@@ -243,14 +257,18 @@ class DummyPolicyTestMixin(PolicyTestMixin):
 class RFC2616PolicyTestMixin(PolicyTestMixin):
     """Mixin containing RFC2616 policy specific test methods."""
 
-    def _process_requestresponse(self, mw, request, response):
+    @staticmethod
+    def _process_requestresponse(
+        mw: HttpCacheMiddleware, request: Request, response: Response | None
+    ) -> Response | Request:
         result = None
         try:
-            result = mw.process_request(request, self.spider)
+            result = mw.process_request(request)
             if result:
                 assert isinstance(result, (Request, Response))
                 return result
-            result = mw.process_response(request, response, self.spider)
+            assert response is not None
+            result = mw.process_response(request, response)
             assert isinstance(result, Response)
             return result
         except Exception:
@@ -270,11 +288,11 @@ class RFC2616PolicyTestMixin(PolicyTestMixin):
             # response for a request with no-store must not be cached
             res1 = self._process_requestresponse(mw, req1, res0)
             self.assertEqualResponse(res1, res0)
-            assert mw.storage.retrieve_response(self.spider, req1) is None
+            assert mw.storage.retrieve_response(mw.crawler.spider, req1) is None
             # Re-do request without no-store and expect it to be cached
             res2 = self._process_requestresponse(mw, req0, res0)
             assert "cached" not in res2.flags
-            res3 = mw.process_request(req0, self.spider)
+            res3 = mw.process_request(req0)
             assert "cached" in res3.flags
             self.assertEqualResponse(res2, res3)
             # request with no-cache directive must not return cached response
@@ -330,7 +348,7 @@ class RFC2616PolicyTestMixin(PolicyTestMixin):
                 )
                 self.assertEqualResponse(res1, res0)
                 self.assertEqualResponse(res2, res0)
-                resc = mw.storage.retrieve_response(self.spider, req0)
+                resc = mw.storage.retrieve_response(mw.crawler.spider, req0)
                 if shouldcache:
                     self.assertEqualResponse(resc, res1)
                     assert "cached" in res2.flags
@@ -354,7 +372,7 @@ class RFC2616PolicyTestMixin(PolicyTestMixin):
                 )
                 self.assertEqualResponse(res1, res0)
                 self.assertEqualResponse(res2, res0)
-                resc = mw.storage.retrieve_response(self.spider, req0)
+                resc = mw.storage.retrieve_response(mw.crawler.spider, req0)
                 if shouldcache:
                     self.assertEqualResponse(resc, res1)
                     assert "cached" in res2.flags
@@ -421,7 +439,7 @@ class RFC2616PolicyTestMixin(PolicyTestMixin):
                 # validate cached response if request max-age set as 0
                 req1 = req0.replace(headers={"Cache-Control": "max-age=0"})
                 res304 = res0.replace(status=304)
-                assert mw.process_request(req1, self.spider) is None
+                assert mw.process_request(req1) is None
                 res3 = self._process_requestresponse(mw, req1, res304)
                 self.assertEqualResponse(res1, res3)
                 assert "cached" in res3.flags
@@ -513,14 +531,14 @@ class RFC2616PolicyTestMixin(PolicyTestMixin):
             self._process_requestresponse(mw, req0, res0)
             for e in mw.DOWNLOAD_EXCEPTIONS:
                 # Simulate encountering an error on download attempts
-                assert mw.process_request(req0, self.spider) is None
-                res1 = mw.process_exception(req0, e("foo"), self.spider)
+                assert mw.process_request(req0) is None
+                res1 = mw.process_exception(req0, e("foo"))
                 # Use cached response as recovery
                 assert "cached" in res1.flags
                 self.assertEqualResponse(res0, res1)
             # Do not use cached response for unhandled exceptions
-            mw.process_request(req0, self.spider)
-            assert mw.process_exception(req0, Exception("foo"), self.spider) is None
+            mw.process_request(req0)
+            assert mw.process_exception(req0, Exception("foo")) is None
 
     def test_ignore_response_cache_controls(self):
         sampledata = [
@@ -578,17 +596,17 @@ class TestDbmStorageWithRFC2616Policy(
 class TestDbmStorageWithCustomDbmModule(TestDbmStorageWithDummyPolicy):
     dbm_module = "tests.mocks.dummydbm"
 
-    def _get_settings(self, **new_settings):
+    def _get_settings(self, **new_settings) -> dict[str, Any]:
         new_settings.setdefault("HTTPCACHE_DBM_MODULE", self.dbm_module)
         return super()._get_settings(**new_settings)
 
     def test_custom_dbm_module_loaded(self):
         # make sure our dbm module has been loaded
-        with self._storage() as storage:
+        with self._storage() as (storage, _):
             assert storage.dbmodule.__name__ == self.dbm_module
 
 
 class TestFilesystemStorageGzipWithDummyPolicy(TestFilesystemStorageWithDummyPolicy):
-    def _get_settings(self, **new_settings):
+    def _get_settings(self, **new_settings) -> dict[str, Any]:
         new_settings.setdefault("HTTPCACHE_GZIP", True)
         return super()._get_settings(**new_settings)

--- a/tests/test_downloadermiddleware_offsite.py
+++ b/tests/test_downloadermiddleware_offsite.py
@@ -28,15 +28,15 @@ UNSET = object()
 )
 def test_process_request_domain_filtering(allowed_domain, url, allowed):
     crawler = get_crawler(Spider)
-    spider = crawler._create_spider(name="a", allowed_domains=[allowed_domain])
+    crawler.spider = crawler._create_spider(name="a", allowed_domains=[allowed_domain])
     mw = OffsiteMiddleware.from_crawler(crawler)
-    mw.spider_opened(spider)
+    mw.spider_opened(crawler.spider)
     request = Request(url)
     if allowed:
-        assert mw.process_request(request, spider) is None
+        assert mw.process_request(request) is None
     else:
         with pytest.raises(IgnoreRequest):
-            mw.process_request(request, spider)
+            mw.process_request(request)
 
 
 @pytest.mark.parametrize(
@@ -50,18 +50,18 @@ def test_process_request_domain_filtering(allowed_domain, url, allowed):
 )
 def test_process_request_dont_filter(value, filtered):
     crawler = get_crawler(Spider)
-    spider = crawler._create_spider(name="a", allowed_domains=["a.example"])
+    crawler.spider = crawler._create_spider(name="a", allowed_domains=["a.example"])
     mw = OffsiteMiddleware.from_crawler(crawler)
-    mw.spider_opened(spider)
+    mw.spider_opened(crawler.spider)
     kwargs = {}
     if value is not UNSET:
         kwargs["dont_filter"] = value
     request = Request("https://b.example", **kwargs)
     if filtered:
         with pytest.raises(IgnoreRequest):
-            mw.process_request(request, spider)
+            mw.process_request(request)
     else:
-        assert mw.process_request(request, spider) is None
+        assert mw.process_request(request) is None
 
 
 @pytest.mark.parametrize(
@@ -79,9 +79,9 @@ def test_process_request_dont_filter(value, filtered):
 )
 def test_process_request_allow_offsite(allow_offsite, dont_filter, filtered):
     crawler = get_crawler(Spider)
-    spider = crawler._create_spider(name="a", allowed_domains=["a.example"])
+    crawler.spider = crawler._create_spider(name="a", allowed_domains=["a.example"])
     mw = OffsiteMiddleware.from_crawler(crawler)
-    mw.spider_opened(spider)
+    mw.spider_opened(crawler.spider)
     kwargs = {"meta": {}}
     if allow_offsite is not UNSET:
         kwargs["meta"]["allow_offsite"] = allow_offsite
@@ -90,9 +90,9 @@ def test_process_request_allow_offsite(allow_offsite, dont_filter, filtered):
     request = Request("https://b.example", **kwargs)
     if filtered:
         with pytest.raises(IgnoreRequest):
-            mw.process_request(request, spider)
+            mw.process_request(request)
     else:
-        assert mw.process_request(request, spider) is None
+        assert mw.process_request(request) is None
 
 
 @pytest.mark.parametrize(
@@ -108,27 +108,27 @@ def test_process_request_no_allowed_domains(value):
     kwargs = {}
     if value is not UNSET:
         kwargs["allowed_domains"] = value
-    spider = crawler._create_spider(name="a", **kwargs)
+    crawler.spider = crawler._create_spider(name="a", **kwargs)
     mw = OffsiteMiddleware.from_crawler(crawler)
-    mw.spider_opened(spider)
+    mw.spider_opened(crawler.spider)
     request = Request("https://example.com")
-    assert mw.process_request(request, spider) is None
+    assert mw.process_request(request) is None
 
 
 def test_process_request_invalid_domains():
     crawler = get_crawler(Spider)
     allowed_domains = ["a.example", None, "http:////b.example", "//c.example"]
-    spider = crawler._create_spider(name="a", allowed_domains=allowed_domains)
+    crawler.spider = crawler._create_spider(name="a", allowed_domains=allowed_domains)
     mw = OffsiteMiddleware.from_crawler(crawler)
     with warnings.catch_warnings():
         warnings.simplefilter("ignore", UserWarning)
-        mw.spider_opened(spider)
+        mw.spider_opened(crawler.spider)
     request = Request("https://a.example")
-    assert mw.process_request(request, spider) is None
+    assert mw.process_request(request) is None
     for letter in ("b", "c"):
         request = Request(f"https://{letter}.example")
         with pytest.raises(IgnoreRequest):
-            mw.process_request(request, spider)
+            mw.process_request(request)
 
 
 @pytest.mark.parametrize(
@@ -149,15 +149,15 @@ def test_process_request_invalid_domains():
 )
 def test_request_scheduled_domain_filtering(allowed_domain, url, allowed):
     crawler = get_crawler(Spider)
-    spider = crawler._create_spider(name="a", allowed_domains=[allowed_domain])
+    crawler.spider = crawler._create_spider(name="a", allowed_domains=[allowed_domain])
     mw = OffsiteMiddleware.from_crawler(crawler)
-    mw.spider_opened(spider)
+    mw.spider_opened(crawler.spider)
     request = Request(url)
     if allowed:
-        assert mw.request_scheduled(request, spider) is None
+        assert mw.request_scheduled(request, crawler.spider) is None
     else:
         with pytest.raises(IgnoreRequest):
-            mw.request_scheduled(request, spider)
+            mw.request_scheduled(request, crawler.spider)
 
 
 @pytest.mark.parametrize(
@@ -171,18 +171,18 @@ def test_request_scheduled_domain_filtering(allowed_domain, url, allowed):
 )
 def test_request_scheduled_dont_filter(value, filtered):
     crawler = get_crawler(Spider)
-    spider = crawler._create_spider(name="a", allowed_domains=["a.example"])
+    crawler.spider = crawler._create_spider(name="a", allowed_domains=["a.example"])
     mw = OffsiteMiddleware.from_crawler(crawler)
-    mw.spider_opened(spider)
+    mw.spider_opened(crawler.spider)
     kwargs = {}
     if value is not UNSET:
         kwargs["dont_filter"] = value
     request = Request("https://b.example", **kwargs)
     if filtered:
         with pytest.raises(IgnoreRequest):
-            mw.request_scheduled(request, spider)
+            mw.request_scheduled(request, crawler.spider)
     else:
-        assert mw.request_scheduled(request, spider) is None
+        assert mw.request_scheduled(request, crawler.spider) is None
 
 
 @pytest.mark.parametrize(
@@ -198,24 +198,24 @@ def test_request_scheduled_no_allowed_domains(value):
     kwargs = {}
     if value is not UNSET:
         kwargs["allowed_domains"] = value
-    spider = crawler._create_spider(name="a", **kwargs)
+    crawler.spider = crawler._create_spider(name="a", **kwargs)
     mw = OffsiteMiddleware.from_crawler(crawler)
-    mw.spider_opened(spider)
+    mw.spider_opened(crawler.spider)
     request = Request("https://example.com")
-    assert mw.request_scheduled(request, spider) is None
+    assert mw.request_scheduled(request, crawler.spider) is None
 
 
 def test_request_scheduled_invalid_domains():
     crawler = get_crawler(Spider)
     allowed_domains = ["a.example", None, "http:////b.example", "//c.example"]
-    spider = crawler._create_spider(name="a", allowed_domains=allowed_domains)
+    crawler.spider = crawler._create_spider(name="a", allowed_domains=allowed_domains)
     mw = OffsiteMiddleware.from_crawler(crawler)
     with warnings.catch_warnings():
         warnings.simplefilter("ignore", UserWarning)
-        mw.spider_opened(spider)
+        mw.spider_opened(crawler.spider)
     request = Request("https://a.example")
-    assert mw.request_scheduled(request, spider) is None
+    assert mw.request_scheduled(request, crawler.spider) is None
     for letter in ("b", "c"):
         request = Request(f"https://{letter}.example")
         with pytest.raises(IgnoreRequest):
-            mw.request_scheduled(request, spider)
+            mw.request_scheduled(request, crawler.spider)

--- a/tests/test_downloadermiddleware_retry.py
+++ b/tests/test_downloadermiddleware_retry.py
@@ -19,20 +19,21 @@ from scrapy.exceptions import IgnoreRequest
 from scrapy.http import Request, Response
 from scrapy.settings.default_settings import RETRY_EXCEPTIONS
 from scrapy.spiders import Spider
+from scrapy.utils.spider import DefaultSpider
 from scrapy.utils.test import get_crawler
 
 
 class TestRetry:
     def setup_method(self):
-        self.crawler = get_crawler(Spider)
-        self.spider = self.crawler._create_spider("foo")
+        self.crawler = get_crawler(DefaultSpider)
+        self.crawler.spider = self.crawler._create_spider()
         self.mw = RetryMiddleware.from_crawler(self.crawler)
         self.mw.max_retry_times = 2
 
     def test_priority_adjust(self):
         req = Request("http://www.scrapytest.org/503")
         rsp = Response("http://www.scrapytest.org/503", body=b"", status=503)
-        req2 = self.mw.process_response(req, rsp, self.spider)
+        req2 = self.mw.process_response(req, rsp)
         assert req2.priority < req.priority
 
     def test_404(self):
@@ -40,14 +41,14 @@ class TestRetry:
         rsp = Response("http://www.scrapytest.org/404", body=b"", status=404)
 
         # dont retry 404s
-        assert self.mw.process_response(req, rsp, self.spider) is rsp
+        assert self.mw.process_response(req, rsp) is rsp
 
     def test_dont_retry(self):
         req = Request("http://www.scrapytest.org/503", meta={"dont_retry": True})
         rsp = Response("http://www.scrapytest.org/503", body=b"", status=503)
 
         # first retry
-        r = self.mw.process_response(req, rsp, self.spider)
+        r = self.mw.process_response(req, rsp)
         assert r is rsp
 
         # Test retry when dont_retry set to False
@@ -55,13 +56,13 @@ class TestRetry:
         rsp = Response("http://www.scrapytest.org/503")
 
         # first retry
-        r = self.mw.process_response(req, rsp, self.spider)
+        r = self.mw.process_response(req, rsp)
         assert r is rsp
 
     def test_dont_retry_exc(self):
         req = Request("http://www.scrapytest.org/503", meta={"dont_retry": True})
 
-        r = self.mw.process_exception(req, DNSLookupError(), self.spider)
+        r = self.mw.process_exception(req, DNSLookupError())
         assert r is None
 
     def test_503(self):
@@ -69,17 +70,17 @@ class TestRetry:
         rsp = Response("http://www.scrapytest.org/503", body=b"", status=503)
 
         # first retry
-        req = self.mw.process_response(req, rsp, self.spider)
+        req = self.mw.process_response(req, rsp)
         assert isinstance(req, Request)
         assert req.meta["retry_times"] == 1
 
         # second retry
-        req = self.mw.process_response(req, rsp, self.spider)
+        req = self.mw.process_response(req, rsp)
         assert isinstance(req, Request)
         assert req.meta["retry_times"] == 2
 
         # discard it
-        assert self.mw.process_response(req, rsp, self.spider) is rsp
+        assert self.mw.process_response(req, rsp) is rsp
 
         assert self.crawler.stats.get_value("retry/max_reached") == 1
         assert (
@@ -118,7 +119,8 @@ class TestRetry:
         settings_dict = {
             "RETRY_EXCEPTIONS": [*RETRY_EXCEPTIONS, exc],
         }
-        crawler = get_crawler(Spider, settings_dict=settings_dict)
+        crawler = get_crawler(DefaultSpider, settings_dict=settings_dict)
+        crawler.spider = crawler._create_spider()
         mw = RetryMiddleware.from_crawler(crawler)
         req = Request(f"http://www.scrapytest.org/{exc.__name__}")
         self._test_retry_exception(req, exc("foo"), mw)
@@ -128,65 +130,61 @@ class TestRetry:
             mw = self.mw
 
         # first retry
-        req = mw.process_exception(req, exception, self.spider)
+        req = mw.process_exception(req, exception)
         assert isinstance(req, Request)
         assert req.meta["retry_times"] == 1
 
         # second retry
-        req = mw.process_exception(req, exception, self.spider)
+        req = mw.process_exception(req, exception)
         assert isinstance(req, Request)
         assert req.meta["retry_times"] == 2
 
         # discard it
-        req = mw.process_exception(req, exception, self.spider)
+        req = mw.process_exception(req, exception)
         assert req is None
 
 
 class TestMaxRetryTimes:
     invalid_url = "http://www.scrapytest.org/invalid_url"
 
-    def get_spider_and_middleware(self, settings=None):
-        crawler = get_crawler(Spider, settings or {})
-        spider = crawler._create_spider("foo")
-        middleware = RetryMiddleware.from_crawler(crawler)
-        return spider, middleware
+    def get_middleware(self, settings=None):
+        crawler = get_crawler(DefaultSpider, settings or {})
+        crawler.spider = crawler._create_spider()
+        return RetryMiddleware.from_crawler(crawler)
 
     def test_with_settings_zero(self):
         max_retry_times = 0
         settings = {"RETRY_TIMES": max_retry_times}
-        spider, middleware = self.get_spider_and_middleware(settings)
+        middleware = self.get_middleware(settings)
         req = Request(self.invalid_url)
         self._test_retry(
             req,
             DNSLookupError("foo"),
             max_retry_times,
-            spider=spider,
             middleware=middleware,
         )
 
     def test_with_metakey_zero(self):
         max_retry_times = 0
-        spider, middleware = self.get_spider_and_middleware()
+        middleware = self.get_middleware()
         meta = {"max_retry_times": max_retry_times}
         req = Request(self.invalid_url, meta=meta)
         self._test_retry(
             req,
             DNSLookupError("foo"),
             max_retry_times,
-            spider=spider,
             middleware=middleware,
         )
 
     def test_without_metakey(self):
         max_retry_times = 5
         settings = {"RETRY_TIMES": max_retry_times}
-        spider, middleware = self.get_spider_and_middleware(settings)
+        middleware = self.get_middleware(settings)
         req = Request(self.invalid_url)
         self._test_retry(
             req,
             DNSLookupError("foo"),
             max_retry_times,
-            spider=spider,
             middleware=middleware,
         )
 
@@ -198,20 +196,18 @@ class TestMaxRetryTimes:
         req2 = Request(self.invalid_url)
 
         settings = {"RETRY_TIMES": middleware_max_retry_times}
-        spider, middleware = self.get_spider_and_middleware(settings)
+        middleware = self.get_middleware(settings)
 
         self._test_retry(
             req1,
             DNSLookupError("foo"),
             meta_max_retry_times,
-            spider=spider,
             middleware=middleware,
         )
         self._test_retry(
             req2,
             DNSLookupError("foo"),
             middleware_max_retry_times,
-            spider=spider,
             middleware=middleware,
         )
 
@@ -223,26 +219,24 @@ class TestMaxRetryTimes:
         req2 = Request(self.invalid_url)
 
         settings = {"RETRY_TIMES": middleware_max_retry_times}
-        spider, middleware = self.get_spider_and_middleware(settings)
+        middleware = self.get_middleware(settings)
 
         self._test_retry(
             req1,
             DNSLookupError("foo"),
             meta_max_retry_times,
-            spider=spider,
             middleware=middleware,
         )
         self._test_retry(
             req2,
             DNSLookupError("foo"),
             middleware_max_retry_times,
-            spider=spider,
             middleware=middleware,
         )
 
     def test_with_dont_retry(self):
         max_retry_times = 4
-        spider, middleware = self.get_spider_and_middleware()
+        middleware = self.get_middleware()
         meta = {
             "max_retry_times": max_retry_times,
             "dont_retry": True,
@@ -252,7 +246,6 @@ class TestMaxRetryTimes:
             req,
             DNSLookupError("foo"),
             0,
-            spider=spider,
             middleware=middleware,
         )
 
@@ -261,18 +254,16 @@ class TestMaxRetryTimes:
         req,
         exception,
         max_retry_times,
-        spider=None,
         middleware=None,
     ):
-        spider = spider or self.spider
         middleware = middleware or self.mw
 
         for i in range(max_retry_times):
-            req = middleware.process_exception(req, exception, spider)
+            req = middleware.process_exception(req, exception)
             assert isinstance(req, Request)
 
         # discard it
-        req = middleware.process_exception(req, exception, spider)
+        req = middleware.process_exception(req, exception)
         assert req is None
 
 

--- a/tests/test_downloadermiddleware_robotstxt.py
+++ b/tests/test_downloadermiddleware_robotstxt.py
@@ -10,7 +10,6 @@ from twisted.internet.defer import Deferred, DeferredList
 from twisted.python import failure
 
 from scrapy.downloadermiddlewares.robotstxt import RobotsTxtMiddleware
-from scrapy.downloadermiddlewares.robotstxt import logger as mw_module_logger
 from scrapy.exceptions import IgnoreRequest, NotConfigured
 from scrapy.http import Request, Response, TextResponse
 from scrapy.http.request import NO_CALLBACK
@@ -83,10 +82,10 @@ Disallow: /some/randome/page.html
     async def test_robotstxt_multiple_reqs(self) -> None:
         middleware = RobotsTxtMiddleware(self._get_successful_crawler())
         d1 = deferred_from_coro(
-            middleware.process_request(Request("http://site.local/allowed1"), None)  # type: ignore[arg-type]
+            middleware.process_request(Request("http://site.local/allowed1"))
         )
         d2 = deferred_from_coro(
-            middleware.process_request(Request("http://site.local/allowed2"), None)  # type: ignore[arg-type]
+            middleware.process_request(Request("http://site.local/allowed2"))
         )
         await maybe_deferred_to_future(DeferredList([d1, d2], fireOnOneErrback=True))
 
@@ -94,8 +93,8 @@ Disallow: /some/randome/page.html
     @deferred_f_from_coro_f
     async def test_robotstxt_multiple_reqs_asyncio(self) -> None:
         middleware = RobotsTxtMiddleware(self._get_successful_crawler())
-        c1 = middleware.process_request(Request("http://site.local/allowed1"), None)  # type: ignore[arg-type]
-        c2 = middleware.process_request(Request("http://site.local/allowed2"), None)  # type: ignore[arg-type]
+        c1 = middleware.process_request(Request("http://site.local/allowed1"))
+        c2 = middleware.process_request(Request("http://site.local/allowed2"))
         await asyncio.gather(c1, c2)
 
     @deferred_f_from_coro_f
@@ -164,7 +163,7 @@ Disallow: /some/randome/page.html
         await self.assertNotIgnored(Request("http://site.local/static/"), middleware)
 
     @deferred_f_from_coro_f
-    async def test_robotstxt_error(self):
+    async def test_robotstxt_error(self, caplog: pytest.LogCaptureFixture) -> None:
         self.crawler.settings.set("ROBOTSTXT_OBEY", True)
         err = error.DNSLookupError("Robotstxt address not found")
 
@@ -176,9 +175,8 @@ Disallow: /some/randome/page.html
         self.crawler.engine.download_async.side_effect = return_failure
 
         middleware = RobotsTxtMiddleware(self.crawler)
-        middleware._logerror = mock.MagicMock(side_effect=middleware._logerror)
-        await middleware.process_request(Request("http://site.local"), None)
-        assert middleware._logerror.called
+        await middleware.process_request(Request("http://site.local"))
+        assert "DNS lookup failed: Robotstxt address not found" in caplog.text
 
     @deferred_f_from_coro_f
     async def test_robotstxt_immediate_error(self):
@@ -205,10 +203,13 @@ Disallow: /some/randome/page.html
         self.crawler.engine.download_async.side_effect = ignore_request
 
         middleware = RobotsTxtMiddleware(self.crawler)
-        mw_module_logger.error = mock.MagicMock()
-
-        await self.assertNotIgnored(Request("http://site.local/allowed"), middleware)
-        assert not mw_module_logger.error.called  # type: ignore[attr-defined]
+        with mock.patch(
+            "scrapy.downloadermiddlewares.robotstxt.logger"
+        ) as mw_module_logger:
+            await self.assertNotIgnored(
+                Request("http://site.local/allowed"), middleware
+            )
+            assert not mw_module_logger.error.called
 
     def test_robotstxt_user_agent_setting(self):
         crawler = self._get_successful_crawler()
@@ -216,7 +217,7 @@ Disallow: /some/randome/page.html
         crawler.settings.set("USER_AGENT", "Mozilla/5.0 (X11; Linux x86_64)")
         middleware = RobotsTxtMiddleware(crawler)
         rp = mock.MagicMock(return_value=True)
-        middleware.process_request_2(rp, Request("http://site.local/allowed"), None)
+        middleware.process_request_2(rp, Request("http://site.local/allowed"))
         rp.allowed.assert_called_once_with("http://site.local/allowed", "Examplebot")
 
     @deferred_f_from_coro_f
@@ -224,34 +225,30 @@ Disallow: /some/randome/page.html
         middleware = RobotsTxtMiddleware(self._get_emptybody_crawler())
         middleware.process_request_2 = mock.MagicMock()
 
-        await middleware.process_request(
-            Request("data:text/plain,Hello World data"), None
-        )
+        await middleware.process_request(Request("data:text/plain,Hello World data"))
         assert not middleware.process_request_2.called
 
         await middleware.process_request(
-            Request("file:///tests/sample_data/test_site/nothinghere.html"), None
+            Request("file:///tests/sample_data/test_site/nothinghere.html")
         )
         assert not middleware.process_request_2.called
 
-        await middleware.process_request(Request("http://site.local/allowed"), None)
+        await middleware.process_request(Request("http://site.local/allowed"))
         assert middleware.process_request_2.called
 
     async def assertNotIgnored(
         self, request: Request, middleware: RobotsTxtMiddleware
     ) -> None:
-        spider = None  # not actually used
         try:
-            await middleware.process_request(request, spider)  # type: ignore[arg-type]
+            await middleware.process_request(request)
         except IgnoreRequest:
             pytest.fail("IgnoreRequest was raised unexpectedly")
 
     async def assertIgnored(
         self, request: Request, middleware: RobotsTxtMiddleware
     ) -> None:
-        spider = None  # not actually used
         with pytest.raises(IgnoreRequest):
-            await middleware.process_request(request, spider)  # type: ignore[arg-type]
+            await middleware.process_request(request)
 
     def assertRobotsTxtRequested(self, base_url: str) -> None:
         calls = self.crawler.engine.download_async.call_args_list

--- a/tests/test_downloadermiddleware_stats.py
+++ b/tests/test_downloadermiddleware_stats.py
@@ -11,7 +11,6 @@ class MyException(Exception):
 class TestDownloaderStats:
     def setup_method(self):
         self.crawler = get_crawler(Spider)
-        self.spider = self.crawler._create_spider("scrapytest.org")
         self.mw = DownloaderStats(self.crawler.stats)
 
         self.crawler.stats.open_spider()
@@ -25,15 +24,15 @@ class TestDownloaderStats:
         )
 
     def test_process_request(self):
-        self.mw.process_request(self.req, self.spider)
+        self.mw.process_request(self.req)
         self.assertStatsEqual("downloader/request_count", 1)
 
     def test_process_response(self):
-        self.mw.process_response(self.req, self.res, self.spider)
+        self.mw.process_response(self.req, self.res)
         self.assertStatsEqual("downloader/response_count", 1)
 
     def test_process_exception(self):
-        self.mw.process_exception(self.req, MyException(), self.spider)
+        self.mw.process_exception(self.req, MyException())
         self.assertStatsEqual("downloader/exception_count", 1)
         self.assertStatsEqual(
             "downloader/exception_type_count/tests.test_downloadermiddleware_stats.MyException",

--- a/tests/test_downloadermiddleware_useragent.py
+++ b/tests/test_downloadermiddleware_useragent.py
@@ -11,9 +11,9 @@ class TestUserAgentMiddleware:
         return spider, UserAgentMiddleware.from_crawler(crawler)
 
     def test_default_agent(self):
-        spider, mw = self.get_spider_and_mw("default_useragent")
+        _, mw = self.get_spider_and_mw("default_useragent")
         req = Request("http://scrapytest.org/")
-        assert mw.process_request(req, spider) is None
+        assert mw.process_request(req) is None
         assert req.headers["User-Agent"] == b"default_useragent"
 
     def test_remove_agent(self):
@@ -22,7 +22,7 @@ class TestUserAgentMiddleware:
         spider.user_agent = None
         mw.spider_opened(spider)
         req = Request("http://scrapytest.org/")
-        assert mw.process_request(req, spider) is None
+        assert mw.process_request(req) is None
         assert req.headers.get("User-Agent") is None
 
     def test_spider_agent(self):
@@ -30,7 +30,7 @@ class TestUserAgentMiddleware:
         spider.user_agent = "spider_useragent"
         mw.spider_opened(spider)
         req = Request("http://scrapytest.org/")
-        assert mw.process_request(req, spider) is None
+        assert mw.process_request(req) is None
         assert req.headers["User-Agent"] == b"spider_useragent"
 
     def test_header_agent(self):
@@ -40,7 +40,7 @@ class TestUserAgentMiddleware:
         req = Request(
             "http://scrapytest.org/", headers={"User-Agent": "header_useragent"}
         )
-        assert mw.process_request(req, spider) is None
+        assert mw.process_request(req) is None
         assert req.headers["User-Agent"] == b"header_useragent"
 
     def test_no_agent(self):
@@ -48,5 +48,5 @@ class TestUserAgentMiddleware:
         spider.user_agent = None
         mw.spider_opened(spider)
         req = Request("http://scrapytest.org/")
-        assert mw.process_request(req, spider) is None
+        assert mw.process_request(req) is None
         assert "User-Agent" not in req.headers

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -20,7 +20,7 @@ class M1:
     def close_spider(self, spider):
         pass
 
-    def process(self, response, request, spider):
+    def process(self, response, request):
         pass
 
 
@@ -33,7 +33,7 @@ class M2:
 
 
 class M3:
-    def process(self, response, request, spider):
+    def process(self, response, request):
         pass
 
 

--- a/tests/test_request_cb_kwargs.py
+++ b/tests/test_request_cb_kwargs.py
@@ -12,11 +12,11 @@ class InjectArgumentsDownloaderMiddleware:
     Make sure downloader middlewares are able to update the keyword arguments
     """
 
-    def process_request(self, request, spider):
+    def process_request(self, request):
         if request.callback.__name__ == "parse_downloader_mw":
             request.cb_kwargs["from_process_request"] = True
 
-    def process_response(self, request, response, spider):
+    def process_response(self, request, response):
         if request.callback.__name__ == "parse_downloader_mw":
             request.cb_kwargs["from_process_response"] = True
         return response


### PR DESCRIPTION
Fixes #6927 