### PR TITLE
Fix meta refresh redirect issue by respecting <base> tag (#7042)

### DIFF
--- a/scrapy/utils/response.py
+++ b/scrapy/utils/response.py
@@ -48,7 +48,7 @@ def get_meta_refresh(
     if response not in _metaref_cache:
         text = response.text[0:4096]
         _metaref_cache[response] = html.get_meta_refresh(
-            text, response.url, response.encoding, ignore_tags=ignore_tags
+            text, get_base_url(response), response.encoding, ignore_tags=ignore_tags
         )
     return _metaref_cache[response]
 

--- a/tests/test_utils_response.py
+++ b/tests/test_utils_response.py
@@ -67,9 +67,23 @@ if(!checkCookies()){
 </script>
     """,
     )
+    r4 = HtmlResponse(
+        "http://www.example.com",
+        body=b"""
+    <html>
+    <head><title>Dummy</title>
+    <base href="http://www.another-domain.com/base/path/">
+    <meta http-equiv="refresh" content="5;url=target.html"</head>
+    <body>blahablsdfsal&amp;</body>
+    </html>""",
+    )
     assert get_meta_refresh(r1) == (5.0, "http://example.org/newpage")
     assert get_meta_refresh(r2) == (None, None)
     assert get_meta_refresh(r3) == (None, None)
+    assert get_meta_refresh(r4) == (
+        5.0,
+        "http://www.another-domain.com/base/path/target.html",
+    )
 
 
 def test_get_base_url():


### PR DESCRIPTION
Fixes #7042 

Problem:
The meta refresh redirect was not working as expected. It was completely ignoring the base URL in the `<base>` HTML tag while resolving the redirect URL for the relative URL in the `<meta>` tag.

Solution:
Replaced usage of `response.url` with `scrapy.utils.response.get_base_url()`, ensuring that the <base> tag is respected when resolving relative URLs in meta refresh redirects.

Testing:
Appropriate testing is added
