### PR TITLE
Document TLS method setting in avoiding bans guide

### DIFF
--- a/docs/topics/practices.rst
+++ b/docs/topics/practices.rst
@@ -412,7 +412,7 @@ Here are some tips to keep in mind when dealing with these kinds of sites:
 * for HTTPS websites, if blocking appears related to TLS behavior, consider
   adjusting the :setting:`DOWNLOADER_CLIENT_TLS_METHOD` setting, since some
   websites may respond differently depending on the TLS method used by the
-  client
+  client.
 * use a ban avoidance service, such as `Zyte API`_, which provides a `Scrapy
   plugin <https://github.com/scrapy-plugins/scrapy-zyte-api>`__ and additional
   features, like `AI web scraping <https://www.zyte.com/ai-web-scraping/>`__

--- a/docs/topics/practices.rst
+++ b/docs/topics/practices.rst
@@ -409,6 +409,10 @@ Here are some tips to keep in mind when dealing with these kinds of sites:
 * use a pool of rotating IPs. For example, the free `Tor project`_ or paid
   services like `ProxyMesh`_. An open source alternative is `scrapoxy`_, a
   super proxy that you can attach your own proxies to.
+* for HTTPS websites, if blocking appears related to TLS behavior, consider
+  adjusting the :setting:`DOWNLOADER_CLIENT_TLS_METHOD` setting, since some
+  websites may respond differently depending on the TLS method used by the
+  client
 * use a ban avoidance service, such as `Zyte API`_, which provides a `Scrapy
   plugin <https://github.com/scrapy-plugins/scrapy-zyte-api>`__ and additional
   features, like `AI web scraping <https://www.zyte.com/ai-web-scraping/>`__


### PR DESCRIPTION
## Summary

This PR adds a short note to the “Avoiding getting banned” section about the DOWNLOADER_CLIENT_TLS_METHOD setting.

The change addresses a documentation gap by mentioning that users troubleshooting blocking behavior related to HTTPS/TLS connections may consider adjusting the TLS method setting.

## Issue

Resolves #5232

## Tests

Not run; documentation only change.