### PR TITLE
[docs] Add Windows note for 'python -m scrapy' alternative in tutoria…

### DIFF
--- a/docs/intro/tutorial.rst
+++ b/docs/intro/tutorial.rst
@@ -53,6 +53,15 @@ directory where you'd like to store your code and run::
 
     scrapy startproject tutorial
 
+.. note::
+
+   On Windows, if the ``scrapy`` command is not found, you can use
+   ``python -m scrapy`` as an alternative. For example::
+
+       python -m scrapy startproject tutorial
+
+   This applies to all ``scrapy`` commands used throughout this tutorial.
+
 This will create a ``tutorial`` directory with the following contents::
 
     tutorial/


### PR DESCRIPTION
[docs] Add Windows note for 'python -m scrapy' alternative in tutorial

Resolves #7306

## What this PR does

Adds a note in the "Creating a project" section of the tutorial for 
Windows users who may encounter the `scrapy` command not being 
recognized after installation.

On Windows, the `scrapy` command can fail if the Python Scripts folder 
is not in PATH. The note informs users they can use `python -m scrapy` 
as an alternative for all commands in the tutorial.

## Changes

- Added a `.. note::` directive in `docs/intro/tutorial.rst` after the 
  first `scrapy startproject tutorial` command.

## Testing

Built the docs locally and verified the note renders correctly in HTML.