### PR TITLE
Allow FilesPipeline downloads for HTTP 201 responses

### DIFF
--- a/scrapy/pipelines/files.py
+++ b/scrapy/pipelines/files.py
@@ -601,7 +601,7 @@ class FilesPipeline(MediaPipeline):
     ) -> FileInfo:
         referer = referer_str(request)
 
-        if response.status != 200:
+        if response.status not in {200, 201}:
             logger.warning(
                 "File (code: %(status)s): Error downloading file from "
                 "%(request)s referred in <%(referer)s>",

--- a/tests/test_pipeline_files.py
+++ b/tests/test_pipeline_files.py
@@ -219,6 +219,24 @@ class TestFilesPipeline:
         for p in patchers:
             p.stop()
 
+    def test_media_downloaded_allows_status_201(self):
+        request = Request("http://example.com/file-201.pdf")
+        response = Response(request.url, status=201, body=b"file-content", request=request)
+
+        with (
+            mock.patch.object(FilesPipeline, "inc_stats", return_value=True),
+            mock.patch.object(FilesPipeline, "file_path", return_value="full/file-201.pdf"),
+            mock.patch.object(FilesPipeline, "file_downloaded", return_value="checksum-201"),
+        ):
+            result = self.pipeline.media_downloaded(
+                response, request, self.pipeline.spiderinfo
+            )
+
+        assert result["url"] == request.url
+        assert result["path"] == "full/file-201.pdf"
+        assert result["checksum"] == "checksum-201"
+        assert result["status"] == "downloaded"
+
     @coroutine_test
     async def test_file_cached(self):
         item_url = "http://example.com/file3.pdf"


### PR DESCRIPTION
## Summary
- allow `FilesPipeline.media_downloaded` to accept HTTP 201 responses
- add a focused regression test for a non-empty file response with status 201

## Testing
- `pytest -q tests/test_pipeline_files.py -k status_201`
- `pytest -q tests/test_pipeline_files.py -k "file_not_expired or file_expired or file_cached or status_201"`

Closes #1615
