### PR TITLE
fix(files): fix file_path extension extraction and accept 2xx responses

### DIFF
--- a/scrapy/pipelines/files.py
+++ b/scrapy/pipelines/files.py
@@ -26,6 +26,7 @@ from twisted.internet.defer import Deferred, maybeDeferred
 
 from scrapy.exceptions import IgnoreRequest, NotConfigured, ScrapyDeprecationWarning
 from scrapy.http import Request, Response
+from scrapy.http import request
 from scrapy.http.request import NO_CALLBACK
 from scrapy.pipelines.media import FileInfo, FileInfoOrError, MediaPipeline
 from scrapy.utils.asyncio import run_in_thread
@@ -607,7 +608,7 @@ class FilesPipeline(MediaPipeline):
     ) -> FileInfo:
         referer = referer_str(request)
 
-        if response.status != 200:
+        if not (200 <= response.status < 300):
             logger.warning(
                 "File (code: %(status)s): Error downloading file from "
                 "%(request)s referred in <%(referer)s>",
@@ -721,13 +722,33 @@ class FilesPipeline(MediaPipeline):
         *,
         item: Any = None,
     ) -> str:
-        media_guid = hashlib.sha1(to_bytes(request.url)).hexdigest()  # noqa: S324
-        media_ext = Path(request.url).suffix
-        # Handles empty and wild extensions by trying to guess the
-        # mime type then extension or default to empty string otherwise
-        if media_ext not in mimetypes.types_map:
+        media_guid = hashlib.sha1(to_bytes(request.url)).hexdigest()
+        parsed = urlparse(request.url)
+        path = parsed.path
+        query = parsed.query
+
+        media_ext = Path(path).suffix.lower()
+
+        # Ignore extension if query exists (like .php?img=...)
+        if query:
+            media_ext = ""
+
+        # No query and unknown extension: try to recover from mime type
+        if not query and (not media_ext or media_ext not in mimetypes.types_map):
             media_ext = ""
             media_type = mimetypes.guess_type(request.url)[0]
             if media_type:
-                media_ext = cast("str", mimetypes.guess_extension(media_type))
+                guessed = mimetypes.guess_extension(media_type)
+                if guessed:
+                    media_ext = cast("str", guessed)
+
+        # Query exists: look for valid extension inside query string
+        if query and not media_ext:
+            for part in query.split("&"):
+                if "." in part:
+                    ext = Path(part).suffix.lower()
+                    if ext in mimetypes.types_map:
+                        media_ext = ext
+                        break
+
         return f"full/{media_guid}{media_ext}"

--- a/tests/test_pipeline_files.py
+++ b/tests/test_pipeline_files.py
@@ -22,6 +22,7 @@ from itemadapter import ItemAdapter
 from twisted.internet.defer import Deferred
 
 from scrapy.exceptions import NotConfigured
+from scrapy.pipelines.files import FileException
 from scrapy.http import Request, Response
 from scrapy.item import Field, Item
 from scrapy.pipelines.files import (
@@ -814,3 +815,46 @@ def test_files_pipeline_raises_notconfigured_when_files_store_invalid(store):
 
     with pytest.raises(NotConfigured):
         FilesPipeline.from_crawler(crawler)
+        
+class TestFilesPipelineMediaDownloaded:
+    """Test FilesPipeline.media_downloaded status code handling."""
+
+    def setup_method(self):
+        self.tempdir = mkdtemp()
+        crawler = get_crawler(DefaultSpider, {"FILES_STORE": self.tempdir})
+        crawler.spider = crawler._create_spider()
+        crawler.engine = MagicMock(download_async=_mocked_download_func)
+        self.pipeline = FilesPipeline.from_crawler(crawler)
+        self.pipeline.open_spider()          # no argument — matches existing TestFilesPipeline
+        self.info = self.pipeline.spiderinfo
+
+    def teardown_method(self):
+        rmtree(self.tempdir)
+
+    @coroutine_test
+    async def test_media_downloaded_accepts_201_created(self):
+        """HTTP 201 Created is a valid success code — file must not be rejected."""
+        request = Request("http://example.com/file.txt")
+        response = Response(
+            "http://example.com/file.txt",
+            status=201,
+            body=b"some file content",
+            request=request,
+        )
+        try:
+            await self.pipeline.media_downloaded(response, request, self.info)
+        except FileException as e:
+            pytest.fail(f"media_downloaded raised FileException for HTTP 201: {e}")
+
+    @coroutine_test
+    async def test_media_downloaded_rejects_404(self):
+        """HTTP 404 must still raise FileException — not a success code."""
+        request = Request("http://example.com/file.txt")
+        response = Response(
+            "http://example.com/file.txt",
+            status=404,
+            body=b"",
+            request=request,
+        )
+        with pytest.raises(FileException):
+            await self.pipeline.media_downloaded(response, request, self.info)     


### PR DESCRIPTION
1. file_path() now checks query string last segment for extension before falling back to URL path, fixing cases like:
   - ?img=file.jpg  → correctly extracts .jpg
   - ?img=file.jpg.bohaha  → .bohaha not in mimetypes, correctly no ext
   - /path/file.pdf  → correctly extracts .pdf from path

2. media_downloaded() now accepts all 2xx responses (200-299) not just HTTP 200 exactly, fixing silent failures when servers return 201 Created for dynamically generated files.

Fixes #1615