### PR TITLE
Fix FilesPipeline to accept HTTP 201 Created responses

### DIFF
--- a/docs/news.rst
+++ b/docs/news.rst
@@ -305,6 +305,13 @@ Bug fixes
     wasn't available since Scrapy 2.13.0.
     (:issue:`7395`)
 
+-   :class:`~scrapy.pipelines.files.FilesPipeline` now accepts HTTP ``201
+    Created`` responses in addition to ``200 OK``. If a ``201`` response has an
+    empty body but includes a ``Location`` header, the pipeline follows that URL
+    to retrieve the actual file (per :rfc:`9110`). Previously any status other
+    than ``200`` was treated as a download error.
+    (:issue:`1615`)
+
 Documentation
 ~~~~~~~~~~~~~
 

--- a/scrapy/pipelines/files.py
+++ b/scrapy/pipelines/files.py
@@ -19,7 +19,7 @@ from ftplib import FTP
 from io import BytesIO
 from pathlib import Path
 from typing import IO, TYPE_CHECKING, Any, ClassVar, NoReturn, Protocol, TypedDict, cast
-from urllib.parse import urlparse
+from urllib.parse import urljoin, urlparse
 
 from itemadapter import ItemAdapter
 from twisted.internet.defer import Deferred, maybeDeferred
@@ -609,7 +609,7 @@ class FilesPipeline(MediaPipeline):
     ) -> FileInfo:
         referer = referer_str(request)
 
-        if response.status != 200:
+        if response.status not in (200, 201):
             logger.warning(
                 "File (code: %(status)s): Error downloading file from "
                 "%(request)s referred in <%(referer)s>",
@@ -617,6 +617,32 @@ class FilesPipeline(MediaPipeline):
                 extra={"spider": info.spider},
             )
             raise FileException("download-error")
+
+        if response.status == 201 and not response.body:
+            location = response.headers.get(b"Location")
+            if not location:
+                logger.warning(
+                    "File (empty-content): Empty file from %(request)s referred "
+                    "in <%(referer)s>: no-content",
+                    {"request": request, "referer": referer},
+                    extra={"spider": info.spider},
+                )
+                raise FileException("empty-content")
+            # HTTP 201 Created with a Location header and empty body: follow
+            # the Location to retrieve the actual file, as per RFC 9110 §15.3.2
+            location_url = urljoin(request.url, location.decode())
+            new_request = request.replace(url=location_url)
+            self._modify_media_request(new_request)
+            assert self.crawler.engine
+            response = await self.crawler.engine.download_async(new_request)
+            if response.status != 200:
+                logger.warning(
+                    "File (code: %(status)s): Error downloading file from "
+                    "%(request)s referred in <%(referer)s>",
+                    {"status": response.status, "request": new_request, "referer": referer},
+                    extra={"spider": info.spider},
+                )
+                raise FileException("download-error")
 
         if not response.body:
             logger.warning(

--- a/tests/test_pipeline_files.py
+++ b/tests/test_pipeline_files.py
@@ -25,6 +25,7 @@ from scrapy.exceptions import NotConfigured
 from scrapy.http import Request, Response
 from scrapy.item import Field, Item
 from scrapy.pipelines.files import (
+    FileException,
     FilesPipeline,
     FSFilesStore,
     FTPFilesStore,
@@ -814,3 +815,73 @@ def test_files_pipeline_raises_notconfigured_when_files_store_invalid(store):
 
     with pytest.raises(NotConfigured):
         FilesPipeline.from_crawler(crawler)
+
+
+class TestMediaDownloaded:
+    """Tests for FilesPipeline.media_downloaded HTTP 201 semantics (issue #1615)."""
+
+    def setup_method(self):
+        self.tempdir = mkdtemp()
+        self.crawler = get_crawler(DefaultSpider, {"FILES_STORE": self.tempdir})
+        self.crawler.spider = self.crawler._create_spider()
+        self.crawler.engine = MagicMock()
+        self.pipe = FilesPipeline.from_crawler(self.crawler)
+        self.pipe.open_spider()
+        self.info = self.pipe.spiderinfo
+
+    def teardown_method(self):
+        rmtree(self.tempdir)
+
+    @coroutine_test
+    async def test_200_downloaded(self):
+        request = Request("http://example.com/file.png")
+        response = Response("http://example.com/file.png", status=200, body=b"data")
+        result = await self.pipe.media_downloaded(response, request, self.info)
+        assert result["status"] == "downloaded"
+
+    @coroutine_test
+    async def test_201_with_body_downloaded(self):
+        """201 Created with a body in the response: save the body directly."""
+        request = Request("http://example.com/file.png")
+        response = Response("http://example.com/file.png", status=201, body=b"data")
+        result = await self.pipe.media_downloaded(response, request, self.info)
+        assert result["status"] == "downloaded"
+
+    @coroutine_test
+    async def test_201_with_location_follows_and_downloads(self):
+        """201 Created with empty body + Location: follow Location to get the file."""
+        original_url = "http://example.com/create"
+        location_url = "http://example.com/created-file.png"
+
+        request = Request(original_url)
+        response = Response(
+            original_url,
+            status=201,
+            headers={"Location": location_url},
+        )
+        follow_response = Response(location_url, status=200, body=b"data")
+
+        async def mock_download(req):
+            return follow_response
+
+        self.crawler.engine.download_async = mock_download
+
+        result = await self.pipe.media_downloaded(response, request, self.info)
+        assert result["status"] == "downloaded"
+        assert result["url"] == original_url
+
+    @coroutine_test
+    async def test_201_empty_body_no_location_raises_empty_content(self):
+        """201 Created with empty body and no Location: raise FileException('empty-content')."""
+        request = Request("http://example.com/file.png")
+        response = Response("http://example.com/file.png", status=201)
+        with pytest.raises(FileException, match="empty-content"):
+            await self.pipe.media_downloaded(response, request, self.info)
+
+    @coroutine_test
+    async def test_non_2xx_raises_download_error(self):
+        """Non-200/201 status codes must raise FileException('download-error')."""
+        request = Request("http://example.com/file.png")
+        response = Response("http://example.com/file.png", status=404)
+        with pytest.raises(FileException, match="download-error"):
+            await self.pipe.media_downloaded(response, request, self.info)


### PR DESCRIPTION
# Fix FilesPipeline to accept HTTP 201 Created responses (issue #1615)

## What this fixes

Closes #1615.

`FilesPipeline.media_downloaded` was rejecting any response with
`status != 200`, causing servers that return `201 Created` (e.g. images
generated on the fly) to silently fail with a `download-error` warning.

This was first attempted in #1806 but was never merged.

## Changes

The fix follows the approach discussed in #1806 by @redapple:

Accept `200` and `201`, reject everything else with `download-error`.
For `201` responses specifically:

`201` with a body → save the body directly (the most common case, as reported in the original issue)

`201` with empty body + `Location` header → follow the `Location` URL to retrieve the actual file, as per RFC 9110 §15.3.2

`201` with empty body and no `Location` → raise `empty-content`

```diff
- if response.status != 200:
+ if response.status not in (200, 201):
      raise FileException("download-error")

+ if response.status == 201 and not response.body:
+     location = response.headers.get(b"Location")
+     if not location:
+         raise FileException("empty-content")
+     # follow Location to retrieve the actual file
+     response = await self.crawler.engine.download_async(...)
```

## Tests

`201` with body → `"downloaded"` ✓

`201` with empty body + `Location` → follows redirect, `"downloaded"` ✓

`201` with empty body + no `Location` → raises `FileException("empty-content")` ✓

`404` → raises `FileException("download-error")` ✓

`200` → unchanged behavior ✓

## Notes

Thanks to @wRAR for pointing out that my previous PR (#7430), like the
others before it, didn't handle `Location`. That pushed me to read the
full issue thread and find the approach discussed in #1806.