### PR TITLE
docs: Add Edit on GitHub

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -68,6 +68,14 @@ html_css_files = [
     "custom.css",
 ]
 
+html_context = {
+    "display_github": True,
+    "github_user": "scrapy",
+    "github_repo": "scrapy",
+    "github_version": "master",
+    "conf_py_path": "/docs/",
+}
+
 # Set canonical URL from the Read the Docs Domain
 html_baseurl = os.environ.get("READTHEDOCS_CANONICAL_URL", "")
 


### PR DESCRIPTION
Today, when someone clicks on View page source in the documentation, they are redirected to raw rst files, _e.g.:_ https://docs.scrapy.org/en/latest/_sources/index.rst.txt.

This PR adds `html_context` so that when someone clicks on **Edit on GitHub**, they are redirected to the correct file in the repository, _e.g.:_ https://github.com/scrapy/scrapy/blob/master/docs/index.rst, making it easier to contribute.

<img width="753" height="217" alt="Captura de Tela 2025-09-27 às 23 23 56" src="https://github.com/user-attachments/assets/c91d18ed-8818-4a07-866b-2de0c65271db" />

