### PR TITLE
Persist batch_id across JOBDIR restarts in FeedExporter

### DIFF
--- a/scrapy/extensions/feedexport.py
+++ b/scrapy/extensions/feedexport.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import logging
+import pickle
 import re
 import sys
 import warnings
@@ -32,6 +33,7 @@ from scrapy.utils.asyncio import is_asyncio_available
 from scrapy.utils.conf import feed_complete_default_values_from_settings
 from scrapy.utils.defer import deferred_from_coro, ensure_awaitable
 from scrapy.utils.ftp import ftp_store_file
+from scrapy.utils.job import job_dir
 from scrapy.utils.misc import build_from_crawler, load_object
 from scrapy.utils.python import without_none_values
 
@@ -446,6 +448,7 @@ class FeedExporter:
         self.slots: list[FeedSlot] = []
         self.filters: dict[str, ItemFilter] = {}
         self._pending_close_coros: list[Coroutine[Any, Any, None]] = []
+        self._jobdir: str | None = job_dir(self.settings)
 
         if not self.settings["FEEDS"] and not self.settings["FEED_URI"]:
             raise NotConfigured
@@ -492,11 +495,15 @@ class FeedExporter:
                 raise NotConfigured
 
     def open_spider(self, spider: Spider) -> None:
+        persisted_batch_ids = self._load_persisted_batch_ids()
         for uri, feed_options in self.feeds.items():
-            uri_params = self._get_uri_params(spider, feed_options["uri_params"])
+            batch_id = persisted_batch_ids.get(uri, 0) + 1
+            uri_params = self._get_uri_params(
+                spider, feed_options["uri_params"], starting_batch_id=batch_id
+            )
             self.slots.append(
                 self._start_new_batch(
-                    batch_id=1,
+                    batch_id=batch_id,
                     uri=uri % uri_params,
                     feed_options=feed_options,
                     spider=spider,
@@ -505,6 +512,7 @@ class FeedExporter:
             )
 
     async def close_spider(self, spider: Spider) -> None:
+        self._persist_batch_ids(spider)
         self._pending_close_coros.extend(
             self._close_slot(slot, spider) for slot in self.slots
         )
@@ -692,6 +700,8 @@ class FeedExporter:
         spider: Spider,
         uri_params_function: str | UriParamsCallableT | None,
         slot: FeedSlot | None = None,
+        *,
+        starting_batch_id: int | None = None,
     ) -> dict[str, Any]:
         params = {}
         for k in dir(spider):
@@ -699,7 +709,10 @@ class FeedExporter:
         utc_now = datetime.now(tz=timezone.utc)
         params["time"] = utc_now.replace(microsecond=0).isoformat().replace(":", "-")
         params["batch_time"] = utc_now.isoformat().replace(":", "-")
-        params["batch_id"] = slot.batch_id + 1 if slot is not None else 1
+        if starting_batch_id is not None:
+            params["batch_id"] = starting_batch_id
+        else:
+            params["batch_id"] = slot.batch_id + 1 if slot is not None else 1
         uripar_function: UriParamsCallableT = (
             load_object(uri_params_function)
             if uri_params_function
@@ -707,6 +720,32 @@ class FeedExporter:
         )
         new_params = uripar_function(params, spider)
         return new_params if new_params is not None else params
+
+    def _load_persisted_batch_ids(self) -> dict[str, int]:
+        """Load persisted batch_ids from the JOBDIR spider state file.
+
+        Reads the file directly because SpiderState may not have loaded
+        spider.state yet when open_spider runs (signal handler ordering).
+        """
+        if not self._jobdir:
+            return {}
+        state_fn = Path(self._jobdir, "spider.state")
+        if not state_fn.exists():
+            return {}
+        try:
+            with state_fn.open("rb") as f:
+                state = pickle.load(f)  # noqa: S301
+            return state.get("_feed_batch_ids", {})
+        except Exception:
+            return {}
+
+    def _persist_batch_ids(self, spider: Spider) -> None:
+        """Save current batch_ids to spider.state for JOBDIR persistence."""
+        if not hasattr(spider, "state"):
+            return
+        batch_ids = spider.state.setdefault("_feed_batch_ids", {})
+        for slot in self.slots:
+            batch_ids[slot.uri_template] = slot.batch_id
 
     def _load_filter(self, feed_options: dict[str, Any]) -> ItemFilter:
         # load the item filter if declared else load the default filter class

--- a/tests/test_feedexport.py
+++ b/tests/test_feedexport.py
@@ -3024,3 +3024,99 @@ class TestURIParamsFeedOption(TestURIParams):
                 uri: options,
             },
         }
+
+
+class TestBatchIdPersistence:
+    """Tests for batch_id persistence across JOBDIR restarts (issue #5153)."""
+
+    def setup_method(self):
+        self.temp_dir = tempfile.mkdtemp()
+        self.job_dir = os.path.join(self.temp_dir, "crawl-job")
+        os.makedirs(self.job_dir)
+
+    def teardown_method(self):
+        shutil.rmtree(self.temp_dir, ignore_errors=True)
+
+    def _write_spider_state(self, state):
+        state_fn = os.path.join(self.job_dir, "spider.state")
+        with open(state_fn, "wb") as f:
+            pickle.dump(state, f, protocol=4)
+
+    def test_batch_id_resumes_after_restart(self):
+        """On restart, batch_id should continue from where the previous crawl left off."""
+        uri_template = build_url(
+            os.path.join(self.temp_dir, "output", "%(batch_id)d.jl")
+        )
+        self._write_spider_state({"_feed_batch_ids": {uri_template: 5}})
+
+        settings = {
+            "FEEDS": {uri_template: {"format": "jl"}},
+            "FEED_EXPORT_BATCH_ITEM_COUNT": 1,
+            "JOBDIR": self.job_dir,
+        }
+        crawler = get_crawler(settings_dict=settings)
+        exporter = FeedExporter(crawler)
+
+        spider = Spider("testspider")
+        exporter.open_spider(spider)
+
+        assert len(exporter.slots) == 1
+        assert exporter.slots[0].batch_id == 6
+
+    def test_batch_id_starts_at_one_without_jobdir(self):
+        """Without JOBDIR, batch_id should start at 1 as usual."""
+        uri_template = build_url(
+            os.path.join(self.temp_dir, "output", "%(batch_id)d.jl")
+        )
+        settings = {
+            "FEEDS": {uri_template: {"format": "jl"}},
+            "FEED_EXPORT_BATCH_ITEM_COUNT": 1,
+        }
+        crawler = get_crawler(settings_dict=settings)
+        exporter = FeedExporter(crawler)
+
+        spider = Spider("testspider")
+        exporter.open_spider(spider)
+
+        assert len(exporter.slots) == 1
+        assert exporter.slots[0].batch_id == 1
+
+    def test_batch_id_starts_at_one_on_first_run(self):
+        """On first run with JOBDIR (no state file), batch_id should start at 1."""
+        uri_template = build_url(
+            os.path.join(self.temp_dir, "output", "%(batch_id)d.jl")
+        )
+        settings = {
+            "FEEDS": {uri_template: {"format": "jl"}},
+            "FEED_EXPORT_BATCH_ITEM_COUNT": 1,
+            "JOBDIR": self.job_dir,
+        }
+        crawler = get_crawler(settings_dict=settings)
+        exporter = FeedExporter(crawler)
+
+        spider = Spider("testspider")
+        exporter.open_spider(spider)
+
+        assert len(exporter.slots) == 1
+        assert exporter.slots[0].batch_id == 1
+
+    def test_persist_batch_ids_saves_to_spider_state(self):
+        """Closing the spider should save batch_ids to spider.state."""
+        uri_template = build_url(
+            os.path.join(self.temp_dir, "output", "%(batch_id)d.jl")
+        )
+        settings = {
+            "FEEDS": {uri_template: {"format": "jl"}},
+            "FEED_EXPORT_BATCH_ITEM_COUNT": 1,
+            "JOBDIR": self.job_dir,
+        }
+        crawler = get_crawler(settings_dict=settings)
+        exporter = FeedExporter(crawler)
+
+        spider = Spider("testspider")
+        spider.state = {}
+        exporter.open_spider(spider)
+
+        exporter._persist_batch_ids(spider)
+
+        assert spider.state["_feed_batch_ids"][uri_template] == 1


### PR DESCRIPTION
## Summary

Fixes #5153

When a crawl using `FEED_EXPORT_BATCH_ITEM_COUNT` is restarted via `JOBDIR`, the `batch_id` counter resets to 1 and existing feed files get overwritten. This persists batch_ids to `spider.state` and restores them on restart, as suggested in the issue discussion.

## How it works

- `open_spider`: loads persisted batch_ids from the JOBDIR `spider.state` file and starts each feed from the saved batch_id + 1
- `close_spider`: saves current batch_ids to `spider.state` so `SpiderState` persists them to disk
- `_get_uri_params`: accepts an optional `starting_batch_id` kwarg so the initial URI gets the correct batch_id for file naming

Because `FeedExporter` receives the `spider_opened` signal before `SpiderState` loads `spider.state` (both extensions have priority 0, dict insertion order determines signal handler order), the batch_ids are read directly from the JOBDIR state file in `open_spider`.

## Changes

- `scrapy/extensions/feedexport.py`: Added `_load_persisted_batch_ids` and `_persist_batch_ids` methods, modified `open_spider` to use persisted batch_ids
- `tests/test_feedexport.py`: Added `TestBatchIdPersistence` with 4 test cases covering restart resume, no-JOBDIR, first run, and state saving