### PR TITLE
Accept HTTP 2xx in FilesPipeline, follow Location header

### DIFF
--- a/scrapy/pipelines/files.py
+++ b/scrapy/pipelines/files.py
@@ -609,7 +609,7 @@ class FilesPipeline(MediaPipeline):
     ) -> FileInfo:
         referer = referer_str(request)
 
-        if response.status != 200:
+        if response.status // 100 != 2:
             logger.warning(
                 "File (code: %(status)s): Error downloading file from "
                 "%(request)s referred in <%(referer)s>",
@@ -617,6 +617,36 @@ class FilesPipeline(MediaPipeline):
                 extra={"spider": info.spider},
             )
             raise FileException("download-error")
+
+        if not response.body:
+            location = response.headers.get(b"Location")
+            if location is not None:
+                location_url = response.urljoin(location.decode("latin-1"))
+                logger.debug(
+                    "File (location): Following Location header from "
+                    "%(request)s to %(location_url)s referred in <%(referer)s>",
+                    {
+                        "request": request,
+                        "location_url": location_url,
+                        "referer": referer,
+                    },
+                    extra={"spider": info.spider},
+                )
+                assert self.crawler.engine
+                location_request = request.replace(url=location_url)
+                response = await self.crawler.engine.download_async(location_request)
+                if response.status // 100 != 2:
+                    logger.warning(
+                        "File (code: %(status)s): Error downloading file from "
+                        "%(request)s referred in <%(referer)s>",
+                        {
+                            "status": response.status,
+                            "request": request,
+                            "referer": referer,
+                        },
+                        extra={"spider": info.spider},
+                    )
+                    raise FileException("download-error")
 
         if not response.body:
             logger.warning(

--- a/tests/test_pipeline_files.py
+++ b/tests/test_pipeline_files.py
@@ -23,6 +23,7 @@ from twisted.internet.defer import Deferred
 
 from scrapy.exceptions import NotConfigured
 from scrapy.http import Request, Response
+from scrapy.http.request import NO_CALLBACK
 from scrapy.item import Field, Item
 from scrapy.pipelines.files import (
     FilesPipeline,
@@ -272,6 +273,86 @@ class TestFilesPipeline:
         path = Path(self.tempdir) / result["files"][0]["path"]
         assert path.exists()
         assert path.read_bytes() == b"data"
+
+    @coroutine_test
+    async def test_file_downloaded_with_2xx_status(self):
+        """HTTP 2xx responses (e.g. 201 Created) should be accepted."""
+        item_url = "http://example.com/file_201.pdf"
+        item = _create_item_with_files(item_url)
+        request = Request(
+            item_url,
+            meta={"response": Response(item_url, status=201, body=b"created-data")},
+        )
+        with (
+            mock.patch.object(FilesPipeline, "inc_stats", return_value=True),
+            mock.patch.object(
+                FilesPipeline,
+                "get_media_requests",
+                return_value=[request],
+            ),
+        ):
+            result = await self.pipeline.process_item(item)
+        assert result["files"][0]["status"] == "downloaded"
+        assert result["files"][0]["checksum"]
+
+    @coroutine_test
+    async def test_file_downloaded_non_2xx_rejected(self):
+        """Non-2xx responses should still be rejected."""
+        item_url = "http://example.com/file_404.pdf"
+        item = _create_item_with_files(item_url)
+        request = Request(
+            item_url,
+            meta={"response": Response(item_url, status=404, body=b"not found")},
+        )
+        with (
+            mock.patch.object(FilesPipeline, "inc_stats", return_value=True),
+            mock.patch.object(
+                FilesPipeline,
+                "get_media_requests",
+                return_value=[request],
+            ),
+        ):
+            result = await self.pipeline.process_item(item)
+        assert result["files"] == []
+
+    @coroutine_test
+    async def test_file_downloaded_201_follows_location(self):
+        """HTTP 201 with empty body and Location header follows the URL."""
+        item_url = "http://example.com/create_file.pdf"
+        location_url = "http://example.com/files/created.pdf"
+        item = _create_item_with_files(item_url)
+
+        initial_response = Response(
+            item_url,
+            status=201,
+            headers={b"Location": location_url.encode()},
+            body=b"",
+        )
+        location_response = Response(location_url, status=200, body=b"file-content")
+
+        call_count = 0
+
+        async def mock_download(request):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return initial_response
+            return location_response
+
+        self.pipeline.crawler.engine = MagicMock(download_async=mock_download)
+
+        with (
+            mock.patch.object(FilesPipeline, "inc_stats", return_value=True),
+            mock.patch.object(
+                FilesPipeline,
+                "get_media_requests",
+                return_value=[Request(item_url, callback=NO_CALLBACK)],
+            ),
+        ):
+            result = await self.pipeline.process_item(item)
+        assert result["files"][0]["status"] == "downloaded"
+        assert result["files"][0]["checksum"]
+        assert call_count == 2
 
     def test_file_path_from_item(self):
         """


### PR DESCRIPTION
## Summary

Resolves #1615.

`FilesPipeline.media_downloaded()` rejected any response where `status != 200`, but HTTP 201 (Created) is a valid success status per [RFC 7231 §6.3.2](https://datatracker.ietf.org/doc/html/rfc7231#section-6.3.2). Servers that generate files on the fly commonly return 201, causing the pipeline to log a warning and raise `FileException("download-error")` instead of saving the file.

### Changes

- Changed the status check from `response.status != 200` to `response.status // 100 != 2`, accepting the full 2xx success range
- When a 2xx response has an empty body **and** includes a `Location` header, the pipeline follows that URL to fetch the actual file content — matching HTTP 201 semantics where `Location` points to the newly created resource
- After following `Location`, the response is validated again (status check + empty body check)

### Why Location handling matters

HTTP 201 Created can return the content directly in the body, or indicate the resource location via the `Location` header with an empty body. Previous PRs for this issue only changed the status check without handling the `Location` redirect, which was [flagged by maintainers](https://github.com/scrapy/scrapy/pull/7271#issuecomment-3112062582) as incomplete.

## Test plan

- [x] `test_file_downloaded_with_2xx_status` — verifies 201 with body is accepted and file is saved
- [x] `test_file_downloaded_non_2xx_rejected` — verifies 404 still rejected (empty result)
- [x] `test_file_downloaded_201_follows_location` — verifies 201 with empty body + `Location` header triggers a follow-up download, saves the file, and confirms two download calls were made
- [x] All 80 existing pipeline tests pass (files + media)
- [x] Pre-commit (ruff check, ruff format) passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>