### PR TITLE
Issue 6946/basic download handler tests

### DIFF
--- a/tests/mockserver/http.py
+++ b/tests/mockserver/http.py
@@ -14,6 +14,7 @@ from .http_resources import (
     BrokenChunkedResource,
     BrokenDownloadResource,
     ChunkedResource,
+    Compress,
     ContentLengthHeaderResource,
     Delay,
     Drop,
@@ -29,6 +30,8 @@ from .http_resources import (
     PayloadResource,
     Raw,
     RedirectTo,
+    ResponseHeadersResource,
+    SetCookie,
     Status,
 )
 
@@ -75,7 +78,10 @@ class Root(resource.Resource):
         self.putChild(b"contentlength", ContentLengthHeaderResource())
         self.putChild(b"nocontenttype", EmptyContentTypeHeaderResource())
         self.putChild(b"largechunkedfile", LargeChunkedFileResource())
+        self.putChild(b"compress", Compress())
         self.putChild(b"duplicate-header", DuplicateHeaderResource())
+        self.putChild(b"response-headers", ResponseHeadersResource())
+        self.putChild(b"set-cookie", SetCookie())
 
     def getChild(self, name, request):
         return self


### PR DESCRIPTION
This PR adds tests that cover these items from #6946:

- the correct status code is returned, both when it's 200 and when it's 4xx or 5xx
- the correct response headers are returned, including custom ones
- the passed request headers are sent to the server, including custom ones
- the passed request body is sent to the server
- no automatic Content-Encoding decoding
- no cookie processing and persistence (Set-Cookie headers are returned as is and cookies set in them are not sent transparently in a next request).

Please let me know if the test approach seems okay. I'm happy to make adjustments to the testing method or add more cases to cover a more comprehensive list of http headers if needed. 