### PR TITLE
Allow genspider --edit to work inside projects

### DIFF
--- a/scrapy/commands/edit.py
+++ b/scrapy/commands/edit.py
@@ -1,10 +1,15 @@
 import argparse
 import os
 import sys
+from pathlib import Path
 
 from scrapy.commands import ScrapyCommand
 from scrapy.exceptions import UsageError
 from scrapy.spiderloader import get_spider_loader
+
+
+def edit_file(editor: str, file_path: str | Path) -> int:
+    return os.system(f'{editor} "{file_path}"')  # noqa: S605
 
 
 class Command(ScrapyCommand):
@@ -44,4 +49,4 @@ class Command(ScrapyCommand):
         sfile = sys.modules[spidercls.__module__].__file__
         assert sfile
         sfile = sfile.replace(".pyc", ".py")
-        self.exitcode = os.system(f'{editor} "{sfile}"')  # noqa: S605
+        self.exitcode = edit_file(editor, sfile)

--- a/scrapy/commands/edit.py
+++ b/scrapy/commands/edit.py
@@ -1,5 +1,7 @@
 import argparse
 import os
+import shlex
+import subprocess
 import sys
 from pathlib import Path
 
@@ -9,7 +11,7 @@ from scrapy.spiderloader import get_spider_loader
 
 
 def edit_file(editor: str, file_path: str | Path) -> int:
-    return os.system(f'{editor} "{file_path}"')  # noqa: S605
+    return subprocess.call([*shlex.split(editor), str(file_path)])
 
 
 class Command(ScrapyCommand):

--- a/scrapy/commands/genspider.py
+++ b/scrapy/commands/genspider.py
@@ -10,6 +10,7 @@ from urllib.parse import urlparse
 
 import scrapy
 from scrapy.commands import ScrapyCommand
+from scrapy.commands.edit import edit_file
 from scrapy.exceptions import UsageError
 from scrapy.spiderloader import get_spider_loader
 from scrapy.utils.template import render_templatefile, string_camelcase
@@ -118,9 +119,9 @@ class Command(ScrapyCommand):
 
         template_file = self._find_template(opts.template)
         if template_file:
-            self._genspider(module, name, url, opts.template, template_file)
+            spider_file = self._genspider(module, name, url, opts.template, template_file)
             if opts.edit:
-                self.exitcode = os.system(f'scrapy edit "{name}"')  # noqa: S605
+                self.exitcode = edit_file(self.settings["EDITOR"], spider_file)
 
     def _generate_template_variables(
         self,
@@ -148,7 +149,7 @@ class Command(ScrapyCommand):
         url: str,
         template_name: str,
         template_file: str | os.PathLike,
-    ) -> None:
+    ) -> Path:
         """Generate the spider module, based on the given template"""
         assert self.settings is not None
         tvars = self._generate_template_variables(module, name, url, template_name)
@@ -168,6 +169,7 @@ class Command(ScrapyCommand):
         )
         if spiders_module:
             print(f"in module:\n  {spiders_module.__name__}.{module}")
+        return Path(spider_file)
 
     def _find_template(self, template: str) -> Path | None:
         template_file = Path(self.templates_dir, f"{template}.tmpl")

--- a/tests/test_command_genspider.py
+++ b/tests/test_command_genspider.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
 import re
+import subprocess
 from os import chmod
 from pathlib import Path
 
 import pytest
 
+from scrapy.commands.edit import edit_file
 from tests.test_commands import TestProjectBase
 from tests.utils.cmdline import call, proc
 
@@ -184,6 +186,19 @@ class TestGenspiderCommand(TestProjectBase):
         m = find_in_file(spider, r"start_urls\s*=\s*\[['\"](.+)['\"]\]")
         assert m is not None
         assert m.group(1) == expected
+
+
+def test_edit_file_handles_paths_with_double_quotes(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[list[str]] = []
+
+    def fake_call(argv: list[str]) -> int:
+        calls.append(argv)
+        return 0
+
+    monkeypatch.setattr(subprocess, "call", fake_call)
+
+    assert edit_file('editor --flag', 'path/with"quote.py') == 0
+    assert calls == [["editor", "--flag", 'path/with"quote.py']]
 
 
 class TestGenspiderStandaloneCommand:

--- a/tests/test_command_genspider.py
+++ b/tests/test_command_genspider.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import re
+from os import chmod
 from pathlib import Path
 
 import pytest
@@ -62,6 +63,28 @@ class TestGenspiderCommand(TestProjectBase):
     def test_dump(self, proj_path: Path) -> None:
         assert call("genspider", "--dump=basic", cwd=proj_path) == 0
         assert call("genspider", "-d", "basic", cwd=proj_path) == 0
+
+    def test_edit(self, proj_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        spider_name = "example2"
+        spider = proj_path / self.project_name / "spiders" / f"{spider_name}.py"
+        edited_path = proj_path / "edited-path.txt"
+        editor = proj_path / "editor.sh"
+        editor.write_text(
+            "#!/bin/sh\nprintf '%s' \"$2\" > \"$1\"\n",
+            encoding="utf-8",
+        )
+        chmod(editor, 0o755)
+        monkeypatch.setenv("EDITOR", f"{editor} {edited_path}")
+
+        returncode, out, err = proc(
+            "genspider", "--edit", spider_name, "example2.com", cwd=proj_path
+        )
+
+        assert returncode == 0
+        assert spider.exists()
+        assert edited_path.read_text(encoding="utf-8") == str(spider)
+        assert f"Created spider {spider_name!r} using template 'basic' in module" in out
+        assert "ModuleNotFoundError" not in err
 
     def test_same_name_as_project(self, proj_path: Path) -> None:
         assert call("genspider", self.project_name, cwd=proj_path) == 2


### PR DESCRIPTION
Summary
- avoid spawning a second `scrapy edit` process from `genspider --edit`
- reuse the existing edit-file helper to open the generated spider directly
- add a regression test covering `genspider --edit` inside a project

Testing
- `python -m pytest tests/test_command_genspider.py`

Closes #7260