### PR TITLE
feat: add optional CRAWL_ORDER setting placeholder

### DIFF
--- a/scrapy/settings/default_settings.py
+++ b/scrapy/settings/default_settings.py
@@ -546,3 +546,7 @@ def __getattr__(name: str):
         return 0
 
     raise AttributeError
+# Optional crawl order setting
+# DFO = Depth-First (default)
+# BFO = Breadth-First (user-selected)
+CRAWL_ORDER = 'DFO'


### PR DESCRIPTION
This PR introduces a new optional Scrapy setting called `CRAWL_ORDER`.
It prepares Scrapy for a future feature that allows switching between
Depth-First (DFO) and Breadth-First (BFO) crawling strategies.

Only adds the configuration setting for now.
