### PR TITLE
Downloader middleware to handle non-compliant HTTP headers

### DIFF
--- a/docs/topics/downloader-middleware.rst
+++ b/docs/topics/downloader-middleware.rst
@@ -1189,6 +1189,37 @@ implementing the methods described below.
 
 .. _robots.txt: https://www.robotstxt.org/
 
+Lenient HTTP Downloader Middleware
+----------------------------------
+
+.. module:: scrapy.downloadermiddlewares.error_headers
+   :synopsis: Lenient Http Downloader Middleware
+.. class:: LenientHttpDownloaderMiddleware
+
+
+When a remote server sends a malformed HTTP response header, Twisted raises
+:class:`twisted.web._newclient.ResponseFailed` and Scrapy aborts the
+request, even though the body may be perfectly usable.
+
+``LenientHttpDownloaderMiddleware`` intercepts that exact exception,
+re-issues the request with a **raw socket GET**, parses the response skipping malformed headers,
+and returns a normal :class:`scrapy.http.Response` so the spider can continue.
+
+* Works for both ``http`` and ``https``.
+* Keeps every valid ``name: value`` header; silently drops malformed headers.
+* Adds the flag ``BAD_HEADER_FALLBACK`` to the response for later inspection.
+
+
+**Configuration**
+
+.. code-block:: python
+
+   # settings.py
+   DOWNLOADER_MIDDLEWARES = {
+       "myproject.middlewares.LenientHttpDownloaderMiddleware": 600,
+   }
+
+
 DownloaderStats
 ---------------
 

--- a/scrapy/downloadermiddlewares/error_headers.py
+++ b/scrapy/downloadermiddlewares/error_headers.py
@@ -1,0 +1,108 @@
+import logging
+import socket
+import ssl
+from urllib.parse import urlsplit
+
+from twisted.web._newclient import ResponseFailed
+
+from scrapy.http import Headers, Response
+
+logger = logging.getLogger(__name__)
+
+
+class LenientHttpDownloaderMiddleware:
+    """
+    Fallback lenient fetch when Twisted fails parsing malformed response headers.
+    see: https://github.com/scrapy/scrapy/issues/210
+    """
+
+    def process_exception(self, request, exception) -> Response | None:
+        if not isinstance(exception, ResponseFailed):
+            return None
+
+        # server sent a malformed header that Twisted couldn't parse
+        # see for details: https://github.com/scrapy/scrapy/issues/210
+        if "not enough values to unpack (expected 2, got 1)" not in str(exception):
+            return None
+
+        try:
+            logger.debug(
+                "LenientHttpDownloaderMiddleware: bad header detected for request: %(request)s",
+                {"request": request},
+            )
+            return self._lenient_fetch(request.url)
+        except Exception:
+            return None
+
+    def _lenient_fetch(self, url: str, timeout: int = 5) -> Response:
+        parts = urlsplit(url)
+        host: str = parts.hostname
+        port: int = parts.port
+        path: str = (parts.path or "/") + (f"?{parts.query}" if parts.query else "")
+
+        sock: socket.socket = socket.create_connection((host, port), timeout=timeout)
+        try:
+            if parts.scheme == "https":
+                sock = ssl.create_default_context().wrap_socket(
+                    sock, server_hostname=host
+                )
+
+            req = f"GET {path} HTTP/1.0\r\nHost: {host}\r\nConnection: close\r\n\r\n"
+            sock.sendall(req.encode("utf-8"))
+
+            data: bytes = b""
+            while chunk := sock.recv(8192):
+                data += chunk
+        finally:
+            sock.close()
+
+        # Find body separator
+        # Try the standard CRLF separator (\r\n\r\n); fall back to LF (\n\n) for non‑compliant servers.
+        headers_raw: bytes = b""
+        body: bytes = data
+        for sep in (b"\r\n\r\n", b"\n\n"):
+            if sep in data:
+                headers_raw, body = data.split(sep, 1)
+                break
+
+        # Default values
+        status: int = 200
+        headers_dict: dict[str, list[bytes]] = {}
+
+        if headers_raw:
+            lines: list[str] = headers_raw.decode("latin-1").splitlines()
+
+            # Parse status line (skip if broken)
+            if lines:
+                first_line = lines[0].strip()
+                parts = first_line.split()
+                if len(parts) >= 2 and parts[1].isdigit():
+                    status = int(parts[1])
+
+            # Parse headers: keep only valid "name: value" lines
+            for line in lines[1:]:
+                line = line.strip()
+
+                # skip blank/whitespace-only lines
+                if not line:
+                    continue
+
+                if ":" in line:
+                    name, value = line.split(":", 1)
+                    name = name.strip()
+                    value = value.strip()
+                    if name:  # valid header name
+                        headers_dict.setdefault(name, []).append(
+                            value.encode("latin-1")
+                        )
+                else:
+                    # Invalid line - drop silently
+                    pass
+
+        return Response(
+            url=url,
+            status=status,
+            headers=Headers(headers_dict),
+            body=body,
+            flags=["BAD_HEADER_FALLBACK"],
+        )

--- a/tests/test_downloadermiddleware_error_headers.py
+++ b/tests/test_downloadermiddleware_error_headers.py
@@ -1,0 +1,62 @@
+import socket
+from unittest.mock import Mock, patch
+
+import pytest
+from twisted.python.failure import Failure
+from twisted.web._newclient import ResponseFailed
+
+from scrapy import Request
+from scrapy.downloadermiddlewares.error_headers import LenientHttpDownloaderMiddleware
+from scrapy.http import Headers
+
+
+@pytest.fixture
+def fresh_middleware():
+    return LenientHttpDownloaderMiddleware()
+
+
+class TestErrorHeadersMiddleware:
+    def test_error_header(self, fresh_middleware):
+        # mock the exception that Twisted would raise on bad headers
+        raw_exception = ValueError("not enough values to unpack (expected 2, got 1)")
+        exception = ResponseFailed([Failure(raw_exception)])
+
+        raw_response = (
+            b"HTTP/1.0 200 OK\n"
+            b"Bad header\n"  # <-- no ':' will raise ValueError
+            b"\n"  # <-- no proper header/body separator
+            b"Hello World"
+        )
+
+        # Simulate TCP streaming: return in 2+ chunks
+        fake_socket = Mock(spec=socket.socket)
+
+        fake_socket.recv.side_effect = [
+            raw_response,  # first recv() - full malformed response
+            b"",  # second recv() - EOF (connection closed)
+        ]
+
+        with patch("scrapy.downloadermiddlewares.error_headers.socket") as mock_socket:
+            mock_socket.create_connection.return_value = fake_socket
+
+            req = Request("http://example.com:80/path?q=123")
+            response = fresh_middleware.process_exception(req, exception)
+
+        assert response.status == 200
+        assert response.headers == Headers({})
+        assert response.body == b"Hello World"
+        assert "BAD_HEADER_FALLBACK" in response.flags
+
+        mock_socket.create_connection.assert_called_once()
+        fake_socket.sendall.assert_called_once()
+        assert fake_socket.recv.call_count == 2
+
+    def test_valid_header(self, fresh_middleware):
+        # Success path: no exception -> middleware should not interfere
+        req = Request("http://example.com:80/path?q=123")
+
+        with patch("scrapy.downloadermiddlewares.error_headers.socket") as mock_socket:
+            response = fresh_middleware.process_exception(req, None)
+            mock_socket.create_connection.assert_not_called()
+
+        assert response is None


### PR DESCRIPTION
Closes #210 

 HTTP Downloader Middleware

* Keeps every valid ``name: value`` header; silently drops malformed headers.
* Adds the flag ``BAD_HEADER_FALLBACK`` to the response for later inspection.