### PR TITLE
adjust httpx error mapping

### DIFF
--- a/scrapy/core/downloader/handlers/_httpx.py
+++ b/scrapy/core/downloader/handlers/_httpx.py
@@ -138,12 +138,14 @@ class HttpxDownloadHandler(BaseHttpDownloadHandler):
         except httpx.UnsupportedProtocol as e:
             raise UnsupportedURLSchemeError(str(e)) from e
         except httpx.ConnectError as e:
+            error_message = str(e)
             if (
-                "Name or service not known" in str(e)
-                or "getaddrinfo failed" in str(e)
-                or "nodename nor servname" in str(e)
+                "Name or service not known" in error_message
+                or "getaddrinfo failed" in error_message
+                or "nodename nor servname" in error_message
+                or "Temporary failure in name resolution" in error_message
             ):
-                raise CannotResolveHostError(str(e)) from e
+                raise CannotResolveHostError(error_message) from e
             raise DownloadConnectionRefusedError(str(e)) from e
         except httpx.NetworkError as e:
             raise DownloadFailedError(str(e)) from e


### PR DESCRIPTION
while checking out is #5409 still relevant and running `bwrap --bind / / --dev /dev --unshare-net -- pytest tests -n auto --dist worksteal`, found out that `ConnectionError` can be raised with yet another error message

```
FAILED tests/test_downloader_handler_httpx.py::TestHttp11::test_download_dns_error - scrapy.exceptions.DownloadConnectionRefusedError: [Errno -3] Temporary failure in name resolution
FAILED tests/test_downloader_handler_httpx.py::TestHttps11::test_download_dns_error - scrapy.exceptions.DownloadConnectionRefusedError: [Errno -3] Temporary failure in name resolution
```

Refs #7252