### PR TITLE
Add deny_tags and deny_attrs parameters to LxmlLinkExtractor

### DIFF
--- a/scrapy/linkextractors/lxmlhtml.py
+++ b/scrapy/linkextractors/lxmlhtml.py
@@ -66,6 +66,8 @@ class LxmlParserLinkExtractor:
         unique: bool = False,
         strip: bool = True,
         canonicalized: bool = False,
+        deny_tag: Callable[[str], bool] | None = None,
+        deny_attr: Callable[[str], bool] | None = None,
     ):
         # mypy doesn't infer types for operator.* and also for partial()
         self.scan_tag: Callable[[str], bool] = (
@@ -88,6 +90,8 @@ class LxmlParserLinkExtractor:
             if canonicalized
             else _canonicalize_link_url
         )
+        self.deny_tag: Callable[[str], bool] | None = deny_tag
+        self.deny_attr: Callable[[str], bool] | None = deny_attr
 
     def _iter_links(
         self, document: HtmlElement
@@ -95,9 +99,13 @@ class LxmlParserLinkExtractor:
         for el in document.iter(etree.Element):
             if not self.scan_tag(_nons(el.tag)):
                 continue
+            if self.deny_tag and self.deny_tag(_nons(el.tag)):
+                continue
             attribs = el.attrib
             for attrib in attribs:
                 if not self.scan_attr(attrib):
+                    continue
+                if self.deny_attr and self.deny_attr(attrib):
                     continue
                 yield el, attrib, attribs[attrib]
 
@@ -173,6 +181,8 @@ class LxmlLinkExtractor:
         restrict_xpaths: str | Iterable[str] = (),
         tags: str | Iterable[str] = ("a", "area"),
         attrs: str | Iterable[str] = ("href",),
+        deny_tags: str | Iterable[str] = (),
+        deny_attrs: str | Iterable[str] = (),
         canonicalize: bool = False,
         unique: bool = True,
         process_value: Callable[[Any], Any] | None = None,
@@ -182,6 +192,8 @@ class LxmlLinkExtractor:
         restrict_text: _RegexOrSeveral | None = None,
     ):
         tags, attrs = set(arg_to_iter(tags)), set(arg_to_iter(attrs))
+        deny_tags_set = set(arg_to_iter(deny_tags))
+        deny_attrs_set = set(arg_to_iter(deny_attrs))
         self.link_extractor = LxmlParserLinkExtractor(
             tag=partial(operator.contains, tags),
             attr=partial(operator.contains, attrs),
@@ -189,6 +201,8 @@ class LxmlLinkExtractor:
             process=process_value,
             strip=strip,
             canonicalized=not canonicalize,
+            deny_tag=partial(operator.contains, deny_tags_set) if deny_tags_set else None,
+            deny_attr=partial(operator.contains, deny_attrs_set) if deny_attrs_set else None,
         )
         self.allow_res: list[re.Pattern[str]] = self._compile_regexes(allow)
         self.deny_res: list[re.Pattern[str]] = self._compile_regexes(deny)

--- a/tests/test_deny_tags_attrs.py
+++ b/tests/test_deny_tags_attrs.py
@@ -1,0 +1,197 @@
+"""
+Tests for deny_tags and deny_attrs parameters in LxmlLinkExtractor.
+Related to GitHub issue #6321.
+"""
+
+import pytest
+from scrapy.http import HtmlResponse
+from scrapy.linkextractors import LinkExtractor
+
+
+def make_response(html: str, url: str = "http://example.com") -> HtmlResponse:
+    return HtmlResponse(url=url, body=html.encode("utf-8"))
+
+
+class TestDenyTags:
+    def test_deny_tags_excludes_matching_tag(self):
+        """Links inside a denied tag should not be extracted."""
+        html = """
+        <html><body>
+            <a href="http://example.com/keep">keep this</a>
+            <script src="http://example.com/script-link">script</script>
+        </body></html>
+        """
+        le = LinkExtractor(tags=["a", "script"], attrs=["href", "src"], deny_tags=["script"])
+        response = make_response(html)
+        links = [l.url for l in le.extract_links(response)]
+        assert "http://example.com/keep" in links
+        assert "http://example.com/script-link" not in links
+
+    def test_deny_tags_single_string(self):
+        """deny_tags should accept a single string, not just a list."""
+        html = """
+        <html><body>
+            <a href="http://example.com/keep">keep</a>
+            <script src="http://example.com/skip">skip</script>
+        </body></html>
+        """
+        le = LinkExtractor(tags=["a", "script"], attrs=["href", "src"], deny_tags="script")
+        response = make_response(html)
+        links = [l.url for l in le.extract_links(response)]
+        assert "http://example.com/keep" in links
+        assert "http://example.com/skip" not in links
+
+    def test_deny_tags_multiple(self):
+        """Multiple tags can be denied at once."""
+        html = """
+        <html><body>
+            <a href="http://example.com/keep">keep</a>
+            <script src="http://example.com/skip-script">skip</script>
+            <iframe src="http://example.com/skip-iframe">skip</iframe>
+        </body></html>
+        """
+        le = LinkExtractor(
+            tags=["a", "script", "iframe"],
+            attrs=["href", "src"],
+            deny_tags=["script", "iframe"],
+        )
+        response = make_response(html)
+        links = [l.url for l in le.extract_links(response)]
+        assert "http://example.com/keep" in links
+        assert "http://example.com/skip-script" not in links
+        assert "http://example.com/skip-iframe" not in links
+
+    def test_deny_tags_empty_default(self):
+        """With no deny_tags set, all matching tags should be extracted normally."""
+        html = """
+        <html><body>
+            <a href="http://example.com/one">one</a>
+            <a href="http://example.com/two">two</a>
+        </body></html>
+        """
+        le = LinkExtractor()
+        response = make_response(html)
+        links = [l.url for l in le.extract_links(response)]
+        assert "http://example.com/one" in links
+        assert "http://example.com/two" in links
+
+    def test_deny_tags_does_not_affect_other_tags(self):
+        """Denying one tag should not affect links from other tags."""
+        html = """
+        <html><body>
+            <a href="http://example.com/a-link">a link</a>
+            <area href="http://example.com/area-link">
+            <script src="http://example.com/script-link">script</script>
+        </body></html>
+        """
+        le = LinkExtractor(
+            tags=["a", "area", "script"],
+            attrs=["href", "src"],
+            deny_tags=["script"],
+        )
+        response = make_response(html)
+        links = [l.url for l in le.extract_links(response)]
+        assert "http://example.com/a-link" in links
+        assert "http://example.com/area-link" in links
+        assert "http://example.com/script-link" not in links
+
+
+class TestDenyAttrs:
+    def test_deny_attrs_excludes_matching_attr(self):
+        """Links found via a denied attribute should not be extracted."""
+        html = """
+        <html><body>
+            <a href="http://example.com/keep">keep</a>
+            <a data-url="http://example.com/skip">skip</a>
+        </body></html>
+        """
+        le = LinkExtractor(attrs=["href", "data-url"], deny_attrs=["data-url"])
+        response = make_response(html)
+        links = [l.url for l in le.extract_links(response)]
+        assert "http://example.com/keep" in links
+        assert "http://example.com/skip" not in links
+
+    def test_deny_attrs_single_string(self):
+        """deny_attrs should accept a single string."""
+        html = """
+        <html><body>
+            <a href="http://example.com/keep">keep</a>
+            <a data-url="http://example.com/skip">skip</a>
+        </body></html>
+        """
+        le = LinkExtractor(attrs=["href", "data-url"], deny_attrs="data-url")
+        response = make_response(html)
+        links = [l.url for l in le.extract_links(response)]
+        assert "http://example.com/keep" in links
+        assert "http://example.com/skip" not in links
+
+    def test_deny_attrs_multiple(self):
+        """Multiple attributes can be denied at once."""
+        html = """
+        <html><body>
+            <a href="http://example.com/keep">keep</a>
+            <a data-url="http://example.com/skip1">skip1</a>
+            <a data-href="http://example.com/skip2">skip2</a>
+        </body></html>
+        """
+        le = LinkExtractor(
+            attrs=["href", "data-url", "data-href"],
+            deny_attrs=["data-url", "data-href"],
+        )
+        response = make_response(html)
+        links = [l.url for l in le.extract_links(response)]
+        assert "http://example.com/keep" in links
+        assert "http://example.com/skip1" not in links
+        assert "http://example.com/skip2" not in links
+
+    def test_deny_attrs_empty_default(self):
+        """With no deny_attrs, all matching attrs are extracted normally."""
+        html = """
+        <html><body>
+            <a href="http://example.com/one">one</a>
+            <a href="http://example.com/two">two</a>
+        </body></html>
+        """
+        le = LinkExtractor()
+        response = make_response(html)
+        links = [l.url for l in le.extract_links(response)]
+        assert len(links) == 2
+
+
+class TestDenyTagsAndDenyAttrsTogether:
+    def test_deny_tags_and_deny_attrs_combined(self):
+        """Both deny_tags and deny_attrs should work together independently."""
+        html = """
+        <html><body>
+            <a href="http://example.com/keep">keep</a>
+            <script src="http://example.com/skip-tag">skip by tag</script>
+            <a data-url="http://example.com/skip-attr">skip by attr</a>
+        </body></html>
+        """
+        le = LinkExtractor(
+            tags=["a", "script"],
+            attrs=["href", "src", "data-url"],
+            deny_tags=["script"],
+            deny_attrs=["data-url"],
+        )
+        response = make_response(html)
+        links = [l.url for l in le.extract_links(response)]
+        assert "http://example.com/keep" in links
+        assert "http://example.com/skip-tag" not in links
+        assert "http://example.com/skip-attr" not in links
+
+    def test_backward_compatibility(self):
+        """Existing behavior with no deny_tags or deny_attrs must be unchanged."""
+        html = """
+        <html><body>
+            <a href="http://example.com/page1">page1</a>
+            <a href="http://example.com/page2">page2</a>
+            <area href="http://example.com/area">area</area>
+        </body></html>
+        """
+        le = LinkExtractor()
+        response = make_response(html)
+        links = [l.url for l in le.extract_links(response)]
+        assert "http://example.com/page1" in links
+        assert "http://example.com/page2" in links
+        assert "http://example.com/area" in links


### PR DESCRIPTION
Closes #6321

## Summary

Add `deny_tags` and `deny_attrs` parameters to `LxmlLinkExtractor` and
`LxmlParserLinkExtractor`. This allows users to exclude links found in
specific HTML tags or via specific attributes, without having to
enumerate every tag/attribute they want to keep.

## Motivation

Currently, users who want broad link extraction with only a few
exclusions must explicitly list every tag and attribute to include.
This is tedious and fragile. The new parameters mirror the existing
`allow`/`deny` pattern already used for URL filtering in Scrapy.

## Usage example

```python
# Exclude links found inside <script> tags or via data-url attributes
le = LinkExtractor(deny_tags=['script'], deny_attrs=['data-url'])
```

## Changes

- `LxmlParserLinkExtractor`: added `deny_tag` and `deny_attr` callable
  parameters; updated `_iter_links` to skip denied tags and attributes
- `LxmlLinkExtractor`: added `deny_tags` and `deny_attrs` parameters
  (accept string or iterable, consistent with existing `tags`/`attrs`)
- Added 11 tests covering deny_tags, deny_attrs, combined use, single
  string input, multiple values, and backward compatibility