### PR TITLE
Add copy-as-markdown button and LLM-friendly doc output

### DIFF
--- a/docs/_static/copy_as_markdown.js
+++ b/docs/_static/copy_as_markdown.js
@@ -1,0 +1,84 @@
+/**
+ * Adds a "Copy as Markdown" button to each documentation page.
+ *
+ * Fetches the pre-built .md file for the current page (generated at build
+ * time by the sphinx-llm extension) and copies its content to the clipboard.
+ * If JS is disabled or the .md file is missing, the button simply won't
+ * appear or will show "Not available" — no existing page content is affected.
+ *
+ * Security notes:
+ * - No innerHTML: all DOM nodes are created via createElement/createElementNS
+ * - fetch() uses a same-origin relative URL only
+ * - All text updates use textContent (not innerHTML) to prevent XSS
+ */
+document.addEventListener("DOMContentLoaded", function () {
+  var contentArea = document.querySelector("[role='main']");
+  if (!contentArea) return;
+
+  // sphinx-llm generates a .md companion for each .html page
+  // e.g. /intro/tutorial.html -> /intro/tutorial.html.md
+  var mdUrl = window.location.pathname;
+  if (mdUrl.endsWith("/")) mdUrl += "index.html";
+  mdUrl += ".md";
+
+  // Build button with DOM APIs only (no innerHTML for security)
+  var btn = document.createElement("button");
+  btn.className = "copy-as-markdown-btn";
+  btn.setAttribute("title", "Copy page as Markdown");
+
+  // Clipboard SVG icon
+  var svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+  svg.setAttribute("width", "16");
+  svg.setAttribute("height", "16");
+  svg.setAttribute("viewBox", "0 0 24 24");
+  svg.setAttribute("fill", "none");
+  svg.setAttribute("stroke", "currentColor");
+  svg.setAttribute("stroke-width", "2");
+  svg.setAttribute("stroke-linecap", "round");
+  svg.setAttribute("stroke-linejoin", "round");
+  var path = document.createElementNS("http://www.w3.org/2000/svg", "path");
+  path.setAttribute("d", "M16 4h2a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h2");
+  var rect = document.createElementNS("http://www.w3.org/2000/svg", "rect");
+  rect.setAttribute("x", "8");
+  rect.setAttribute("y", "2");
+  rect.setAttribute("width", "8");
+  rect.setAttribute("height", "4");
+  rect.setAttribute("rx", "1");
+  rect.setAttribute("ry", "1");
+  svg.appendChild(path);
+  svg.appendChild(rect);
+
+  var label = document.createElement("span");
+  label.className = "copy-as-markdown-label";
+  label.textContent = "Copy as Markdown";
+
+  btn.appendChild(svg);
+  btn.appendChild(label);
+  contentArea.insertBefore(btn, contentArea.firstChild);
+
+  // Fetch the pre-built markdown and copy to clipboard
+  btn.addEventListener("click", function () {
+    fetch(mdUrl)
+      .then(function (response) {
+        if (!response.ok) throw new Error("Not found");
+        return response.text();
+      })
+      .then(function (markdown) {
+        return navigator.clipboard.writeText(markdown);
+      })
+      .then(function () {
+        label.textContent = "Copied!";
+        btn.classList.add("copied");
+        setTimeout(function () {
+          label.textContent = "Copy as Markdown";
+          btn.classList.remove("copied");
+        }, 2000);
+      })
+      .catch(function () {
+        label.textContent = "Not available";
+        setTimeout(function () {
+          label.textContent = "Copy as Markdown";
+        }, 2000);
+      });
+  });
+});

--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -44,6 +44,52 @@ html[data-theme="dark"] .sig.sig-object {
     background-color: #202325 !important
 }
 
+/* Copy as Markdown button */
+.copy-as-markdown-btn {
+    position: sticky;
+    top: 0;
+    float: right;
+    z-index: 100;
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 6px 12px;
+    margin: 0 0 8px 8px;
+    border: 1px solid #d1d5db;
+    border-radius: 6px;
+    background: #f9fafb;
+    color: #374151;
+    font-size: 13px;
+    cursor: pointer;
+}
+
+.copy-as-markdown-btn:hover {
+    border-color: #9ca3af;
+}
+
+.copy-as-markdown-btn.copied {
+    background: #ecfdf5;
+    border-color: #6ee7b7;
+    color: #065f46;
+}
+
+html[data-theme="dark"] .copy-as-markdown-btn {
+    background: #2d3239;
+    border-color: #4b5563;
+    color: #d1d5db;
+}
+
+html[data-theme="dark"] .copy-as-markdown-btn.copied {
+    background: #064e3b;
+    border-color: #6ee7b7;
+    color: #a7f3d0;
+}
+
+@media (max-width: 768px) {
+    .copy-as-markdown-label { display: none; }
+    .copy-as-markdown-btn { padding: 8px; }
+}
+
 html[data-theme="dark"] .sig-name,
 html[data-theme="dark"] .sig-prename,
 html[data-theme="dark"] .property,

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -34,7 +34,16 @@ extensions = [
     "sphinx.ext.intersphinx",
     "sphinx.ext.viewcode",
     "sphinx_rtd_dark_mode",
+    "sphinx_copybutton",
+    "sphinx_llm.txt",
 ]
+
+# -- Options for sphinx-copybutton ------------------------------------------
+copybutton_prompt_text = r">>> |\.\.\. |\$ "
+copybutton_prompt_is_regexp = True
+
+# -- Options for sphinx-llm ------------------------------------------------
+llms_txt_description = "Scrapy is a fast high-level web crawling and web scraping framework for Python."
 
 templates_path = ["_templates"]
 exclude_patterns = ["build", "Thumbs.db", ".DS_Store"]
@@ -66,6 +75,10 @@ html_last_updated_fmt = "%b %d, %Y"
 
 html_css_files = [
     "custom.css",
+]
+
+html_js_files = [
+    "copy_as_markdown.js",
 ]
 
 html_context = {

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -2,6 +2,8 @@ h2==4.3.0
 pydantic==2.12.3
 scrapy-spider-metadata==0.2.0
 sphinx==8.1.3
+sphinx-copybutton==0.5.2
+sphinx-llm==0.3.0
 sphinx-notfound-page==1.0.4
 sphinx-rtd-theme==3.0.2
 sphinx-rtd-dark-mode==1.3.0


### PR DESCRIPTION
## Summary

Adds modern documentation patterns for LLM-friendly consumption and improved code copy UX:

- **Copy button on code blocks** via `sphinx-copybutton` (strips `$`, `>>>` prompts)
- **"Copy as Markdown" button** on each page (fetches pre-built `.md` file, copies to clipboard)
- **`llms.txt` and `llms-full.txt` generation** at build time for LLM consumption
- **Per-page `.md` endpoints** (e.g. `tutorial.html.md`) for programmatic access

These follow patterns adopted by [Stripe](https://docs.stripe.com/building-with-llms), [Vercel](https://vercel.com/docs/agent-resources/markdown-access), and [Anthropic](https://docs.claude.com/llms.txt). [Read the Docs has built-in support](https://docs.readthedocs.com/platform/latest/reference/llms-txt.html) for serving `llms.txt` from built output.

No existing content or behavior is changed. All features degrade gracefully without JS (buttons simply don't appear).

## New dependencies

| Package | Maintainer | Stars | Version | License | Purpose |
|---------|-----------|-------|---------|---------|---------|
| [sphinx-copybutton](https://github.com/executablebooks/sphinx-copybutton) | [Executable Books Project](https://github.com/executablebooks) (Jupyter/NumPy ecosystem) | 265 | 0.5.2 (stable, 8 years old) | MIT | Copy button on code blocks |
| [sphinx-llm](https://github.com/NVIDIA/sphinx-llm) | [NVIDIA](https://github.com/NVIDIA) | 10 | 0.3.0 | Apache 2.0 | Generates per-page `.md` files, `llms.txt`, `llms-full.txt` |

## Files changed

- `docs/conf.py` — add `sphinx_copybutton`, `sphinx_llm.txt` extensions and config
- `docs/requirements.txt` — add `sphinx-copybutton==0.5.2`, `sphinx-llm==0.3.0`
- `docs/_static/custom.css` — button styling (light + dark mode)
- `docs/_static/copy_as_markdown.js` — fetches `.md` file and copies to clipboard (DOM APIs only, no innerHTML, same-origin fetch only)

## Test plan

- [x] `make html` builds without warnings
- [x] Copy button appears on code blocks and copies code correctly
- [x] "Copy as Markdown" button copies page content as markdown
- [x] `llms.txt` and `llms-full.txt` are generated in build output
- [x] Pages render correctly with JS disabled (buttons simply absent)
- [x] Dark mode styling works for the copy-as-markdown button

🤖 Generated with [Claude Code](https://claude.com/claude-code)