### PR TITLE
fix: raise ValueError when formname/formid matches no form

### DIFF
--- a/scrapy/http/request/form.py
+++ b/scrapy/http/request/form.py
@@ -138,11 +138,13 @@ def _get_form(
         f = root.xpath(f'//form[@name="{formname}"]')
         if f:
             return cast("FormElement", f[0])
+        raise ValueError(f'No <form> with name "{formname}" found in {response}')
 
     if formid is not None:
         f = root.xpath(f'//form[@id="{formid}"]')
         if f:
             return cast("FormElement", f[0])
+        raise ValueError(f'No <form> with id "{formid}" found in {response}')
 
     # Get form element from xpath, if not found, go up
     if formxpath is not None:

--- a/tests/test_http_request_form.py
+++ b/tests/test_http_request_form.py
@@ -602,10 +602,8 @@ class TestFormRequest(TestRequest):
             <input type="hidden" name="two" value="2">
             </form>"""
         )
-        r1 = self.request_class.from_response(response, formname="form3")
-        assert r1.method == "POST"
-        fs = _qs(r1)
-        assert fs == {b"one": [b"1"]}
+        with pytest.raises(ValueError, match='No <form> with name "form3"'):
+            self.request_class.from_response(response, formname="form3")
 
     def test_from_response_formname_errors_formnumber(self):
         response = _buildresponse(
@@ -616,7 +614,7 @@ class TestFormRequest(TestRequest):
             <input type="hidden" name="two" value="2">
             </form>"""
         )
-        with pytest.raises(IndexError):
+        with pytest.raises(ValueError, match='No <form> with name "form3"'):
             self.request_class.from_response(response, formname="form3", formnumber=2)
 
     def test_from_response_formid_exists(self):
@@ -646,12 +644,10 @@ class TestFormRequest(TestRequest):
             <input type="hidden" name="four" value="4">
             </form>"""
         )
-        r1 = self.request_class.from_response(
-            response, formname="form3", formid="form2"
-        )
-        assert r1.method == "POST"
-        fs = _qs(r1)
-        assert fs == {b"four": [b"4"], b"three": [b"3"]}
+        with pytest.raises(ValueError, match='No <form> with name "form3"'):
+            self.request_class.from_response(
+                response, formname="form3", formid="form2"
+            )
 
     def test_from_response_formid_nonexistent(self):
         response = _buildresponse(
@@ -662,10 +658,8 @@ class TestFormRequest(TestRequest):
             <input type="hidden" name="two" value="2">
             </form>"""
         )
-        r1 = self.request_class.from_response(response, formid="form3")
-        assert r1.method == "POST"
-        fs = _qs(r1)
-        assert fs == {b"one": [b"1"]}
+        with pytest.raises(ValueError, match='No <form> with id "form3"'):
+            self.request_class.from_response(response, formid="form3")
 
     def test_from_response_formid_errors_formnumber(self):
         response = _buildresponse(
@@ -676,7 +670,7 @@ class TestFormRequest(TestRequest):
             <input type="hidden" name="two" value="2">
             </form>"""
         )
-        with pytest.raises(IndexError):
+        with pytest.raises(ValueError, match='No <form> with id "form3"'):
             self.request_class.from_response(response, formid="form3", formnumber=2)
 
     def test_from_response_select(self):


### PR DESCRIPTION
## Summary

- Raises `ValueError` with a descriptive message when `formname` or `formid` does not match any `<form>` in the response
- Previously, a non-matching `formname` or `formid` silently fell through to `formnumber` selection (defaulting to the first form), which made debugging difficult

Resolves #1163

## Test plan

- [x] Existing tests updated to expect `ValueError` instead of silent fallback
- [x] `pytest tests/test_http_request_form.py` -- all tests pass
- [x] Error messages include the unmatched name/id and the response URL for debugging