### PR TITLE
Warn when TWISTED_REACTOR is ignored without FORCE_CRAWLER_PROCESS

### DIFF
--- a/scrapy/crawler.py
+++ b/scrapy/crawler.py
@@ -116,6 +116,24 @@ class Crawler:
                     install_reactor(reactor_class, event_loop)
                 else:
                     from twisted.internet import reactor  # noqa: F401
+
+            elif (
+                reactor_class
+                and is_reactor_installed()
+                and not self.settings.getbool("FORCE_CRAWLER_PROCESS")
+            ):
+                from twisted.internet import reactor as _reactor
+
+                if load_object(reactor_class) is not type(_reactor):
+                    warnings.warn(
+                        f"The spider {getattr(self.spidercls, 'name', self.spidercls.__name__)!r} sets TWISTED_REACTOR to "
+                        f"{reactor_class!r}, but this setting is ignored when running "
+                        "'scrapy crawl' (or any command using CrawlerProcess). "
+                        "To use the spider's reactor, either set FORCE_CRAWLER_PROCESS=True in your "
+                        "project settings, or use CrawlerRunner instead of CrawlerProcess.",
+                        ScrapyDeprecationWarning,
+                        stacklevel=2,
+                    )
             if reactor_class:
                 verify_installed_reactor(reactor_class)
                 if is_asyncio_reactor_installed() and event_loop:

--- a/tests/test_crawler.py
+++ b/tests/test_crawler.py
@@ -1,4 +1,5 @@
 import asyncio
+import contextlib
 import logging
 import platform
 import re
@@ -502,6 +503,24 @@ class TestSpiderSettings:
         crawler = get_crawler(MySpider)
         enabled_exts = [e.__class__ for e in crawler.extensions.middlewares]
         assert AutoThrottle in enabled_exts
+
+    def test_warn_twisted_reactor_ignored_without_force_crawler_process(self):
+        class MySpider(scrapy.Spider):
+            name = "spider"
+            custom_settings = {
+                "TWISTED_REACTOR": "twisted.internet.selectreactor.SelectReactor",
+            }
+
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            with contextlib.suppress(RuntimeError):
+                get_crawler(MySpider, prevent_warnings=False)
+
+        messages = [str(warning.message) for warning in w]
+        assert any(
+            "TWISTED_REACTOR" in msg and "FORCE_CRAWLER_PROCESS" in msg
+            for msg in messages
+        )
 
 
 class TestCrawlerLogging:


### PR DESCRIPTION
Fixes #7221

If a spider configures a custom reactor by setting `TWISTED_REACTOR` in
`custom_settings`, it will be silently ignored if the spider is run with
`scrapy crawl` (which uses `CrawlerProcess` internally).

This PR will raise a `ScrapyDeprecationWarning` in
`Crawler._apply_settings()` if:
- The spider configures a custom reactor with `TWISTED_REACTOR`
- A reactor is already installed
- The configured reactor is different from the installed one
- `FORCE_CRAWLER_PROCESS` is not configured

The warning will indicate two possible solutions:
- Set `FORCE_CRAWLER_PROCESS=True` in your project settings
- Switch to using `CrawlerRunner` instead of `CrawlerProcess`