### PR TITLE
Line buffering for RFPDupeFilter

### DIFF
--- a/scrapy/dupefilters.py
+++ b/scrapy/dupefilters.py
@@ -84,7 +84,11 @@ class RFPDupeFilter(BaseDupeFilter):
         self.debug = debug
         self.logger = logging.getLogger(__name__)
         if path:
-            self.file = Path(path, "requests.seen").open("a+", encoding="utf-8")
+            # line-by-line writing, see: https://github.com/scrapy/scrapy/issues/6019
+            self.file = Path(path, "requests.seen").open(
+                "a+", buffering=1, encoding="utf-8"
+            )
+            self.file.reconfigure(write_through=True)
             self.file.seek(0)
             self.fingerprints.update(x.rstrip() for x in self.file)
 


### PR DESCRIPTION
Closes #6019

Adds line-by-line writing to RFPDupeFilter:
1. durability (less chance of data loss & no partial fingerprints in the file)
2. simplicity of the code, if users need performance with better configurability, they can use [scrapy-redis](https://github.com/rmax/scrapy-redis).