### PR TITLE
Avoid mutating original cookie dicts in _get_request_cookies

### DIFF
--- a/scrapy/downloadermiddlewares/cookies.py
+++ b/scrapy/downloadermiddlewares/cookies.py
@@ -181,7 +181,7 @@ class CookiesMiddleware:
         if isinstance(request.cookies, dict):
             cookies = tuple({"name": k, "value": v} for k, v in request.cookies.items())
         else:
-            cookies = request.cookies
+            cookies = [dict(c) for c in request.cookies]
         for cookie in cookies:
             cookie.setdefault("secure", urlparse_cached(request).scheme == "https")
         formatted = filter(None, (self._format_cookie(c, request) for c in cookies))


### PR DESCRIPTION
When `request.cookies` is a list of dicts (the `VerboseCookie` form), `_get_request_cookies()` takes a direct reference and then calls `setdefault("secure", ...)` on each dict. This mutates the caller's original cookie dicts in place.

If a spider reuses the same cookie dicts across multiple requests, the `secure` flag set during the first request persists into later ones. For example, an HTTPS request adds `secure=True` to the dict, then a follow-up HTTP request to the same domain still carries `secure=True` because `setdefault` won't overwrite an existing key — even though the scheme changed.

The `dict` code path is unaffected because it creates new dicts via the generator expression. This fix makes the list-of-dicts path consistent by shallow-copying each dict before modification.
