### PR TITLE
Fix scrapy genspider --edit failing with ModuleNotFoundError

### DIFF
--- a/scrapy/commands/genspider.py
+++ b/scrapy/commands/genspider.py
@@ -118,9 +118,13 @@ class Command(ScrapyCommand):
 
         template_file = self._find_template(opts.template)
         if template_file:
-            self._genspider(module, name, url, opts.template, template_file)
+            spider_file = self._genspider(
+                module, name, url, opts.template, template_file
+            )
             if opts.edit:
-                self.exitcode = os.system(f'scrapy edit "{name}"')  # noqa: S605
+                self.exitcode = os.system(  # noqa: S605
+                    f'{self.settings["EDITOR"]} "{spider_file}"'
+                )
 
     def _generate_template_variables(
         self,
@@ -148,8 +152,9 @@ class Command(ScrapyCommand):
         url: str,
         template_name: str,
         template_file: str | os.PathLike,
-    ) -> None:
-        """Generate the spider module, based on the given template"""
+    ) -> str:
+        """Generate the spider module, based on the given template, and return
+        the path of the generated file."""
         assert self.settings is not None
         tvars = self._generate_template_variables(module, name, url, template_name)
         if self.settings.get("NEWSPIDER_MODULE"):
@@ -168,6 +173,7 @@ class Command(ScrapyCommand):
         )
         if spiders_module:
             print(f"in module:\n  {spiders_module.__name__}.{module}")
+        return spider_file
 
     def _find_template(self, template: str) -> Path | None:
         template_file = Path(self.templates_dir, f"{template}.tmpl")

--- a/tests/test_command_genspider.py
+++ b/tests/test_command_genspider.py
@@ -63,6 +63,22 @@ class TestGenspiderCommand(TestProjectBase):
         assert call("genspider", "--dump=basic", cwd=proj_path) == 0
         assert call("genspider", "-d", "basic", cwd=proj_path) == 0
 
+    def test_edit(self, proj_path: Path) -> None:
+        spider_file = proj_path / self.project_name / "spiders" / "test_edit.py"
+        assert (
+            call(
+                "genspider",
+                "-s",
+                "EDITOR=echo",
+                "--edit",
+                "test_edit",
+                "example.com",
+                cwd=proj_path,
+            )
+            == 0
+        )
+        assert spider_file.exists()
+
     def test_same_name_as_project(self, proj_path: Path) -> None:
         assert call("genspider", self.project_name, cwd=proj_path) == 2
         assert not (
@@ -167,6 +183,22 @@ class TestGenspiderStandaloneCommand:
     def test_generate_standalone_spider(self, tmp_path: Path) -> None:
         call("genspider", "example", "example.com", cwd=tmp_path)
         assert Path(tmp_path, "example.py").exists()
+
+    def test_edit(self, tmp_path: Path) -> None:
+        spider_file = tmp_path / "test_edit.py"
+        assert (
+            call(
+                "genspider",
+                "-s",
+                "EDITOR=echo",
+                "--edit",
+                "test_edit",
+                "example.com",
+                cwd=tmp_path,
+            )
+            == 0
+        )
+        assert spider_file.exists()
 
     @pytest.mark.parametrize("force", [True, False])
     def test_same_name_as_existing_file(self, force: bool, tmp_path: Path) -> None:


### PR DESCRIPTION
## What the bug is

Running `scrapy genspider --edit name domain` inside a Scrapy project fails with `ModuleNotFoundError: No module named 'proj'`. The spider is created successfully, but the editor never opens. Running the two steps separately (`scrapy genspider name domain` then `scrapy edit name`) works fine.

## Root cause

In `scrapy/commands/genspider.py`, the `--edit` path called:

```python
self.exitcode = os.system(f'scrapy edit "{name}"')
```

This spawns a subprocess that inherits `SCRAPY_SETTINGS_MODULE` from the parent's environment. Because the env var is already set, `get_project_settings()` skips `init_env()` — the function responsible for appending the project directory to `sys.path`. Without that path, the subprocess cannot import the settings module.

## Fix

Remove the subprocess entirely. `_genspider()` already knows the path of the file it just created; return it and open it directly with `self.settings["EDITOR"]`, mirroring the pattern in `scrapy/commands/edit.py`.

This also fixes `genspider --edit` run outside a project, which previously failed because the `edit` command is filtered out when `requires_project = True` and no project is active.

## Changes

- `scrapy/commands/genspider.py`: `_genspider` now returns the spider file path; the `--edit` handler opens it directly instead of shelling out to `scrapy edit`.
- `tests/test_command_genspider.py`: two regression tests added — `TestGenspiderCommand.test_edit` (in-project) and `TestGenspiderStandaloneCommand.test_edit` (standalone), both previously failing.

Closes #7260