### PR TITLE
Fix NameError in getwithbase() for FEED_EXPORTERS keys with dots

### DIFF
--- a/scrapy/settings/__init__.py
+++ b/scrapy/settings/__init__.py
@@ -348,7 +348,7 @@ class BaseSettings(MutableMapping[_SettingsKey, Any]):
         def normalize_key(key: Any) -> str:
             try:
                 loaded_key = load_object(key)
-            except (AttributeError, TypeError, ValueError):
+            except (AttributeError, TypeError, ValueError, NameError):
                 loaded_key = key
             else:
                 import_path = global_object_name(loaded_key)


### PR DESCRIPTION
## Problem

getwithbase() calls load_object() on dict keys. FEED_EXPORTERS uses format string keys like csv.gz which are not import paths. load_object(csv.gz) raises NameError which was not caught, crashing since Scrapy 2.15.0.

## Fix

Add NameError to the except clause in normalize_key(). Non-path keys fall through correctly.

Fixes #7426