### PR TITLE
Pin pyOpenSSL to the versions allowing mutable contexts.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,8 @@ dependencies = [
     "packaging",
     "parsel>=1.5.0",
     "protego>=0.1.15",
-    "pyOpenSSL>=22.0.0",
+    # pyOpenSSL pinned until Twisted with immutable contexts is released and supported in Scrapy
+    "pyOpenSSL>=22.0.0,<26.2.0",
     "queuelib>=1.4.2",
     "service_identity>=18.1.0",
     "tldextract",


### PR DESCRIPTION
26.2.0 released today makes changing the context after making a connection an error, so at least some of our tests break due to Twisted not being fixed yet.