### PR TITLE
Use Twisted default TLS ciphers for None setting

### DIFF
--- a/docs/news.rst
+++ b/docs/news.rst
@@ -28,6 +28,14 @@ Backward-incompatible changes
 
     (:issue:`7496`, #TBD)
 
+Bug fixes
+~~~~~~~~~
+
+-   Setting :setting:`DOWNLOADER_CLIENT_TLS_CIPHERS` to ``None`` now makes
+    Twisted-based download handlers use Twisted's default cipher list instead
+    of ``'DEFAULT'``.
+    (:issue:`7499`, #TBD)
+
 .. _release-2.15.2:
 
 Scrapy 2.15.2 (2026-04-28)

--- a/docs/topics/settings.rst
+++ b/docs/topics/settings.rst
@@ -727,6 +727,12 @@ these ciphers will be used as client ciphers. Changing this setting may be
 necessary to access certain HTTPS websites: for example, you may need to use
 ``'DEFAULT:!DH'`` for a website with weak DH parameters or enable a
 specific cipher that is not included in ``DEFAULT`` if a website requires it.
+Set this setting to ``None`` to use the default cipher list of the TLS library.
+
+.. versionchanged:: VERSION
+
+    Setting this to ``None`` now makes the Twisted-based download handlers use
+    Twisted's default cipher list. Previously, they used ``'DEFAULT'`` instead.
 
 .. _OpenSSL cipher list format: https://docs.openssl.org/master/man1/openssl-ciphers/#cipher-list-format
 

--- a/docs/topics/settings.rst
+++ b/docs/topics/settings.rst
@@ -729,10 +729,8 @@ necessary to access certain HTTPS websites: for example, you may need to use
 specific cipher that is not included in ``DEFAULT`` if a website requires it.
 Set this setting to ``None`` to use the default cipher list of the TLS library.
 
-.. versionchanged:: VERSION
-
-    Setting this to ``None`` now makes the Twisted-based download handlers use
-    Twisted's default cipher list. Previously, they used ``'DEFAULT'`` instead.
+Setting this to ``None`` now makes the Twisted-based download handlers use
+Twisted's default cipher list. Previously, they used ``'DEFAULT'`` instead.
 
 .. _OpenSSL cipher list format: https://docs.openssl.org/master/man1/openssl-ciphers/#cipher-list-format
 

--- a/scrapy/core/downloader/contextfactory.py
+++ b/scrapy/core/downloader/contextfactory.py
@@ -16,7 +16,6 @@ from zope.interface.declarations import implementer
 from zope.interface.verify import verifyObject
 
 from scrapy.core.downloader.tls import (
-    DEFAULT_CIPHERS,
     _ScrapyClientTLSOptions,
     _ScrapyClientTLSOptions26,
     openssl_methods,
@@ -74,11 +73,12 @@ class _ScrapyClientContextFactory(BrowserLikePolicyForHTTPS):
         super().__init__(*args, **kwargs)  # type: ignore[no-untyped-call]
         self._ssl_method: int = method
         self.tls_verbose_logging: bool = tls_verbose_logging  # unused
-        self.tls_ciphers: AcceptableCiphers
-        if tls_ciphers:
-            self.tls_ciphers = AcceptableCiphers.fromOpenSSLCipherString(tls_ciphers)
-        else:
-            self.tls_ciphers = DEFAULT_CIPHERS
+        self.tls_ciphers: AcceptableCiphers | None
+        self.tls_ciphers = (
+            AcceptableCiphers.fromOpenSSLCipherString(tls_ciphers)
+            if tls_ciphers is not None
+            else None
+        )
         self._verify_certificates = verify_certificates
 
     @classmethod

--- a/tests/test_core_downloader.py
+++ b/tests/test_core_downloader.py
@@ -6,9 +6,10 @@ from typing import TYPE_CHECKING, cast
 import OpenSSL.SSL
 import pytest
 from pytest_twisted import async_yield_fixture
+from twisted.internet._sslverify import defaultCiphers
 from twisted.internet.protocol import Factory
 from twisted.internet.protocol import Protocol as TxProtocol
-from twisted.internet.ssl import optionsForClientTLS
+from twisted.internet.ssl import CertificateOptions, optionsForClientTLS
 from twisted.protocols.tls import TLSMemoryBIOFactory, TLSMemoryBIOProtocol
 from twisted.web import server, static
 from twisted.web.client import Agent, BrowserLikePolicyForHTTPS, readBody
@@ -232,6 +233,20 @@ class TestContextFactoryTLSMethod(TestContextFactoryBase):
         client_context_factory = _ScrapyClientContextFactory(OpenSSL.SSL.TLSv1_2_METHOD)
         assert client_context_factory._ssl_method == OpenSSL.SSL.TLSv1_2_METHOD
         await self._assert_factory_works(server_url, client_context_factory)
+
+
+class TestContextFactoryTLSCiphers:
+    def test_setting_none_uses_twisted_default_ciphers(self) -> None:
+        crawler = get_crawler(settings_dict={"DOWNLOADER_CLIENT_TLS_CIPHERS": None})
+        client_context_factory = _load_context_factory_from_settings(crawler)
+        expected_cipher_string = CertificateOptions(
+            acceptableCiphers=defaultCiphers
+        )._cipherString
+
+        assert (
+            client_context_factory._get_cert_options()._cipherString
+            == expected_cipher_string
+        )
 
 
 @coroutine_test


### PR DESCRIPTION
Resolves #7499

## Summary

- Preserve `DOWNLOADER_CLIENT_TLS_CIPHERS=None` in the Twisted context factory.
- Let Twisted apply its default cipher list instead of Scrapy forcing `"DEFAULT"`.
- Add a regression test and update docs/release notes.

## Tests

- `tox -e py -- tests/test_core_downloader.py::TestContextFactoryTLSCiphers::test_setting_none_uses_twisted_default_ciphers -q`
- `tox -e py -- tests/test_core_downloader.py -q`
- `tox -e pre-commit`
- `tox -e docs -- -q`
- `tox -e py -- scrapy tests -n 4`

Note: `tox -e typing` could not run locally because `python3.10` is not installed.