### PR TITLE
Fix file download with HTTP 201 status code

### DIFF
--- a/scrapy/pipelines/files.py
+++ b/scrapy/pipelines/files.py
@@ -645,7 +645,7 @@ class FilesPipeline(MediaPipeline):
     ) -> FileInfo:
         referer = referer_str(request)
 
-        if response.status != 200:
+        if response.status not in (200, 201):
             logger.warning(
                 "File (code: %(status)s): Error downloading file from "
                 "%(request)s referred in <%(referer)s>",


### PR DESCRIPTION
## Description

This PR fixes issue #1615 where files were not being downloaded when the server returned HTTP 201 (Created) status code.

## Problem
The FilesPipeline.media_downloaded() method was only accepting HTTP 200 responses, rejecting all other status codes including 201. This caused issues with websites that generate images/files on-the-fly and return HTTP 201 to indicate successful resource creation.

## Solution
Changed the status code check from esponse.status != 200 to esponse.status not in (200, 201) to accept both HTTP 200 (OK) and HTTP 201 (Created) as valid success responses.

## Changes
- Modified scrapy/pipelines/files.py line 648
- Now accepts both 200 and 201 HTTP status codes for file downloads

## Testing
This fix allows the pipeline to properly handle responses from servers that:
- Generate resources on-the-fly (images, documents, etc.)
- Follow HTTP specifications by returning 201 for newly created resources
- Use 201 status for dynamic content generation

Closes #1615