### PR TITLE
fix: allow disabling components by class object in settings

### DIFF
--- a/scrapy/utils/conf.py
+++ b/scrapy/utils/conf.py
@@ -11,7 +11,7 @@ from typing import TYPE_CHECKING, Any, cast
 from scrapy.exceptions import UsageError
 from scrapy.settings import BaseSettings
 from scrapy.utils.deprecate import update_classpath
-from scrapy.utils.python import without_none_values
+from scrapy.utils.python import global_object_name, without_none_values
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Collection, Iterable, Mapping, MutableMapping
@@ -25,8 +25,13 @@ def build_component_list(
     """Compose a component list from a :ref:`component priority dictionary
     <component-priority-dictionaries>`."""
 
+    def _key_to_str(key: Any) -> Any:
+        if isinstance(key, type):
+            return global_object_name(key)
+        return key
+
     def _check_components(complist: Collection[Any]) -> None:
-        if len({convert(c) for c in complist}) != len(complist):
+        if len({convert(_key_to_str(c)) for c in complist}) != len(complist):
             raise ValueError(
                 f"Some paths in {complist!r} convert to the same object, "
                 "please update your settings"
@@ -38,16 +43,17 @@ def build_component_list(
             for k, v in compdict.items():
                 prio = compdict.getpriority(k)
                 assert prio is not None
-                if compbs.getpriority(convert(k)) == prio:
+                converted_key = convert(_key_to_str(k))
+                if compbs.getpriority(converted_key) == prio:
                     raise ValueError(
                         f"Some paths in {list(compdict.keys())!r} "
                         "convert to the same "
                         "object, please update your settings"
                     )
-                compbs.set(convert(k), v, priority=prio)
+                compbs.set(converted_key, v, priority=prio)
             return compbs
         _check_components(compdict)
-        return {convert(k): v for k, v in compdict.items()}
+        return {convert(_key_to_str(k)): v for k, v in compdict.items()}
 
     def _validate_values(compdict: Mapping[Any, Any]) -> None:
         """Fail if a value in the components dict is not a real number or None."""

--- a/tests/test_utils_conf.py
+++ b/tests/test_utils_conf.py
@@ -1,5 +1,6 @@
 import pytest
 
+from scrapy.downloadermiddlewares.stats import DownloaderStats
 from scrapy.exceptions import UsageError
 from scrapy.settings import BaseSettings, Settings
 from scrapy.utils.conf import (
@@ -45,6 +46,18 @@ class TestBuildComponentList:
             "c": 22222222222222222222,
         }
         assert build_component_list(d, convert=lambda x: x) == ["b", "c", "a"]
+
+    def test_disable_component_by_class_in_dict(self):
+        d = {
+            "scrapy.downloadermiddlewares.stats.DownloaderStats": 850,
+            DownloaderStats: None,
+        }
+        assert build_component_list(d) == []
+
+    def test_disable_component_by_class_in_basesettings(self):
+        d = BaseSettings({"scrapy.downloadermiddlewares.stats.DownloaderStats": 850})
+        d.set(DownloaderStats, None, priority="cmdline")
+        assert build_component_list(d) == []
 
 
 def test_arglist_to_dict():


### PR DESCRIPTION
closes #6912

fixes build_component_list so class object keys (e.g. middleware classes) are normalized to import-path strings before conversion. this allows disabling components by passing class objects in settings.

added regression tests for both dict and BaseSettings inputs.