### PR TITLE
Document customizing Scrapy shell variables

### DIFF
--- a/docs/topics/shell.rst
+++ b/docs/topics/shell.rst
@@ -148,7 +148,9 @@ override its ``update_vars`` method. See :ref:`topics-commands` for more
 information about creating custom Scrapy commands.
 
 For example, if your project defines a custom ``shell`` command, you can update
-the shell namespace like this::
+the shell namespace like this:
+
+.. code-block:: python
 
     from scrapy.commands.shell import Command as ShellCommand
 

--- a/docs/topics/shell.rst
+++ b/docs/topics/shell.rst
@@ -139,6 +139,25 @@ Those objects are:
 
 -   ``settings`` - the current :ref:`Scrapy settings <topics-settings>`
 
+Customizing shell variables
+---------------------------
+
+If you want to make project-specific helpers, imports, or objects available
+whenever the Scrapy shell starts, you can create a custom shell command and
+override its ``update_vars`` method. See :ref:`topics-commands` for more
+information about creating custom Scrapy commands.
+
+For example, if your project defines a custom ``shell`` command, you can update
+the shell namespace like this::
+
+    from scrapy.commands.shell import Command as ShellCommand
+
+
+    class Command(ShellCommand):
+        def update_vars(self, vars):
+            super().update_vars(vars)
+            vars["parse_title"] = lambda response: response.css("title::text").get()
+
 Example of shell session
 ========================
 


### PR DESCRIPTION
Summary

This PR adds documentation explaining how to customize the objects available in the Scrapy shell by creating a custom shell command and overriding the update_vars method.

The change addresses the documentation gap discussed in issue #6554 and documents an existing extension point rather than adding new shell functionality.

Issue

Resolves #6554

Tests

Not run, documentation only change.