### PR TITLE
Docs: clarify JOBDIR common files (requests.seen, spider.state) (#4842)

### DIFF
--- a/docs/topics/jobs.rst
+++ b/docs/topics/jobs.rst
@@ -27,6 +27,18 @@ this directory must not be shared by different spiders, or even different
 jobs/runs of the same spider, as it's meant to be used for storing the state of
 a *single* job.
 
+Common files
+------------
+
+In addition to requests persisted by the scheduler, a job directory commonly
+includes auxiliary files:
+
+- ``requests.seen`` — stores SHA1 fingerprints of visited URLs used by the
+  duplicates filter to avoid re-crawling the same URL.
+- ``spider.state`` — persists the spider’s ``state`` dictionary between runs
+  (see :ref:`topics-keeping-persistent-state-between-batches`).
+
+
 How to use it
 =============
 


### PR DESCRIPTION
This PR adds a brief “Common files” subsection to the JOBDIR documentation,
describing two files that frequently appear:

- `requests.seen`: URL fingerprints used by the duplicates filter.
- `spider.state`: persisted custom spider state between runs.

The goal is to improve newcomer understanding of JOBDIR without locking in
internal implementation details.

Resolves #4842.