### PR TITLE
docs: add Windows PATH note for scrapy startproject

### DIFF
--- a/docs/intro/tutorial.rst
+++ b/docs/intro/tutorial.rst
@@ -53,6 +53,15 @@ directory where you'd like to store your code and run::
 
     scrapy startproject tutorial
 
+.. note::
+
+   **Windows users:** If you see ``'scrapy' is not recognized as an internal or
+   external command``, use ``python -m scrapy`` instead::
+
+       python -m scrapy startproject tutorial
+
+   This typically happens when Python's ``Scripts`` folder is not on your PATH.
+
 This will create a ``tutorial`` directory with the following contents::
 
     tutorial/


### PR DESCRIPTION
## Summary

- Adds a `.. note::` block in `docs/intro/tutorial.rst` immediately after the `scrapy startproject tutorial` command.
- The note explains that Windows users who see `'scrapy' is not recognized` can use `python -m scrapy` instead, and tells them why (Python's `Scripts` folder not on PATH).

## Test plan

- [ ] Build docs locally (`tox -e docs`) and confirm the note renders correctly in the *Creating a project* section.
- [ ] Confirm surrounding content (the directory-tree block that follows) is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)