### PR TITLE
Issue 6946/test download handler content encoding and cookie persistence

### DIFF
--- a/tests/mockserver/http.py
+++ b/tests/mockserver/http.py
@@ -30,6 +30,7 @@ from .http_resources import (
     PayloadResource,
     Raw,
     RedirectTo,
+    SetCookie,
     Status,
 )
 
@@ -78,6 +79,7 @@ class Root(resource.Resource):
         self.putChild(b"largechunkedfile", LargeChunkedFileResource())
         self.putChild(b"compress", Compress())
         self.putChild(b"duplicate-header", DuplicateHeaderResource())
+        self.putChild(b"set-cookie", SetCookie())
 
     def getChild(self, name, request):
         return self

--- a/tests/mockserver/http_resources.py
+++ b/tests/mockserver/http_resources.py
@@ -326,3 +326,14 @@ class Compress(resource.Resource):
         # just set this to trigger a test failure if no valid accept-encoding header was set
         request.setResponseCode(500)
         return b"Did not receive a valid accept-encoding header"
+
+
+class SetCookie(resource.Resource):
+    """Return a response with a Set-Cookie header for each request url parameter"""
+
+    def render(self, request):
+        for cookie_name, cookie_values in request.args.items():
+            for cookie_value in cookie_values:
+                cookie = (cookie_name.decode() + "=" + cookie_value.decode()).encode()
+                request.setHeader(b"Set-Cookie", cookie)
+        return b""

--- a/tests/test_downloader_handlers_http_base.py
+++ b/tests/test_downloader_handlers_http_base.py
@@ -259,6 +259,65 @@ class TestHttpBase(ABC):
         response = await download_request(download_handler, request)
         assert response.headers.getlist(b"Set-Cookie") == [b"a=b", b"c=d"]
 
+    @deferred_f_from_coro_f
+    async def test_download_is_not_automatically_gzip_decoded(
+        self, download_handler: DownloadHandlerProtocol, mockserver: MockServer
+    ) -> None:
+        """Test download handler does not automatically decode content using the scheme provided in Content-Encoding header"""
+
+        data = "compress-me"
+
+        # send a request to mock resource that gzip encodes the "data" url parameter
+        request = Request(
+            mockserver.url(f"/compress?data={data}", is_secure=self.is_secure),
+            headers={
+                "accept-encoding": "gzip",
+            },
+        )
+        response = await download_request(download_handler, request)
+
+        assert response.status == 200
+
+        # check that the Content-Encoding header is gzip
+        content_encoding = response.headers[b"Content-Encoding"]
+        assert content_encoding == b"gzip"
+
+        # check that the response is still encoded
+        # by checking for the magic number that is always included at the start of a gzip encoding
+        # see https://datatracker.ietf.org/doc/html/rfc1952#page-5 section 2.3.1
+        GZIP_MAGIC = b"\x1f\x8b"
+        assert response.body[:2] == GZIP_MAGIC, "Response body was not in gzip format"
+
+        # check that a gzip decoding matches the data sent in the request
+        expected_decoding = bytes(data, encoding="utf-8")
+        assert gzip.decompress(response.body) == expected_decoding
+
+    @deferred_f_from_coro_f
+    async def test_no_cookie_processing_or_persistence(
+        self, mockserver: MockServer, download_handler: DownloadHandlerProtocol
+    ) -> None:
+        cookie_name = "foo"
+        cookie_value = "bar"
+
+        # check that cookies are not modified
+        request = Request(
+            mockserver.url(
+                f"/set-cookie?{cookie_name}={cookie_value}", is_secure=self.is_secure
+            )
+        )
+        response = await download_request(download_handler, request)
+        assert response.status == 200
+        set_cookie = response.headers.get(b"Set-Cookie")
+        assert set_cookie == f"{cookie_name}={cookie_value}".encode()
+
+        # check that cookies are not sent in the next request
+        request = Request(mockserver.url("/echo", is_secure=self.is_secure))
+        response = await download_request(download_handler, request)
+        assert response.status == 200
+        headers = Headers(json.loads(response.text)["headers"])
+        assert "Cookie" not in headers
+        assert "cookie" not in headers
+
 
 class TestHttp11Base(TestHttpBase):
     """HTTP 1.1 test case"""
@@ -412,39 +471,6 @@ class TestHttp11Base(TestHttpBase):
             if d is not None:
                 await maybe_deferred_to_future(d)
         assert response.flags == ["dataloss"]
-
-    @deferred_f_from_coro_f
-    async def test_download_is_not_automatically_gzip_decoded(
-        self, download_handler: DownloadHandlerProtocol, mockserver: MockServer
-    ) -> None:
-        """Test download handler does not automatically decode content using the scheme provided in Content-Encoding header"""
-
-        data = "compress-me"
-
-        # send a request to mock resource that gzip encodes the "data" url parameter
-        request = Request(
-            mockserver.url(f"/compress?data={data}", is_secure=self.is_secure),
-            headers={
-                "accept-encoding": "gzip",
-            },
-        )
-        response = await download_request(download_handler, request)
-
-        assert response.status == 200
-
-        # check that the Content-Encoding header is gzip
-        content_encoding = response.headers[b"Content-Encoding"]
-        assert content_encoding == b"gzip"
-
-        # check that the response is still encoded
-        # by checking for the magic number that is always included at the start of a gzip encoding
-        # see https://datatracker.ietf.org/doc/html/rfc1952#page-5 section 2.3.1
-        GZIP_MAGIC = b"\x1f\x8b"
-        assert response.body[:2] == GZIP_MAGIC, "Response body was not in gzip format"
-
-        # check that a gzip decoding matches the data sent in the request
-        expected_decoding = bytes(data, encoding="utf-8")
-        assert gzip.decompress(response.body) == expected_decoding
 
     @deferred_f_from_coro_f
     async def test_protocol(


### PR DESCRIPTION
This PR addresses this item from #6946 

- no automatic Content-Encoding decoding
- no cookie processing and persistence (Set-Cookie headers are returned as is and cookies set in them are not sent transparently in a next request).

I started with tests for `Content-Encoding: gzip` and `Content-Encoding: deflate` headers because the the python standard library includes implementations for these algorithms. We could also add tests from Brotli and Zstandard compression, but I think these would require adding dependencies to the tests so I held off for now. Just lmk if we want them added to this PR.