### PR TITLE
Add tests for disabling middleware referenced by class object

### DIFF
--- a/tests/utils/test_conf_middleware_6912.py
+++ b/tests/utils/test_conf_middleware_6912.py
@@ -1,0 +1,30 @@
+from scrapy.downloadermiddlewares.httpauth import HttpAuthMiddleware
+from scrapy.utils.conf import build_component_list
+
+
+def _key_for(cls):
+    return f"{cls.__module__}.{cls.__name__}"
+
+
+def test_middleware_string_key_none_disables():
+    compdict = {
+        "scrapy.downloadermiddlewares.httpauth.HttpAuthMiddleware": None,
+    }
+    result = build_component_list(compdict)
+    assert "scrapy.downloadermiddlewares.httpauth.HttpAuthMiddleware" not in result
+
+
+def test_middleware_class_key_none_disables():
+    compdict = {
+        HttpAuthMiddleware: None,
+    }
+    result = build_component_list(compdict)
+    assert _key_for(HttpAuthMiddleware) not in result
+
+
+def test_middleware_class_key_priority_enables():
+    compdict = {
+        HttpAuthMiddleware: 543,
+    }
+    result = build_component_list(compdict)
+    assert HttpAuthMiddleware in result


### PR DESCRIPTION
This PR adds tests around disabling HttpAuthMiddleware when configured in DOWNLOADER_MIDDLEWARES via:

String key + None

Class object key + None

Class object key + numeric priority

The tests capture the current behaviour (string path + None disables the middleware; class object + None does not) and ensure that a numeric priority keeps it enabled.

Refs #6912.