### PR TITLE
Undeprecate download_delay.

### DIFF
--- a/scrapy/core/downloader/__init__.py
+++ b/scrapy/core/downloader/__init__.py
@@ -95,13 +95,6 @@ def _get_concurrency_delay(
 ) -> tuple[int, float]:
     delay: float = settings.getfloat("DOWNLOAD_DELAY")
     if hasattr(spider, "download_delay"):
-        warnings.warn(
-            "The 'download_delay' spider attribute is deprecated. "
-            "Use Spider.custom_settings or Spider.update_settings() instead. "
-            "The corresponding setting name is 'DOWNLOAD_DELAY'.",
-            category=ScrapyDeprecationWarning,
-            stacklevel=2,
-        )
         delay = spider.download_delay
 
     if hasattr(spider, "max_concurrent_requests"):


### PR DESCRIPTION
This reverts a part of #6994 per https://github.com/scrapy/scrapy/pull/7039#discussion_r2405903806, as this attribute is used by the autothrottle extension to pass the delay to the engine.

I've also just found that the attribute is mentioned in the docs several times, we will need to fix that when we deprecate it again.