### PR TITLE
tests: fix utf-16 body bytes on big-endian

### DIFF
--- a/tests/test_http_response_text.py
+++ b/tests/test_http_response_text.py
@@ -158,7 +158,7 @@ class TestTextResponse(TestResponse):
         """Test utf-16 because UnicodeDammit is known to have problems with"""
         r = self.response_class(
             "http://www.example.com",
-            body=b"\xff\xfeh\x00i\x00",
+            body="hi".encode("utf-16"),
             encoding="utf-16",
         )
         self._assert_response_values(r, "utf-16", "hi")


### PR DESCRIPTION
## Summary
- replace hardcoded UTF-16 little-endian bytes in `test_utf16` with `"hi".encode("utf-16")`
- align the regression test with Python's platform-native UTF-16 BOM behavior
- fix big-endian test failure without changing runtime code

## Testing
- `python -m pytest tests/test_http_response_text.py -k utf16 -q`

Fixes #5954