### PR TITLE
Set dont_filter on SitemapSpider start requests

### DIFF
--- a/scrapy/spiders/sitemap.py
+++ b/scrapy/spiders/sitemap.py
@@ -55,7 +55,7 @@ class SitemapSpider(Spider):
 
     async def start(self) -> AsyncIterator[Any]:
         for url in self.sitemap_urls:
-            yield Request(url, self._parse_sitemap)
+            yield Request(url, self._parse_sitemap, dont_filter=True)
 
     def sitemap_filter(
         self, entries: Iterable[dict[str, Any]]

--- a/tests/test_spider_sitemap.py
+++ b/tests/test_spider_sitemap.py
@@ -11,6 +11,7 @@ from pathlib import Path
 import pytest
 from testfixtures import LogCapture
 
+from scrapy.dupefilters import RFPDupeFilter
 from scrapy.http import HtmlResponse, Request, Response, TextResponse, XmlResponse
 from scrapy.spiders import SitemapSpider
 from scrapy.utils.test import get_crawler
@@ -436,5 +437,29 @@ Sitemap: /sitemap-relative-url.xml
         assert len(requests) == 1
         request = requests[0]
         assert request.url == "https://toscrape.com/sitemap.xml"
-        assert request.dont_filter is False
+        assert request.dont_filter is True
         assert request.callback == spider._parse_sitemap
+
+    @coroutine_test
+    async def test_sitemap_urls_not_filtered(self):
+        # Requests for sitemap_urls are start requests and must not be dropped
+        # by the dupefilter, otherwise resuming a job (JOBDIR) where the start
+        # request has already been seen would stop the spider immediately.
+        # See https://github.com/scrapy/scrapy/issues/4479.
+        class TestSpider(self.spider_class):
+            name = "test"
+            sitemap_urls = ["https://toscrape.com/robots.txt"]
+
+        crawler = get_crawler(TestSpider)
+        spider = TestSpider.from_crawler(crawler)
+        requests = [request async for request in spider.start()]
+
+        dupefilter = RFPDupeFilter()
+        for request in requests:
+            # The request was already seen in a previous run, as it would be
+            # when resuming with JOBDIR.
+            dupefilter.request_seen(request)
+            # The scheduler only drops a request when it is both already seen
+            # and does not have dont_filter set (see Scheduler.enqueue_request),
+            # so dont_filter must be set for start requests to survive a resume.
+            assert not (not request.dont_filter and dupefilter.request_seen(request))


### PR DESCRIPTION
## Problem

`SitemapSpider` does not resume correctly when a `JOBDIR` is set (#4479).

The default `Spider.start()` yields requests for `start_urls` with `dont_filter=True` (and documents this as its contract). `SitemapSpider.start()` overrides `start()` to yield requests for `sitemap_urls`, but it did so **without** `dont_filter=True`:

```python
async def start(self):
    for url in self.sitemap_urls:
        yield Request(url, self._parse_sitemap)
```

When a job is resumed from `JOBDIR`, the fingerprints of previously seen requests are loaded into the dupefilter. Because the start request (often a `robots.txt` or sitemap URL) is no longer marked with `dont_filter`, the scheduler drops it as a duplicate (`Scheduler.enqueue_request` only enqueues a seen request when `dont_filter` is set). With no other requests to process, the spider closes immediately and crawls nothing.

## Fix

Yield the `sitemap_urls` requests with `dont_filter=True`, matching the documented behaviour of the base `Spider.start()`:

```python
yield Request(url, self._parse_sitemap, dont_filter=True)
```

These are start requests, so this brings `SitemapSpider` in line with the base class and lets a sitemap-based crawl resume from `JOBDIR` as expected. Requests discovered later (sitemap index children, etc.) are unaffected and remain subject to dupe filtering.

## Tests

- Updated `test_sitemap_urls` to assert the start request now has `dont_filter=True`.
- Added `test_sitemap_urls_not_filtered`, which marks the start request as already seen (as it would be on a resumed run) and checks it would not be filtered out by the scheduler's condition.

Both tests fail on `master` and pass with this change. `ruff` (check + format) and the pre-commit hooks are green.

Fixes #4479.

This PR was written entirely using an LLM.