### PR TITLE
Fix FeedExporter exception with Path objects containing URI parameters

### DIFF
--- a/scrapy/extensions/feedexport.py
+++ b/scrapy/extensions/feedexport.py
@@ -479,10 +479,12 @@ class FeedExporter:
         # 'FEEDS' setting takes precedence over 'FEED_URI'
         for settings_uri, feed_options in self.settings.getdict("FEEDS").items():
             # handle pathlib.Path objects
+            # Use str() to preserve %-format characters (e.g. %(time)s)
+            # that as_uri() would URL-encode and break
             uri = (
                 str(settings_uri)
                 if not isinstance(settings_uri, Path)
-                else settings_uri.absolute().as_uri()
+                else str(settings_uri.absolute())
             )
             self.feeds[uri] = feed_complete_default_values_from_settings(
                 feed_options, self.settings


### PR DESCRIPTION
## Summary

Fixes #6425

When using a `pathlib.Path` object as a key in the `FEEDS` setting that contains URI parameters (e.g., `%(time)s`), the `FeedExporter` would crash because `Path.absolute().as_uri()` URL-encodes the `%` format characters.

For example:
- `Path('./%(time)s.csv')` → `as_uri()` produces `file:///path/%25%28time%29s.csv`
- The `%(time)s` format string is lost, and `uri % uri_params` fails

## Fix

Use `str(Path.absolute())` instead of `Path.absolute().as_uri()` to preserve the `%`-format characters. `FileFeedStorage` already handles raw paths correctly (falls through to using the URI directly as a file path when it doesn't start with `file:`).

## Testing

Verified that:
```python
from pathlib import Path
p = Path('./%(time)s.csv').absolute()
str(p)  # '/path/%(time)s.csv' ✓ (format chars preserved)
p.as_uri()  # 'file:///path/%25%28time%29s.csv' ✗ (format chars broken)
```