### PR TITLE
Merge runner settings into passed crawlers

### DIFF
--- a/scrapy/crawler.py
+++ b/scrapy/crawler.py
@@ -363,7 +363,8 @@ class CrawlerRunnerBase(ABC):
         """
         Return a :class:`~scrapy.crawler.Crawler` object.
 
-        * If ``crawler_or_spidercls`` is a Crawler, it is returned as-is.
+        * If ``crawler_or_spidercls`` is a Crawler, this runner's settings are
+          merged into it as defaults before it is returned.
         * If ``crawler_or_spidercls`` is a Spider subclass, a new Crawler
           is constructed for it.
         * If ``crawler_or_spidercls`` is a string, this function finds
@@ -376,8 +377,22 @@ class CrawlerRunnerBase(ABC):
                 "it must be a spider class (or a Crawler object)"
             )
         if isinstance(crawler_or_spidercls, Crawler):
+            self._apply_settings_to_crawler(crawler_or_spidercls)
             return crawler_or_spidercls
         return self._create_crawler(crawler_or_spidercls)
+
+    def _apply_settings_to_crawler(self, crawler: Crawler) -> None:
+        if crawler.settings.frozen:
+            return
+
+        for name, value in self.settings.items():
+            runner_priority = self.settings.getpriority(name)
+            crawler_priority = crawler.settings.getpriority(name)
+            if runner_priority is not None and (
+                crawler_priority is None or runner_priority > crawler_priority
+            ):
+                crawler.settings.set(name, value, runner_priority)
+        crawler._update_root_log_handler()
 
     def _create_crawler(self, spidercls: str | type[Spider]) -> Crawler:
         if isinstance(spidercls, str):

--- a/tests/test_crawler.py
+++ b/tests/test_crawler.py
@@ -633,6 +633,36 @@ class TestCrawlerProcess(TestBaseCrawler):
         runner = CrawlerProcess(install_root_handler=False)
         self.assertOptionIsDefault(runner.settings, "RETRY_ENABLED")
 
+    def test_crawler_process_settings_are_crawler_defaults(self):
+        class CustomSettingsSpider(DefaultSpider):
+            custom_settings = {
+                "PROCESS_AND_SPIDER": "spider",
+            }
+
+        crawler = Crawler(
+            CustomSettingsSpider,
+            {
+                "PROCESS_AND_CRAWLER": "crawler",
+            },
+        )
+        runner = CrawlerProcess(
+            {
+                "LOG_ENABLED": False,
+                "PROCESS_ONLY": "process",
+                "PROCESS_AND_CRAWLER": "process",
+                "PROCESS_AND_SPIDER": "process",
+            },
+            install_root_handler=False,
+        )
+
+        result = runner.create_crawler(crawler)
+
+        assert result is crawler
+        assert crawler.settings["LOG_ENABLED"] is False
+        assert crawler.settings["PROCESS_ONLY"] == "process"
+        assert crawler.settings["PROCESS_AND_CRAWLER"] == "crawler"
+        assert crawler.settings["PROCESS_AND_SPIDER"] == "spider"
+
 
 @pytest.mark.only_asyncio
 class TestAsyncCrawlerProcess(TestBaseCrawler):


### PR DESCRIPTION
Resolves #1280.

Summary:
- Merge runner settings into prebuilt `Crawler` instances before returning them from `create_crawler()`.
- Keep crawler and spider settings in control by only applying runner values with higher priority.
- Add regression coverage for `CrawlerProcess` defaults with a passed `Crawler`.

Tests:
- `python -m pytest tests/test_crawler.py -q`
- `python -m ruff check scrapy/crawler.py tests/test_crawler.py`
- `python -m ruff format --check scrapy/crawler.py tests/test_crawler.py`
- `python -m pre_commit run --color never --files scrapy/crawler.py tests/test_crawler.py`