### PR TITLE
fix(settings): handle NameError in getwithbase normalize_key for non-class keys

### DIFF
--- a/scrapy/settings/__init__.py
+++ b/scrapy/settings/__init__.py
@@ -348,7 +348,7 @@ class BaseSettings(MutableMapping[_SettingsKey, Any]):
         def normalize_key(key: Any) -> str:
             try:
                 loaded_key = load_object(key)
-            except (AttributeError, TypeError, ValueError):
+            except (AttributeError, NameError, TypeError, ValueError):
                 loaded_key = key
             else:
                 import_path = global_object_name(loaded_key)


### PR DESCRIPTION
## Summary

FEED_EXPORTERS and similar settings with `_BASE` counterparts use string format identifiers as dictionary keys (e.g. `'csv.gz'`, `'json.gz'`), not import paths. The `getwithbase()` method introduced in 2.15.0 normalizes keys by calling `load_object(key)`, which treats dots in these keys as module paths and raises `NameError` when it cannot resolve them (e.g. trying to load `'gz'` from module `'csv'`).

`NameError` was not in the exception handler, so it propagated up and crashed with:

```
NameError: Module 'csv' doesn't define any object named 'gz'
```

## Fix

Add `NameError` to the exception tuple in `normalize_key()`. When `load_object()` fails to resolve a key (whether due to missing attribute, bad type, or unresolved name), the key is treated as a plain string identifier — which is the correct behavior for settings like FEED_EXPORTERS whose keys are format names, not class paths.

**Change:** 1 line added to exception handler

Fixes #7426