### PR TITLE
Fix FEED_EXPORTERS keys with dots causing NameError (#7426)

### DIFF
--- a/scrapy/core/downloader/handlers/__init__.py
+++ b/scrapy/core/downloader/handlers/__init__.py
@@ -60,7 +60,7 @@ class DownloadHandlers:
         handlers: dict[str, str | Callable[..., Any]] = without_none_values(
             cast(
                 "dict[str, str | Callable[..., Any]]",
-                crawler.settings.getwithbase("DOWNLOAD_HANDLERS"),
+                crawler.settings.getwithbase("DOWNLOAD_HANDLERS", normalize_keys=False),
             )
         )
         for scheme, clspath in handlers.items():

--- a/scrapy/extensions/feedexport.py
+++ b/scrapy/extensions/feedexport.py
@@ -644,7 +644,10 @@ class FeedExporter:
 
     def _load_components(self, setting_prefix: str) -> dict[str, Any]:
         conf = without_none_values(
-            cast("dict[str, str]", self.settings.getwithbase(setting_prefix))
+            cast(
+                "dict[str, str]",
+                self.settings.getwithbase(setting_prefix, normalize_keys=False),
+            )
         )
         d = {}
         for k, v in conf.items():

--- a/scrapy/settings/__init__.py
+++ b/scrapy/settings/__init__.py
@@ -322,15 +322,30 @@ class BaseSettings(MutableMapping[_SettingsKey, Any]):
             )
         return copy.deepcopy(value)
 
-    def getwithbase(self, name: _SettingsKey) -> BaseSettings:
+    def getwithbase(
+        self, name: _SettingsKey, normalize_keys: bool = True
+    ) -> BaseSettings:
         """Get a composition of a dictionary-like setting and its `_BASE`
         counterpart.
 
         :param name: name of the dictionary-like setting
         :type name: str
+
+        :param normalize_keys: whether to normalize keys by loading objects.
+            Set to False for settings like FEED_EXPORTERS where keys are
+            format names (e.g. 'csv.gz'), not import paths.
+        :type normalize_keys: bool
         """
         if not isinstance(name, str):
             raise ValueError(f"Base setting key must be a string, got {name}")
+
+        if not normalize_keys:
+            # Skip key normalization for settings where keys are not import paths
+            # (e.g., FEED_EXPORTERS, FEED_STORAGES, DOWNLOAD_HANDLERS)
+            result = dict(self[name + "_BASE"] or {})
+            override = dict(self[name] or {})
+            result.update(override)
+            return BaseSettings({k: v for k, v in result.items() if v is not None})
 
         normalized_keys = {}
         obj_keys = set()

--- a/tests/test_settings/__init__.py
+++ b/tests/test_settings/__init__.py
@@ -465,6 +465,35 @@ class TestBaseSettings:
             assert isinstance(value, BaseSettings)
             assert dict(value) == expected
 
+    def test_getwithbase_with_normalize_keys_false(self):
+        """Test that format names containing dots (like 'csv.gz') work correctly
+        when normalize_keys=False.
+
+        This addresses the regression from PR #6993 where getwithbase() would
+        incorrectly treat format names as import paths.
+        """
+        settings = BaseSettings()
+        settings["FEED_EXPORTERS_BASE"] = BaseSettings(
+            {
+                "json": "scrapy.exporters.JsonItemExporter",
+                "csv": "scrapy.exporters.CsvItemExporter",
+            }
+        )
+        settings["FEED_EXPORTERS"] = {
+            "csv.gz": "my_exporter.CsvGzipExporter",
+            "json.gz": "my_exporter.JsonGzipExporter",
+        }
+
+        # With normalize_keys=False, keys with dots should work correctly
+        result = settings.getwithbase("FEED_EXPORTERS", normalize_keys=False)
+        assert isinstance(result, BaseSettings)
+        assert "csv.gz" in result
+        assert "json.gz" in result
+        assert "json" in result
+        assert "csv" in result
+        assert result["csv.gz"] == "my_exporter.CsvGzipExporter"
+        assert result["json.gz"] == "my_exporter.JsonGzipExporter"
+
     def test_getwithbase_warns_on_duplicate_import_paths(self, caplog):
         settings = BaseSettings()
         settings["FOO"] = BaseSettings(


### PR DESCRIPTION
Fixes #7426

  ## Problem

  Regression from PR #6993 which introduced key normalization in `getwithbase()`.
  When users define format names containing dots in `FEED_EXPORTERS` (e.g., `"csv.gz"`),
  the system incorrectly treats them as Python import paths, causing:

  NameError: Module 'csv' doesn't define any object named 'gz'

  ## Root Cause

  PR #6993 added `normalize_key()` to handle class import paths as keys. However,
  not all `_BASE` settings use import paths as keys:

  - `FEED_EXPORTERS` - keys are format names (`"json"`, `"csv.gz"`)
  - `FEED_STORAGES` - keys are storage schemes (`"file"`, `"s3"`)
  - `DOWNLOAD_HANDLERS` - keys are URL schemes (`"http"`, `"ftp"`)

  When a user defines `"csv.gz"` as a format name, `load_object("csv.gz")` attempts
  to import `gz` from the `csv` module, resulting in a `NameError`.

  ## Solution

  Added a `normalize_keys` parameter to `getwithbase()`:
  - `normalize_keys=True` (default): normalizes keys by loading objects (existing behavior)
  - `normalize_keys=False`: skips normalization for settings where keys are not import paths

  Updated callers to pass `normalize_keys=False`:
  - `FeedExporter._load_components()` for `FEED_EXPORTERS` and `FEED_STORAGES`
  - `DownloadHandlers.__init__()` for `DOWNLOAD_HANDLERS`

  ## Changes

  - `scrapy/settings/__init__.py`: add `normalize_keys` parameter to `getwithbase()`
  - `scrapy/extensions/feedexport.py`: pass `normalize_keys=False`
  - `scrapy/core/downloader/handlers/__init__.py`: pass `normalize_keys=False`
  - `tests/test_settings/__init__.py`: add test for format names with dots
