### PR TITLE
Don't force the unavailable sysmon coverage core.

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -28,8 +28,6 @@ deps =
 
     # mitmproxy does not support PyPy
     mitmproxy; implementation_name != "pypy"
-setenv =
-    COVERAGE_CORE=sysmon
 passenv =
     S3_TEST_FILE_URI
     AWS_ACCESS_KEY_ID


### PR DESCRIPTION
On `coverage < 7.11.1` (except some older versions which we no longer use) this produced a warning on all supported Python versions (3.10-3.11 with "sys.monitoring isn’t available in this version", 3.12-3.13 with "sys.monitoring can’t measure branches in this version"), with 7.11.1+ it now produces an error. And on Python 3.14 this core is the default anyway.