### PR TITLE
fix: use subprocess instead of os.system in genspider.py

### DIFF
--- a/scrapy/commands/genspider.py
+++ b/scrapy/commands/genspider.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import os
 import shutil
 import string
+import subprocess
 from importlib import import_module
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, ClassVar, cast
@@ -120,7 +121,7 @@ class Command(ScrapyCommand):
         if template_file:
             self._genspider(module, name, url, opts.template, template_file)
             if opts.edit:
-                self.exitcode = os.system(f'scrapy edit "{name}"')  # noqa: S605
+                self.exitcode = subprocess.call(["scrapy", "edit", name])
 
     def _generate_template_variables(
         self,


### PR DESCRIPTION
## Summary
Fix critical severity security issue in `scrapy/commands/genspider.py`.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | V-001 |
| **Severity** | CRITICAL |
| **Scanner** | multi_agent_ai |
| **Rule** | `V-001` |
| **File** | `scrapy/commands/genspider.py:123` |

**Description**: The genspider command constructs shell commands using f-string interpolation with the user-provided spider name parameter, passing it directly to os.system() without any sanitization or validation. This allows attackers to inject arbitrary shell commands by including metacharacters in the spider name.

## Changes
- `scrapy/commands/genspider.py`

## Verification
- [x] Build passes
- [x] Scanner re-scan confirms fix
- [x] LLM code review passed

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
