### PR TITLE
docs: add Windows note for 'python -m scrapy' alternative in tutorial

### DIFF
--- a/docs/intro/tutorial.rst
+++ b/docs/intro/tutorial.rst
@@ -53,6 +53,13 @@ directory where you'd like to store your code and run::
 
     scrapy startproject tutorial
 
+.. note::
+
+   **Windows users:** If you see ``'scrapy' is not recognized as an internal or external command``,
+   try using ``python -m scrapy`` instead::
+
+       python -m scrapy startproject tutorial
+
 This will create a ``tutorial`` directory with the following contents::
 
     tutorial/


### PR DESCRIPTION
## Description

Fixes #7306

Added a note in the tutorial's 'Creating a project' section to help Windows users who encounter the  error.

## Changes

- Added a  block after the  command
- Suggests using  as an alternative for Windows users
- Provides a concrete example: 

## Why this helps

Many Windows newcomers encounter PATH issues where the  command isn't recognized. This simple note guides them to the  alternative without requiring them to dig through installation docs or Stack Overflow.

## Testing

- Verified the RST syntax is correct
- The note appears right where users need it (at their first command)