### PR TITLE
Fix genspider --edit failing with ModuleNotFoundError

### DIFF
--- a/scrapy/commands/genspider.py
+++ b/scrapy/commands/genspider.py
@@ -118,9 +118,14 @@ class Command(ScrapyCommand):
 
         template_file = self._find_template(opts.template)
         if template_file:
-            self._genspider(module, name, url, opts.template, template_file)
+            spider_file = self._genspider(
+                module, name, url, opts.template, template_file
+            )
             if opts.edit:
-                self.exitcode = os.system(f'scrapy edit "{name}"')  # noqa: S605
+                editor = self.settings.get("EDITOR")
+                self.exitcode = os.system(  # noqa: S605
+                    f'{editor} "{spider_file}"'
+                )
 
     def _generate_template_variables(
         self,
@@ -148,8 +153,11 @@ class Command(ScrapyCommand):
         url: str,
         template_name: str,
         template_file: str | os.PathLike,
-    ) -> None:
-        """Generate the spider module, based on the given template"""
+    ) -> str:
+        """Generate the spider module, based on the given template.
+
+        Returns the path of the generated spider file.
+        """
         assert self.settings is not None
         tvars = self._generate_template_variables(module, name, url, template_name)
         if self.settings.get("NEWSPIDER_MODULE"):
@@ -168,6 +176,7 @@ class Command(ScrapyCommand):
         )
         if spiders_module:
             print(f"in module:\n  {spiders_module.__name__}.{module}")
+        return spider_file
 
     def _find_template(self, template: str) -> Path | None:
         template_file = Path(self.templates_dir, f"{template}.tmpl")


### PR DESCRIPTION
## Summary

`scrapy genspider --edit` fails with `ModuleNotFoundError: No module named 'proj'` because the `--edit` flag spawns `scrapy edit` as a subprocess via `os.system()`. The subprocess inherits `SCRAPY_SETTINGS_MODULE` from the parent environment, causing `get_project_settings()` to skip `init_env()` (which adds the project directory to `sys.path`). The subsequent `settings.setmodule()` then can't find the project module.

**Root cause:** In `get_project_settings()`, when `SCRAPY_SETTINGS_MODULE` is already set in the environment (inherited from the parent process), `init_env()` is skipped entirely:

```python
if ENVVAR not in os.environ:
    project = os.environ.get("SCRAPY_PROJECT", "default")
    init_env(project)
```

Without `init_env()`, the project directory is never added to `sys.path`.

**Fix:** Instead of spawning a new `scrapy edit` process, open the editor directly on the generated spider file (whose path `_genspider()` already knows). This eliminates the subprocess environment inheritance problem entirely.

Fixes #7260

## Test plan

- [x] Added regression test that runs `genspider --edit` with `EDITOR=true` and verifies no `ModuleNotFoundError`
- [x] All 31 existing genspider tests pass