### PR TITLE
fix: preserve original Content-Encoding header after decompression

### DIFF
--- a/scrapy/downloadermiddlewares/httpcompression.py
+++ b/scrapy/downloadermiddlewares/httpcompression.py
@@ -111,6 +111,7 @@ class HttpCompressionMiddleware:
         if isinstance(response, Response):
             content_encoding = response.headers.getlist("Content-Encoding")
             if content_encoding:
+                original_encoding = list(content_encoding)
                 max_size = request.meta.get("download_maxsize", self._max_size)
                 warn_size = request.meta.get("download_warnsize", self._warn_size)
                 try:
@@ -132,7 +133,9 @@ class HttpCompressionMiddleware:
                     )
                 if content_encoding:
                     self._warn_unknown_encoding(response, content_encoding)
-                response.headers["Content-Encoding"] = content_encoding
+                # Preserve the original Content-Encoding header so spiders
+                # can inspect it (see https://github.com/scrapy/scrapy/issues/1988)
+                response.headers["Content-Encoding"] = original_encoding
                 if self.stats:
                     self.stats.inc_value(
                         "httpcompression/response_bytes",
@@ -148,9 +151,6 @@ class HttpCompressionMiddleware:
                     # responsetypes guessing is reliable
                     kwargs["encoding"] = None
                 response = response.replace(cls=respcls, **kwargs)
-                if not content_encoding:
-                    del response.headers["Content-Encoding"]
-
         return response
 
     def _handle_encoding(


### PR DESCRIPTION
Preserves the original Content-Encoding header value after decompression instead of deleting it, so spiders can inspect the original response headers. Fixes #1988