### PR TITLE
docs: warn about cb_kwargs mutable object deep copy with JOBDIR

### DIFF
--- a/docs/topics/jobs.rst
+++ b/docs/topics/jobs.rst
@@ -104,6 +104,13 @@ If you wish to log the requests that couldn't be serialized, you can set the
 :setting:`SCHEDULER_DEBUG` setting to ``True`` in the project's settings page.
 It is ``False`` by default.
 
+.. note:: Deserialization of persisted requests creates deep copies of the
+    objects in :attr:`~scrapy.Request.cb_kwargs`. This means any mutable
+    object (e.g. :class:`list`, :class:`dict`, :class:`set`) inside
+    ``cb_kwargs`` will not be the same object in the callback after a
+    pause/resume cycle — it will be an independent copy. Changes made to the
+    copy will not affect the original object.
+
 .. _job-dir-contents:
 
 Job directory contents

--- a/docs/topics/request-response.rst
+++ b/docs/topics/request-response.rst
@@ -181,6 +181,12 @@ Request objects
         ``failure.request.cb_kwargs`` in the request's errback. For more information,
         see :ref:`errback-cb_kwargs`.
 
+        .. caution:: When :setting:`JOBDIR` is set, request serialization creates
+            deep copies of ``cb_kwargs`` values. Mutable objects (e.g.
+            :class:`list`, :class:`dict`, :class:`set`) will not be the same
+            object after a pause/resume cycle. See :ref:`topics-jobs` for
+            details.
+
     .. attribute:: Request.meta
        :value: {}
 


### PR DESCRIPTION
Closes #6120

When `JOBDIR` is set, request serialization/deserialization via `pickle` creates deep copies of `cb_kwargs` values. Mutable objects (e.g. `list`, `dict`, `set`) inside `cb_kwargs` will not be the same object in the callback after a pause/resume cycle — changes to the copy won't affect the original.

This adds documentation about this behavior in two places:

1. **`docs/topics/jobs.rst`** — A note in the "Request serialization" section explaining the deep copy behavior.
2. **`docs/topics/request-response.rst`** — A caution in the `cb_kwargs` attribute docs, cross-referencing the jobs page.