### PR TITLE
Drop PyPy 3.10 support, restore coverage for subprocesses

### DIFF
--- a/.github/workflows/tests-ubuntu.yml
+++ b/.github/workflows/tests-ubuntu.yml
@@ -35,9 +35,6 @@ jobs:
         - python-version: "3.13"
           env:
             TOXENV: default-reactor
-        - python-version: pypy3.10
-          env:
-            TOXENV: pypy3
         - python-version: pypy3.11
           env:
             TOXENV: pypy3
@@ -49,7 +46,7 @@ jobs:
         - python-version: "3.9.21"
           env:
             TOXENV: default-reactor-pinned
-        - python-version: pypy3.10
+        - python-version: pypy3.11
           env:
             TOXENV: pypy3-pinned
         - python-version: "3.9.21"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -135,6 +135,9 @@ branch = true
 include = ["scrapy/*"]
 omit = ["tests/*"]
 disable_warnings = ["include-ignored"]
+patch = [
+    "subprocess",
+]
 
 [tool.coverage.paths]
 source = [

--- a/tox.ini
+++ b/tox.ini
@@ -198,22 +198,22 @@ deps =
 commands = {[testenv:pypy3]commands}
 
 [testenv:pypy3-pinned]
-basepython = pypy3.10
+basepython = pypy3.11
 deps =
     PyPyDispatcher==2.1.0
     {[test-requirements]deps}
     pytest==8.4.0
     Protego==0.1.15
     Twisted==21.7.0
-    cryptography==41.0.5
+    cryptography==44.0.2
     cssselect==0.9.1
     itemadapter==0.1.0
-    lxml==4.6.0
+    lxml==5.3.2
     parsel==1.5.0
-    pyOpenSSL==23.3.0
+    pyOpenSSL==24.3.0
     queuelib==1.4.2
     service_identity==18.1.0
-    w3lib==1.17.0
+    w3lib==1.20.0
     zope.interface==5.1.0
 commands =
     ; disabling both coverage and docs tests

--- a/tox.ini
+++ b/tox.ini
@@ -10,12 +10,12 @@ minversion = 1.7.0
 [test-requirements]
 deps =
     attrs
-    coverage >= 7.4.0
+    coverage >= 7.10.6
     pexpect >= 4.8.0
     pyftpdlib >= 2.0.1
     pygments
     pytest
-    pytest-cov >= 4.0.0
+    pytest-cov >= 7.0.0
     pytest-xdist
     sybil >= 1.3.0  # https://github.com/cjw296/sybil/issues/20#issuecomment-605433422
     testfixtures


### PR DESCRIPTION
Discontinued in July: https://pypy.org/posts/2025/07/pypy-v7320-release.html