### PR TITLE
Docs: Add Windows note for scrapy alternative command #7306

### DIFF
--- a/docs/intro/tutorial.rst
+++ b/docs/intro/tutorial.rst
@@ -47,6 +47,9 @@ as well as the `suggested resources in the learnpython-subreddit`_.
 
 Creating a project
 ==================
+.. note::
+   If you are on Windows and the ``scrapy`` command doesn't work, 
+   try using ``python -m scrapy`` instead.
 
 Before you start scraping, you will have to set up a new Scrapy project. Enter a
 directory where you'd like to store your code and run::


### PR DESCRIPTION
This PR addresses issue #7306 by adding a note for Windows users. It clarifies the need to use python -m scrapy instead of just scrapy in certain environments. This ensures the tutorial is accessible to all users as discussed in the issue tracker.