### PR TITLE
[Fix]Exit code for pipeline initialization failures

### DIFF
--- a/tests/test_crawler.py
+++ b/tests/test_crawler.py
@@ -752,12 +752,8 @@ class TestCrawlerRunnerHasSpider:
     def test_crawler_runner_bootstrap_failed_pipeline_exception(self):
         runner = self._runner()
 
-        try:
+        with pytest.raises(ValueError):
             yield self._crawl(runner, PipelineExceptionSpider)
-        except ValueError:
-            pass
-        else:
-            pytest.fail("Exception should be raised from pipeline")
 
         assert runner.bootstrap_failed
 


### PR DESCRIPTION
Fixes #7092 

When an exception occurred in ItemPipeline.from_crawler(), the crawler process exited with code 0 (success)
  instead of a non-zero error code. This made it impossible to detect failures in automated monitoring and CI/CD
  systems.

Root Cause: The bootstrap_failed flag only checked if the spider was created (crawler.spider is not None),
  but didn't detect failures occurring after spider creation during pipeline/middleware/engine initialization.

Solution
Added initialization_failed flag to track exceptions during the initialization phase:

1. New flag in Crawler.__init__: self.initialization_failed = False
2. Set flag on exceptions in both crawl() and crawl_async() exception handlers
3. Enhanced bootstrap check in CrawlerRunner._crawl() and AsyncCrawlerRunner._crawl(): self.bootstrap_failed |= ( not getattr(crawler, "spider", None) or getattr(crawler, "initialization_failed", False) )

Changes

- scrapy/crawler.py: 5 modifications
  - Added initialization_failed flag to Crawler class
  - Updated exception handlers in crawl() and crawl_async()
  - Enhanced bootstrap_failed checks in both runner classes
- tests/test_crawler.py: Added comprehensive test
  - ExceptionPipeline: Test helper that raises in from_crawler
  - PipelineExceptionSpider: Spider with the exception pipeline configured
  - test_crawler_runner_bootstrap_failed_pipeline_exception: Test verifying the fix