### PR TITLE
Fix unhandled exception handling in CrawlerRunner._crawl

### DIFF
--- a/scrapy/crawler.py
+++ b/scrapy/crawler.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+from twisted.python.failure import  Failure
 
 import asyncio
 import contextlib
@@ -183,13 +184,26 @@ class Crawler:
             )
         self.crawling = self._started = True
 
+        def _log_crawl_error(failure):
+            logger.error("error in crawler.crawl", 
+                         exc_info= (type(failure.value), failure.value, failure.getTracebackObject()),)
+            return failure
+
         try:
             self.spider = self._create_spider(*args, **kwargs)
             self._apply_settings()
             self._update_root_log_handler()
             self.engine = self._create_engine()
-            yield deferred_from_coro(self.engine.open_spider_async())
+
+            yield  deferred_from_coro(self.engine.open_spider_async())
+             
+
+
             yield deferred_from_coro(self.engine.start_async())
+            
+              
+
+
         except Exception:
             self.crawling = False
             if self.engine is not None:
@@ -451,6 +465,11 @@ class CrawlerRunner(CrawlerRunnerBase):
             )
         crawler = self.create_crawler(crawler_or_spidercls)
         return self._crawl(crawler, *args, **kwargs)
+    
+
+    def _log_crawl_error(self,failure: Failure) -> Failure:
+        logger.error("error during crawl",exc_info=failure)
+        return failure
 
     @inlineCallbacks
     def _crawl(
@@ -462,9 +481,14 @@ class CrawlerRunner(CrawlerRunnerBase):
         failed = False
         try:
             yield d
-        except Exception:
+        except Exception as exc:
             failed = True
-            raise
+            logger.error(
+                "error while crawling %(spider)s",{
+                    "spider": crawler.spidercls.name
+                },
+                exc_info=exc
+            )
         finally:
             self.crawlers.discard(crawler)
             self._active.discard(d)
@@ -575,19 +599,21 @@ class AsyncCrawlerRunner(CrawlerRunnerBase):
         self.crawlers.add(crawler)
 
         async def _crawl_and_track() -> None:
-            try:
                 await crawler.crawl_async(*args, **kwargs)
-            except Exception:
-                self.bootstrap_failed = True
-                raise  # re-raise so asyncio still logs it to stderr naturally
 
         task = loop.create_task(_crawl_and_track())
         self._active.add(task)
+        
 
-        def _done(_: asyncio.Task[None]) -> None:
+        def _done(t: asyncio.Task[None]) -> None:
             self.crawlers.discard(crawler)
             self._active.discard(task)
             self.bootstrap_failed |= not getattr(crawler, "spider", None)
+            if not t.cancelled():
+                exc = t.exception()
+                if exc is not None:
+                    logger.error("error while crawling %(spider)s",
+                                 {"spider":crawler.spidercls.name}, exc_info= exc)
 
         task.add_done_callback(_done)
         return task

--- a/tests/testFailingSpider.py
+++ b/tests/testFailingSpider.py
@@ -1,0 +1,19 @@
+from scrapy import Spider
+from scrapy.crawler import CrawlerProcess
+
+class FailingSpider(Spider):
+    name = "fail"
+
+    def __init__(self,*args, **kwargs):
+        print("parse hit")
+        raise RuntimeError("simulated init error")
+
+if __name__ == "__main__":
+    process = CrawlerProcess(
+        {
+            "TWISTED_REACTOR_ENABLED" : True, "LOG_LEVEL": "DEBUG"
+        }
+    ) 
+    process.crawl(FailingSpider)
+    process.start()
+print("all done")


### PR DESCRIPTION
fixed the issue #6047 
reason was because the caller (process.crawl()) never attached an errback, Twisted itself logged it as error. the fix was to log the error and not re-raise, so that the deferred can be resolved.