### PR TITLE
docs: add Windows note for python -m scrapy alternative in tutorial

### DIFF
--- a/docs/intro/tutorial.rst
+++ b/docs/intro/tutorial.rst
@@ -53,6 +53,13 @@ directory where you'd like to store your code and run::
 
     scrapy startproject tutorial
 
+.. note::
+
+   On Windows, if the scrapy command is not found, you can use
+   python -m scrapy as an alternative. For example::
+
+       python -m scrapy startproject tutorial
+
 This will create a ``tutorial`` directory with the following contents::
 
     tutorial/


### PR DESCRIPTION
Fixes #7306

On Windows, the scrapy command is sometimes isn't being found after installation.
So, regarding that I added a note in the tutorial's "Creating a project" section to let 
Windows users know they can use python -m scrapy as an alternative.