### PR TITLE
Fix FEED_EXPORTERS keys with dots causing NameError (#7426)

### DIFF
--- a/scrapy/core/downloader/handlers/__init__.py
+++ b/scrapy/core/downloader/handlers/__init__.py
@@ -60,7 +60,7 @@ class DownloadHandlers:
         handlers: dict[str, str | Callable[..., Any]] = without_none_values(
             cast(
                 "dict[str, str | Callable[..., Any]]",
-                crawler.settings.getwithbase("DOWNLOAD_HANDLERS"),
+                crawler.settings.getwithbase("DOWNLOAD_HANDLERS", normalize_keys=False),
             )
         )
         for scheme, clspath in handlers.items():

--- a/scrapy/extensions/feedexport.py
+++ b/scrapy/extensions/feedexport.py
@@ -644,7 +644,10 @@ class FeedExporter:
 
     def _load_components(self, setting_prefix: str) -> dict[str, Any]:
         conf = without_none_values(
-            cast("dict[str, str]", self.settings.getwithbase(setting_prefix))
+            cast(
+                "dict[str, str]",
+                self.settings.getwithbase(setting_prefix, normalize_keys=False),
+            )
         )
         d = {}
         for k, v in conf.items():

--- a/scrapy/settings/__init__.py
+++ b/scrapy/settings/__init__.py
@@ -322,15 +322,30 @@ class BaseSettings(MutableMapping[_SettingsKey, Any]):
             )
         return copy.deepcopy(value)
 
-    def getwithbase(self, name: _SettingsKey) -> BaseSettings:
+    def getwithbase(
+        self, name: _SettingsKey, normalize_keys: bool = True
+    ) -> BaseSettings:
         """Get a composition of a dictionary-like setting and its `_BASE`
         counterpart.
 
         :param name: name of the dictionary-like setting
         :type name: str
+
+        :param normalize_keys: whether to normalize keys by loading objects.
+            Set to False for settings like FEED_EXPORTERS where keys are
+            format names (e.g. 'csv.gz'), not import paths.
+        :type normalize_keys: bool
         """
         if not isinstance(name, str):
             raise ValueError(f"Base setting key must be a string, got {name}")
+
+        if not normalize_keys:
+            # Skip key normalization for settings where keys are not import paths
+            # (e.g., FEED_EXPORTERS, FEED_STORAGES, DOWNLOAD_HANDLERS)
+            result = dict(self[name + "_BASE"] or {})
+            override = dict(self[name] or {})
+            result.update(override)
+            return BaseSettings({k: v for k, v in result.items() if v is not None})
 
         normalized_keys = {}
         obj_keys = set()

--- a/scrapy/utils/conf.py
+++ b/scrapy/utils/conf.py
@@ -153,7 +153,10 @@ def feed_process_params_from_cli(
     suitable to be used as the FEEDS setting.
     """
     valid_output_formats: Iterable[str] = without_none_values(
-        cast("dict[str, str]", settings.getwithbase("FEED_EXPORTERS"))
+        cast(
+            "dict[str, str]",
+            settings.getwithbase("FEED_EXPORTERS", normalize_keys=False),
+        )
     ).keys()
 
     def check_valid_format(output_format: str) -> None:

--- a/tests/test_settings/__init__.py
+++ b/tests/test_settings/__init__.py
@@ -465,6 +465,35 @@ class TestBaseSettings:
             assert isinstance(value, BaseSettings)
             assert dict(value) == expected
 
+    def test_getwithbase_with_normalize_keys_false(self):
+        """Test that format names containing dots (like 'csv.gz') work correctly
+        when normalize_keys=False.
+
+        This addresses the regression from PR #6993 where getwithbase() would
+        incorrectly treat format names as import paths.
+        """
+        settings = BaseSettings()
+        settings["FEED_EXPORTERS_BASE"] = BaseSettings(
+            {
+                "json": "scrapy.exporters.JsonItemExporter",
+                "csv": "scrapy.exporters.CsvItemExporter",
+            }
+        )
+        settings["FEED_EXPORTERS"] = {
+            "csv.gz": "my_exporter.CsvGzipExporter",
+            "json.gz": "my_exporter.JsonGzipExporter",
+        }
+
+        # With normalize_keys=False, keys with dots should work correctly
+        result = settings.getwithbase("FEED_EXPORTERS", normalize_keys=False)
+        assert isinstance(result, BaseSettings)
+        assert "csv.gz" in result
+        assert "json.gz" in result
+        assert "json" in result
+        assert "csv" in result
+        assert result["csv.gz"] == "my_exporter.CsvGzipExporter"
+        assert result["json.gz"] == "my_exporter.JsonGzipExporter"
+
     def test_getwithbase_warns_on_duplicate_import_paths(self, caplog):
         settings = BaseSettings()
         settings["FOO"] = BaseSettings(

--- a/tests/test_utils_conf.py
+++ b/tests/test_utils_conf.py
@@ -105,6 +105,20 @@ class TestFeedExportConfig:
                 Settings(), ["output1.json"], overwrite_output=["output2.json"]
             )
 
+    def test_feed_export_config_with_dotted_format_names(self):
+        """Test that format names containing dots (like 'csv.gz') work correctly
+        in CLI feed processing. This addresses Issue #7426.
+        """
+        settings = Settings()
+        # Override FEED_EXPORTERS to include a format name with a dot
+        settings["FEED_EXPORTERS"] = {
+            "csv.gz": "scrapy.exporters.CsvItemExporter",
+        }
+        # User should explicitly specify format with colon when format contains dots
+        # e.g., scrapy crawl -o output:csv.gz
+        result = feed_process_params_from_cli(settings, ["output:csv.gz"])
+        assert result == {"output": {"format": "csv.gz"}}
+
     def test_feed_complete_default_values_from_settings_empty(self):
         feed = {}
         settings = Settings(


### PR DESCRIPTION
 Fixes #7426

  This is a regression from PR #6993 which added key normalization in
  `getwithbase()`. The problem is that not all `_BASE` settings use
  import paths as keys:

  - `FEED_EXPORTERS` uses format names (e.g. `csv.gz`, `json.gz`)
  - `FEED_STORAGES` uses storage schemes (e.g. `file`, `s3`)
  - `DOWNLOAD_HANDLERS` uses URL schemes (e.g. `http`, `ftp`)

  When a user defines `"csv.gz"` as a format name,
  `load_object("csv.gz")` tries to import `gz` from the `csv` module,
  resulting in a `NameError`.

  ## Solution

  Added a `normalize_keys` parameter to `getwithbase()`:

  - `normalize_keys=True` (default): normalizes keys by loading objects
  (existing behavior)
  - `normalize_keys=False`: skips normalization for settings where keys
  are not import paths

  ## Changes

  - `scrapy/settings/__init__.py`: add `normalize_keys` parameter to
  `getwithbase()`
  - `scrapy/extensions/feedexport.py`: pass `normalize_keys=False` for
  `FEED_EXPORTERS` and `FEED_STORAGES`
  - `scrapy/core/downloader/handlers/__init__.py`: pass
  `normalize_keys=False` for `DOWNLOAD_HANDLERS`
  - `scrapy/utils/conf.py`: pass `normalize_keys=False` in
  `feed_process_params_from_cli()`
  - `tests/test_settings/__init__.py`: add test for format names with
  dots
  - `tests/test_utils_conf.py`: add end-to-end test for CLI feed
  processing

  ## Testing

  - 105 passed in `tests/test_settings/`
  - 40 passed in `tests/test_feedexport.py`
  - 21 passed in `tests/test_downloader_handlers.py`
  - Pre-commit checks pass
  
  This is my first time to do a PR, I'm sorry if I cause some trouble. All want to do is to try my best to fix an issue, thanks for your patience.