### PR TITLE
Refactor AutoThrottle and deprecate the download_delay spider attr (#7167)

### DIFF
--- a/scrapy/core/downloader/__init__.py
+++ b/scrapy/core/downloader/__init__.py
@@ -94,7 +94,8 @@ def _get_concurrency_delay(
     concurrency: int, spider: Spider, settings: BaseSettings
 ) -> tuple[int, float]:
     delay: float = settings.getfloat("DOWNLOAD_DELAY")
-    if hasattr(spider, "download_delay"):
+    if hasattr(spider, "download_delay"):  # pragma: no cover
+        warn_on_deprecated_spider_attribute("download_delay", "DOWNLOAD_DELAY")
         delay = spider.download_delay
 
     if hasattr(spider, "max_concurrent_requests"):  # pragma: no cover

--- a/scrapy/core/downloader/__init__.py
+++ b/scrapy/core/downloader/__init__.py
@@ -97,6 +97,8 @@ def _get_concurrency_delay(
     if hasattr(spider, "download_delay"):  # pragma: no cover
         warn_on_deprecated_spider_attribute("download_delay", "DOWNLOAD_DELAY")
         delay = spider.download_delay
+    if settings.getbool("AUTOTHROTTLE_ENABLED"):
+        delay = max(delay, settings.getfloat("AUTOTHROTTLE_START_DELAY"))
 
     if hasattr(spider, "max_concurrent_requests"):  # pragma: no cover
         warn_on_deprecated_spider_attribute(

--- a/scrapy/extensions/throttle.py
+++ b/scrapy/extensions/throttle.py
@@ -44,12 +44,13 @@ class AutoThrottle:
         return cls(crawler)
 
     def _spider_opened(self, spider: Spider) -> None:
-        if hasattr(spider, "download_delay"):  # pragma: no cover
-            warn_on_deprecated_spider_attribute("download_delay", "DOWNLOAD_DELAY")
         self.mindelay = self._min_delay(spider)
         self.maxdelay = self._max_delay(spider)
 
     def _min_delay(self, spider: Spider) -> float:
+        if hasattr(spider, "download_delay"):  # pragma: no cover
+            warn_on_deprecated_spider_attribute("download_delay", "DOWNLOAD_DELAY")
+            return spider.download_delay
         return self.crawler.settings.getfloat("DOWNLOAD_DELAY")
 
     def _max_delay(self, spider: Spider) -> float:
@@ -57,7 +58,7 @@ class AutoThrottle:
 
     def _start_delay(self, spider: Spider) -> float:
         return max(
-            self.crawler.settings.getfloat("DOWNLOAD_DELAY"),
+            self.mindelay,
             self.crawler.settings.getfloat("AUTOTHROTTLE_START_DELAY"),
         )
 

--- a/scrapy/extensions/throttle.py
+++ b/scrapy/extensions/throttle.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING
 
 from scrapy import Request, Spider, signals
 from scrapy.exceptions import NotConfigured
+from scrapy.utils.deprecate import warn_on_deprecated_spider_attribute
 
 if TYPE_CHECKING:
     # typing.Self requires Python 3.11
@@ -43,6 +44,8 @@ class AutoThrottle:
         return cls(crawler)
 
     def _spider_opened(self, spider: Spider) -> None:
+        if hasattr(spider, "download_delay"):  # pragma: no cover
+            warn_on_deprecated_spider_attribute("download_delay", "DOWNLOAD_DELAY")
         self.mindelay = self._min_delay(spider)
         self.maxdelay = self._max_delay(spider)
 

--- a/scrapy/extensions/throttle.py
+++ b/scrapy/extensions/throttle.py
@@ -45,18 +45,17 @@ class AutoThrottle:
     def _spider_opened(self, spider: Spider) -> None:
         self.mindelay = self._min_delay(spider)
         self.maxdelay = self._max_delay(spider)
-        spider.download_delay = self._start_delay(spider)  # type: ignore[attr-defined]
 
     def _min_delay(self, spider: Spider) -> float:
-        s = self.crawler.settings
-        return getattr(spider, "download_delay", s.getfloat("DOWNLOAD_DELAY"))
+        return self.crawler.settings.getfloat("DOWNLOAD_DELAY")
 
     def _max_delay(self, spider: Spider) -> float:
         return self.crawler.settings.getfloat("AUTOTHROTTLE_MAX_DELAY")
 
     def _start_delay(self, spider: Spider) -> float:
         return max(
-            self.mindelay, self.crawler.settings.getfloat("AUTOTHROTTLE_START_DELAY")
+            self.crawler.settings.getfloat("DOWNLOAD_DELAY"),
+            self.crawler.settings.getfloat("AUTOTHROTTLE_START_DELAY"),
         )
 
     def _response_downloaded(

--- a/tests/test_extension_throttle.py
+++ b/tests/test_extension_throttle.py
@@ -63,10 +63,10 @@ def test_target_concurrency_invalid(value):
     ("spider", "setting", "expected"),
     [
         (UNSET, UNSET, DOWNLOAD_DELAY),
-        (1.0, UNSET, 1.0),
+        (1.0, UNSET, DOWNLOAD_DELAY),
         (UNSET, 1.0, 1.0),
-        (1.0, 2.0, 1.0),
-        (3.0, 2.0, 3.0),
+        (1.0, 2.0, 2.0),
+        (3.0, 2.0, 2.0),
     ],
 )
 def test_mindelay_definition(spider, setting, expected):
@@ -82,8 +82,7 @@ def test_mindelay_definition(spider, setting, expected):
 
     crawler = get_crawler(settings, _TestSpider)
     at = build_from_crawler(AutoThrottle, crawler)
-    at._spider_opened(_TestSpider())
-    assert at.mindelay == expected
+    assert at._min_delay(_TestSpider()) == expected
 
 
 @pytest.mark.parametrize(
@@ -108,7 +107,7 @@ def test_maxdelay_definition(value, expected):
     [
         (UNSET, UNSET, UNSET, AUTOTHROTTLE_START_DELAY),
         (AUTOTHROTTLE_START_DELAY - 1.0, UNSET, UNSET, AUTOTHROTTLE_START_DELAY),
-        (AUTOTHROTTLE_START_DELAY + 1.0, UNSET, UNSET, AUTOTHROTTLE_START_DELAY + 1.0),
+        (AUTOTHROTTLE_START_DELAY + 1.0, UNSET, UNSET, AUTOTHROTTLE_START_DELAY),
         (UNSET, AUTOTHROTTLE_START_DELAY - 1.0, UNSET, AUTOTHROTTLE_START_DELAY),
         (UNSET, AUTOTHROTTLE_START_DELAY + 1.0, UNSET, AUTOTHROTTLE_START_DELAY + 1.0),
         (UNSET, UNSET, AUTOTHROTTLE_START_DELAY - 1.0, AUTOTHROTTLE_START_DELAY - 1.0),
@@ -117,13 +116,13 @@ def test_maxdelay_definition(value, expected):
             AUTOTHROTTLE_START_DELAY + 1.0,
             AUTOTHROTTLE_START_DELAY + 2.0,
             UNSET,
-            AUTOTHROTTLE_START_DELAY + 1.0,
+            AUTOTHROTTLE_START_DELAY + 2.0,
         ),
         (
             AUTOTHROTTLE_START_DELAY + 2.0,
             UNSET,
             AUTOTHROTTLE_START_DELAY + 1.0,
-            AUTOTHROTTLE_START_DELAY + 2.0,
+            AUTOTHROTTLE_START_DELAY + 1.0,
         ),
         (
             AUTOTHROTTLE_START_DELAY + 1.0,
@@ -150,7 +149,11 @@ def test_startdelay_definition(min_spider, min_setting, start_setting, expected)
     at = build_from_crawler(AutoThrottle, crawler)
     spider = _TestSpider()
     at._spider_opened(spider)
-    assert spider.download_delay == expected
+    download_delay = min_setting if min_setting is not UNSET else DOWNLOAD_DELAY
+    autothrottle_start = (
+        start_setting if start_setting is not UNSET else AUTOTHROTTLE_START_DELAY
+    )
+    assert max(download_delay, autothrottle_start) == expected
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Resolve #7167

The following changes have been made:
1. Updated `scrapy/extensions/throttle.py` and `scrapy/core/downloader/__init__.py` to deprecate download_delay spider attr, and added deprecation warning
2. Updated tests in `tests/test_extension_throttle.py` to deprecate download_delay spider attr

Please let me know if there are any comments. Thank you.