### PR TITLE
Close GCS feed temp files after upload

### DIFF
--- a/scrapy/extensions/feedexport.py
+++ b/scrapy/extensions/feedexport.py
@@ -306,12 +306,15 @@ class GCSFeedStorage(BlockingFeedStorage):
 
     def _store_in_thread(self, file: IO[bytes]) -> None:
         file.seek(0)
-        from google.cloud.storage import Client  # noqa: PLC0415
+        try:
+            from google.cloud.storage import Client  # noqa: PLC0415
 
-        client = Client(project=self.project_id)
-        bucket = client.get_bucket(self.bucket_name)
-        blob = bucket.blob(self.blob_name)
-        blob.upload_from_file(file, predefined_acl=self.acl)
+            client = Client(project=self.project_id)
+            bucket = client.get_bucket(self.bucket_name)
+            blob = bucket.blob(self.blob_name)
+            blob.upload_from_file(file, predefined_acl=self.acl)
+        finally:
+            file.close()
 
 
 class FTPFeedStorage(BlockingFeedStorage):

--- a/tests/test_feedexport_storages.py
+++ b/tests/test_feedexport_storages.py
@@ -513,6 +513,34 @@ class TestGCSFeedStorage:
             client_mock.get_bucket.assert_called_once_with("mybucket")
             bucket_mock.blob.assert_called_once_with("export.csv")
             blob_mock.upload_from_file.assert_called_once_with(f, predefined_acl=acl)
+            f.close.assert_called_once_with()
+
+    @coroutine_test
+    async def test_store_closes_file_on_upload_error(self):
+        try:
+            from google.cloud.storage import Client  # noqa: F401,PLC0415
+        except ImportError:
+            pytest.skip("GCSFeedStorage requires google-cloud-storage")
+
+        uri = "gs://mybucket/export.csv"
+        project_id = "myproject-123"
+        acl = "publicRead"
+        (client_mock, bucket_mock, blob_mock) = mock_google_cloud_storage()
+        blob_mock.upload_from_file.side_effect = OSError("Upload failed")
+        with mock.patch("google.cloud.storage.Client") as m:
+            m.return_value = client_mock
+
+            f = mock.Mock()
+            storage = GCSFeedStorage(uri, project_id, acl)
+            with pytest.raises(OSError, match="Upload failed"):
+                await maybe_deferred_to_future(storage.store(f))
+
+            f.seek.assert_called_once_with(0)
+            m.assert_called_once_with(project=project_id)
+            client_mock.get_bucket.assert_called_once_with("mybucket")
+            bucket_mock.blob.assert_called_once_with("export.csv")
+            blob_mock.upload_from_file.assert_called_once_with(f, predefined_acl=acl)
+            f.close.assert_called_once_with()
 
     def test_overwrite_default(self):
         with LogCapture() as log:


### PR DESCRIPTION
## Summary

Fixes a temporary file leak in the GCS feed storage backend.

`GCSFeedStorage` uses `BlockingFeedStorage`, which writes feed output to a local temporary file before uploading it to Google Cloud Storage. Unlike the S3 and FTP feed storage backends, the GCS backend did not close that temporary file after upload.

Since the file is created with `NamedTemporaryFile`, not closing it can leave the file handle open and keep the temporary file on disk.

## Changes

- Close the GCS feed temporary file after upload.
- Use a `finally` block so the file is closed even if the upload fails.
- Add regression coverage for successful and failed GCS uploads.

## Testing

```bash
pytest tests/test_feedexport_storages.py -k GCSFeedStorage
pytest tests/test_feedexport_storages.py