### PR TITLE
Add support for async HTTP cache storages

### DIFF
--- a/docs/topics/downloader-middleware.rst
+++ b/docs/topics/downloader-middleware.rst
@@ -494,6 +494,10 @@ Writing your own storage backend
 You can implement a cache storage backend by creating a Python class that
 defines the methods described below.
 
+.. note::
+    All methods of a custom HTTP cache storage can also be defined as asynchronous
+    coroutines using ``async def``.
+
 .. module:: scrapy.extensions.httpcache
 
 .. class:: CacheStorage

--- a/scrapy/downloadermiddlewares/httpcache.py
+++ b/scrapy/downloadermiddlewares/httpcache.py
@@ -14,6 +14,7 @@ from scrapy.exceptions import (
     NotConfigured,
 )
 from scrapy.utils.decorators import _warn_spider_arg
+from scrapy.utils.defer import ensure_awaitable
 from scrapy.utils.misc import load_object
 
 if TYPE_CHECKING:
@@ -58,14 +59,14 @@ class HttpCacheMiddleware:
         o.crawler = crawler
         return o
 
-    def spider_opened(self, spider: Spider) -> None:
-        self.storage.open_spider(spider)
+    async def spider_opened(self, spider: Spider) -> None:
+        await ensure_awaitable(self.storage.open_spider(spider))
 
-    def spider_closed(self, spider: Spider) -> None:
-        self.storage.close_spider(spider)
+    async def spider_closed(self, spider: Spider) -> None:
+        await ensure_awaitable(self.storage.close_spider(spider))
 
     @_warn_spider_arg
-    def process_request(
+    async def process_request(
         self, request: Request, spider: Spider | None = None
     ) -> Request | Response | None:
         if request.meta.get("dont_cache", False):
@@ -77,8 +78,8 @@ class HttpCacheMiddleware:
             return None
 
         # Look for cached response and check if expired
-        cachedresponse: Response | None = self.storage.retrieve_response(
-            self.crawler.spider, request
+        cachedresponse: Response | None = await ensure_awaitable(
+            self.storage.retrieve_response(self.crawler.spider, request)
         )
         if cachedresponse is None:
             self.stats.inc_value("httpcache/miss")
@@ -100,7 +101,7 @@ class HttpCacheMiddleware:
         return None
 
     @_warn_spider_arg
-    def process_response(
+    async def process_response(
         self, request: Request, response: Response, spider: Spider | None = None
     ) -> Request | Response:
         if request.meta.get("dont_cache", False):
@@ -120,7 +121,7 @@ class HttpCacheMiddleware:
         cachedresponse: Response | None = request.meta.pop("cached_response", None)
         if cachedresponse is None:
             self.stats.inc_value("httpcache/firsthand")
-            self._cache_response(response, request)
+            await self._cache_response(response, request)
             return response
 
         if self.policy.is_cached_response_valid(cachedresponse, response, request):
@@ -128,7 +129,7 @@ class HttpCacheMiddleware:
             return cachedresponse
 
         self.stats.inc_value("httpcache/invalidate")
-        self._cache_response(response, request)
+        await self._cache_response(response, request)
         return response
 
     @_warn_spider_arg
@@ -143,9 +144,11 @@ class HttpCacheMiddleware:
             return cachedresponse
         return None
 
-    def _cache_response(self, response: Response, request: Request) -> None:
+    async def _cache_response(self, response: Response, request: Request) -> None:
         if self.policy.should_cache_response(response, request):
             self.stats.inc_value("httpcache/store")
-            self.storage.store_response(self.crawler.spider, request, response)
+            await ensure_awaitable(
+                self.storage.store_response(self.crawler.spider, request, response)
+            )
         else:
             self.stats.inc_value("httpcache/uncacheable")

--- a/tests/test_downloadermiddleware_httpcache.py
+++ b/tests/test_downloadermiddleware_httpcache.py
@@ -8,16 +8,17 @@ from contextlib import asynccontextmanager
 from typing import TYPE_CHECKING, Any
 
 import pytest
-from twisted.internet.task import deferLater
 
 from scrapy.downloadermiddlewares.httpcache import HttpCacheMiddleware
 from scrapy.exceptions import IgnoreRequest
 from scrapy.http import HtmlResponse, Request, Response
 from scrapy.spiders import Spider
+from scrapy.utils.defer import deferred_from_coro, ensure_awaitable
 from scrapy.utils.test import get_crawler
+from tests.utils import async_sleep
 
 if TYPE_CHECKING:
-    from collections.abc import Generator
+    from collections.abc import AsyncGenerator
 
     from scrapy.crawler import Crawler
 
@@ -57,7 +58,7 @@ class TestBase:
         return settings
 
     @asynccontextmanager
-    async def _get_crawler(self, **new_settings: Any) -> Generator[Crawler]:
+    async def _get_crawler(self, **new_settings: Any) -> AsyncGenerator[Crawler, None]:
         settings = self._get_settings(**new_settings)
         crawler = get_crawler(Spider, settings)
         crawler.spider = crawler._create_spider("example.com")
@@ -69,12 +70,16 @@ class TestBase:
             crawler.stats.close_spider()
 
     @asynccontextmanager
-    async def _storage(self, **new_settings: Any):
+    async def _storage(
+        self, **new_settings: Any
+    ) -> AsyncGenerator[tuple[Any, Crawler], None]:
         async with self._middleware(**new_settings) as mw:
             yield mw.storage, mw.crawler
 
     @asynccontextmanager
-    async def _middleware(self, **new_settings: Any) -> Generator[HttpCacheMiddleware]:
+    async def _middleware(
+        self, **new_settings: Any
+    ) -> AsyncGenerator[HttpCacheMiddleware, None]:
         async with self._get_crawler(**new_settings) as crawler:
             assert crawler.spider
             mw = HttpCacheMiddleware.from_crawler(crawler)
@@ -94,44 +99,82 @@ class TestBase:
 class StorageTestMixin:
     """Mixin containing storage-specific test methods."""
 
-    async def test_storage(self):
-        from twisted.internet import reactor
+    def test_storage(self):
+        async def _test():
+            async with self._storage() as (storage, crawler):
+                request2 = self.request.copy()
+                assert (
+                    await ensure_awaitable(
+                        storage.retrieve_response(crawler.spider, request2)
+                    )
+                    is None
+                )
 
-        async with self._storage() as (storage, crawler):
-            request2 = self.request.copy()
-            assert storage.retrieve_response(crawler.spider, request2) is None
+                await ensure_awaitable(
+                    storage.store_response(crawler.spider, self.request, self.response)
+                )
+                response2 = await ensure_awaitable(
+                    storage.retrieve_response(crawler.spider, request2)
+                )
+                assert isinstance(response2, HtmlResponse)  # content-type header
+                self.assertEqualResponse(self.response, response2)
 
-            storage.store_response(crawler.spider, self.request, self.response)
-            response2 = storage.retrieve_response(crawler.spider, request2)
-            assert isinstance(response2, HtmlResponse)  # content-type header
-            self.assertEqualResponse(self.response, response2)
+                await async_sleep(2)  # wait for cache to expire
+                assert (
+                    await ensure_awaitable(
+                        storage.retrieve_response(crawler.spider, request2)
+                    )
+                    is None
+                )
 
-            await deferLater(reactor, 2, lambda: None)  # wait for cache to expire
-            assert storage.retrieve_response(crawler.spider, request2) is None
+        return deferred_from_coro(_test())
 
-    async def test_storage_never_expire(self):
-        from twisted.internet import reactor
+    def test_storage_never_expire(self):
+        async def _test():
+            async with self._storage(HTTPCACHE_EXPIRATION_SECS=0) as (storage, crawler):
+                assert (
+                    await ensure_awaitable(
+                        storage.retrieve_response(crawler.spider, self.request)
+                    )
+                    is None
+                )
+                await ensure_awaitable(
+                    storage.store_response(crawler.spider, self.request, self.response)
+                )
+                await async_sleep(0.5)  # give the chance to expire
+                assert await ensure_awaitable(
+                    storage.retrieve_response(crawler.spider, self.request)
+                )
 
-        async with self._storage(HTTPCACHE_EXPIRATION_SECS=0) as (storage, crawler):
-            assert storage.retrieve_response(crawler.spider, self.request) is None
-            storage.store_response(crawler.spider, self.request, self.response)
-            await deferLater(reactor, 0.5, lambda: None)  # give the chance to expire
-            assert storage.retrieve_response(crawler.spider, self.request)
+        return deferred_from_coro(_test())
 
-    async def test_storage_no_content_type_header(self):
+    def test_storage_no_content_type_header(self):
         """Test that the response body is used to get the right response class
         even if there is no Content-Type header"""
-        async with self._storage() as (storage, crawler):
-            assert storage.retrieve_response(crawler.spider, self.request) is None
-            response = Response(
-                "http://www.example.com",
-                body=b"<!DOCTYPE html>\n<title>.</title>",
-                status=202,
-            )
-            storage.store_response(crawler.spider, self.request, response)
-            cached_response = storage.retrieve_response(crawler.spider, self.request)
-            assert isinstance(cached_response, HtmlResponse)
-            self.assertEqualResponse(response, cached_response)
+
+        async def _test():
+            async with self._storage() as (storage, crawler):
+                assert (
+                    await ensure_awaitable(
+                        storage.retrieve_response(crawler.spider, self.request)
+                    )
+                    is None
+                )
+                response = Response(
+                    "http://www.example.com",
+                    body=b"<!DOCTYPE html>\n<title>.</title>",
+                    status=202,
+                )
+                await ensure_awaitable(
+                    storage.store_response(crawler.spider, self.request, response)
+                )
+                cached_response = await ensure_awaitable(
+                    storage.retrieve_response(crawler.spider, self.request)
+                )
+                assert isinstance(cached_response, HtmlResponse)
+                self.assertEqualResponse(response, cached_response)
+
+        return deferred_from_coro(_test())
 
 
 class PolicyTestMixin:

--- a/tests/test_downloadermiddleware_httpcache.py
+++ b/tests/test_downloadermiddleware_httpcache.py
@@ -13,9 +13,10 @@ from scrapy.downloadermiddlewares.httpcache import HttpCacheMiddleware
 from scrapy.exceptions import IgnoreRequest
 from scrapy.http import HtmlResponse, Request, Response
 from scrapy.spiders import Spider
-from scrapy.utils.defer import deferred_from_coro, ensure_awaitable
+from scrapy.utils.defer import ensure_awaitable
 from scrapy.utils.test import get_crawler
 from tests.utils import async_sleep
+from tests.utils.decorators import coroutine_test
 
 if TYPE_CHECKING:
     from collections.abc import AsyncGenerator
@@ -99,82 +100,75 @@ class TestBase:
 class StorageTestMixin:
     """Mixin containing storage-specific test methods."""
 
-    def test_storage(self):
-        async def _test():
-            async with self._storage() as (storage, crawler):
-                request2 = self.request.copy()
-                assert (
-                    await ensure_awaitable(
-                        storage.retrieve_response(crawler.spider, request2)
-                    )
-                    is None
-                )
-
+    @coroutine_test
+    async def test_storage(self):
+        async with self._storage() as (storage, crawler):
+            request2 = self.request.copy()
+            assert (
                 await ensure_awaitable(
-                    storage.store_response(crawler.spider, self.request, self.response)
-                )
-                response2 = await ensure_awaitable(
                     storage.retrieve_response(crawler.spider, request2)
                 )
-                assert isinstance(response2, HtmlResponse)  # content-type header
-                self.assertEqualResponse(self.response, response2)
+                is None
+            )
 
-                await async_sleep(2)  # wait for cache to expire
-                assert (
-                    await ensure_awaitable(
-                        storage.retrieve_response(crawler.spider, request2)
-                    )
-                    is None
-                )
+            await ensure_awaitable(
+                storage.store_response(crawler.spider, self.request, self.response)
+            )
+            response2 = await ensure_awaitable(
+                storage.retrieve_response(crawler.spider, request2)
+            )
+            assert isinstance(response2, HtmlResponse)  # content-type header
+            self.assertEqualResponse(self.response, response2)
 
-        return deferred_from_coro(_test())
-
-    def test_storage_never_expire(self):
-        async def _test():
-            async with self._storage(HTTPCACHE_EXPIRATION_SECS=0) as (storage, crawler):
-                assert (
-                    await ensure_awaitable(
-                        storage.retrieve_response(crawler.spider, self.request)
-                    )
-                    is None
-                )
+            await async_sleep(2)  # wait for cache to expire
+            assert (
                 await ensure_awaitable(
-                    storage.store_response(crawler.spider, self.request, self.response)
+                    storage.retrieve_response(crawler.spider, request2)
                 )
-                await async_sleep(0.5)  # give the chance to expire
-                assert await ensure_awaitable(
+                is None
+            )
+
+    @coroutine_test
+    async def test_storage_never_expire(self):
+        async with self._storage(HTTPCACHE_EXPIRATION_SECS=0) as (storage, crawler):
+            assert (
+                await ensure_awaitable(
                     storage.retrieve_response(crawler.spider, self.request)
                 )
+                is None
+            )
+            await ensure_awaitable(
+                storage.store_response(crawler.spider, self.request, self.response)
+            )
+            await async_sleep(0.5)  # give the chance to expire
+            assert await ensure_awaitable(
+                storage.retrieve_response(crawler.spider, self.request)
+            )
 
-        return deferred_from_coro(_test())
-
-    def test_storage_no_content_type_header(self):
+    @coroutine_test
+    async def test_storage_no_content_type_header(self):
         """Test that the response body is used to get the right response class
         even if there is no Content-Type header"""
-
-        async def _test():
-            async with self._storage() as (storage, crawler):
-                assert (
-                    await ensure_awaitable(
-                        storage.retrieve_response(crawler.spider, self.request)
-                    )
-                    is None
-                )
-                response = Response(
-                    "http://www.example.com",
-                    body=b"<!DOCTYPE html>\n<title>.</title>",
-                    status=202,
-                )
+        async with self._storage() as (storage, crawler):
+            assert (
                 await ensure_awaitable(
-                    storage.store_response(crawler.spider, self.request, response)
-                )
-                cached_response = await ensure_awaitable(
                     storage.retrieve_response(crawler.spider, self.request)
                 )
-                assert isinstance(cached_response, HtmlResponse)
-                self.assertEqualResponse(response, cached_response)
-
-        return deferred_from_coro(_test())
+                is None
+            )
+            response = Response(
+                "http://www.example.com",
+                body=b"<!DOCTYPE html>\n<title>.</title>",
+                status=202,
+            )
+            await ensure_awaitable(
+                storage.store_response(crawler.spider, self.request, response)
+            )
+            cached_response = await ensure_awaitable(
+                storage.retrieve_response(crawler.spider, self.request)
+            )
+            assert isinstance(cached_response, HtmlResponse)
+            self.assertEqualResponse(response, cached_response)
 
 
 class PolicyTestMixin:

--- a/tests/test_downloadermiddleware_httpcache.py
+++ b/tests/test_downloadermiddleware_httpcache.py
@@ -11,6 +11,7 @@ import pytest
 
 from scrapy.downloadermiddlewares.httpcache import HttpCacheMiddleware
 from scrapy.exceptions import IgnoreRequest
+from scrapy.extensions.httpcache import FilesystemCacheStorage
 from scrapy.http import HtmlResponse, Request, Response
 from scrapy.spiders import Spider
 from scrapy.utils.defer import ensure_awaitable
@@ -179,14 +180,21 @@ class PolicyTestMixin:
         async with self._middleware() as mw:
             self.request.meta["dont_cache"] = True
             await mw.process_response(self.request, self.response)
-            assert mw.storage.retrieve_response(mw.crawler.spider, self.request) is None
+            assert (
+                await ensure_awaitable(
+                    mw.storage.retrieve_response(mw.crawler.spider, self.request)
+                )
+                is None
+            )
 
         async with self._middleware() as mw:
             self.request.meta["dont_cache"] = False
             await mw.process_response(self.request, self.response)
             if mw.policy.should_cache_response(self.response, self.request):
                 assert isinstance(
-                    mw.storage.retrieve_response(mw.crawler.spider, self.request),
+                    await ensure_awaitable(
+                        mw.storage.retrieve_response(mw.crawler.spider, self.request)
+                    ),
                     self.response.__class__,
                 )
 
@@ -246,7 +254,12 @@ class DummyPolicyTestMixin(PolicyTestMixin):
             assert await mw.process_request(req) is None
             await mw.process_response(req, res)
 
-            assert mw.storage.retrieve_response(mw.crawler.spider, req) is None
+            assert (
+                await ensure_awaitable(
+                    mw.storage.retrieve_response(mw.crawler.spider, req)
+                )
+                is None
+            )
             assert await mw.process_request(req) is None
 
         # s3 scheme response is cached by default
@@ -266,7 +279,12 @@ class DummyPolicyTestMixin(PolicyTestMixin):
             assert await mw.process_request(req) is None
             await mw.process_response(req, res)
 
-            assert mw.storage.retrieve_response(mw.crawler.spider, req) is None
+            assert (
+                await ensure_awaitable(
+                    mw.storage.retrieve_response(mw.crawler.spider, req)
+                )
+                is None
+            )
             assert await mw.process_request(req) is None
 
     @coroutine_test
@@ -276,7 +294,12 @@ class DummyPolicyTestMixin(PolicyTestMixin):
             assert await mw.process_request(self.request) is None
             await mw.process_response(self.request, self.response)
 
-            assert mw.storage.retrieve_response(mw.crawler.spider, self.request) is None
+            assert (
+                await ensure_awaitable(
+                    mw.storage.retrieve_response(mw.crawler.spider, self.request)
+                )
+                is None
+            )
             assert await mw.process_request(self.request) is None
 
         # test response is cached
@@ -323,7 +346,12 @@ class RFC2616PolicyTestMixin(PolicyTestMixin):
             # response for a request with no-store must not be cached
             res1 = await self._process_requestresponse(mw, req1, res0)
             self.assertEqualResponse(res1, res0)
-            assert mw.storage.retrieve_response(mw.crawler.spider, req1) is None
+            assert (
+                await ensure_awaitable(
+                    mw.storage.retrieve_response(mw.crawler.spider, req1)
+                )
+                is None
+            )
             # Re-do request without no-store and expect it to be cached
             res2 = await self._process_requestresponse(mw, req0, res0)
             assert "cached" not in res2.flags
@@ -384,7 +412,9 @@ class RFC2616PolicyTestMixin(PolicyTestMixin):
                 )
                 self.assertEqualResponse(res1, res0)
                 self.assertEqualResponse(res2, res0)
-                resc = mw.storage.retrieve_response(mw.crawler.spider, req0)
+                resc = await ensure_awaitable(
+                    mw.storage.retrieve_response(mw.crawler.spider, req0)
+                )
                 if shouldcache:
                     self.assertEqualResponse(resc, res1)
                     assert "cached" in res2.flags
@@ -604,6 +634,26 @@ class RFC2616PolicyTestMixin(PolicyTestMixin):
                 assert "cached" in res2.flags
 
 
+class AsyncDummyCacheStorage(FilesystemCacheStorage):
+    """A simple async storage that wraps FilesystemCacheStorage for testing."""
+
+    async def open_spider(self, spider):
+        await async_sleep(0.01)
+        super().open_spider(spider)
+
+    async def close_spider(self, spider):
+        await async_sleep(0.01)
+        super().close_spider(spider)
+
+    async def retrieve_response(self, spider, request):
+        await async_sleep(0.01)
+        return super().retrieve_response(spider, request)
+
+    async def store_response(self, spider, request, response):
+        await async_sleep(0.01)
+        super().store_response(spider, request, response)
+
+
 # Concrete test classes that combine storage and policy mixins
 
 
@@ -651,3 +701,8 @@ class TestFilesystemStorageGzipWithDummyPolicy(TestFilesystemStorageWithDummyPol
     def _get_settings(self, **new_settings) -> dict[str, Any]:
         new_settings.setdefault("HTTPCACHE_GZIP", True)
         return super()._get_settings(**new_settings)
+
+
+class TestAsyncStorageWithDummyPolicy(TestBase, StorageTestMixin, DummyPolicyTestMixin):
+    storage_class = f"{__name__}.AsyncDummyCacheStorage"
+    policy_class = "scrapy.extensions.httpcache.DummyPolicy"

--- a/tests/test_downloadermiddleware_httpcache.py
+++ b/tests/test_downloadermiddleware_httpcache.py
@@ -174,6 +174,7 @@ class StorageTestMixin:
 class PolicyTestMixin:
     """Mixin containing policy-specific test methods."""
 
+    @coroutine_test
     async def test_dont_cache(self):
         async with self._middleware() as mw:
             self.request.meta["dont_cache"] = True
@@ -193,6 +194,7 @@ class PolicyTestMixin:
 class DummyPolicyTestMixin(PolicyTestMixin):
     """Mixin containing dummy policy specific test methods."""
 
+    @coroutine_test
     async def test_middleware(self):
         async with self._middleware() as mw:
             assert await mw.process_request(self.request) is None
@@ -202,6 +204,7 @@ class DummyPolicyTestMixin(PolicyTestMixin):
             self.assertEqualResponse(self.response, response)
             assert "cached" in response.flags
 
+    @coroutine_test
     async def test_different_request_response_urls(self):
         async with self._middleware() as mw:
             req = Request("http://host.com/path")
@@ -213,6 +216,7 @@ class DummyPolicyTestMixin(PolicyTestMixin):
             self.assertEqualResponse(res, cached)
             assert "cached" in cached.flags
 
+    @coroutine_test
     async def test_middleware_ignore_missing(self):
         async with self._middleware(HTTPCACHE_IGNORE_MISSING=True) as mw:
             with pytest.raises(IgnoreRequest):
@@ -223,6 +227,7 @@ class DummyPolicyTestMixin(PolicyTestMixin):
             self.assertEqualResponse(self.response, response)
             assert "cached" in response.flags
 
+    @coroutine_test
     async def test_middleware_ignore_schemes(self):
         # http responses are cached by default
         req, res = Request("http://test.com/"), Response("http://test.com/")
@@ -264,6 +269,7 @@ class DummyPolicyTestMixin(PolicyTestMixin):
             assert mw.storage.retrieve_response(mw.crawler.spider, req) is None
             assert await mw.process_request(req) is None
 
+    @coroutine_test
     async def test_middleware_ignore_http_codes(self):
         # test response is not cached
         async with self._middleware(HTTPCACHE_IGNORE_HTTP_CODES=[202]) as mw:
@@ -305,6 +311,7 @@ class RFC2616PolicyTestMixin(PolicyTestMixin):
             print("Result", result)
             raise
 
+    @coroutine_test
     async def test_request_cacheability(self):
         res0 = Response(
             self.request.url, status=200, headers={"Expires": self.tomorrow}
@@ -333,6 +340,7 @@ class RFC2616PolicyTestMixin(PolicyTestMixin):
             self.assertEqualResponse(res5, res0b)
             assert "cached" in res5.flags
 
+    @coroutine_test
     async def test_response_cacheability(self):
         responses = [
             # 304 is not cacheable no matter what servers sends
@@ -409,6 +417,7 @@ class RFC2616PolicyTestMixin(PolicyTestMixin):
                     assert not resc
                     assert "cached" not in res2.flags
 
+    @coroutine_test
     async def test_cached_and_fresh(self):
         sampledata = [
             (200, {"Date": self.yesterday, "Expires": self.tomorrow}),
@@ -472,6 +481,7 @@ class RFC2616PolicyTestMixin(PolicyTestMixin):
                 self.assertEqualResponse(res1, res3)
                 assert "cached" in res3.flags
 
+    @coroutine_test
     async def test_cached_and_stale(self):
         sampledata = [
             (200, {"Date": self.today, "Expires": self.yesterday}),
@@ -552,6 +562,7 @@ class RFC2616PolicyTestMixin(PolicyTestMixin):
                 else:
                     assert "cached" in res5.flags
 
+    @coroutine_test
     async def test_process_exception(self):
         async with self._middleware() as mw:
             res0 = Response(self.request.url, headers={"Expires": self.yesterday})
@@ -568,6 +579,7 @@ class RFC2616PolicyTestMixin(PolicyTestMixin):
             await mw.process_request(req0)
             assert mw.process_exception(req0, Exception("foo")) is None
 
+    @coroutine_test
     async def test_ignore_response_cache_controls(self):
         sampledata = [
             (200, {"Date": self.yesterday, "Expires": self.tomorrow}),
@@ -628,6 +640,7 @@ class TestDbmStorageWithCustomDbmModule(TestDbmStorageWithDummyPolicy):
         new_settings.setdefault("HTTPCACHE_DBM_MODULE", self.dbm_module)
         return super()._get_settings(**new_settings)
 
+    @coroutine_test
     async def test_custom_dbm_module_loaded(self):
         # make sure our dbm module has been loaded
         async with self._storage() as (storage, _):

--- a/tests/test_downloadermiddleware_httpcache.py
+++ b/tests/test_downloadermiddleware_httpcache.py
@@ -4,10 +4,11 @@ import email.utils
 import shutil
 import tempfile
 import time
-from contextlib import contextmanager
+from contextlib import asynccontextmanager
 from typing import TYPE_CHECKING, Any
 
 import pytest
+from twisted.internet.task import deferLater
 
 from scrapy.downloadermiddlewares.httpcache import HttpCacheMiddleware
 from scrapy.exceptions import IgnoreRequest
@@ -55,8 +56,8 @@ class TestBase:
         settings.update(new_settings)
         return settings
 
-    @contextmanager
-    def _get_crawler(self, **new_settings: Any) -> Generator[Crawler]:
+    @asynccontextmanager
+    async def _get_crawler(self, **new_settings: Any) -> Generator[Crawler]:
         settings = self._get_settings(**new_settings)
         crawler = get_crawler(Spider, settings)
         crawler.spider = crawler._create_spider("example.com")
@@ -67,21 +68,21 @@ class TestBase:
         finally:
             crawler.stats.close_spider()
 
-    @contextmanager
-    def _storage(self, **new_settings: Any):
-        with self._middleware(**new_settings) as mw:
+    @asynccontextmanager
+    async def _storage(self, **new_settings: Any):
+        async with self._middleware(**new_settings) as mw:
             yield mw.storage, mw.crawler
 
-    @contextmanager
-    def _middleware(self, **new_settings: Any) -> Generator[HttpCacheMiddleware]:
-        with self._get_crawler(**new_settings) as crawler:
+    @asynccontextmanager
+    async def _middleware(self, **new_settings: Any) -> Generator[HttpCacheMiddleware]:
+        async with self._get_crawler(**new_settings) as crawler:
             assert crawler.spider
             mw = HttpCacheMiddleware.from_crawler(crawler)
-            mw.spider_opened(crawler.spider)
+            await mw.spider_opened(crawler.spider)
             try:
                 yield mw
             finally:
-                mw.spider_closed(crawler.spider)
+                await mw.spider_closed(crawler.spider)
 
     def assertEqualResponse(self, response1, response2):
         assert response1.url == response2.url
@@ -93,8 +94,10 @@ class TestBase:
 class StorageTestMixin:
     """Mixin containing storage-specific test methods."""
 
-    def test_storage(self):
-        with self._storage() as (storage, crawler):
+    async def test_storage(self):
+        from twisted.internet import reactor
+
+        async with self._storage() as (storage, crawler):
             request2 = self.request.copy()
             assert storage.retrieve_response(crawler.spider, request2) is None
 
@@ -103,20 +106,22 @@ class StorageTestMixin:
             assert isinstance(response2, HtmlResponse)  # content-type header
             self.assertEqualResponse(self.response, response2)
 
-            time.sleep(2)  # wait for cache to expire
+            await deferLater(reactor, 2, lambda: None)  # wait for cache to expire
             assert storage.retrieve_response(crawler.spider, request2) is None
 
-    def test_storage_never_expire(self):
-        with self._storage(HTTPCACHE_EXPIRATION_SECS=0) as (storage, crawler):
+    async def test_storage_never_expire(self):
+        from twisted.internet import reactor
+
+        async with self._storage(HTTPCACHE_EXPIRATION_SECS=0) as (storage, crawler):
             assert storage.retrieve_response(crawler.spider, self.request) is None
             storage.store_response(crawler.spider, self.request, self.response)
-            time.sleep(0.5)  # give the chance to expire
+            await deferLater(reactor, 0.5, lambda: None)  # give the chance to expire
             assert storage.retrieve_response(crawler.spider, self.request)
 
-    def test_storage_no_content_type_header(self):
+    async def test_storage_no_content_type_header(self):
         """Test that the response body is used to get the right response class
         even if there is no Content-Type header"""
-        with self._storage() as (storage, crawler):
+        async with self._storage() as (storage, crawler):
             assert storage.retrieve_response(crawler.spider, self.request) is None
             response = Response(
                 "http://www.example.com",
@@ -132,15 +137,15 @@ class StorageTestMixin:
 class PolicyTestMixin:
     """Mixin containing policy-specific test methods."""
 
-    def test_dont_cache(self):
-        with self._middleware() as mw:
+    async def test_dont_cache(self):
+        async with self._middleware() as mw:
             self.request.meta["dont_cache"] = True
-            mw.process_response(self.request, self.response)
+            await mw.process_response(self.request, self.response)
             assert mw.storage.retrieve_response(mw.crawler.spider, self.request) is None
 
-        with self._middleware() as mw:
+        async with self._middleware() as mw:
             self.request.meta["dont_cache"] = False
-            mw.process_response(self.request, self.response)
+            await mw.process_response(self.request, self.response)
             if mw.policy.should_cache_response(self.response, self.request):
                 assert isinstance(
                     mw.storage.retrieve_response(mw.crawler.spider, self.request),
@@ -151,90 +156,90 @@ class PolicyTestMixin:
 class DummyPolicyTestMixin(PolicyTestMixin):
     """Mixin containing dummy policy specific test methods."""
 
-    def test_middleware(self):
-        with self._middleware() as mw:
-            assert mw.process_request(self.request) is None
-            mw.process_response(self.request, self.response)
-            response = mw.process_request(self.request)
+    async def test_middleware(self):
+        async with self._middleware() as mw:
+            assert await mw.process_request(self.request) is None
+            await mw.process_response(self.request, self.response)
+            response = await mw.process_request(self.request)
             assert isinstance(response, HtmlResponse)
             self.assertEqualResponse(self.response, response)
             assert "cached" in response.flags
 
-    def test_different_request_response_urls(self):
-        with self._middleware() as mw:
+    async def test_different_request_response_urls(self):
+        async with self._middleware() as mw:
             req = Request("http://host.com/path")
             res = Response("http://host2.net/test.html")
-            assert mw.process_request(req) is None
-            mw.process_response(req, res)
-            cached = mw.process_request(req)
+            assert await mw.process_request(req) is None
+            await mw.process_response(req, res)
+            cached = await mw.process_request(req)
             assert isinstance(cached, Response)
             self.assertEqualResponse(res, cached)
             assert "cached" in cached.flags
 
-    def test_middleware_ignore_missing(self):
-        with self._middleware(HTTPCACHE_IGNORE_MISSING=True) as mw:
+    async def test_middleware_ignore_missing(self):
+        async with self._middleware(HTTPCACHE_IGNORE_MISSING=True) as mw:
             with pytest.raises(IgnoreRequest):
-                mw.process_request(self.request)
-            mw.process_response(self.request, self.response)
-            response = mw.process_request(self.request)
+                await mw.process_request(self.request)
+            await mw.process_response(self.request, self.response)
+            response = await mw.process_request(self.request)
             assert isinstance(response, HtmlResponse)
             self.assertEqualResponse(self.response, response)
             assert "cached" in response.flags
 
-    def test_middleware_ignore_schemes(self):
+    async def test_middleware_ignore_schemes(self):
         # http responses are cached by default
         req, res = Request("http://test.com/"), Response("http://test.com/")
-        with self._middleware() as mw:
-            assert mw.process_request(req) is None
-            mw.process_response(req, res)
+        async with self._middleware() as mw:
+            assert await mw.process_request(req) is None
+            await mw.process_response(req, res)
 
-            cached = mw.process_request(req)
+            cached = await mw.process_request(req)
             assert isinstance(cached, Response), type(cached)
             self.assertEqualResponse(res, cached)
             assert "cached" in cached.flags
 
         # file response is not cached by default
         req, res = Request("file:///tmp/t.txt"), Response("file:///tmp/t.txt")
-        with self._middleware() as mw:
-            assert mw.process_request(req) is None
-            mw.process_response(req, res)
+        async with self._middleware() as mw:
+            assert await mw.process_request(req) is None
+            await mw.process_response(req, res)
 
             assert mw.storage.retrieve_response(mw.crawler.spider, req) is None
-            assert mw.process_request(req) is None
+            assert await mw.process_request(req) is None
 
         # s3 scheme response is cached by default
         req, res = Request("s3://bucket/key"), Response("http://bucket/key")
-        with self._middleware() as mw:
-            assert mw.process_request(req) is None
-            mw.process_response(req, res)
+        async with self._middleware() as mw:
+            assert await mw.process_request(req) is None
+            await mw.process_response(req, res)
 
-            cached = mw.process_request(req)
+            cached = await mw.process_request(req)
             assert isinstance(cached, Response), type(cached)
             self.assertEqualResponse(res, cached)
             assert "cached" in cached.flags
 
         # ignore s3 scheme
         req, res = Request("s3://bucket/key2"), Response("http://bucket/key2")
-        with self._middleware(HTTPCACHE_IGNORE_SCHEMES=["s3"]) as mw:
-            assert mw.process_request(req) is None
-            mw.process_response(req, res)
+        async with self._middleware(HTTPCACHE_IGNORE_SCHEMES=["s3"]) as mw:
+            assert await mw.process_request(req) is None
+            await mw.process_response(req, res)
 
             assert mw.storage.retrieve_response(mw.crawler.spider, req) is None
-            assert mw.process_request(req) is None
+            assert await mw.process_request(req) is None
 
-    def test_middleware_ignore_http_codes(self):
+    async def test_middleware_ignore_http_codes(self):
         # test response is not cached
-        with self._middleware(HTTPCACHE_IGNORE_HTTP_CODES=[202]) as mw:
-            assert mw.process_request(self.request) is None
-            mw.process_response(self.request, self.response)
+        async with self._middleware(HTTPCACHE_IGNORE_HTTP_CODES=[202]) as mw:
+            assert await mw.process_request(self.request) is None
+            await mw.process_response(self.request, self.response)
 
             assert mw.storage.retrieve_response(mw.crawler.spider, self.request) is None
-            assert mw.process_request(self.request) is None
+            assert await mw.process_request(self.request) is None
 
         # test response is cached
-        with self._middleware(HTTPCACHE_IGNORE_HTTP_CODES=[203]) as mw:
-            mw.process_response(self.request, self.response)
-            response = mw.process_request(self.request)
+        async with self._middleware(HTTPCACHE_IGNORE_HTTP_CODES=[203]) as mw:
+            await mw.process_response(self.request, self.response)
+            response = await mw.process_request(self.request)
             assert isinstance(response, HtmlResponse)
             self.assertEqualResponse(self.response, response)
             assert "cached" in response.flags
@@ -244,17 +249,17 @@ class RFC2616PolicyTestMixin(PolicyTestMixin):
     """Mixin containing RFC2616 policy specific test methods."""
 
     @staticmethod
-    def _process_requestresponse(
+    async def _process_requestresponse(
         mw: HttpCacheMiddleware, request: Request, response: Response | None
     ) -> Response | Request:
         result = None
         try:
-            result = mw.process_request(request)
+            result = await mw.process_request(request)
             if result:
                 assert isinstance(result, (Request, Response))
                 return result
             assert response is not None
-            result = mw.process_response(request, response)
+            result = await mw.process_response(request, response)
             assert isinstance(result, Response)
             return result
         except Exception:
@@ -263,35 +268,35 @@ class RFC2616PolicyTestMixin(PolicyTestMixin):
             print("Result", result)
             raise
 
-    def test_request_cacheability(self):
+    async def test_request_cacheability(self):
         res0 = Response(
             self.request.url, status=200, headers={"Expires": self.tomorrow}
         )
         req0 = Request("http://example.com")
         req1 = req0.replace(headers={"Cache-Control": "no-store"})
         req2 = req0.replace(headers={"Cache-Control": "no-cache"})
-        with self._middleware() as mw:
+        async with self._middleware() as mw:
             # response for a request with no-store must not be cached
-            res1 = self._process_requestresponse(mw, req1, res0)
+            res1 = await self._process_requestresponse(mw, req1, res0)
             self.assertEqualResponse(res1, res0)
             assert mw.storage.retrieve_response(mw.crawler.spider, req1) is None
             # Re-do request without no-store and expect it to be cached
-            res2 = self._process_requestresponse(mw, req0, res0)
+            res2 = await self._process_requestresponse(mw, req0, res0)
             assert "cached" not in res2.flags
-            res3 = mw.process_request(req0)
+            res3 = await mw.process_request(req0)
             assert "cached" in res3.flags
             self.assertEqualResponse(res2, res3)
             # request with no-cache directive must not return cached response
             # but it allows new response to be stored
             res0b = res0.replace(body=b"foo")
-            res4 = self._process_requestresponse(mw, req2, res0b)
+            res4 = await self._process_requestresponse(mw, req2, res0b)
             self.assertEqualResponse(res4, res0b)
             assert "cached" not in res4.flags
-            res5 = self._process_requestresponse(mw, req0, None)
+            res5 = await self._process_requestresponse(mw, req0, None)
             self.assertEqualResponse(res5, res0b)
             assert "cached" in res5.flags
 
-    def test_response_cacheability(self):
+    async def test_response_cacheability(self):
         responses = [
             # 304 is not cacheable no matter what servers sends
             (False, 304, {}),
@@ -323,13 +328,13 @@ class RFC2616PolicyTestMixin(PolicyTestMixin):
             (True, 302, {"Expires": self.tomorrow}),
             (True, 200, {"Etag": "foo"}),
         ]
-        with self._middleware() as mw:
+        async with self._middleware() as mw:
             for idx, (shouldcache, status, headers) in enumerate(responses):
                 req0 = Request(f"http://example-{idx}.com")
                 res0 = Response(req0.url, status=status, headers=headers)
-                res1 = self._process_requestresponse(mw, req0, res0)
+                res1 = await self._process_requestresponse(mw, req0, res0)
                 res304 = res0.replace(status=304)
-                res2 = self._process_requestresponse(
+                res2 = await self._process_requestresponse(
                     mw, req0, res304 if shouldcache else res0
                 )
                 self.assertEqualResponse(res1, res0)
@@ -344,16 +349,16 @@ class RFC2616PolicyTestMixin(PolicyTestMixin):
                     assert "cached" not in res2.flags
 
         # cache unconditionally unless response contains no-store or is a 304
-        with self._middleware(HTTPCACHE_ALWAYS_STORE=True) as mw:
+        async with self._middleware(HTTPCACHE_ALWAYS_STORE=True) as mw:
             for idx, (_, status, headers) in enumerate(responses):
                 shouldcache = (
                     "no-store" not in headers.get("Cache-Control", "") and status != 304
                 )
                 req0 = Request(f"http://example2-{idx}.com")
                 res0 = Response(req0.url, status=status, headers=headers)
-                res1 = self._process_requestresponse(mw, req0, res0)
+                res1 = await self._process_requestresponse(mw, req0, res0)
                 res304 = res0.replace(status=304)
-                res2 = self._process_requestresponse(
+                res2 = await self._process_requestresponse(
                     mw, req0, res304 if shouldcache else res0
                 )
                 self.assertEqualResponse(res1, res0)
@@ -367,7 +372,7 @@ class RFC2616PolicyTestMixin(PolicyTestMixin):
                     assert not resc
                     assert "cached" not in res2.flags
 
-    def test_cached_and_fresh(self):
+    async def test_cached_and_fresh(self):
         sampledata = [
             (200, {"Date": self.yesterday, "Expires": self.tomorrow}),
             (200, {"Date": self.yesterday, "Cache-Control": "max-age=86405"}),
@@ -410,27 +415,27 @@ class RFC2616PolicyTestMixin(PolicyTestMixin):
             (301, {}),
             (308, {}),
         ]
-        with self._middleware() as mw:
+        async with self._middleware() as mw:
             for idx, (status, headers) in enumerate(sampledata):
                 req0 = Request(f"http://example-{idx}.com")
                 res0 = Response(req0.url, status=status, headers=headers)
                 # cache fresh response
-                res1 = self._process_requestresponse(mw, req0, res0)
+                res1 = await self._process_requestresponse(mw, req0, res0)
                 self.assertEqualResponse(res1, res0)
                 assert "cached" not in res1.flags
                 # return fresh cached response without network interaction
-                res2 = self._process_requestresponse(mw, req0, None)
+                res2 = await self._process_requestresponse(mw, req0, None)
                 self.assertEqualResponse(res1, res2)
                 assert "cached" in res2.flags
                 # validate cached response if request max-age set as 0
                 req1 = req0.replace(headers={"Cache-Control": "max-age=0"})
                 res304 = res0.replace(status=304)
-                assert mw.process_request(req1) is None
-                res3 = self._process_requestresponse(mw, req1, res304)
+                assert await mw.process_request(req1) is None
+                res3 = await self._process_requestresponse(mw, req1, res304)
                 self.assertEqualResponse(res1, res3)
                 assert "cached" in res3.flags
 
-    def test_cached_and_stale(self):
+    async def test_cached_and_stale(self):
         sampledata = [
             (200, {"Date": self.today, "Expires": self.yesterday}),
             (
@@ -467,18 +472,18 @@ class RFC2616PolicyTestMixin(PolicyTestMixin):
             ),
             (200, {"Cache-Control": "max-age=86400,must-revalidate", "Age": "86405"}),
         ]
-        with self._middleware() as mw:
+        async with self._middleware() as mw:
             for idx, (status, headers) in enumerate(sampledata):
                 req0 = Request(f"http://example-{idx}.com")
                 res0a = Response(req0.url, status=status, headers=headers)
                 # cache expired response
-                res1 = self._process_requestresponse(mw, req0, res0a)
+                res1 = await self._process_requestresponse(mw, req0, res0a)
                 self.assertEqualResponse(res1, res0a)
                 assert "cached" not in res1.flags
                 # Same request but as cached response is stale a new response must
                 # be returned
                 res0b = res0a.replace(body=b"bar")
-                res2 = self._process_requestresponse(mw, req0, res0b)
+                res2 = await self._process_requestresponse(mw, req0, res0b)
                 self.assertEqualResponse(res2, res0b)
                 assert "cached" not in res2.flags
                 cc = headers.get("Cache-Control", "")
@@ -487,13 +492,13 @@ class RFC2616PolicyTestMixin(PolicyTestMixin):
                 # are present
                 if "ETag" in headers or "Last-Modified" in headers:
                     res0c = res0b.replace(status=304)
-                    res3 = self._process_requestresponse(mw, req0, res0c)
+                    res3 = await self._process_requestresponse(mw, req0, res0c)
                     self.assertEqualResponse(res3, res0b)
                     assert "cached" in res3.flags
                     # get cached response on server errors unless must-revalidate
                     # in cached response
                     res0d = res0b.replace(status=500)
-                    res4 = self._process_requestresponse(mw, req0, res0d)
+                    res4 = await self._process_requestresponse(mw, req0, res0d)
                     if "must-revalidate" in cc:
                         assert "cached" not in res4.flags
                         self.assertEqualResponse(res4, res0d)
@@ -503,30 +508,30 @@ class RFC2616PolicyTestMixin(PolicyTestMixin):
                 # Requests with max-stale can fetch expired cached responses
                 # unless cached response has must-revalidate
                 req1 = req0.replace(headers={"Cache-Control": "max-stale"})
-                res5 = self._process_requestresponse(mw, req1, res0b)
+                res5 = await self._process_requestresponse(mw, req1, res0b)
                 self.assertEqualResponse(res5, res0b)
                 if "no-cache" in cc or "must-revalidate" in cc:
                     assert "cached" not in res5.flags
                 else:
                     assert "cached" in res5.flags
 
-    def test_process_exception(self):
-        with self._middleware() as mw:
+    async def test_process_exception(self):
+        async with self._middleware() as mw:
             res0 = Response(self.request.url, headers={"Expires": self.yesterday})
             req0 = Request(self.request.url)
-            self._process_requestresponse(mw, req0, res0)
+            await self._process_requestresponse(mw, req0, res0)
             for e in mw.DOWNLOAD_EXCEPTIONS:
                 # Simulate encountering an error on download attempts
-                assert mw.process_request(req0) is None
+                assert await mw.process_request(req0) is None
                 res1 = mw.process_exception(req0, e("foo"))
                 # Use cached response as recovery
                 assert "cached" in res1.flags
                 self.assertEqualResponse(res0, res1)
             # Do not use cached response for unhandled exceptions
-            mw.process_request(req0)
+            await mw.process_request(req0)
             assert mw.process_exception(req0, Exception("foo")) is None
 
-    def test_ignore_response_cache_controls(self):
+    async def test_ignore_response_cache_controls(self):
         sampledata = [
             (200, {"Date": self.yesterday, "Expires": self.tomorrow}),
             (200, {"Date": self.yesterday, "Cache-Control": "no-store,max-age=86405"}),
@@ -534,18 +539,18 @@ class RFC2616PolicyTestMixin(PolicyTestMixin):
             (300, {"Cache-Control": "no-cache"}),
             (200, {"Expires": self.tomorrow, "Cache-Control": "no-store"}),
         ]
-        with self._middleware(
+        async with self._middleware(
             HTTPCACHE_IGNORE_RESPONSE_CACHE_CONTROLS=["no-cache", "no-store"]
         ) as mw:
             for idx, (status, headers) in enumerate(sampledata):
                 req0 = Request(f"http://example-{idx}.com")
                 res0 = Response(req0.url, status=status, headers=headers)
                 # cache fresh response
-                res1 = self._process_requestresponse(mw, req0, res0)
+                res1 = await self._process_requestresponse(mw, req0, res0)
                 self.assertEqualResponse(res1, res0)
                 assert "cached" not in res1.flags
                 # return fresh cached response without network interaction
-                res2 = self._process_requestresponse(mw, req0, None)
+                res2 = await self._process_requestresponse(mw, req0, None)
                 self.assertEqualResponse(res1, res2)
                 assert "cached" in res2.flags
 
@@ -586,9 +591,9 @@ class TestDbmStorageWithCustomDbmModule(TestDbmStorageWithDummyPolicy):
         new_settings.setdefault("HTTPCACHE_DBM_MODULE", self.dbm_module)
         return super()._get_settings(**new_settings)
 
-    def test_custom_dbm_module_loaded(self):
+    async def test_custom_dbm_module_loaded(self):
         # make sure our dbm module has been loaded
-        with self._storage() as (storage, _):
+        async with self._storage() as (storage, _):
             assert storage.dbmodule.__name__ == self.dbm_module
 
 


### PR DESCRIPTION
Fixes #6643, closes https://github.com/scrapy/scrapy/pull/2799.

Core: Converted HttpCacheMiddleware methods to async def and utilized ensure_awaitable for all storage interactions (open, close, retrieve, store).

Tests: Migrated tests/test_downloadermiddleware_httpcache.py to asyncio/pytest-twisted patterns.

Refactor: Replaced time.sleep with deferLater to maintain Twisted reactor compatibility during tests.