### PR TITLE
[docs] Add Windows note for python -m scrapy alternative in tutorial

### DIFF
--- a/docs/intro/tutorial.rst
+++ b/docs/intro/tutorial.rst
@@ -53,6 +53,14 @@ directory where you'd like to store your code and run::
 
     scrapy startproject tutorial
 
+.. note::
+   On Windows, if running the ``scrapy`` command fails with an error like
+   ``'scrapy' is not recognized as an internal or external command``,
+   make sure you followed the :ref:`intro-install-windows` instructions so that the
+   Python ``Scripts`` directory is on your ``PATH``.
+   As a workaround, you can use ``python -m scrapy`` instead, e.g.
+   ``python -m scrapy startproject tutorial``.
+
 This will create a ``tutorial`` directory with the following contents::
 
     tutorial/


### PR DESCRIPTION
Resolves #7306

Windows users following the tutorial may see 'scrapy' is not recognized as an internal or external command when running the scrapy command-line tool (e.g. if the Python Scripts directory is not on PATH). The tutorial currently does not mention this.

This PR adds a short note to the “Creating a project” section linking to the Windows installation instructions (PATH) and mentioning python -m scrapy as a workaround.

Test plan:
tox -e docs