### PR TITLE
docs: add Windows note for 'python -m scrapy' alternative in tutorial

### DIFF
--- a/docs/intro/tutorial.rst
+++ b/docs/intro/tutorial.rst
@@ -53,6 +53,14 @@ directory where you'd like to store your code and run::
 
     scrapy startproject tutorial
 
+.. note::
+
+   On Windows, if you run the command and get an error saying ``'scrapy' is not
+   recognized as an internal or external command``, you can run the command
+   using the ``python -m scrapy`` alternative::
+
+       python -m scrapy startproject tutorial
+
 This will create a ``tutorial`` directory with the following contents::
 
     tutorial/


### PR DESCRIPTION
Fixes #7306

Many Windows users encounter `'scrapy' is not recognized` errors because
the Python Scripts folder is not in PATH. This adds a note in the tutorial
suggesting `python -m scrapy` as a fallback alternative.

- Added a Sphinx note under the first `scrapy startproject` command in
  `docs/intro/tutorial.rst`