### PR TITLE
Fix subject-verb agreement in LocalCache docstring

### DIFF
--- a/scrapy/utils/datatypes.py
+++ b/scrapy/utils/datatypes.py
@@ -144,7 +144,7 @@ class CaseInsensitiveDict(collections.UserDict):
 class LocalCache(OrderedDict[_KT, _VT]):
     """Dictionary with a finite number of keys.
 
-    Older items expires first.
+    Older items expire first.
     """
 
     def __init__(self, limit: int | None = None):


### PR DESCRIPTION
## Description
Corrected a grammatical error in the LocalCache class docstring where the plural subject 'items' was incorrectly paired with the singular verb 'expires'.

## Changes
- Changed 'Older items expires first' to 'Older items expire first'

## Motivation
This change improves the grammatical correctness of the documentation. In English, plural subjects require plural verb forms, so 'items' (plural) should be paired with 'expire' (plural verb) rather than 'expires' (singular verb).

## Type of Change
- [x] Documentation improvement
- [x] Grammar fix

A minor but important fix to maintain professional documentation quality.