### PR TITLE
Fix genspider --edit crash by opening editor directly on spider file

### DIFF
--- a/scrapy/commands/genspider.py
+++ b/scrapy/commands/genspider.py
@@ -118,9 +118,14 @@ class Command(ScrapyCommand):
 
         template_file = self._find_template(opts.template)
         if template_file:
-            self._genspider(module, name, url, opts.template, template_file)
-            if opts.edit:
-                self.exitcode = os.system(f'scrapy edit "{name}"')  # noqa: S605
+            spider_file = self._genspider(
+                module, name, url, opts.template, template_file
+            )
+            if opts.edit and spider_file:
+                editor = self.settings.get("EDITOR")
+                self.exitcode = os.system(  # noqa: S605
+                    f'{editor} "{spider_file}"'
+                )
 
     def _generate_template_variables(
         self,
@@ -148,7 +153,7 @@ class Command(ScrapyCommand):
         url: str,
         template_name: str,
         template_file: str | os.PathLike,
-    ) -> None:
+    ) -> str:
         """Generate the spider module, based on the given template"""
         assert self.settings is not None
         tvars = self._generate_template_variables(module, name, url, template_name)
@@ -168,6 +173,7 @@ class Command(ScrapyCommand):
         )
         if spiders_module:
             print(f"in module:\n  {spiders_module.__name__}.{module}")
+        return spider_file
 
     def _find_template(self, template: str) -> Path | None:
         template_file = Path(self.templates_dir, f"{template}.tmpl")


### PR DESCRIPTION
Fixes #7260

## What this does

`scrapy genspider --edit` crashed because it spawned `scrapy edit` as a subprocess after creating the spider file. The subprocess called `get_project_settings()` which reimported the full project settings and spider package — including the just-created spider file — and this reimport could fail depending on the project's import chain.

The fix opens the EDITOR directly on the spider file path instead of going through `scrapy edit`. Since `_genspider` already knows the exact path of the file it just created, there's no need to reimport the entire project just to find it again.

## Changes

- `_genspider()` now returns the spider file path (changed return type from `None` to `str`)
- `run()` uses the returned path to invoke the editor directly with the `EDITOR` setting
- No change in behavior for `scrapy genspider` without `--edit`

## Testing

- All 30 existing genspider tests pass (`pytest tests/test_command_genspider.py`)
- `ruff check` and `ruff format` clean