### PR TITLE
fix(settings): catch NameError in getwithbase() normalize_key

### DIFF
--- a/scrapy/settings/__init__.py
+++ b/scrapy/settings/__init__.py
@@ -348,7 +348,7 @@ class BaseSettings(MutableMapping[_SettingsKey, Any]):
         def normalize_key(key: Any) -> str:
             try:
                 loaded_key = load_object(key)
-            except (AttributeError, TypeError, ValueError):
+            except (AttributeError, NameError, TypeError, ValueError):
                 loaded_key = key
             else:
                 import_path = global_object_name(loaded_key)

--- a/tests/test_settings/__init__.py
+++ b/tests/test_settings/__init__.py
@@ -494,6 +494,28 @@ class TestBaseSettings:
         msg = caplog.records[0].message
         assert "tests.test_settings.Component1" in msg
 
+    def test_getwithbase_dotted_string_keys(self):
+        """getwithbase() must not raise NameError for dotted format string keys.
+
+        FEED_EXPORTERS and similar settings may use dotted strings as dict keys
+        (e.g. "csv.gz", "json.gz").  In 2.15.0 getwithbase() began normalising
+        keys via load_object(), which imports the left-hand side as a module and
+        then tries to look up the right-hand side as an attribute.  For "csv.gz"
+        that raises NameError (``csv`` module has no ``gz`` attribute).
+
+        Regression: https://github.com/scrapy/scrapy/issues/7426
+        """
+        s = BaseSettings()
+        s.set("FEED_EXPORTERS", {"csv.gz": "scrapy.exporters.CsvItemExporter"})
+        s.set(
+            "FEED_EXPORTERS_BASE",
+            {"json": "scrapy.exporters.JsonItemExporter"},
+        )
+        # Should not raise NameError
+        result = s.getwithbase("FEED_EXPORTERS")
+        assert "csv.gz" in result
+        assert "json" in result
+
     def test_getwithbase_invalid_setting_name(self):
         settings = BaseSettings()
         with pytest.raises(


### PR DESCRIPTION
## Summary

Fixes #7426

In 2.15.0, `getwithbase()` began normalising dict keys via `load_object()`. Settings like `FEED_EXPORTERS` can use dotted format strings as keys (e.g. `csv.gz`, `json.gz`) which are not Python import paths.

For a key like `csv.gz`, `load_object()` successfully imports the `csv` module then calls `getattr(csv, 'gz')`, which raises `AttributeError` — but `load_object` deliberately re-raises that as a `NameError`. The inner `normalize_key()` function only caught `(AttributeError, TypeError, ValueError)`, so the `NameError` propagated to the caller.

## Fix

Add `NameError` to the `except` tuple in `normalize_key()`:

`python
# before
except (AttributeError, TypeError, ValueError):
# after
except (AttributeError, NameError, TypeError, ValueError):
`

This restores the pre-2.15.0 behaviour where such keys are used as-is (plain strings) rather than treated as import paths.

## Test

Added `test_getwithbase_dotted_string_keys` to `tests/test_settings/__init__.py` which exercises the exact scenario from the issue (`FEED_EXPORTERS` with `csv.gz` / `json.gz` keys).