### PR TITLE
Fix scrapy genspider --edit by inlining editor invocation

### DIFF
--- a/scrapy/commands/genspider.py
+++ b/scrapy/commands/genspider.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import os
 import shutil
 import string
+import subprocess
+import sys
 from importlib import import_module
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, cast
@@ -120,7 +122,20 @@ class Command(ScrapyCommand):
         if template_file:
             self._genspider(module, name, url, opts.template, template_file)
             if opts.edit:
-                self.exitcode = os.system(f'scrapy edit "{name}"')  # noqa: S605
+                editor = self.settings["EDITOR"]
+                spider_loader = get_spider_loader(self.settings)
+                try:
+                    spidercls = spider_loader.load(name)
+                except KeyError:
+                    print(f"Spider not found: {name}")
+                    self.exitcode = 1
+                    return
+                sfile = sys.modules[spidercls.__module__].__file__
+                assert sfile
+                sfile = sfile.replace(".pyc", ".py")
+                self.exitcode = subprocess.run(  # noqa: S603
+                    [editor, sfile],
+                ).returncode
 
     def _generate_template_variables(
         self,


### PR DESCRIPTION
## Problem

`scrapy genspider --edit <name> <domain>` fails with `ModuleNotFoundError` because it calls `os.system("scrapy edit ...")` which spawns a subprocess that cannot find the project module.

See #7260 for details and reproduction steps.

## Root Cause

The `genspider` command uses `os.system()` to invoke `scrapy edit` as a subprocess. The subprocess cannot import the project settings module because the environment setup (`sys.path`, etc.) from the parent process is not inherited by the new Python process.

## Fix

Replace the `os.system("scrapy edit ...")` call with direct editor invocation using the same logic as the `edit` command:

1. Get the editor from `self.settings["EDITOR"]`
2. Load the spider and get its file path
3. Call the editor via `subprocess.run()`

This avoids the broken cross-command subprocess call entirely. The spider module is already loaded in the current process after `_genspider()` creates it, so looking it up works correctly.

## Changes

- Added `import subprocess` and `import sys` to `scrapy/commands/genspider.py`
- Replaced `os.system(f"scrapy edit ...")` with direct `subprocess.run([editor, sfile])`