### PR TITLE
docs: add Windows note about python -m scrapy alternative

### DIFF
--- a/docs/intro/tutorial.rst
+++ b/docs/intro/tutorial.rst
@@ -53,6 +53,12 @@ directory where you'd like to store your code and run::
 
     scrapy startproject tutorial
 
+.. note::
+
+    **Windows users:** If you see a message like ``'scrapy' is not recognized as an
+    internal or external command``, try running ``python -m scrapy`` instead
+    (e.g., ``python -m scrapy startproject tutorial``).
+
 This will create a ``tutorial`` directory with the following contents::
 
     tutorial/


### PR DESCRIPTION
Fixes #7306

Adds a note to the tutorial "Creating a project" section for Windows users who may encounter `scrapy is not recognized` errors, recommending `python -m scrapy` as an alternative.

This is a small RST note block inserted right after the `scrapy startproject tutorial` command.