### PR TITLE
Fix flaky test_download_with_proxy_https_timeout().

### DIFF
--- a/tests/mockserver/http_resources.py
+++ b/tests/mockserver/http_resources.py
@@ -308,7 +308,8 @@ class UriResource(resource.Resource):
         # ToDo: implement proper HTTPS proxy tests, not faking them.
         if request.method != b"CONNECT":
             return request.uri
-        return b""
+        request.transport.write(b"HTTP/1.1 200 Connection established\r\n\r\n")
+        return NOT_DONE_YET
 
 
 class ResponseHeadersResource(resource.Resource):


### PR DESCRIPTION
Fixes #7060 (_hopefully_).

I've got the initial fix from an LLM and it works fine locally, I still don't have the complete picture though (but I don't think it's required since this is a test-only problem). It goes like this:

Before the fix, returning `b""` makes the mock proxy send a full HTTP response, with `Content-Length: 0` and all that, and I assume make the Twisted HTTP server state machines to just switch to some "awaiting request" mode. After the fix, the server sends a raw 200 response and (because of `NOT_DONE_YET`) lets the Twisted code know that the request is still being handled. To be clear, I don't think extra response headers in the "before" case are the problem.

The failure case happens like this: the client sends some binary data (which I assume is the TLS handshake) to the server, the server tries to interpret it as a HTTP request and so replies with "400 Bad Request", the client tries to interpret that as a response to the hadshake and produces an OpenSSL error. Now, I don't know why the failure happens rarely, as if it's some kind of a race condition, probably normally the connection is closed before all of that, but I stopped investigating at this point.