### PR TITLE
Add Windows note for scrapy command not recognized error

### DIFF
--- a/docs/intro/tutorial.rst
+++ b/docs/intro/tutorial.rst
@@ -53,6 +53,10 @@ directory where you'd like to store your code and run::
 
     scrapy startproject tutorial
 
+.. note:: **Windows users:** If you encounter an error like ``'scrapy' is not recognized as an internal or external command``, you can use ``python -m scrapy`` instead. For example::
+
+       python -m scrapy startproject tutorial
+
 This will create a ``tutorial`` directory with the following contents::
 
     tutorial/


### PR DESCRIPTION
- Added a note under 'Creating a project' section
- Explains the 'scrapy' is not recognized error on Windows
- Provides python -m scrapy as alternative solution
- Closes #7306 
