### PR TITLE
docs: add Windows note for 'python -m scrapy' alternative in tutorial

### DIFF
--- a/docs/intro/tutorial.rst
+++ b/docs/intro/tutorial.rst
@@ -53,6 +53,13 @@ directory where you'd like to store your code and run::
 
     scrapy startproject tutorial
 
+.. note::
+
+    If you're on Windows and the ``scrapy`` command is not recognized, try
+    using ``python -m scrapy`` instead (e.g.,
+    ``python -m scrapy startproject tutorial``). This can happen when the
+    Python Scripts folder is not in your ``PATH``.
+
 This will create a ``tutorial`` directory with the following contents::
 
     tutorial/


### PR DESCRIPTION
Fixes #7306

Adds a note to the tutorial's "Creating a project" section for Windows users who may encounter the `scrapy` command not being recognized, recommending `python -m scrapy` as an alternative.

The note is placed right after the `scrapy startproject tutorial` command, where users are most likely to encounter this issue.