### PR TITLE
Add docstring to _getarg helper function in benchserver

### DIFF
--- a/scrapy/utils/benchserver.py
+++ b/scrapy/utils/benchserver.py
@@ -28,6 +28,21 @@ class Root(Resource):
 
 
 def _getarg(request, name: bytes, default: Any = None, type_=str):
+    """Extract and convert an argument from the request.
+
+    Retrieves the first value of a named argument from the request and
+    converts it to the specified type. Returns a default value if the
+    argument is not present in the request.
+
+    Args:
+        request: The HTTP request object
+        name: The argument name to retrieve (as bytes)
+        default: Value to return if argument is not found (default: None)
+        type_: Callable to convert the argument value (default: str)
+
+    Returns:
+        The converted argument value if present, otherwise the default value
+    """
     return type_(request.args[name][0]) if name in request.args else default
 
 


### PR DESCRIPTION
## Description

This PR adds a comprehensive docstring to the _getarg() helper function in scrapy/utils/benchserver.py.

## Changes
- Added Google-style docstring documenting the function's purpose
- Documented all parameters: request, name, default, and type_
- Clarified the type conversion behavior and default value handling

## Motivation
The _getarg() function was missing documentation explaining its purpose and parameters. This helper function extracts and converts request arguments, and proper documentation makes it easier to understand the benchserver implementation.