### PR TITLE
Switch default SCHEDULER_PRIORITY_QUEUE to DownloaderAwarePriorityQueue for fairer broad crawls

### DIFF
--- a/docs/news.rst
+++ b/docs/news.rst
@@ -15,6 +15,13 @@ Backward-incompatible changes
     ``True`` when running Scrapy via :ref:`its command-line tool
     <topics-commands-crawlerprocess>` to avoid a reactor mismatch exception.
 
+-   The default value of the :setting:`SCHEDULER_PRIORITY_QUEUE` setting is now
+    ``"scrapy.pqueues.DownloaderAwarePriorityQueue"`` (previously
+    ``"scrapy.pqueues.ScrapyPriorityQueue"``) so that the default configuration
+    performs better when crawling many domains concurrently. Override the
+    setting if you prefer the previous behaviour optimized for single-domain
+    crawls.
+
 -   The ``log_count/*`` stats no longer count some of the early messages that
     they counted before. While the earliest log messages, emitted before the
     counter is initialized, were never counted, the counter initialization now

--- a/docs/topics/broad-crawls.rst
+++ b/docs/topics/broad-crawls.rst
@@ -44,11 +44,10 @@ efficient broad crawl.
 Use the right :setting:`SCHEDULER_PRIORITY_QUEUE`
 =================================================
 
-Scrapy’s default scheduler priority queue is ``'scrapy.pqueues.ScrapyPriorityQueue'``.
-It works best during single-domain crawl. It does not work well with crawling
-many different domains in parallel
-
-To apply the recommended priority queue use:
+Scrapy’s default scheduler priority queue is
+``'scrapy.pqueues.DownloaderAwarePriorityQueue'``. It works best when crawling
+many different domains in parallel. If you are using an older Scrapy version or
+have customized the setting, make sure it is set to this value:
 
 .. code-block:: python
 

--- a/docs/topics/settings.rst
+++ b/docs/topics/settings.rst
@@ -1739,13 +1739,13 @@ Type of in-memory queue used by the scheduler. Other available type is:
 SCHEDULER_PRIORITY_QUEUE
 ------------------------
 
-Default: ``'scrapy.pqueues.ScrapyPriorityQueue'``
+Default: ``'scrapy.pqueues.DownloaderAwarePriorityQueue'``
 
 Type of priority queue used by the scheduler. Another available type is
-``scrapy.pqueues.DownloaderAwarePriorityQueue``.
-``scrapy.pqueues.DownloaderAwarePriorityQueue`` works better than
-``scrapy.pqueues.ScrapyPriorityQueue`` when you crawl many different
-domains in parallel.
+``scrapy.pqueues.ScrapyPriorityQueue``.
+``scrapy.pqueues.ScrapyPriorityQueue`` works better than
+``scrapy.pqueues.DownloaderAwarePriorityQueue`` when your crawl focuses on a
+single domain.
 
 
 .. setting:: SCHEDULER_START_DISK_QUEUE

--- a/scrapy/settings/default_settings.py
+++ b/scrapy/settings/default_settings.py
@@ -481,7 +481,7 @@ SCHEDULER = "scrapy.core.scheduler.Scheduler"
 SCHEDULER_DEBUG = False
 SCHEDULER_DISK_QUEUE = "scrapy.squeues.PickleLifoDiskQueue"
 SCHEDULER_MEMORY_QUEUE = "scrapy.squeues.LifoMemoryQueue"
-SCHEDULER_PRIORITY_QUEUE = "scrapy.pqueues.ScrapyPriorityQueue"
+SCHEDULER_PRIORITY_QUEUE = "scrapy.pqueues.DownloaderAwarePriorityQueue"
 SCHEDULER_START_DISK_QUEUE = "scrapy.squeues.PickleFifoDiskQueue"
 SCHEDULER_START_MEMORY_QUEUE = "scrapy.squeues.FifoMemoryQueue"
 


### PR DESCRIPTION
### Summary
Switches the default `SCHEDULER_PRIORITY_QUEUE` to `scrapy.pqueues.DownloaderAwarePriorityQueue` so new Scrapy projects benefit from downloader-aware fairness out of the box.  
This ensures more balanced request scheduling across domains during broad crawls.

### Details
- Updated default queue in settings.
- Updated settings reference, broad-crawls guide, and release notes to reflect the change.
- Legacy `ScrapyPriorityQueue` remains available for single-domain crawls.

### Testing
All scheduler tests pass:
```bash
pytest -v tests/test_scheduler.py
# 17 passed in 1.58s
