### PR TITLE
Fix test_utf16 on big-endian architectures

### DIFF
--- a/tests/test_http_response.py
+++ b/tests/test_http_response.py
@@ -491,9 +491,10 @@ class TestTextResponse(TestResponseBase):
 
     def test_utf16(self):
         """Test utf-16 because UnicodeDammit is known to have problems with"""
+        body = "hi".encode("utf-16")
         r = self.response_class(
             "http://www.example.com",
-            body=b"\xff\xfeh\x00i\x00",
+            body=body,
             encoding="utf-16",
         )
         self._assert_response_values(r, "utf-16", "hi")


### PR DESCRIPTION
## Summary

Fixes #5954

`test_utf16` fails on big-endian architectures (e.g. s390x) because it hardcodes UTF-16 LE body bytes (`b"\xff\xfeh\x00i\x00"`), but `_assert_response_values` computes expected bytes via `"hi".encode("utf-16")` which produces platform-native byte order.

## Changes

- `tests/test_http_response.py`: Generate UTF-16 body bytes dynamically via `"hi".encode("utf-16")` instead of hardcoding little-endian bytes. Python's `utf-16` codec produces the platform-native byte order with BOM, so the body bytes always match what the assertion helper expects.