### PR TITLE
Fix FilesPipeline rejecting valid 2xx responses as download errors

### DIFF
--- a/docs/news.rst
+++ b/docs/news.rst
@@ -277,6 +277,11 @@ Improvements
 Bug fixes
 ~~~~~~~~~
 
+-   :meth:`FilesPipeline.media_downloaded
+    <scrapy.pipelines.files.FilesPipeline.media_downloaded>` now accepts any
+    2xx HTTP response as a successful download, instead of only ``200 OK``.
+    (:issue:`1615`)
+
 -   :ref:`Media pipelines <topics-media-pipeline>` should now wait for uploads
     to asynchronous storages (e.g.
     :class:`~scrapy.pipelines.files.S3FilesStore`) to complete.

--- a/scrapy/pipelines/files.py
+++ b/scrapy/pipelines/files.py
@@ -609,7 +609,7 @@ class FilesPipeline(MediaPipeline):
     ) -> FileInfo:
         referer = referer_str(request)
 
-        if response.status != 200:
+        if not (200 <= response.status < 300):
             logger.warning(
                 "File (code: %(status)s): Error downloading file from "
                 "%(request)s referred in <%(referer)s>",

--- a/tests/test_pipeline_files.py
+++ b/tests/test_pipeline_files.py
@@ -273,6 +273,39 @@ class TestFilesPipeline:
         assert path.exists()
         assert path.read_bytes() == b"data"
 
+    @pytest.mark.parametrize("status", [201, 202, 204])
+    @coroutine_test
+    async def test_file_download_accepts_2xx_status(self, status):
+        item_url = "http://example.com/file.pdf"
+        item = _create_item_with_files(item_url)
+        request = Request(
+            item_url,
+            meta={"response": Response(item_url, status=status, body=b"data")},
+        )
+        with mock.patch.object(
+            FilesPipeline,
+            "get_media_requests",
+            return_value=[request],
+        ):
+            result = await self.pipeline.process_item(item)
+        assert result["files"][0]["status"] == "downloaded"
+
+    @coroutine_test
+    async def test_file_download_rejects_non_2xx_status(self):
+        item_url = "http://example.com/file.pdf"
+        item = _create_item_with_files(item_url)
+        request = Request(
+            item_url,
+            meta={"response": Response(item_url, status=404, body=b"not found")},
+        )
+        with mock.patch.object(
+            FilesPipeline,
+            "get_media_requests",
+            return_value=[request],
+        ):
+            result = await self.pipeline.process_item(item)
+        assert result["files"] == []
+
     def test_file_path_from_item(self):
         """
         Custom file path based on item data, overriding default implementation


### PR DESCRIPTION
## What this fixes

Closes #1615.

`FilesPipeline.media_downloaded` was comparing `response.status != 200`, which caused it to treat any successful HTTP response that wasn't exactly `200 OK` as a download failure. Servers that return `201 Created` (e.g. images generated on the fly) were silently dropped with a `download-error` warning, and the files were never saved.

## Change

One-line fix in `scrapy/pipelines/files.py`:

```diff
- if response.status != 200:
+ if not (200 <= response.status < 300):
```

This brings the behavior in line with HTTP semantics — any 2xx status is a successful response.

## Tests

Added parametrized tests for `201`, `202`, and `204` (all pass through as `"downloaded"`), plus a regression test confirming that `404` still raises `FileException("download-error")` as expected.

## Checklist

- [x] Tests added/updated
- [x] Changelog entry added in `docs/news.rst`