### PR TITLE
fix(settings): catch NameError in getwithbase for dotted FEED_EXPORTERS keys

### DIFF
--- a/scrapy/settings/__init__.py
+++ b/scrapy/settings/__init__.py
@@ -348,7 +348,7 @@ class BaseSettings(MutableMapping[_SettingsKey, Any]):
         def normalize_key(key: Any) -> str:
             try:
                 loaded_key = load_object(key)
-            except (AttributeError, TypeError, ValueError):
+            except (AttributeError, TypeError, ValueError, NameError):
                 loaded_key = key
             else:
                 import_path = global_object_name(loaded_key)


### PR DESCRIPTION
Regression in 2.15.0: `FEED_EXPORTERS` keys containing dots (e.g. `"csv.gz"`, `"json.gz"`) raise `NameError` because `load_object` interprets them as `module.attribute` paths.

In `getwithbase` → `normalize_key`, `load_object("csv.gz")` imports the `csv` module and tries `getattr(csv, "gz")`, which raises `NameError`. The except clause only caught `AttributeError`, `TypeError`, and `ValueError`, so `NameError` propagated up.

Fix: add `NameError` to the caught exceptions so dotted format keys are treated as plain strings, matching the behavior before the normalization was added.

Reproduction:
```python
# settings.py
FEED_EXPORTERS = {
    "csv.gz": "scrapy.exporters.CsvItemExporter",
}
```
```log
NameError: Module "csv" doesn't define any object named "gz"
```

Ref: #7426