### PR TITLE
[docs] Add Windows note for 'python -m scrapy' alternative in tutorial

### DIFF
--- a/docs/intro/tutorial.rst
+++ b/docs/intro/tutorial.rst
@@ -51,6 +51,15 @@ Creating a project
 Before you start scraping, you will have to set up a new Scrapy project. Enter a
 directory where you'd like to store your code and run::
 
+.. note::
+
+   On Windows, if the ``scrapy`` command is not recognized, use
+   ``python -m scrapy`` as an alternative. For example::
+
+       python -m scrapy startproject tutorial
+
+Then run::
+
     scrapy startproject tutorial
 
 This will create a ``tutorial`` directory with the following contents::


### PR DESCRIPTION
## What does this PR do?

Adds a note in the tutorial's "Creating a project" section to inform 
Windows users that they can use `python -m scrapy` as an alternative 
if the `scrapy` command is not recognized in their terminal.

## Motivation

Fixes #7306

Windows users sometimes face issues where the `scrapy` command is not 
found after installation. This note helps them unblock themselves 
without leaving the tutorial.

## Changes

- Added a `.. note::` block in `docs/intro/tutorial.rst` before the 
  `scrapy startproject tutorial` command