### PR TITLE
Fixes UnicodeDecodeError from response.json()

### DIFF
--- a/docs/topics/request-response.rst
+++ b/docs/topics/request-response.rst
@@ -1210,6 +1210,8 @@ TextResponse objects
 
         Returns a Python object from deserialized JSON document.
         The result is cached after the first call.
+        The response body is decoded using :attr:`TextResponse.encoding` before
+        deserialization.
 
     .. method:: TextResponse.urljoin(url)
 

--- a/scrapy/http/response/text.py
+++ b/scrapy/http/response/text.py
@@ -79,7 +79,7 @@ class TextResponse(Response):
     def json(self) -> Any:
         """Deserialize a JSON document to a Python object."""
         if self._cached_decoded_json is _NONE:
-            self._cached_decoded_json = json.loads(self.body)
+            self._cached_decoded_json = json.loads(self.text)
         return self._cached_decoded_json
 
     @property

--- a/task_guide.md
+++ b/task_guide.md
@@ -1,0 +1,64 @@
+
+
+## ✅ High-Accuracy Research Prompt for Scrapy
+
+> You are acting as a senior Scrapy core contributor performing issue triage.
+>
+> Your task is to **actively browse the Scrapy GitHub repository issues AND related pull requests** and identify the **most technically complex, non-trivial open issues** that require deep architectural understanding to solve.
+>
+> ⚠️ You MUST read multiple issues and PR discussions before answering. Do NOT rely on prior knowledge.
+>
+> ---
+>
+> ### Only consider issues that involve at least one of the following:
+>
+> * Async / Await / Twisted reactor / asyncio integration
+> * Pipelines, middlewares, downloader handlers, scheduler, or engine internals
+> * Failing tests, flaky tests, CI instability, or regressions
+> * Race conditions, concurrency bugs, lifecycle/state management problems
+> * Incorrect request/response handling, retry logic, or HTTP status handling
+> * File handling, streaming, encoding, or filesystem edge cases
+> * Proxy, headers, timeout, or networking edge cases
+>
+> ---
+>
+> ### Strictly ignore:
+>
+> * Documentation, typing, comments, or refactor-only issues
+> * “Good first issue”, “easy”, or beginner tags
+> * UI, spelling, formatting, or trivial cleanups
+>
+> ---
+>
+> ### Extra filter (very important):
+>
+> Prefer issues whose likely fix would require **changes across 3 or more files**, such as:
+>
+> * pipeline + middleware + test
+> * downloader + retry middleware + tests
+> * engine/scheduler + pipeline + tests
+> * core module + utils + tests
+>
+> These indicate deep cross-component bugs.
+>
+> ---
+>
+> ### For each issue you select, provide:
+>
+> 1. Issue title
+> 2. Direct GitHub link
+> 3. Why this issue is technically difficult
+> 4. Which Scrapy internal components are involved
+> 5. Why solving it likely requires modifying 3–4 files
+> 6. What deep Scrapy/Twisted/async knowledge is required
+> 7. summery of what you have resoleve
+>
+> ---
+>
+> ### Prioritize issues that:
+>
+> * Have been open for a long time with discussion but no solution
+> * Mention failing tests but unclear root cause
+> * Reference async behavior, pipelines, middleware, or scheduler
+> * Have related PRs that were attempted but not merged
+>

--- a/tests/test_http_response.py
+++ b/tests/test_http_response.py
@@ -810,6 +810,14 @@ class TestTextResponse(TestResponseBase):
         json_response = self.response_class("http://www.example.com", body=json_body)
         assert json_response.json() == {"ip": "109.187.217.200"}
 
+        json_body = '{"price": "£"}'.encode("iso-8859-1")
+        json_response = self.response_class(
+            "http://www.example.com",
+            body=json_body,
+            headers={"Content-Type": ["application/json; charset=iso-8859-1"]},
+        )
+        assert json_response.json() == {"price": "£"}
+
         text_body = b"""<html><body>text</body></html>"""
         text_response = self.response_class("http://www.example.com", body=text_body)
         with pytest.raises(
@@ -827,7 +835,7 @@ class TestTextResponse(TestResponseBase):
             with mock.patch("json.loads") as mock_json:
                 for _ in range(2):
                     json_response.json()
-                mock_json.assert_called_once_with(json_body)
+                mock_json.assert_called_once_with(json_response.text)
 
 
 class TestHtmlResponse(TestTextResponse):


### PR DESCRIPTION
issue #6456

Summary of what I resolved:

- TextResponse.json() now deserializes from self.text (decoded using TextResponse.encoding) to avoid UnicodeDecodeError when JSON is not UTF‑8.
- Added a regression test covering non‑UTF‑8 JSON with an explicit charset.
- Updated the JSON caching test to match the new decoding path.
- Documented that TextResponse.json() decodes with response encoding before parsing.