### PR TITLE
Fixes the ModuleNotFoundError that occurs when using the genspider --edit command.

### DIFF
--- a/scrapy/commands/genspider.py
+++ b/scrapy/commands/genspider.py
@@ -1,12 +1,13 @@
 from __future__ import annotations
 
-import os
 import shutil
 import string
 from importlib import import_module
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, cast
 from urllib.parse import urlparse
+import shlex
+import subprocess
 
 import scrapy
 from scrapy.commands import ScrapyCommand
@@ -121,10 +122,11 @@ class Command(ScrapyCommand):
             # Capture the absolute path of the created file
             spider_file = self._genspider(module, name, url, opts.template, template_file)
             if opts.edit:
-                # Get the editor from settings (falls back to EDITOR env var)
-                editor = self.settings.get("EDITOR", "nano")
-                # Open the editor DIRECTLY on the file path
-                os.system(f'{editor} "{spider_file}"')
+                editor = self.settings.get("EDITOR", "vi")
+                # Securely split the editor command and add the file path
+                args = shlex.split(editor) + [str(Path(spider_file).resolve())]
+                # Launch the editor without using os.system
+                self.exitcode = subprocess.run(args).returncode
 
     def _generate_template_variables(
         self,


### PR DESCRIPTION
**Description**
I have refactored this fix to address the feedback provided in #7281. Instead of spawning a new scrapy edit subprocess (which causes environment conflicts), the code now captures the generated spider's file path directly from `_genspider` and opens the editor using `os.system`.

**The Problem**
Spawning a subprocess via `scrapy edit` inherited `SCRAPY_SETTINGS_MODULE`, causing `init_env()` to be skipped and leading to a `ModuleNotFoundError`.

**The Fix**
- Modified `_genspider` to return the absolute path of the created file.
- In the `run` method, used `self.settings.get("EDITOR")` to launch the editor directly on that path.
- Matches the implementation pattern found in Scrapy's own `commands/edit.py`.

Fixes: #7260