### PR TITLE
fix CrawlTestCase.test_start_requests_lazyness

### DIFF
--- a/scrapy/core/engine.py
+++ b/scrapy/core/engine.py
@@ -303,12 +303,14 @@ class ExecutionEngine:
             self._slot.heartbeat.start(self._SLOT_HEARTBEAT_INTERVAL)
 
             while self._start and self.spider and self.running:
-                await self._process_start_next()
-                if not self.needs_backout():
-                    # Give room for the outcome of self._process_start_next() to be
-                    # processed before continuing with the next iteration.
-                    self._slot.nextcall.schedule()
+                if self.needs_backout():
                     await self._slot.nextcall.wait()
+                    continue
+                await self._process_start_next()
+                # Give room for the outcome of self._process_start_next() to be
+                # processed before continuing with the next iteration.
+                self._slot.nextcall.schedule()
+                await self._slot.nextcall.wait()
         except (asyncio.exceptions.CancelledError, CancelledError):
             # self.stop_async() has cancelled us, nothing to do
             return


### PR DESCRIPTION
in _start_request_processing() in scrapy/core/engine.py, when needs_backout() returns True (meaning the downloader or scraper is at capacity) 
the code skips the schedule() + wait() and immediately loops back to pull the next request from the start_requests generator. 
this causes the generator to be exhausted eagerly instead of being consumed lazily, which is the root cause of issue 

this fix moves the needs_backout() check before the generator is consumed. 
when the engine is at capacity, it now waits for a running request to complete before pulling the next one from the generator.

Fixes #5703