### PR TITLE
docs: add Windows note for python -m scrapy alternative in tutorial

### DIFF
--- a/docs/intro/tutorial.rst
+++ b/docs/intro/tutorial.rst
@@ -137,6 +137,13 @@ To put our spider to work, go to the project's top level directory and run::
 
    scrapy crawl quotes
 
+.. note::
+
+   On Windows, if the ``scrapy`` command is not found, you can use the
+   ``python -m scrapy`` alternative instead::
+
+       python -m scrapy crawl quotes
+
 This command runs the spider named ``quotes`` that we've just added, that
 will send some requests for the ``quotes.toscrape.com`` domain. You will get an output
 similar to this::


### PR DESCRIPTION
Fixes #7908

Added a note for Windows users who may encounter issues running the `scrapy` command directly, suggesting the `python -m scrapy` alternative.