### PR TITLE
docs: add Windows note for 'python -m scrapy' alternative in tutorial

### DIFF
--- a/docs/intro/tutorial.rst
+++ b/docs/intro/tutorial.rst
@@ -53,6 +53,18 @@ directory where you'd like to store your code and run::
 
     scrapy startproject tutorial
 
+.. note::
+
+    If you get an error like ``'scrapy' is not recognized as an internal or
+    external command`` on Windows, try running Scrapy as a Python module
+    instead::
+
+        python -m scrapy startproject tutorial
+
+    This can happen when the Python ``Scripts`` folder is not in your ``PATH``.
+    You can use ``python -m scrapy`` as a replacement for the ``scrapy``
+    command throughout this tutorial.
+
 This will create a ``tutorial`` directory with the following contents::
 
     tutorial/


### PR DESCRIPTION
## Problem
Windows users frequently encounter `'scrapy' is not recognized as an internal or external command` when following the tutorial, typically because the Python `Scripts` folder is not in their `PATH`.

## Solution
Added a `.. note::` admonition in the tutorial's "Creating a project" section informing Windows users they can use `python -m scrapy` as an alternative to the `scrapy` command.

## Files Changed
- `docs/intro/tutorial.rst`: Added Windows note after the first `scrapy startproject` command

Closes #7306