### PR TITLE
docs: add local development setup guide

### DIFF
--- a/docs/local_development_setup.txt
+++ b/docs/local_development_setup.txt
@@ -1,0 +1,7 @@
+### Local Development Setup
+1. Clone your fork: `git clone https://github.com/YOUR_USERNAME/scrapy.git`
+2. Create a virtual environment: `python -m venv venv && source venv/bin/activate` or ' conda create -p venv python=3.13 -y '
+3. Install dev tools: `pip install tox pre-commit`
+4. Install in editable mode: `pip install -e .`
+5. Initialize hooks: `pre-commit install`
+6. Run tests: `tox -e py313`


### PR DESCRIPTION
### Description
As a new contributor to Scrapy, I found that having a clear, sequential command-line guide for setting up a local development environment is very helpful. Currently, the documentation is thorough but spread across different sections. 

This PR adds a concise "Local Development Setup" guide that takes a developer from cloning the repository to successfully running tests via `tox`.

### Changes
- Added a step-by-step command sequence for local setup.
- Included instructions for creating a virtual environment and performing an "editable" install (`pip install -e .`).
- Added the `pre-commit install` step to ensure code quality hooks are active for new contributors.
- Mentioned `tox -e py313` as the standard verification step.

### Validation
- I have personally verified these steps on my local machine (macOS arm64).
- Confirmed that the setup correctly links the source code and allows all 3500+ tests to pass via `tox`.

### Note to Maintainers
I am a first-time contributor! I wanted to contribute this based on my own onboarding experience to make it even easier for the next person to join the project.