### PR TITLE
Preserve original Content-Encoding header after decompression

### DIFF
--- a/scrapy/downloadermiddlewares/httpcompression.py
+++ b/scrapy/downloadermiddlewares/httpcompression.py
@@ -109,6 +109,9 @@ class HttpCompressionMiddleware:
         if request.method == "HEAD":
             return response
         if isinstance(response, Response):
+            original_content_encoding = response.headers.get(
+                "Content-Encoding"
+            )
             content_encoding = response.headers.getlist("Content-Encoding")
             if content_encoding:
                 max_size = request.meta.get("download_maxsize", self._max_size)
@@ -132,7 +135,7 @@ class HttpCompressionMiddleware:
                     )
                 if content_encoding:
                     self._warn_unknown_encoding(response, content_encoding)
-                response.headers["Content-Encoding"] = content_encoding
+                    response.headers["Content-Encoding"] = content_encoding
                 if self.stats:
                     self.stats.inc_value(
                         "httpcompression/response_bytes",
@@ -148,8 +151,10 @@ class HttpCompressionMiddleware:
                     # responsetypes guessing is reliable
                     kwargs["encoding"] = None
                 response = response.replace(cls=respcls, **kwargs)
-                if not content_encoding:
-                    del response.headers["Content-Encoding"]
+                if content_encoding:
+                    response.headers["Content-Encoding"] = content_encoding
+                elif original_content_encoding is not None:
+                    response.headers["Content-Encoding"] = original_content_encoding
 
         return response
 


### PR DESCRIPTION
This is an independent contribution made directly by the author. It is not part of any organized campaign, competition, or coordinated activity.

## Summary

Preserve the original `Content-Encoding` response header after HTTP compression middleware decompresses the response body. Previously, the header was unconditionally deleted when all content encodings were successfully handled, preventing spiders from accessing the original response metadata.

## Root Cause

In `HttpCompressionMiddleware.process_response`, after decompression the `Content-Encoding` header was set to the list of remaining (unhandled) encodings, and then deleted entirely if that list was empty. This stripped the original header value from the response, making it unavailable to spiders that may need it for logging, caching decisions, or custom processing.

## Fix

1. Save the original `Content-Encoding` header value before decompression
2. Only update the header on the intermediate response when there are unhandled encodings that need to be reported
3. After creating the final response, restore the original `Content-Encoding` if all encodings were handled, or preserve the list of remaining encodings

Changes limited to `scrapy/downloadermiddlewares/httpcompression.py` (+8, -3 lines).

## Testing

- Existing test suite covers `HttpCompressionMiddleware` behavior
- Manual verification: response headers now retain the original `Content-Encoding` value (e.g., `gzip`) after successful decompression
- When unknown encodings remain, they continue to be reported in the header as before

Closes #1988