### PR TITLE
Fix mutable default argument anti-pattern in console utils

### DIFF
--- a/scrapy/utils/console.py
+++ b/scrapy/utils/console.py
@@ -13,9 +13,11 @@ KnownShellsT = dict[str, Callable[..., EmbedFuncT]]
 
 
 def _embed_ipython_shell(
-    namespace: dict[str, Any] = {}, banner: str = ""
+    namespace: dict[str, Any] | None = None, banner: str = ""
 ) -> EmbedFuncT:
     """Start an IPython Shell"""
+    if namespace is None:
+        namespace = {}
     try:
         from IPython.terminal.embed import InteractiveShellEmbed  # noqa: T100,PLC0415
         from IPython.terminal.ipapp import load_default_config  # noqa: PLC0415
@@ -44,9 +46,11 @@ def _embed_ipython_shell(
 
 
 def _embed_bpython_shell(
-    namespace: dict[str, Any] = {}, banner: str = ""
+    namespace: dict[str, Any] | None = None, banner: str = ""
 ) -> EmbedFuncT:
     """Start a bpython shell"""
+    if namespace is None:
+        namespace = {}
     import bpython  # noqa: PLC0415
 
     @wraps(_embed_bpython_shell)
@@ -57,9 +61,11 @@ def _embed_bpython_shell(
 
 
 def _embed_ptpython_shell(
-    namespace: dict[str, Any] = {}, banner: str = ""
+    namespace: dict[str, Any] | None = None, banner: str = ""
 ) -> EmbedFuncT:
     """Start a ptpython shell"""
+    if namespace is None:
+        namespace = {}
     import ptpython.repl  # noqa: PLC0415  # pylint: disable=import-error
 
     @wraps(_embed_ptpython_shell)
@@ -71,9 +77,11 @@ def _embed_ptpython_shell(
 
 
 def _embed_standard_shell(
-    namespace: dict[str, Any] = {}, banner: str = ""
+    namespace: dict[str, Any] | None = None, banner: str = ""
 ) -> EmbedFuncT:
     """Start a standard python shell"""
+    if namespace is None:
+        namespace = {}
     try:  # readline module is only available on unix systems
         import readline  # noqa: PLC0415
     except ImportError:


### PR DESCRIPTION
## Description
This PR fixes a well-known Python anti-pattern in scrapy/utils/console.py where mutable default arguments (empty dictionaries) were used as function parameters. This can lead to unexpected behavior since the same mutable object is shared across all function calls.

## Problem
Using mutable default arguments like def func(arg={}) is considered an anti-pattern in Python because:
1. The default object is created once when the function is defined, not each time it's called
2. If the object is mutated, those changes persist across function calls
3. This can cause hard-to-debug issues

This is documented in many Python style guides and linters (pylint, flake8) flag this as a warning.

## Changes
Fixed four functions by:
- Changing 
amespace: dict[str, Any] = {} to 
amespace: dict[str, Any] | None = None`n- Adding if namespace is None: namespace = {} at the start of each function

Affected functions:
- _embed_ipython_shell()
- _embed_bpython_shell()
- _embed_ptpython_shell()
- _embed_standard_shell()

## Type of Change
- [x] Bug fix (fixes anti-pattern)
- [x] Code quality improvement

## References
- [Python Common Pitfalls](https://docs.python-guide.org/writing/gotchas/#mutable-default-arguments)
- [PEP 8 Programming Recommendations](https://peps.python.org/pep-0008/#programming-recommendations)

This follows Python best practices and prevents potential bugs.