### PR TITLE
Log warning when decompressed response exceeds DOWNLOAD_MAXSIZE

### DIFF
--- a/scrapy/downloadermiddlewares/httpcompression.py
+++ b/scrapy/downloadermiddlewares/httpcompression.py
@@ -117,12 +117,14 @@ class HttpCompressionMiddleware:
                         response.body, content_encoding, max_size
                     )
                 except _DecompressionMaxSizeExceeded as e:
-                    raise IgnoreRequest(
-                        f"Ignored response {response} because its body "
-                        f"({len(response.body)} B compressed, "
-                        f"{e.decompressed_size} B decompressed so far) exceeded "
-                        f"DOWNLOAD_MAXSIZE ({max_size} B) during decompression."
-                    ) from e
+                    warning_msg = (
+                        f"Received a response ({response}) with a compressed body"
+                        f" of {len(response.body)} B that, so far, has been"
+                        f" decompressed to {e.decompressed_size} B, exceeding"
+                        f" the DOWNLOAD_MAXSIZE limit of {max_size} B."
+                    )
+                    logger.warning(warning_msg)
+                    raise IgnoreRequest(warning_msg) from e
                 if len(response.body) < warn_size <= len(decoded_body):
                     logger.warning(
                         f"{response} body size after decompression "

--- a/tests/test_downloadermiddleware_httpcompression.py
+++ b/tests/test_downloadermiddleware_httpcompression.py
@@ -522,9 +522,19 @@ class TestHttpCompression:
         mw.open_spider(spider)
 
         response = self._getresponse(f"bomb-{compression_id}")  # 11_511_612 B
-        with pytest.raises(IgnoreRequest) as exc_info:
+        with (
+            LogCapture(
+                "scrapy.downloadermiddlewares.httpcompression",
+                propagate=False,
+                level=WARNING,
+            ) as log,
+            pytest.raises(IgnoreRequest) as exc_info,
+        ):
             mw.process_response(response.request, response)
         assert exc_info.value.__cause__.decompressed_size < 1_100_000
+        assert len(log.records) == 1
+        assert log.records[0].levelname == "WARNING"
+        assert "DOWNLOAD_MAXSIZE" in log.records[0].getMessage()
 
     def test_compression_bomb_setting_br(self):
         _skip_if_no_br()
@@ -552,9 +562,19 @@ class TestHttpCompression:
         mw.open_spider(spider)
 
         response = self._getresponse(f"bomb-{compression_id}")
-        with pytest.raises(IgnoreRequest) as exc_info:
+        with (
+            LogCapture(
+                "scrapy.downloadermiddlewares.httpcompression",
+                propagate=False,
+                level=WARNING,
+            ) as log,
+            pytest.raises(IgnoreRequest) as exc_info,
+        ):
             mw.process_response(response.request, response)
         assert exc_info.value.__cause__.decompressed_size < 1_100_000
+        assert len(log.records) == 1
+        assert log.records[0].levelname == "WARNING"
+        assert "DOWNLOAD_MAXSIZE" in log.records[0].getMessage()
 
     @pytest.mark.filterwarnings("ignore::scrapy.exceptions.ScrapyDeprecationWarning")
     def test_compression_bomb_spider_attr_br(self):
@@ -584,9 +604,19 @@ class TestHttpCompression:
 
         response = self._getresponse(f"bomb-{compression_id}")
         response.meta["download_maxsize"] = 1_000_000
-        with pytest.raises(IgnoreRequest) as exc_info:
+        with (
+            LogCapture(
+                "scrapy.downloadermiddlewares.httpcompression",
+                propagate=False,
+                level=WARNING,
+            ) as log,
+            pytest.raises(IgnoreRequest) as exc_info,
+        ):
             mw.process_response(response.request, response)
         assert exc_info.value.__cause__.decompressed_size < 1_100_000
+        assert len(log.records) == 1
+        assert log.records[0].levelname == "WARNING"
+        assert "DOWNLOAD_MAXSIZE" in log.records[0].getMessage()
 
     def test_compression_bomb_request_meta_br(self):
         _skip_if_no_br()


### PR DESCRIPTION
## Summary

- Fixes #6616: `HttpCompressionMiddleware` now logs a warning before raising `IgnoreRequest` when a response's decompressed body exceeds `DOWNLOAD_MAXSIZE`. Previously, the request was silently ignored with no log output, making it difficult to diagnose dropped responses.
- Updated existing tests to verify the warning is emitted with the expected log level and message content.

## Details

When `_DecompressionMaxSizeExceeded` is raised during decompression in `HttpCompressionMiddleware.process_response()`, the middleware now calls `logger.warning()` with details about the response, compressed size, decompressed size so far, and the `DOWNLOAD_MAXSIZE` limit before raising `IgnoreRequest`. This aligns behavior with how the HTTP/1.1 download handler already logs warnings for oversized responses.

## Test plan

- [x] Verified all existing `compression_bomb` tests pass with the added warning assertions (setting, spider attr, and request meta variants)
- [x] Full `test_downloadermiddleware_httpcompression.py` test suite passes (46 passed, 9 skipped for missing brotli)