### PR TITLE
fix: handle NameError in settings normalize_key for dotted format keys

### DIFF
--- a/scrapy/settings/__init__.py
+++ b/scrapy/settings/__init__.py
@@ -348,7 +348,7 @@ class BaseSettings(MutableMapping[_SettingsKey, Any]):
         def normalize_key(key: Any) -> str:
             try:
                 loaded_key = load_object(key)
-            except (AttributeError, TypeError, ValueError):
+            except (AttributeError, NameError, TypeError, ValueError):
                 loaded_key = key
             else:
                 import_path = global_object_name(loaded_key)


### PR DESCRIPTION
Fixes #7426

`getwithbase()` in `BaseSettings` normalizes dictionary keys by calling `load_object()`. When a key contains dots that are not import paths (e.g. `"csv.gz"` in `FEED_EXPORTERS`), `load_object()` raises `NameError` instead of `AttributeError`. The existing except clause only catches `AttributeError`, `TypeError`, and `ValueError`, so `NameError` propagates and crashes the spider.

Added `NameError` to the except tuple so dotted format keys fall through to the key-as-is path, matching the existing behavior for unresolvable paths.