### PR TITLE
Replace asserts in getdictorlist() with ValueError (#6876)

### DIFF
--- a/scrapy/settings/__init__.py
+++ b/scrapy/settings/__init__.py
@@ -293,13 +293,18 @@ class BaseSettings(MutableMapping[_SettingsKeyT, Any]):
         if isinstance(value, str):
             try:
                 value_loaded = json.loads(value)
-                assert isinstance(value_loaded, (dict, list))
+                if not isinstance(value_loaded, (dict, list)):
+                    raise ValueError(
+                        f"{name} must be a dict or list when given as JSON, "
+                        f"got {type(value_loaded).__name__}"
+                    )
                 return value_loaded
-            except ValueError:
+            except json.JSONDecodeError:
                 return value.split(",")
         if isinstance(value, tuple):
             return list(value)
-        assert isinstance(value, (dict, list))
+        if not isinstance(value, (dict, list)):
+            raise ValueError(f"{name} must be a dict or list, got {type(value).__name__}")
         return copy.deepcopy(value)
 
     def getwithbase(self, name: _SettingsKeyT) -> BaseSettings:


### PR DESCRIPTION
This PR replaces two assert statements in Settings.getdictorlist() with explicit ValueError to ensure invalid user-provided settings fail predictably.

Fixes #6876