### PR TITLE
Fix peek() KeyError crash and queue priority mismatch with pop()

### DIFF
--- a/scrapy/pqueues.py
+++ b/scrapy/pqueues.py
@@ -229,10 +229,14 @@ class ScrapyPriorityQueue:
         """
         if self.curprio is None:
             return None
+        # Check regular queues first, matching pop() priority order
         try:
-            queue = self._start_queues[self.curprio]
-        except KeyError:
             queue = self.queues[self.curprio]
+        except KeyError:
+            try:
+                queue = self._start_queues[self.curprio]
+            except KeyError:
+                return None
         # Protocols can't declare optional members
         return cast("Request", queue.peek())  # type: ignore[attr-defined]
 


### PR DESCRIPTION
`ScrapyPriorityQueue.peek()` has two issues:

**1. Crash when `curprio` is stale**

After `pop()` empties a regular queue at some priority while start queues exist at a different priority, `curprio` isn't updated (by design — `pop()` skips `_update_curprio()` when `_start_queues` is non-empty). A subsequent `peek()` call hits `_start_queues[curprio]` → `KeyError`, falls through to `queues[curprio]` → second `KeyError`, which is unhandled:

```python
try:
    queue = self._start_queues[self.curprio]   # KeyError
except KeyError:
    queue = self.queues[self.curprio]          # KeyError — unhandled, crash
```

While `pop()` handles this via its `while` loop that self-corrects, `peek()` has no such recovery.

**2. Queue check order doesn't match `pop()`**

`pop()` checks regular queues first, then start queues. `peek()` does the opposite, returning a different item than what `pop()` would actually return — violating its documented contract of returning "the next object to be returned by `pop()`."

The fix handles both: check regular queues first (matching `pop()`) and gracefully return `None` when neither queue exists at the current priority.
