### PR TITLE
Accept 2xx status codes in FilesPipeline.media_downloaded

### DIFF
--- a/scrapy/pipelines/files.py
+++ b/scrapy/pipelines/files.py
@@ -601,7 +601,7 @@ class FilesPipeline(MediaPipeline):
     ) -> FileInfo:
         referer = referer_str(request)
 
-        if response.status != 200:
+        if not (200 <= response.status < 300):
             logger.warning(
                 "File (code: %(status)s): Error downloading file from "
                 "%(request)s referred in <%(referer)s>",


### PR DESCRIPTION
Resolves #1615

`FilesPipeline.media_downloaded()` rejects any response where `status != 200`, but HTTP 201 (Created) is a valid success status per RFC 7231. Servers that generate files on the fly commonly return 201, causing the pipeline to log a warning and raise `FileException("download-error")` instead of saving the file.

### Changes

- Changed the status check in `media_downloaded()` from `response.status != 200` to `not (200 <= response.status < 300)`, accepting the full 2xx success range.
- Added `test_file_download_status_201` to verify that 201 responses are processed correctly and the file is saved.
- Added `test_file_download_non_2xx_rejected` to verify that non-2xx responses (e.g. 404) are still rejected.

The existing `not response.body` check (line 613) already handles the edge case of a 201 response with no body.

### Testing

```
$ python -m pytest tests/test_pipeline_files.py -k "test_file_download" -v
tests/test_pipeline_files.py::TestFilesPipeline::test_file_download_status_201 PASSED
tests/test_pipeline_files.py::TestFilesPipeline::test_file_download_non_2xx_rejected PASSED
```

All pre-existing tests also pass. Pre-commit hooks pass.

*This PR was created with the assistance of Claude Opus 4.6 by Anthropic. Happy to make any adjustments! Reviewed and submitted by a human.*