### PR TITLE
Fix grammar in xmliter docstring

### DIFF
--- a/scrapy/utils/iterators.py
+++ b/scrapy/utils/iterators.py
@@ -21,7 +21,7 @@ logger = logging.getLogger(__name__)
 
 
 def xmliter(obj: Response | str | bytes, nodename: str) -> Iterator[Selector]:
-    """Return a iterator of Selector's over all nodes of a XML document,
+    """Return an iterator of Selector's over all nodes of an XML document,
        given the name of the node to iterate. Useful for parsing XML feeds.
 
     obj can be:


### PR DESCRIPTION
## Description

This PR fixes grammar issues in the xmliter() function docstring in scrapy/utils/iterators.py.

## Changes
- Changed 'a iterator' to 'an iterator'
- Changed 'a XML' to 'an XML'

## Motivation
Proper English grammar uses 'an' before words starting with vowel sounds. This improves the readability and professionalism of the documentation.