### PR TITLE
docs: add Windows note for 'scrapy' command in tutorial

### DIFF
--- a/docs/intro/tutorial.rst
+++ b/docs/intro/tutorial.rst
@@ -53,6 +53,14 @@ directory where you'd like to store your code and run::
 
     scrapy startproject tutorial
 
+.. note::
+   On **Windows**, if you get an error like ``'scrapy' is not recognized as an
+   internal or external command``, you can use ``python -m scrapy`` instead::
+
+       python -m scrapy startproject tutorial
+
+   This runs Scrapy as a Python module and avoids common PATH-related issues.
+
 This will create a ``tutorial`` directory with the following contents::
 
     tutorial/


### PR DESCRIPTION
## Summary

On Windows, the `scrapy` command may not be recognized due to PATH issues or multiple Python installations. This adds a callout note in the tutorial suggesting `python -m scrapy` as an alternative.

## Changes

- Added a `.. note::` directive after the `scrapy startproject` command in the tutorial docs

Closes #7306

## Checklist

- [x] I have read the [contribution guidelines](https://docs.scrapy.org/en/master/contributing.html)
- [x] I have updated the documentation accordingly
- [x] All new and existing tests passed