### PR TITLE
Add comprehensive docstring to job_dir function

### DIFF
--- a/scrapy/utils/job.py
+++ b/scrapy/utils/job.py
@@ -8,6 +8,18 @@ if TYPE_CHECKING:
 
 
 def job_dir(settings: BaseSettings) -> str | None:
+    """Return the job directory path from settings, creating it if needed.
+
+    Returns the path specified in the JOBDIR setting. If the directory doesn't
+    exist, it will be created (including any necessary parent directories).
+
+    Args:
+        settings: The Scrapy settings object
+
+    Returns:
+        str | None: The job directory path if JOBDIR is set and non-empty,
+                    None otherwise
+    """
     path: str | None = settings["JOBDIR"]
     if not path:
         return None


### PR DESCRIPTION
## Description
Added a detailed docstring to the job_dir() function in scrapy/utils/job.py, which was previously undocumented. The function is used throughout the codebase but lacked documentation explaining its behavior.

## Changes
- Added comprehensive docstring following Google style format
- Documented the function's purpose and behavior
- Explained the automatic directory creation feature
- Added parameter and return value documentation

## Motivation
The job_dir() function is imported and used in multiple modules:
- scrapy.dupefilters  
- scrapy.extensions.spiderstate`n- scrapy.core.scheduler`n
Despite its widespread use, it lacked documentation explaining:
1. What it returns
2. When it returns None
3. The side effect of creating directories

This improvement helps developers understand the function's behavior without needing to read the implementation, especially the automatic directory creation which is an important side effect.

## Type of Change
- [x] Documentation improvement
- [x] Code maintainability enhancement

This follows Python best practices for documenting public functions and improves overall codebase documentation quality.