### PR TITLE
Fix: deprecation warning for spider attributes overriding settings

### DIFF
--- a/scrapy/core/downloader/handlers/http11.py
+++ b/scrapy/core/downloader/handlers/http11.py
@@ -38,6 +38,7 @@ from scrapy.responsetypes import responsetypes
 from scrapy.utils.httpobj import urlparse_cached
 from scrapy.utils.python import to_bytes, to_unicode
 from scrapy.utils.url import add_http_if_no_scheme
+from scrapy.utils.deprecate import get_spider_attr
 
 if TYPE_CHECKING:
     from twisted.internet.base import ReactorBase
@@ -95,8 +96,12 @@ class HTTP11DownloadHandler:
         agent = ScrapyAgent(
             contextFactory=self._contextFactory,
             pool=self._pool,
-            maxsize=getattr(spider, "download_maxsize", self._default_maxsize),
-            warnsize=getattr(spider, "download_warnsize", self._default_warnsize),
+            maxsize=get_spider_attr(
+                spider, "download_maxsize", self._default_maxsize, "DOWNLOAD_MAXSIZE"
+            ),
+            warnsize=get_spider_attr(
+                spider, "download_warnsize", self._default_warnsize, "DOWNLOAD_WARNSIZE"
+            ),
             fail_on_dataloss=self._fail_on_dataloss,
             crawler=self._crawler,
         )

--- a/scrapy/core/http2/protocol.py
+++ b/scrapy/core/http2/protocol.py
@@ -34,6 +34,7 @@ from zope.interface import implementer
 
 from scrapy.core.http2.stream import Stream, StreamCloseReason
 from scrapy.http import Request, Response
+from scrapy.utils.deprecate import get_spider_attr
 
 if TYPE_CHECKING:
     from ipaddress import IPv4Address, IPv6Address
@@ -195,11 +196,11 @@ class H2ClientProtocol(Protocol, TimeoutMixin):
             stream_id=next(self._stream_id_generator),
             request=request,
             protocol=self,
-            download_maxsize=getattr(
-                spider, "download_maxsize", self.metadata["default_download_maxsize"]
+            download_maxsize=get_spider_attr(
+                spider, "download_maxsize", self.metadata["default_download_maxsize"], "DOWNLOAD_MAXSIZE"
             ),
-            download_warnsize=getattr(
-                spider, "download_warnsize", self.metadata["default_download_warnsize"]
+            download_warnsize=get_spider_attr(
+                spider, "download_warnsize", self.metadata["default_download_warnsize"], "DOWNLOAD_WARNSIZE"
             ),
         )
         self.streams[stream.stream_id] = stream

--- a/scrapy/downloadermiddlewares/downloadtimeout.py
+++ b/scrapy/downloadermiddlewares/downloadtimeout.py
@@ -10,6 +10,7 @@ from typing import TYPE_CHECKING
 
 from scrapy import Request, Spider, signals
 from scrapy.utils.decorators import _warn_spider_arg
+from scrapy.utils.deprecate import get_spider_attr
 
 if TYPE_CHECKING:
     # typing.Self requires Python 3.11
@@ -30,7 +31,9 @@ class DownloadTimeoutMiddleware:
         return o
 
     def spider_opened(self, spider: Spider) -> None:
-        self._timeout = getattr(spider, "download_timeout", self._timeout)
+        self._timeout = get_spider_attr(
+            spider, "download_timeout", self._timeout, "DOWNLOAD_TIMEOUT"
+        )
 
     @_warn_spider_arg
     def process_request(

--- a/scrapy/downloadermiddlewares/useragent.py
+++ b/scrapy/downloadermiddlewares/useragent.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING
 
 from scrapy import Request, Spider, signals
 from scrapy.utils.decorators import _warn_spider_arg
+from scrapy.utils.deprecate import get_spider_attr
 
 if TYPE_CHECKING:
     # typing.Self requires Python 3.11
@@ -28,7 +29,7 @@ class UserAgentMiddleware:
         return o
 
     def spider_opened(self, spider: Spider) -> None:
-        self.user_agent = getattr(spider, "user_agent", self.user_agent)
+        self.user_agent = get_spider_attr(spider, "user_agent", self.user_agent, "USER_AGENT")
 
     @_warn_spider_arg
     def process_request(

--- a/scrapy/extensions/throttle.py
+++ b/scrapy/extensions/throttle.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING
 
 from scrapy import Request, Spider, signals
 from scrapy.exceptions import NotConfigured
+from scrapy.utils.deprecate import get_spider_attr
 
 if TYPE_CHECKING:
     # typing.Self requires Python 3.11
@@ -49,7 +50,7 @@ class AutoThrottle:
 
     def _min_delay(self, spider: Spider) -> float:
         s = self.crawler.settings
-        return getattr(spider, "download_delay", s.getfloat("DOWNLOAD_DELAY"))
+        return get_spider_attr(spider, "download_delay", s.getfloat("DOWNLOAD_DELAY"), "DOWNLOAD_DELAY")
 
     def _max_delay(self, spider: Spider) -> float:
         return self.crawler.settings.getfloat("AUTOTHROTTLE_MAX_DELAY")

--- a/scrapy/spiders/sitemap.py
+++ b/scrapy/spiders/sitemap.py
@@ -12,6 +12,7 @@ from scrapy.spiders import Spider
 from scrapy.utils._compression import _DecompressionMaxSizeExceeded
 from scrapy.utils.gz import gunzip, gzip_magic_number
 from scrapy.utils.sitemap import Sitemap, sitemap_urls_from_robots
+from scrapy.utils.deprecate import get_spider_attr
 
 if TYPE_CHECKING:
     # typing.Self requires Python 3.11
@@ -36,11 +37,11 @@ class SitemapSpider(Spider):
     @classmethod
     def from_crawler(cls, crawler: Crawler, *args: Any, **kwargs: Any) -> Self:
         spider = super().from_crawler(crawler, *args, **kwargs)
-        spider._max_size = getattr(
-            spider, "download_maxsize", spider.settings.getint("DOWNLOAD_MAXSIZE")
+        spider._max_size = get_spider_attr(
+            spider, "download_maxsize", spider.settings.getint("DOWNLOAD_MAXSIZE"), "DOWNLOAD_MAXSIZE"
         )
-        spider._warn_size = getattr(
-            spider, "download_warnsize", spider.settings.getint("DOWNLOAD_WARNSIZE")
+        spider._warn_size = get_spider_attr(
+            spider, "download_warnsize", spider.settings.getint("DOWNLOAD_WARNSIZE"), "DOWNLOAD_WARNSIZE"
         )
         return spider
 

--- a/scrapy/utils/deprecate.py
+++ b/scrapy/utils/deprecate.py
@@ -1,5 +1,3 @@
-"""Some helpers for deprecation messages"""
-
 from __future__ import annotations
 
 import inspect
@@ -11,6 +9,33 @@ from scrapy.utils.python import get_func_args_dict
 
 if TYPE_CHECKING:
     from collections.abc import Callable
+
+
+def get_spider_attr(spider: object, new_attr: str, default: Any, old_attr: str | None = None) -> Any:
+    """Return spider attribute value checking for deprecated attribute names.
+
+    Preference order:
+    1. New attribute (``new_attr``) if present on the spider.
+    2. Deprecated attribute (``old_attr``) if present on the spider -- emits
+       a ScrapyDeprecationWarning recommending the new attribute name.
+    3. The provided ``default`` value.
+
+    This centralizes the deprecation warning logic so callers don't repeat it.
+    """
+    # Prefer the new attribute if present
+    if hasattr(spider, new_attr):
+        return getattr(spider, new_attr)
+
+    # If old/deprecated attribute is present, warn and return it
+    if old_attr and hasattr(spider, old_attr):
+        message = (
+            f"Spider attribute '{old_attr}' is deprecated, use '{new_attr}' "
+            "attribute instead."
+        )
+        warnings.warn(message, category=ScrapyDeprecationWarning, stacklevel=3)
+        return getattr(spider, old_attr)
+
+    return default
 
 
 def attribute(obj: Any, oldattr: str, newattr: str, version: str = "0.12") -> None:

--- a/tests/test_deprecate_helper.py
+++ b/tests/test_deprecate_helper.py
@@ -1,0 +1,43 @@
+import warnings
+
+import pytest
+
+from scrapy.exceptions import ScrapyDeprecationWarning
+from scrapy.utils.deprecate import get_spider_attr
+
+
+def test_get_spider_attr_deprecated_uppercase_used():
+    class S:
+        DOWNLOAD_TIMEOUT = 5
+
+    s = S()
+    with warnings.catch_warnings(record=True) as rec:
+        warnings.simplefilter("always")
+        val = get_spider_attr(s, "download_timeout", 10, "DOWNLOAD_TIMEOUT")
+        assert val == 5
+        assert any(isinstance(w.category, type) and issubclass(w.category, ScrapyDeprecationWarning.__class__) for w in rec) or any(
+            "DOWNLOAD_TIMEOUT" in str(w.message) for w in rec
+        )
+
+
+def test_get_spider_attr_prefers_lowercase_no_warning():
+    class S:
+        download_timeout = 7
+        DOWNLOAD_TIMEOUT = 5
+
+    s = S()
+    with warnings.catch_warnings(record=True) as rec:
+        warnings.simplefilter("always")
+        val = get_spider_attr(s, "download_timeout", 10, "DOWNLOAD_TIMEOUT")
+        assert val == 7
+        # No ScrapyDeprecationWarning should be raised because lowercase is preferred
+        assert not any("DOWNLOAD_TIMEOUT" in str(w.message) for w in rec)
+
+
+def test_get_spider_attr_default_used():
+    class S:
+        pass
+
+    s = S()
+    val = get_spider_attr(s, "download_timeout", 10, "DOWNLOAD_TIMEOUT")
+    assert val == 10


### PR DESCRIPTION
To close issue #7038.
Scrapy allowed spider attributes to override project-level settings, which has been deprecated since v1.0. The codebase was still allowing this behavior without warning users.

My fix: Created a function to log this deprecation, and updated inline usage to this function. Added a unit test to test the reliability of this function.