### PR TITLE
Add missing doc deps for new examples

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,5 @@
+pydantic==2.12.3
+scrapy-spider-metadata==0.2.0
 sphinx==8.1.3
 sphinx-notfound-page==1.0.4
 sphinx-rtd-theme==3.0.2

--- a/tox.ini
+++ b/tox.ini
@@ -40,7 +40,7 @@ passenv =
 #allow tox virtualenv to upgrade pip/wheel/setuptools
 download = true
 commands =
-    pytest {posargs:--cov-config=pyproject.toml --cov=scrapy --cov-report= --cov-report=term-missing --cov-report=xml --junitxml=testenv.junit.xml -o junit_family=legacy --durations=10 docs scrapy tests --doctest-modules}
+    pytest {posargs:--cov-config=pyproject.toml --cov=scrapy --cov-report= --cov-report=term-missing --cov-report=xml --junitxml=testenv.junit.xml -o junit_family=legacy --durations=10 scrapy tests --doctest-modules}
 
 [testenv:typing]
 basepython = python3.9
@@ -120,7 +120,6 @@ deps =
 setenv =
     _SCRAPY_PINNED=true
 commands =
-    ; tests for docs fail with parsel < 1.8.0
     pytest {posargs:--cov-config=pyproject.toml --cov=scrapy --cov-report=xml --cov-report= --junitxml=pinned.junit.xml -o junit_family=legacy --durations=10 scrapy tests}
 
 [testenv:pinned]
@@ -182,7 +181,7 @@ setenv =
 basepython = pypy3
 commands =
     ; not enabling coverage as it significantly increases the run time
-    pytest {posargs:--durations=10 docs scrapy tests}
+    pytest {posargs:--durations=10 scrapy tests}
 
 [testenv:pypy3-extra-deps]
 basepython = pypy3
@@ -209,7 +208,7 @@ deps =
     w3lib==1.20.0
     zope.interface==5.1.0
 commands =
-    ; disabling both coverage and docs tests
+    ; disabling coverage
     pytest {posargs:--durations=10 scrapy tests}
 setenv =
     {[pinned]setenv}
@@ -225,10 +224,13 @@ setenv =
 [testenv:docs]
 basepython = python3
 changedir = {[docs]changedir}
-deps = {[docs]deps}
+deps =
+    {[test-requirements]deps}
+    {[docs]deps}
 setenv = {[docs]setenv}
 commands =
     sphinx-build -W -b html . {envtmpdir}/html
+    pytest
 
 [testenv:docs-coverage]
 basepython = python3


### PR DESCRIPTION
Includes moving the pytest call for the `docs/` folder to the `docs` tox env.