### PR TITLE
Change default SCHEDULER_PRIORITY_QUEUE to DownloaderAwarePriorityQueue

### DIFF
--- a/scrapy/settings/default_settings.py
+++ b/scrapy/settings/default_settings.py
@@ -480,7 +480,7 @@ SCHEDULER = "scrapy.core.scheduler.Scheduler"
 SCHEDULER_DEBUG = False
 SCHEDULER_DISK_QUEUE = "scrapy.squeues.PickleLifoDiskQueue"
 SCHEDULER_MEMORY_QUEUE = "scrapy.squeues.LifoMemoryQueue"
-SCHEDULER_PRIORITY_QUEUE = "scrapy.pqueues.ScrapyPriorityQueue"
+SCHEDULER_PRIORITY_QUEUE = "scrapy.pqueues.DownloaderAwarePriorityQueue"
 SCHEDULER_START_DISK_QUEUE = "scrapy.squeues.PickleFifoDiskQueue"
 SCHEDULER_START_MEMORY_QUEUE = "scrapy.squeues.FifoMemoryQueue"
 


### PR DESCRIPTION
Changes the default SCHEDULER_PRIORITY_QUEUE from ScrapyPriorityQueue to DownloaderAwarePriorityQueue for better multi-domain crawl performance.

Benefits:
- Better load balancing across domains
- Improved performance for broad crawls  
- Aligns with existing documentation recommendations

Fixes #6924