### PR TITLE
docs: Add Windows note for 'python -m scrapy' alternative

### DIFF
--- a/docs/intro/tutorial.rst
+++ b/docs/intro/tutorial.rst
@@ -53,6 +53,12 @@ directory where you'd like to store your code and run::
 
     scrapy startproject tutorial
 
+.. note::
+
+   **Windows users:** If you see an error like ``'scrapy' is not recognized as an
+   internal or external command``, you can use ``python -m scrapy`` instead. For
+   example: ``python -m scrapy startproject tutorial``
+
 This will create a ``tutorial`` directory with the following contents::
 
     tutorial/


### PR DESCRIPTION
Fixes #7306

## Summary
Added a note in the tutorial for Windows users who may encounter the `scrapy` command not being recognized due to PATH issues or multiple Python installations.

## Changes
- Added a `.. note::` block in `docs/intro/tutorial.rst` after the `scrapy startproject tutorial` command
- Provided clear guidance for Windows users to use `python -m scrapy` as an alternative
- Included a concrete example: `python -m scrapy startproject tutorial`

## Testing
- Verified the reStructuredText syntax is correct
- The note appears in the appropriate location in the tutorial

This should help newcomers on Windows who run into this common issue during their first steps with Scrapy.