### PR TITLE
Fix #6293: SitemapSpider will ignore sitemap with URLs like https://web

### DIFF
--- a/scrapy/spiders/sitemap.py
+++ b/scrapy/spiders/sitemap.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 import re
+from urllib.parse import urlparse
 
 # Iterable is needed at the run time for the SitemapSpider._parse_sitemap() annotation
 from collections.abc import AsyncIterator, Iterable, Sequence  # noqa: TC003
@@ -127,7 +128,8 @@ class SitemapSpider(Spider):
         # without actually being a .xml.gz file in the first place,
         # merely XML gzip-compressed on the fly,
         # in other word, here, we have plain XML
-        if response.url.endswith(".xml") or response.url.endswith(".xml.gz"):
+        url_path = urlparse(response.url).path
+        if url_path.endswith(".xml") or url_path.endswith(".xml.gz"):
             return response.body
         return None
 

--- a/tests/test_spider.py
+++ b/tests/test_spider.py
@@ -566,6 +566,20 @@ class TestSitemapSpider(TestSpider):
         r = Response(url="http://www.example.com/sitemap.xml.gz", body=self.BODY)
         self.assertSitemapBody(r, self.BODY)
 
+    def test_get_sitemap_body_xml_url_with_query_params(self):
+        # Test URLs with query parameters (issue #6293)
+        r = TextResponse(
+            url="http://www.example.com/sitemap.xml?from=123&to=456",
+            body=self.BODY,
+        )
+        self.assertSitemapBody(r, self.BODY)
+
+        r = TextResponse(
+            url="http://www.example.com/sitemap.xml.gz?context=abc",
+            body=self.BODY,
+        )
+        self.assertSitemapBody(r, self.BODY)
+
     def test_get_sitemap_urls_from_robotstxt(self):
         robots = b"""# Sitemap files
 Sitemap: http://example.com/sitemap.xml


### PR DESCRIPTION
Fixes #6293

## Summary
This PR addresses: SitemapSpider will ignore sitemap with URLs like https://website.com/filename.xml?from=7155352010944&to=7482320519360

## Changes
```
scrapy/spiders/sitemap.py |  4 +++-
 tests/test_spider.py      | 14 ++++++++++++++
 2 files changed, 17 insertions(+), 1 deletion(-)
```

## Testing
Please review the changes carefully. The fix was verified against the existing test suite.

---
*This PR was created with the assistance of Claude Haiku 4.5 by Anthropic | effort: low. Happy to make any adjustments!*

By submitting this pull request, I confirm that my contribution is made under the terms of the project's license (contributor license agreement).