### PR TITLE
Add connection check utility in Scrapy utils

### DIFF
--- a/scrapy/utils/connection_check.py
+++ b/scrapy/utils/connection_check.py
@@ -1,0 +1,16 @@
+import socket
+
+def is_port_open(host: str = "127.0.0.1", port: int = 80, timeout: float = 1.0) -> bool:
+    """
+    Check if a network port is open.
+    Returns True if connection succeeds, otherwise False.
+    """
+    try:
+        with socket.create_connection((host, port), timeout=timeout):
+            return True
+    except OSError:
+        return False
+
+
+if __name__ == "__main__":
+    print(is_port_open("example.com", 80))  # Expected: True


### PR DESCRIPTION
### Summary
Added a small utility `is_port_open()` under `scrapy/utils/connection_check.py`.

### Details
- Checks if a given host and port are reachable.
- Helps for network debugging and testing Scrapy spiders.
- Returns True if connection succeeds, False otherwise.

### Example Usage
```python
from scrapy.utils.connection_check import is_port_open
print(is_port_open("example.com", 80))
# True
