### PR TITLE
Fix double space in string_camelcase docstring

### DIFF
--- a/scrapy/utils/template.py
+++ b/scrapy/utils/template.py
@@ -29,7 +29,7 @@ CAMELCASE_INVALID_CHARS = re.compile(r"[^a-zA-Z\d]")
 
 
 def string_camelcase(string: str) -> str:
-    """Convert a word  to its CamelCase version and remove invalid chars
+    """Convert a word to its CamelCase version and remove invalid chars
 
     >>> string_camelcase('lost-pound')
     'LostPound'


### PR DESCRIPTION
## Description
Fixed a formatting issue in the string_camelcase() function docstring where there was an extra space between 'word' and 'to'.

## Changes
- Removed double space: 'Convert a word  to'  'Convert a word to'

## Type of Change
- [x] Documentation improvement
- [x] Formatting fix

## Motivation
Double spaces in documentation are typically unintentional typos that can affect readability and look unprofessional. This simple fix ensures clean, properly formatted documentation consistent with the rest of the codebase.