### PR TITLE
fix(tests): make test_utf16 endian-agnostic

### DIFF
--- a/tests/test_http_response_text.py
+++ b/tests/test_http_response_text.py
@@ -156,12 +156,16 @@ class TestTextResponse(TestResponse):
 
     def test_utf16(self):
         """Test utf-16 because UnicodeDammit is known to have problems with"""
+        body = b"\xff\xfeh\x00i\x00"
         r = self.response_class(
             "http://www.example.com",
-            body=b"\xff\xfeh\x00i\x00",
+            body=body,
             encoding="utf-16",
         )
-        self._assert_response_values(r, "utf-16", "hi")
+        # Pass the body as bytes so the assertion does not re-encode "hi" with
+        # the host's native UTF-16 byte order, which would break this test on
+        # big-endian architectures (see scrapy/scrapy#5954).
+        self._assert_response_values(r, "utf-16", body)
 
     def test_invalid_utf8_encoded_body_with_valid_utf8_BOM(self):
         r6 = self.response_class(


### PR DESCRIPTION
Closes #5954

<!-- Drafted by an agent run; please review carefully before merging. -->

## Repo
scrapy/scrapy

## Issue
https://github.com/scrapy/scrapy/issues/5954

## Root cause
`tests/test_http_response_text.py::test_utf16` builds a `TextResponse`
with a hard-coded UTF-16 LE body (`b"\xff\xfeh\x00i\x00"`), but the
helper `_assert_response_values(r, "utf-16", "hi")` re-encodes the
unicode string `"hi"` using `str.encode("utf-16")`, which emits bytes in
the host's native byte order. On big-endian architectures (e.g. Debian
s390x) this produced `b"\xfe\xff\x00h\x00i"` and the assertion against
the LE body failed.

## Fix
Pass the body as bytes to `_assert_response_values` so the helper
decodes via the BOM-aware UTF-16 codec rather than re-encoding the
string with the host's native byte order. The runtime UTF-16 decoding in
`TextResponse` was already endian-correct via the BOM; only the test
needed adjustment.

## Regression test
`tests/test_http_response_text.py::TextResponseTest::test_utf16`
(and the same test inherited by `HtmlResponseTest` /
`XmlResponseTest`). It now asserts that `response.body` equals the
original LE-encoded bytes and `response.text` equals `"hi"` regardless
of host endianness.

## Risk
trivial

## Verification
Ran `python3 -m pytest tests/test_http_response_text.py -k test_utf16 -p no:dash`
on macOS (little-endian): 4 passed. Logic verified against simulated
big-endian byte order: old assertion would have compared
`b"\xfe\xff\x00h\x00i"` against `b"\xff\xfeh\x00i\x00"` (fail); new
assertion compares the body to itself (pass).
