### PR TITLE
Fix downloader-aware queue starvation with middleware-delayed requests

### DIFF
--- a/scrapy/pqueues.py
+++ b/scrapy/pqueues.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import hashlib
 import logging
+from collections import Counter
 from typing import TYPE_CHECKING, Protocol, cast
 
 from scrapy.utils.misc import build_from_crawler
@@ -262,7 +263,11 @@ class DownloaderInterface:
         self.downloader: Downloader = crawler.engine.downloader
 
     def stats(self, possible_slots: Iterable[str]) -> list[tuple[int, str]]:
-        return [(self._active_downloads(slot), slot) for slot in possible_slots]
+        slots = tuple(possible_slots)
+        active_counts = self._active_downloads_by_request(slots)
+        if active_counts:
+            return [(active_counts.get(slot, 0), slot) for slot in slots]
+        return [(self._active_downloads(slot), slot) for slot in slots]
 
     def get_slot_key(self, request: Request) -> str:
         return self.downloader.get_slot_key(request)
@@ -272,6 +277,25 @@ class DownloaderInterface:
         if slot not in self.downloader.slots:
             return 0
         return len(self.downloader.slots[slot].active)
+
+    def _active_downloads_by_request(self, slots: Iterable[str]) -> Counter[str]:
+        """
+        Return active downloads grouped by slot using downloader-level requests.
+
+        This includes requests waiting inside downloader middleware, which are
+        present in downloader.active but not yet in slot.active.
+        """
+        downloader_active = getattr(self.downloader, "active", None)
+        if not downloader_active:
+            return Counter()
+
+        slot_set = set(slots)
+        active_counts: Counter[str] = Counter()
+        for request in downloader_active:
+            slot = self.downloader.get_slot_key(request)
+            if slot in slot_set:
+                active_counts[slot] += 1
+        return active_counts
 
 
 class DownloaderAwarePriorityQueue:

--- a/tests/test_pqueues.py
+++ b/tests/test_pqueues.py
@@ -98,7 +98,9 @@ class TestPriorityQueue:
 class TestDownloaderAwarePriorityQueue:
     def setup_method(self):
         crawler = get_crawler(Spider)
-        crawler.engine = MockEngine(downloader=MockDownloader())
+        self.downloader = MockDownloader()
+        self.downloader.active = set()
+        crawler.engine = MockEngine(downloader=self.downloader)
         self.queue = DownloaderAwarePriorityQueue.from_crawler(
             crawler=crawler,
             downstream_queue_cls=FifoMemoryQueue,
@@ -156,6 +158,18 @@ class TestDownloaderAwarePriorityQueue:
         assert self.queue.peek().url == req3.url
         assert self.queue.pop().url == req3.url
         assert self.queue.peek() is None
+
+    def test_pop_uses_downloader_active_when_slot_active_is_empty(self):
+        req_books = Request("http://books.toscrape.com/queued")
+        req_quotes = Request("http://quotes.toscrape.com/queued")
+        self.queue.push(req_books)
+        self.queue.push(req_quotes)
+
+        # Simulate a request stalled in downloader middleware. Real downloader
+        # keeps it in downloader.active before it appears in slot.active.
+        self.downloader.active.add(Request("http://books.toscrape.com/inflight"))
+
+        assert self.queue.pop().url == req_quotes.url
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

Fixes starvation in `DownloaderAwarePriorityQueue` when requests are delayed inside downloader middleware.

`DownloaderInterface.stats()` previously relied on `downloader.slots[slot].active`, which can be empty for requests that are already in `downloader.active` but have not yet reached `slot.active`. In that state, slot counts become all zeros and queue selection falls back to lexicographical slot order, causing domain starvation.

This PR changes slot activity accounting to:

- Prefer counting active requests from `downloader.active` grouped by slot.
- Fall back to `slot.active` if downloader-level active requests are unavailable.

## Changes

- Update `scrapy/pqueues.py`:
  - `DownloaderInterface.stats()` now computes counts from downloader-level active requests first.
  - Add `_active_downloads_by_request()` helper.
- Add regression test in `tests/test_pqueues.py`:
  - `test_pop_uses_downloader_active_when_slot_active_is_empty`
  - Reproduces middleware-delayed request scenario and verifies no starvation.

## Validation

- `python3 -m ruff check scrapy/pqueues.py tests/test_pqueues.py`
- `pytest tests/test_pqueues.py -q`
- `pytest tests/test_scheduler.py -k DownloaderAware --reactor=default -q`
- `pytest tests/test_pqueues.py tests/test_scheduler.py -k 'DownloaderAware or test_pop_uses_downloader_active_when_slot_active_is_empty' --reactor=default -q`

Closes #7293
