### PR TITLE
docs: add Windows note about python -m scrapy to tutorial

### DIFF
--- a/docs/intro/tutorial.rst
+++ b/docs/intro/tutorial.rst
@@ -53,6 +53,13 @@ directory where you'd like to store your code and run::
 
     scrapy startproject tutorial
 
+.. note::
+
+   **Windows users:** If you get an error like ``'scrapy' is not recognized as an
+   internal or external command``, try running ``python -m scrapy startproject tutorial``
+   instead. You can use ``python -m scrapy`` as a replacement for the ``scrapy`` command
+   throughout this tutorial.
+
 This will create a ``tutorial`` directory with the following contents::
 
     tutorial/


### PR DESCRIPTION
Closes #7306

Adds a note in the tutorial docs (`docs/intro/tutorial.rst`) after the `scrapy startproject tutorial` command, informing Windows users that they can use `python -m scrapy` if the `scrapy` command is not recognized.

This is a common issue for Windows users whose PATH does not include the Scripts directory.