### PR TITLE
docs: add Windows note for python -m scrapy alternative in tutorial

### DIFF
--- a/docs/intro/tutorial.rst
+++ b/docs/intro/tutorial.rst
@@ -53,6 +53,15 @@ directory where you'd like to store your code and run::
 
     scrapy startproject tutorial
 
+.. note:: **Windows users**
+    If you see ``'scrapy' is not recognized as an internal or external command``,
+    you can use ``python -m scrapy`` instead::
+
+        python -m scrapy startproject tutorial
+
+    This is often needed when the ``Scripts`` directory is not in your ``PATH``
+    or when you have multiple Python installations.
+
 This will create a ``tutorial`` directory with the following contents::
 
     tutorial/


### PR DESCRIPTION
## What

Add a short note to the tutorial's "Creating a project" section for Windows users who may encounter the `scrapy` command not being recognized.

## Why

On Windows, the `scrapy` command may not work out-of-the-box for some users, often due to the `Scripts` folder not being in `PATH` or issues with multiple Python installations. Many newcomers run into this during the project creation step.

## Changes

Added a `.. note::` directive after the first `scrapy startproject` command recommending `python -m scrapy` as an alternative:

```
.. note:: **Windows users**
    If you see 'scrapy' is not recognized as an internal or external command,
    you can use python -m scrapy instead::

        python -m scrapy startproject tutorial
```

Fixes #7306