### PR TITLE
Fix test_utf16 on big-endian systems

### DIFF
--- a/tests/test_http_response_text.py
+++ b/tests/test_http_response_text.py
@@ -156,12 +156,13 @@ class TestTextResponse(TestResponse):
 
     def test_utf16(self):
         """Test utf-16 because UnicodeDammit is known to have problems with"""
+        body = b"\xff\xfeh\x00i\x00"
         r = self.response_class(
             "http://www.example.com",
-            body=b"\xff\xfeh\x00i\x00",
+            body=body,
             encoding="utf-16",
         )
-        self._assert_response_values(r, "utf-16", "hi")
+        self._assert_response_values(r, "utf-16", body)
 
     def test_invalid_utf8_encoded_body_with_valid_utf8_BOM(self):
         r6 = self.response_class(


### PR DESCRIPTION
Fixes #5954.

The test used hard-coded UTF-16 bytes with a little-endian BOM. On big-endian systems, encoding the expected text with "utf-16" produces a big-endian BOM instead, so the body assertion fails.

This changes the test body bytes to be generated with "hi".encode("utf-16"), matching the expectation used by the shared response assertion helper on both little-endian and big-endian platforms.

Tests:
- python -m pytest tests/test_http_response_text.py -q
