### PR TITLE
Add docstring to gzip_magic_number function

### DIFF
--- a/scrapy/utils/gz.py
+++ b/scrapy/utils/gz.py
@@ -43,4 +43,15 @@ def gunzip(data: bytes, *, max_size: int = 0) -> bytes:
 
 
 def gzip_magic_number(response: Response) -> bool:
+    """Check if response body starts with gzip magic number.
+
+    Returns True if the first three bytes of the response body match
+    the gzip file format magic number (1f 8b 08), False otherwise.
+
+    Args:
+        response: The HTTP response to check
+
+    Returns:
+        bool: True if response appears to be gzip-compressed, False otherwise
+    """
     return response.body[:3] == b"\x1f\x8b\x08"


### PR DESCRIPTION
## Description

This PR adds a comprehensive docstring to the gzip_magic_number() function in scrapy/utils/gz.py.

## Changes
- Added Google-style docstring documenting the function's purpose
- Documented the esponse parameter and return value
- Clarified that the function checks for gzip magic number bytes (1f 8b 08)

## Motivation
The function was missing documentation explaining what it does and what the magic number bytes represent. This makes the codebase more accessible to new contributors and improves code maintainability.