### PR TITLE
Limit the queue size in _parallel_asyncio().

### DIFF
--- a/scrapy/utils/asyncio.py
+++ b/scrapy/utils/asyncio.py
@@ -80,7 +80,7 @@ async def _parallel_asyncio(
     assumes that neither *callable* nor iterating *iterable* will raise an
     exception.
     """
-    queue: asyncio.Queue[_T | None] = asyncio.Queue()
+    queue: asyncio.Queue[_T | None] = asyncio.Queue(count * 2)
 
     async def worker() -> None:
         while True:


### PR DESCRIPTION
Found in https://github.com/scrapy/scrapy/issues/7158#issuecomment-3557986309

Limiting the queue size makes `fill_queue()` pause instead of consuming the whole iterator right away.