### PR TITLE
Fix duplicate assertion in test_utils_deprecate

### DIFF
--- a/tests/test_utils_deprecate.py
+++ b/tests/test_utils_deprecate.py
@@ -169,9 +169,6 @@ class TestWarnWhenSubclassed:
             class UnrelatedClass:
                 pass
 
-            class OldStyleClass:
-                pass
-
         assert issubclass(UpdatedUserClass1, NewName)
         assert issubclass(UpdatedUserClass1a, NewName)
         assert issubclass(UpdatedUserClass1, DeprecatedName)
@@ -204,9 +201,6 @@ class TestWarnWhenSubclassed:
             class UnrelatedClass:
                 pass
 
-            class OldStyleClass:
-                pass
-
         assert isinstance(UpdatedUserClass2(), NewName)
         assert isinstance(UpdatedUserClass2a(), NewName)
         assert isinstance(UpdatedUserClass2(), DeprecatedName)
@@ -216,7 +210,6 @@ class TestWarnWhenSubclassed:
         assert not isinstance(OutdatedUserClass2a(), OutdatedUserClass2)
         assert not isinstance(OutdatedUserClass2(), OutdatedUserClass2a)
         assert not isinstance(UnrelatedClass(), DeprecatedName)
-        assert not isinstance(OldStyleClass(), DeprecatedName)
 
     def test_clsdict(self):
         with warnings.catch_warnings():


### PR DESCRIPTION
Resolves #7143

Removed duplicate assertion for OldStyleClass. OldStyleClass is a Python 2 artifact.