### PR TITLE
Fix grammar and punctuation in ftp_store_file docstring

### DIFF
--- a/scrapy/utils/ftp.py
+++ b/scrapy/utils/ftp.py
@@ -29,8 +29,8 @@ def ftp_store_file(
     use_active_mode: bool = False,
     overwrite: bool = True,
 ) -> None:
-    """Opens a FTP connection with passed credentials,sets current directory
-    to the directory extracted from given path, then uploads the file to server
+    """Opens an FTP connection with passed credentials, sets current directory
+    to the directory extracted from given path, then uploads the file to server.
     """
     with FTP() as ftp:
         ftp.connect(host, port)


### PR DESCRIPTION
## Description
Fixed multiple grammar and punctuation issues in the tp_store_file() function docstring in scrapy/utils/ftp.py.

## Changes
1. **Article correction**: Changed 'a FTP' to 'an FTP'
   - 'FTP' is pronounced as individual letters (eff-tee-pee), starting with a vowel sound
   - Standard English grammar requires 'an' before words starting with vowel sounds

2. **Missing space**: Added space after comma in 'credentials,sets'  'credentials, sets'
   - Improves readability
   - Follows standard punctuation rules

3. **Added period**: Added period at the end of the docstring
   - Maintains consistency with other docstrings in the codebase
   - Follows PEP 257 docstring conventions

## Type of Change
- [x] Documentation improvement
- [x] Grammar/punctuation fix

## Motivation
While small, these fixes improve the professional quality of the documentation and ensure consistency with English grammar rules and Python conventions. Proper grammar in documentation helps maintain the project's credibility and makes it easier for international contributors to learn from the codebase.