### PR TITLE
Fix: lowercase READTHEDOCS_CANONICAL_URL for sitemap (#7463)

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -75,7 +75,7 @@ html_context = {
 }
 
 # Set canonical URL from the Read the Docs Domain
-html_baseurl = os.environ.get("READTHEDOCS_CANONICAL_URL", "")
+html_baseurl = os.environ.get("READTHEDOCS_CANONICAL_URL", "").lower()
 
 # -- Options for LaTeX output ------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-latex-output


### PR DESCRIPTION
lower cased READTHEDOCS_CANONICAL_URL for sitemap