### PR TITLE
[docs] Add Windows note for python -m scrapy in tutorial

### DIFF
--- a/docs/intro/tutorial.rst
+++ b/docs/intro/tutorial.rst
@@ -53,6 +53,14 @@ directory where you'd like to store your code and run::
 
     scrapy startproject tutorial
 
+.. note::
+
+   On Windows, if the ``scrapy`` command is not recognized (e.g. the
+   ``Scripts`` folder is not in your ``PATH``), you can use
+   ``python -m scrapy`` as an alternative::
+
+       python -m scrapy startproject tutorial
+
 This will create a ``tutorial`` directory with the following contents::
 
     tutorial/


### PR DESCRIPTION
Fixes #7306

On Windows, the `scrapy` command may not be recognized if the `Scripts` folder is not in `PATH`. This adds a short note in the tutorial's "Creating a project" section pointing users to the `python -m scrapy` alternative.