### PR TITLE
[docs] Add Windows note for python -m scrapy alternative in tutorial

### DIFF
--- a/docs/intro/tutorial.rst
+++ b/docs/intro/tutorial.rst
@@ -136,6 +136,10 @@ How to run our spider
 To put our spider to work, go to the project's top level directory and run::
 
    scrapy crawl quotes
+   .. note::
+
+   On Windows, you can also use ``python -m scrapy crawl quotes``
+   if the ``scrapy`` command is not found in your PATH.
 
 This command runs the spider named ``quotes`` that we've just added, that
 will send some requests for the ``quotes.toscrape.com`` domain. You will get an output


### PR DESCRIPTION
## What does this PR do?
Adds a note in the tutorial for Windows users explaining that they can use `python -m scrapy crawl quotes` as an alternative when the `scrapy` command is not found in PATH.

## Motivation
Fixes #7306 - Windows users often struggle with the `scrapy` command not being recognized. This note provides a clear alternative.

## How was this tested?
Verified the RST syntax is correct and the note renders properly.
