### PR TITLE
FIX: FilesPipeline now accepts any 2xx response status, not only 200

### DIFF
--- a/scrapy/pipelines/files.py
+++ b/scrapy/pipelines/files.py
@@ -609,7 +609,7 @@ class FilesPipeline(MediaPipeline):
     ) -> FileInfo:
         referer = referer_str(request)
 
-        if response.status != 200:
+        if response.status // 100 != 2:
             logger.warning(
                 "File (code: %(status)s): Error downloading file from "
                 "%(request)s referred in <%(referer)s>",

--- a/tests/test_pipeline_files.py
+++ b/tests/test_pipeline_files.py
@@ -180,6 +180,34 @@ class TestFilesPipeline:
         assert self.pipeline.store._get_filesystem_path(path) == fullpath
 
     @coroutine_test
+    async def test_file_download_non_200_2xx_status(self):
+        """Files with 2xx status codes other than 200 (e.g. 201 Created) should
+        be downloaded successfully. Regression test for issue #1615."""
+        for status in (201, 202, 206):
+            item_url = f"http://example.com/file_{status}.pdf"
+            item = _create_item_with_files(item_url)
+            request = Request(
+                item_url,
+                meta={
+                    "response": Response(
+                        item_url, status=status, body=b"data", flags=[]
+                    )
+                },
+            )
+            with (
+                mock.patch.object(FilesPipeline, "inc_stats", return_value=True),
+                mock.patch.object(
+                    FilesPipeline,
+                    "get_media_requests",
+                    return_value=[request],
+                ),
+            ):
+                result = await self.pipeline.process_item(item)
+            assert result["files"][0]["status"] == "downloaded", (
+                f"Expected status 'downloaded' for HTTP {status} response"
+            )
+
+    @coroutine_test
     async def test_file_not_expired(self):
         item_url = "http://example.com/file.pdf"
         item = _create_item_with_files(item_url)


### PR DESCRIPTION
## Summary

Fixes #1615.

`FilesPipeline.file_downloaded` was raising `FileException("download-error")` for any response whose status code was not exactly **200 OK**, silently skipping files that the server returned with:

- **201 Created** — common when a resource is generated on-the-fly
- **202 Accepted**
- **206 Partial Content**
- Any other 2xx success code

## Change

```python
# Before
if response.status != 200:

# After
if response.status // 100 != 2:
```

This accepts the full class of HTTP success responses.  Responses with no body (e.g. 204 No Content) are still rejected by the existing empty-body check that immediately follows.

## Test plan

- [x] New test `test_file_download_non_200_2xx_status` checks that 201, 202, and 206 responses are downloaded successfully
- [x] Existing test suite continues to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)