### PR TITLE
docs: add Windows note for python -m scrapy alternative in tutorial

### DIFF
--- a/docs/intro/tutorial.rst
+++ b/docs/intro/tutorial.rst
@@ -53,6 +53,17 @@ directory where you'd like to store your code and run::
 
     scrapy startproject tutorial
 
+.. note::
+
+    **Windows users:** If you see ``'scrapy' is not recognized as an internal
+    or external command``, use ``python -m scrapy`` instead::
+
+        python -m scrapy startproject tutorial
+
+    This commonly happens when Python's ``Scripts`` folder is not in your
+    ``PATH``. Using ``python -m scrapy <command>`` works as an alternative
+    for any Scrapy command throughout this tutorial.
+
 This will create a ``tutorial`` directory with the following contents::
 
     tutorial/


### PR DESCRIPTION
## Summary

Windows users frequently encounter `'scrapy' is not recognized as an internal or external command` when following the tutorial. This happens because Python's `Scripts` folder is not always in `PATH` on Windows.

## Changes

Added a `.. note::` directive under the "Creating a project" section explaining that Windows users can use `python -m scrapy` as a drop-in alternative for any Scrapy command.

## Related Issue

Closes #7306