### PR TITLE
Add Windows note for 'python -m scrapy' alternative in tutorial

### DIFF
--- a/docs/intro/tutorial.rst
+++ b/docs/intro/tutorial.rst
@@ -53,6 +53,16 @@ directory where you'd like to store your code and run::
 
     scrapy startproject tutorial
 
+.. note::
+
+    If the ``scrapy`` command is not recognized on Windows (e.g., because the
+    Python Scripts folder is not in your ``PATH``), you can use the following
+    alternative::
+
+        python -m scrapy startproject tutorial
+
+    This applies to all ``scrapy`` commands mentioned in this tutorial.
+
 This will create a ``tutorial`` directory with the following contents::
 
     tutorial/


### PR DESCRIPTION
## Summary

- Adds a note in the tutorial's "Creating a project" section for Windows users who may encounter issues with the `scrapy` command not being recognized (e.g., Python Scripts folder not in PATH)
- Recommends `python -m scrapy` as an alternative and notes it applies to all `scrapy` commands in the tutorial

Closes #7306