### PR TITLE
Update on Request objects

### DIFF
--- a/docs/topics/request-response.rst
+++ b/docs/topics/request-response.rst
@@ -24,6 +24,11 @@ below in :ref:`topics-request-response-ref-request-subclasses` and
 Request objects
 ===============
 
+
+.. note::
+    While you can import the request object using :class:`scrapy.http.Request`, it is highly recommended to use the standard shortcut :class:`scrapy.Request` instead.
+
+
 .. autoclass:: scrapy.Request
 
     :param url: the URL of this request

--- a/docs/topics/request-response.rst
+++ b/docs/topics/request-response.rst
@@ -23,12 +23,6 @@ below in :ref:`topics-request-response-ref-request-subclasses` and
 
 Request objects
 ===============
-
-
-.. note::
-    While you can import the request object using :class:`scrapy.http.Request`, it is highly recommended to use the standard shortcut :class:`scrapy.Request` instead.
-
-
 .. autoclass:: scrapy.Request
 
     :param url: the URL of this request
@@ -68,13 +62,13 @@ Request objects
 
         .. invisible-code-block: python
 
-            from scrapy.http import Request
+            import scrapy
 
         1. Using a dict:
 
         .. code-block:: python
 
-            request_with_cookies = Request(
+            request_with_cookies = scrapy.Request(
                 url="http://www.example.com",
                 cookies={"currency": "USD", "country": "UY"},
             )
@@ -83,7 +77,7 @@ Request objects
 
         .. code-block:: python
 
-            request_with_cookies = Request(
+            request_with_cookies = scrapy.Request(
                 url="https://www.example.com",
                 cookies=[
                     {

--- a/docs/topics/request-response.rst
+++ b/docs/topics/request-response.rst
@@ -23,6 +23,7 @@ below in :ref:`topics-request-response-ref-request-subclasses` and
 
 Request objects
 ===============
+
 .. autoclass:: scrapy.Request
 
     :param url: the URL of this request
@@ -62,13 +63,13 @@ Request objects
 
         .. invisible-code-block: python
 
-            import scrapy
+            from scrapy import Request
 
         1. Using a dict:
 
         .. code-block:: python
 
-            request_with_cookies = scrapy.Request(
+            request_with_cookies = Request(
                 url="http://www.example.com",
                 cookies={"currency": "USD", "country": "UY"},
             )
@@ -77,7 +78,7 @@ Request objects
 
         .. code-block:: python
 
-            request_with_cookies = scrapy.Request(
+            request_with_cookies = Request(
                 url="https://www.example.com",
                 cookies=[
                     {


### PR DESCRIPTION
While analyzing Scrapy's documentation for a university project on Software Architecture, our team noticed a small area where the documentation could be clarified for new users.

Currently, the documentation under `Request objects` doesn't explicitly mention the standard shortcut. Since most official tutorials and best practices use `scrapy.Request` rather than importing directly from `scrapy.http.Request`, we added a small `.. note::` to make this recommendation explicit right at the beginning of the section.

We believe this minor addition will help standardize code for newcomers and improve the overall Developer Experience (DX).