### PR TITLE
fix: open spider file directly in genspider --edit instead of calling scrapy edit

### DIFF
--- a/scrapy/commands/genspider.py
+++ b/scrapy/commands/genspider.py
@@ -118,9 +118,18 @@ class Command(ScrapyCommand):
 
         template_file = self._find_template(opts.template)
         if template_file:
-            self._genspider(module, name, url, opts.template, template_file)
+            spider_file = self._genspider(module, name, url, opts.template, template_file)
             if opts.edit:
-                self.exitcode = os.system(f'scrapy edit "{name}"')  # noqa: S605
+                # Open the spider file directly instead of calling
+                # `scrapy edit <name>`, which would try to import the project
+                # module via get_spider_loader().  At this point the newly
+                # created spider file has not been imported yet, so that call
+                # raises ModuleNotFoundError when the project root is not on
+                # sys.path (e.g. when running from inside the project dir
+                # without having run `pip install -e .`).
+                assert self.settings is not None
+                editor = self.settings["EDITOR"]
+                self.exitcode = os.system(f'{editor} "{spider_file}"')  # noqa: S605
 
     def _generate_template_variables(
         self,
@@ -148,8 +157,12 @@ class Command(ScrapyCommand):
         url: str,
         template_name: str,
         template_file: str | os.PathLike,
-    ) -> None:
-        """Generate the spider module, based on the given template"""
+    ) -> str:
+        """Generate the spider module, based on the given template.
+
+        Returns:
+            str: absolute path to the generated spider file.
+        """
         assert self.settings is not None
         tvars = self._generate_template_variables(module, name, url, template_name)
         if self.settings.get("NEWSPIDER_MODULE"):
@@ -168,6 +181,7 @@ class Command(ScrapyCommand):
         )
         if spiders_module:
             print(f"in module:\n  {spiders_module.__name__}.{module}")
+        return spider_file
 
     def _find_template(self, template: str) -> Path | None:
         template_file = Path(self.templates_dir, f"{template}.tmpl")


### PR DESCRIPTION
## Summary

Fixes #7260.

`scrapy genspider --edit name domain` fails with `ModuleNotFoundError` because after creating the spider, it calls:

```python
os.system('scrapy edit "name"')
```

`scrapy edit` internally calls `get_spider_loader()`, which tries to `import_module(NEWSPIDER_MODULE)`. In a fresh subprocess spawned by `os.system`, the project root is not on `sys.path`, so the import fails:

```
ModuleNotFoundError: No module named 'proj'
```

## Fix

Return the generated spider file path from `_genspider()` and open it directly using the configured `EDITOR`, bypassing the spider-loader import entirely:

```python
spider_file = self._genspider(module, name, url, opts.template, template_file)
if opts.edit:
    editor = self.settings["EDITOR"]
    self.exitcode = os.system(f'{editor} "{spider_file}"')
```

This matches exactly what `scrapy edit` would do after the spider is registered, but without the module-import step that fails immediately after creation.

## Changes

- `_genspider()` now returns the path to the generated spider file (`str`)
- `run()` uses the returned path to open the editor directly when `--edit` is passed