### PR TITLE
Explanatory error in case `from_crawler` classmethod is not implemented but constructor still requires a crawler

### DIFF
--- a/scrapy/utils/misc.py
+++ b/scrapy/utils/misc.py
@@ -208,14 +208,27 @@ def build_from_crawler(
     Raises ``TypeError`` if the resulting instance is ``None``.
     """
     if hasattr(objcls, "from_crawler"):
+        raise TypeError()
         instance = objcls.from_crawler(crawler, *args, **kwargs)
         method_name = "from_crawler"
     else:
+        #before instantiating the object, inspect the arguments of the constructor
+        if _is_crawler_required_to_construct(objcls):
+            raise TypeError(f"{objcls.__qualname__} constructor requires a crawler but no \"from_crawler\" classmethod is implemented for it. We suggest you implement it")
         instance = objcls(*args, **kwargs)
+        # NOTE: in most download handlers the __init__ seems to be used instead of __new__
         method_name = "__new__"
     if instance is None:
         raise TypeError(f"{objcls.__qualname__}.{method_name} returned None")
     return instance
+
+
+def _is_crawler_required_to_construct(objcls: Any) -> bool:
+    """Returns True in case a crawler object is required by the class' constructor    
+    """
+    # the codeline below assumes that the constructor will be invoked using __init__, also a check on __new__ would be necessary
+    fargs = inspect.getfullargspec(objcls.__init__)
+    return "crawler" in fargs.args
 
 
 @contextmanager

--- a/scrapy/utils/misc.py
+++ b/scrapy/utils/misc.py
@@ -210,24 +210,18 @@ def build_from_crawler(
     if hasattr(objcls, "from_crawler"):
         instance = objcls.from_crawler(crawler, *args, **kwargs)
         method_name = "from_crawler"
-    # before instantiating the object, inspect the arguments of the constructor
-    if _is_crawler_required_to_construct(objcls):
+    # before instantiating the object, inspect the arguments of the constructor,
+    # in case the crawler is required but no from_crawler method is implemented
+    # then an exception shall be raised
+    elif "crawler" in inspect.getfullargspec(objcls.__init__):
         raise TypeError(
             f'{objcls.__qualname__} constructor requires a crawler but no "from_crawler" classmethod is implemented for it. We suggest you implement it'
         )
     instance = objcls(*args, **kwargs)
-    # NOTE: in most download handlers the __init__ seems to be used instead of __new__
     method_name = "__new__"
     if instance is None:
         raise TypeError(f"{objcls.__qualname__}.{method_name} returned None")
     return instance
-
-
-def _is_crawler_required_to_construct(objcls: Any) -> bool:
-    """Returns True in case a crawler object is required by the class' constructor"""
-    # the codeline below assumes that the constructor will be invoked using __init__, also a check on __new__ would be necessary
-    fargs = inspect.getfullargspec(objcls.__init__)
-    return "crawler" in fargs.args
 
 
 @contextmanager

--- a/scrapy/utils/misc.py
+++ b/scrapy/utils/misc.py
@@ -213,12 +213,13 @@ def build_from_crawler(
     # before instantiating the object, inspect the arguments of the constructor,
     # in case the crawler is required but no from_crawler method is implemented
     # then an exception shall be raised
-    elif "crawler" in inspect.getfullargspec(objcls.__init__):
+    elif "crawler" in inspect.getfullargspec(objcls.__init__).args:
         raise TypeError(
             f'{objcls.__qualname__} constructor requires a crawler but no "from_crawler" classmethod is implemented for it. We suggest you implement it'
         )
-    instance = objcls(*args, **kwargs)
-    method_name = "__new__"
+    else:
+        instance = objcls(*args, **kwargs)
+        method_name = "__new__"
     if instance is None:
         raise TypeError(f"{objcls.__qualname__}.{method_name} returned None")
     return instance

--- a/scrapy/utils/misc.py
+++ b/scrapy/utils/misc.py
@@ -208,24 +208,23 @@ def build_from_crawler(
     Raises ``TypeError`` if the resulting instance is ``None``.
     """
     if hasattr(objcls, "from_crawler"):
-        raise TypeError()
         instance = objcls.from_crawler(crawler, *args, **kwargs)
         method_name = "from_crawler"
-    else:
-        #before instantiating the object, inspect the arguments of the constructor
-        if _is_crawler_required_to_construct(objcls):
-            raise TypeError(f"{objcls.__qualname__} constructor requires a crawler but no \"from_crawler\" classmethod is implemented for it. We suggest you implement it")
-        instance = objcls(*args, **kwargs)
-        # NOTE: in most download handlers the __init__ seems to be used instead of __new__
-        method_name = "__new__"
+    # before instantiating the object, inspect the arguments of the constructor
+    if _is_crawler_required_to_construct(objcls):
+        raise TypeError(
+            f'{objcls.__qualname__} constructor requires a crawler but no "from_crawler" classmethod is implemented for it. We suggest you implement it'
+        )
+    instance = objcls(*args, **kwargs)
+    # NOTE: in most download handlers the __init__ seems to be used instead of __new__
+    method_name = "__new__"
     if instance is None:
         raise TypeError(f"{objcls.__qualname__}.{method_name} returned None")
     return instance
 
 
 def _is_crawler_required_to_construct(objcls: Any) -> bool:
-    """Returns True in case a crawler object is required by the class' constructor    
-    """
+    """Returns True in case a crawler object is required by the class' constructor"""
     # the codeline below assumes that the constructor will be invoked using __init__, also a check on __new__ would be necessary
     fargs = inspect.getfullargspec(objcls.__init__)
     return "crawler" in fargs.args


### PR DESCRIPTION
I was reading in [Submitting patches](https://docs.scrapy.org/en/master/contributing.html#submitting-patches) that one can propose a PR just to discuss, so this PR doesn't have a dedicated unit test, but I can work on it if what I'm proposing makes sense


## Issue

It happens to me to develop custom `DownloadHandler` classes with an `__init__` method requiring a `crawler` in input, but I forget to implement the simple `from_crawler` classmethod.

In such case the error message that arises is an exception saying that a required argument is not provided, and I lose time until I remember that there was a `from_crawler` method to be implemented.

So I thought a more explicative error message could be useful (to me, honestly).

## Proposed solution

It looks my problems arise in `build_from_crawler` function in `scrapy/utils/misc.py`, in case no `from_crawler` is among the class' attributes then the constructor is invoked in the `else` branch.

I thought of inserting a dedicated check on whether or not `crawler` is a required argument for the constructor

## TODO

I need to implement appropriate tests both to verify that an exception with the expected message is raised, and tests for `_is_crawler_required_to_construct`

In general the logic could be discussed, improved or refined