### PR TITLE
File download error fix at staus code 201

### DIFF
--- a/scrapy/pipelines/files.py
+++ b/scrapy/pipelines/files.py
@@ -594,7 +594,7 @@ class FilesPipeline(MediaPipeline):
     ) -> FileInfo:
         referer = referer_str(request)
 
-        if response.status != 200:
+        if response.status not in [200,201]:
             logger.warning(
                 "File (code: %(status)s): Error downloading file from "
                 "%(request)s referred in <%(referer)s>",


### PR DESCRIPTION
## This PR fixes a file download handling issue in the Scrapy pipeline where responses with HTTP status 201 were not being properly processed.

**Changes Made**

                   `if response.status !=200:
                            logger.warning(
                               "File (code: %(status)s): Error downloading file from "
                               "%(request)s referred in <%(referer)s>",
                               {"status": response.status, "request": request, "referer": referer},
                               extra={"spider": info.spider},
                            )
                           raise FileException("download-error")`
**To**

                 `if response.status not in [200,201]:
                        logger.warning(
                           "File (code: %(status)s): Error downloading file from "
                           "%(request)s referred in <%(referer)s>",
                          {"status": response.status, "request": request, "referer": referer},
                          extra={"spider": info.spider},
                        )
                       raise FileException("download-error")`

**Result**
Ensured downloaded files are stored and validated as expected.

**Testing**
Verified locally with multiple endpoints returning 200 and 201 responses.
Confirmed successful downloads and no runtime errors.

Please review and let me know if any improvements are needed.