### PR TITLE
Implements the dropping of python3.9 and adoption of python3.14 (#7087)

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -20,10 +20,10 @@ jobs:
         - python-version: "3.13"
           env:
             TOXENV: pylint
-        - python-version: "3.9"
+        - python-version: "3.10"
           env:
             TOXENV: typing
-        - python-version: "3.9"
+        - python-version: "3.10"
           env:
             TOXENV: typing-tests
         - python-version: "3.13"  # Keep in sync with .readthedocs.yml
@@ -32,6 +32,9 @@ jobs:
         - python-version: "3.13"
           env:
             TOXENV: twinecheck
+        - python-version: "3.14"
+          env:
+            TOXENV: py
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/tests-macos.yml
+++ b/.github/workflows/tests-macos.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/tests-ubuntu.yml
+++ b/.github/workflows/tests-ubuntu.yml
@@ -17,9 +17,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-        - python-version: "3.9"
-          env:
-            TOXENV: py
         - python-version: "3.10"
           env:
             TOXENV: py
@@ -35,24 +32,27 @@ jobs:
         - python-version: "3.13"
           env:
             TOXENV: default-reactor
+        - python-version: "3.14"
+          env:
+            TOXENV: py
         - python-version: pypy3.11
           env:
             TOXENV: pypy3
 
         # pinned deps
-        - python-version: "3.9.21"
+        - python-version: "3.10"
           env:
             TOXENV: pinned
-        - python-version: "3.9.21"
+        - python-version: "3.10"
           env:
             TOXENV: default-reactor-pinned
         - python-version: pypy3.11
           env:
             TOXENV: pypy3-pinned
-        - python-version: "3.9.21"
+        - python-version: "3.10"
           env:
             TOXENV: extra-deps-pinned
-        - python-version: "3.9.21"
+        - python-version: "3.10"
           env:
             TOXENV: botocore-pinned
 

--- a/.github/workflows/tests-windows.yml
+++ b/.github/workflows/tests-windows.yml
@@ -17,9 +17,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-        - python-version: "3.9"
-          env:
-            TOXENV: py
         - python-version: "3.10"
           env:
             TOXENV: py
@@ -35,12 +32,15 @@ jobs:
         - python-version: "3.13"
           env:
             TOXENV: default-reactor
+        - python-version: "3.14"
+          env:
+            TOXENV: py
 
         # pinned deps
-        - python-version: "3.9.13"
+        - python-version: "3.10"
           env:
             TOXENV: pinned
-        - python-version: "3.9.13"
+        - python-version: "3.10"
           env:
             TOXENV: extra-deps-pinned
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,11 +35,11 @@ classifiers = [
     "Operating System :: OS Independent",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Programming Language :: Python :: Implementation :: CPython",
     "Programming Language :: Python :: Implementation :: PyPy",
     "Topic :: Internet :: WWW/HTTP",
@@ -49,7 +49,7 @@ classifiers = [
 license = "BSD-3-Clause"
 license-files = ["LICENSE", "AUTHORS"]
 readme = "README.rst"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 authors = [{ name = "Scrapy developers", email = "pablo@pablohoffman.com" }]
 maintainers = [{ name = "Pablo Hoffman", email = "pablo@pablohoffman.com" }]
 

--- a/tox.ini
+++ b/tox.ini
@@ -43,7 +43,7 @@ commands =
     pytest {posargs:--cov-config=pyproject.toml --cov=scrapy --cov-report= --cov-report=term-missing --cov-report=xml --junitxml=testenv.junit.xml -o junit_family=legacy --durations=10 docs scrapy tests --doctest-modules}
 
 [testenv:typing]
-basepython = python3.9
+basepython = python3.10
 deps =
     mypy==1.16.1
     typing-extensions==4.14.1
@@ -64,7 +64,7 @@ commands =
     mypy {posargs:scrapy tests}
 
 [testenv:typing-tests]
-basepython = python3.9
+basepython = python3.10
 deps =
     {[test-requirements]deps}
     {[testenv:typing]deps}
@@ -97,7 +97,7 @@ commands =
     twine check dist/*
 
 [pinned]
-basepython = python3.9
+basepython = python3.10
 deps =
     # pytest 8.4.1 adds support for Twisted 25.5.0 but drops support for Twisted < 24.10.0
     pytest==8.4.0


### PR DESCRIPTION
**Dropped python3.9** and make the **base-python version as 3.10** and **included 3.14** wherever tests are required and used.

Also, asking if the **publishing version** also needs to be upgraded to 3.14 from 3.13,
**if yes, I will also include that change,** 
or else, since for publishing, we only need a Python version that can successfully build the package, which **Python 3.13 already works**, so **this change is optional,** 

**Thus, requesting for a review and merging this PR.**