### PR TITLE
Add tests for MemoryUsage extension (#7002)

### DIFF
--- a/tests/test_extension_memusage.py
+++ b/tests/test_extension_memusage.py
@@ -1,0 +1,66 @@
+import sys
+import unittest
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from scrapy.exceptions import NotConfigured
+from scrapy.extensions.memusage import MemoryUsage
+from scrapy.utils.test import get_crawler
+
+
+@pytest.mark.skipif(
+    sys.platform == "win32", reason="resource module not available on Windows"
+)
+class MemoryUsageExtensionTest(unittest.TestCase):
+    def test_extension_disabled_by_default(self):
+        crawler = get_crawler(settings_dict={"MEMUSAGE_ENABLED": False})
+        with pytest.raises(NotConfigured):
+            MemoryUsage(crawler)
+
+    def test_extension_enabled(self):
+        crawler = get_crawler(settings_dict={"MEMUSAGE_ENABLED": True})
+        ext = MemoryUsage(crawler)
+        assert not ext.warned
+
+    @patch("scrapy.extensions.memusage.MemoryUsage.get_virtual_size")
+    def test_check_warning_reached(self, mock_get_virtual_size):
+        crawler = get_crawler(
+            settings_dict={
+                "MEMUSAGE_ENABLED": True,
+                "MEMUSAGE_WARNING_MB": 10,
+            }
+        )
+        ext = MemoryUsage(crawler)
+        crawler.stats = MagicMock()
+        crawler.signals = MagicMock()
+
+        mock_get_virtual_size.return_value = 15 * 1024 * 1024
+
+        ext._check_warning()
+
+        crawler.stats.set_value.assert_any_call("memusage/warning_reached", 1)
+        assert ext.warned
+
+    @patch("scrapy.extensions.memusage.MemoryUsage.get_virtual_size")
+    @patch("scrapy.extensions.memusage._schedule_coro")
+    def test_check_limit_reached(self, mock_schedule_coro, mock_get_virtual_size):
+        crawler = get_crawler(
+            settings_dict={
+                "MEMUSAGE_ENABLED": True,
+                "MEMUSAGE_LIMIT_MB": 20,
+            }
+        )
+        ext = MemoryUsage(crawler)
+        crawler.stats = MagicMock()
+        crawler.engine = MagicMock()
+        crawler.engine.spider = MagicMock()
+
+        mock_get_virtual_size.return_value = 25 * 1024 * 1024
+
+        ext._check_limit()
+
+        crawler.stats.set_value.assert_any_call("memusage/limit_reached", 1)
+        crawler.engine.close_spider_async.assert_called_once_with(
+            reason="memusage_exceeded"
+        )


### PR DESCRIPTION
## What does this PR do?
This PR adds unit tests for `scrapy.extensions.memusage.MemoryUsage`. It checks initialization, warning thresholds, and limit enforcement using `unittest.mock`.
I know some Devs did it before me and with more tests, but that's what I was capable off.
All 4 tests pass.

## Why is this change needed?
Resolves #7002 to improve test coverage for extensions.

## How to test?
tox -e py312 -- tests/test_extension_memusage.py
I tested it this way. If it's not right, contact me so I can learn.

## Disclaimer
Disclaimer: this contribution is part of work carried out as a student at Université Paris-Cité. 
Apologies if this is inappropriate or if the contribution does not meet the project’s standards 
— any feedback is welcome.


Resolves https://github.com/scrapy/scrapy/issues/7002