### PR TITLE
docs: clarify feed URI parameters with Path objects

### DIFF
--- a/docs/topics/feed-exports.rst
+++ b/docs/topics/feed-exports.rst
@@ -130,6 +130,10 @@ Any other named parameter gets replaced by the spider attribute of the same
 name. For example, ``%(site_id)s`` would get replaced by the ``spider.site_id``
 attribute the moment the feed is being created.
 
+Storage URI parameters are only supported for string URIs. If you use a
+:class:`pathlib.Path` object as a feed URI, it is used as-is, without parameter
+substitution. Convert it to ``str`` if you need parameters.
+
 Here are some examples to illustrate:
 
 -   Store in FTP using one directory per spider:


### PR DESCRIPTION
## Summary
- clarify that storage URI parameters are only supported for string feed URIs
- note that pathlib.Path feed URIs are used as-is without parameter substitution

## Testing
- not run (python3 -m sphinx -b dummy docs docs/_build/dummy failed: No module named sphinx; docs/requirements.txt pins sphinx==8.1.3 which is unavailable for system python)

Fixes #6425
