### PR TITLE
Fix request utility edge cases

### DIFF
--- a/docs/news.rst
+++ b/docs/news.rst
@@ -6,6 +6,21 @@ Release notes
 Scrapy VERSION (unreleased)
 ---------------------------
 
+Bug fixes
+~~~~~~~~~
+
+-   Fixed :meth:`scrapy.Request.copy` sharing cookies between the original
+    and copied requests. (#TBD)
+
+-   Fixed :func:`scrapy.utils.url.strip_url` corrupting credentials when
+    stripping default ports from URLs that keep credentials. (#TBD)
+
+-   Fixed :func:`scrapy.utils.request.request_to_curl` generating shell-unsafe
+    commands for some requests and dropping repeated header values. (#TBD)
+
+-   Fixed :func:`scrapy.utils.response.open_in_browser` injecting a ``base``
+    element into an HTML comment instead of the actual ``head`` element. (#TBD)
+
 Backward-incompatible changes
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/scrapy/http/request/__init__.py
+++ b/scrapy/http/request/__init__.py
@@ -200,7 +200,12 @@ class Request(object_ref):
         #: .. seealso:: :ref:`topics-request-response-ref-errbacks`
         self.errback: Callable[[Failure], Any] | None = errback
 
-        self._cookies: CookiesT | None = cookies or None
+        if isinstance(cookies, dict):
+            self._cookies = dict(cookies) or None
+        elif isinstance(cookies, list):
+            self._cookies = [dict(cookie) for cookie in cookies] or None
+        else:
+            self._cookies = None
         self._headers: Headers | None = (
             Headers(headers, encoding=encoding) if headers else None
         )

--- a/scrapy/utils/request.py
+++ b/scrapy/utils/request.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import shlex
 from typing import TYPE_CHECKING, Any, Protocol
 from urllib.parse import urlunparse
 from weakref import WeakKeyDictionary
@@ -179,26 +180,28 @@ def request_to_curl(request: Request) -> str:
     :param :class:`~scrapy.Request`: Request object to be converted
     :return: string containing the curl command
     """
-    method = request.method
+    command = ["curl", "-X", request.method, request.url]
 
-    data = f"--data-raw '{request.body.decode('utf-8')}'" if request.body else ""
+    if request.body:
+        command.extend(["--data-raw", request.body.decode("utf-8")])
 
-    headers = " ".join(
-        f"-H '{k.decode()}: {v[0].decode()}'" for k, v in request.headers.items()
-    )
+    for key, values in request.headers.items():
+        for value in values:
+            command.extend(["-H", f"{key.decode()}: {value.decode()}"])
 
-    url = request.url
-    cookies = ""
     if request.cookies:
         if isinstance(request.cookies, dict):
             cookie = "; ".join(f"{k}={v}" for k, v in request.cookies.items())
-            cookies = f"--cookie '{cookie}'"
+            command.extend(["--cookie", cookie])
         elif isinstance(request.cookies, list):
             cookie = "; ".join(
-                f"{next(iter(c.keys()))}={next(iter(c.values()))}"
+                (
+                    f"{c['name']}={c['value']}"
+                    if "name" in c and "value" in c
+                    else f"{next(iter(c.keys()))}={next(iter(c.values()))}"
+                )
                 for c in request.cookies
             )
-            cookies = f"--cookie '{cookie}'"
+            command.extend(["--cookie", cookie])
 
-    curl_cmd = f"curl -X {method} {url} {data} {headers} {cookies}".strip()
-    return " ".join(curl_cmd.split())
+    return " ".join(shlex.quote(argument) for argument in command)

--- a/scrapy/utils/response.py
+++ b/scrapy/utils/response.py
@@ -71,6 +71,23 @@ def _remove_html_comments(body: bytes) -> bytes:
     return body
 
 
+def _find_html_head_end(body: bytes) -> int | None:
+    pos = 0
+    while pos < len(body):
+        comment_start = body.find(b"<!--", pos)
+        search_end = len(body) if comment_start == -1 else comment_start
+        match = re.search(rb"<head(?:[^<>]*?>)", body[pos:search_end])
+        if match:
+            return pos + match.end()
+        if comment_start == -1:
+            return None
+        comment_end = body.find(b"-->", comment_start + 4)
+        if comment_end == -1:
+            return None
+        pos = comment_end + 3
+    return None
+
+
 def open_in_browser(
     response: TextResponse,
     _openfunc: Callable[[str], Any] = webbrowser.open,
@@ -97,10 +114,9 @@ def open_in_browser(
     # XXX: this implementation is a bit dirty and could be improved
     body = response.body
     if isinstance(response, HtmlResponse):
-        if b"<base" not in body:
-            _remove_html_comments(body)
-            repl = rf'\g<0><base href="{response.url}">'
-            body = re.sub(rb"<head(?:[^<>]*?>)", to_bytes(repl), body, count=1)
+        if b"<base" not in body and (pos := _find_html_head_end(body)) is not None:
+            base = to_bytes(f'<base href="{response.url}">')
+            body = body[:pos] + base + body[pos:]
         ext = ".html"
     elif isinstance(response, TextResponse):
         ext = ".txt"

--- a/scrapy/utils/url.py
+++ b/scrapy/utils/url.py
@@ -139,7 +139,8 @@ def strip_url(
             ("ftp", 21),
         }
     ):
-        netloc = netloc.replace(f":{parsed_url.port}", "")
+        port_suffix = f":{parsed_url.port}"
+        netloc = netloc.removesuffix(port_suffix)
 
     return urlunparse(
         (

--- a/tests/test_http_request.py
+++ b/tests/test_http_request.py
@@ -228,6 +228,28 @@ class TestRequest:
 
         # Request.body can be identical since it's an immutable object (str)
 
+        # make sure cookies are shallow copied
+        r1 = self.request_class("http://www.example.com", cookies={"a": "b"})
+        r2 = r1.copy()
+        assert r1.cookies is not r2.cookies, (
+            "cookies must be a shallow copy, not identical"
+        )
+        assert r1.cookies == r2.cookies
+        r2.cookies["c"] = "d"
+        assert r1.cookies == {"a": "b"}
+
+        # Verbose cookies are mutable and may be modified by middleware.
+        r1 = self.request_class(
+            "http://www.example.com",
+            cookies=[{"name": "a", "value": "b"}],
+        )
+        r2 = r1.copy()
+        assert r1.cookies is not r2.cookies, (
+            "cookies must be a shallow copy, not identical"
+        )
+        assert r1.cookies[0] is not r2.cookies[0]
+        assert r1.cookies == r2.cookies
+
     def test_copy_inherited_classes(self):
         """Test Request children copies preserve their class"""
 

--- a/tests/test_utils_request.py
+++ b/tests/test_utils_request.py
@@ -333,6 +333,13 @@ class TestRequestToCurl:
         expected_curl_command = "curl -X GET https://www.example.com"
         self._test_request(request_object, expected_curl_command)
 
+    def test_url_with_shell_metacharacter(self):
+        request_object = Request("https://www.example.com/search?q=a&x=1")
+        expected_curl_command = (
+            "curl -X GET 'https://www.example.com/search?q=a&x=1'"
+        )
+        self._test_request(request_object, expected_curl_command)
+
     def test_post(self):
         request_object = Request(
             "https://www.httpbin.org/post",
@@ -358,6 +365,33 @@ class TestRequestToCurl:
         )
         self._test_request(request_object, expected_curl_command)
 
+    def test_repeated_headers(self):
+        request_object = Request(
+            "https://www.httpbin.org/post",
+            headers={"X-Test": ["one", "two"]},
+        )
+        expected_curl_command = (
+            "curl -X GET https://www.httpbin.org/post"
+            " -H 'X-Test: one' -H 'X-Test: two'"
+        )
+        self._test_request(request_object, expected_curl_command)
+
+    def test_quote_single_quotes(self):
+        request_object = Request(
+            "https://www.httpbin.org/post",
+            method="POST",
+            headers={"X-Test": "it's"},
+            body="it's",
+            cookies={"foo": "it's"},
+        )
+        expected_curl_command = (
+            "curl -X POST https://www.httpbin.org/post"
+            " --data-raw 'it'\"'\"'s'"
+            " -H 'X-Test: it'\"'\"'s'"
+            " --cookie 'foo=it'\"'\"'s'"
+        )
+        self._test_request(request_object, expected_curl_command)
+
     def test_cookies_dict(self):
         request_object = Request(
             "https://www.httpbin.org/post",
@@ -367,7 +401,7 @@ class TestRequestToCurl:
         )
         expected_curl_command = (
             "curl -X POST https://www.httpbin.org/post"
-            " --data-raw '{\"foo\": \"bar\"}' --cookie 'foo=bar'"
+            " --data-raw '{\"foo\": \"bar\"}' --cookie foo=bar"
         )
         self._test_request(request_object, expected_curl_command)
 
@@ -380,6 +414,19 @@ class TestRequestToCurl:
         )
         expected_curl_command = (
             "curl -X POST https://www.httpbin.org/post"
-            " --data-raw '{\"foo\": \"bar\"}' --cookie 'foo=bar'"
+            " --data-raw '{\"foo\": \"bar\"}' --cookie foo=bar"
+        )
+        self._test_request(request_object, expected_curl_command)
+
+    def test_verbose_cookies_list(self):
+        request_object = Request(
+            "https://www.httpbin.org/post",
+            method="POST",
+            cookies=[{"name": "foo", "value": "bar"}],
+            body=json.dumps({"foo": "bar"}),
+        )
+        expected_curl_command = (
+            "curl -X POST https://www.httpbin.org/post"
+            " --data-raw '{\"foo\": \"bar\"}' --cookie foo=bar"
         )
         self._test_request(request_object, expected_curl_command)

--- a/tests/test_utils_response.py
+++ b/tests/test_utils_response.py
@@ -174,6 +174,7 @@ def test_inject_base_url(body: bytes) -> None:
             path = burl.replace("file://", "")
         bbody = Path(path).read_bytes()
         assert bbody.count(b'><base href="' + to_bytes(url) + b'">') == 1
+        assert b"<!-- <head><base " not in bbody
         assert b"<head" in bbody
         return True
 

--- a/tests/test_utils_url.py
+++ b/tests/test_utils_url.py
@@ -346,6 +346,14 @@ class TestStripUrl:
                 "ftp://username:password@www.example.com:221/file.txt",
                 "ftp://username:password@www.example.com:221/file.txt",
             ),
+            (
+                "http://user:80pass@www.example.com:80/index.html",
+                "http://user:80pass@www.example.com/index.html",
+            ),
+            (
+                "http://user:80pass@[::1]:80/index.html",
+                "http://user:80pass@[::1]/index.html",
+            ),
         ],
     )
     def test_default_ports(self, url: str, expected: str) -> None:


### PR DESCRIPTION
Fix four small edge cases in Scrapy request and utility helpers:

- Copy request cookies when creating copied/replaced requests, matching the existing behavior for other mutable request attributes such as `meta`, `cb_kwargs`, `headers`, and `flags`.
- Avoid corrupting URL credentials in `strip_url()` when stripping a default host port.
- Generate safer `request_to_curl()` commands by shell-quoting arguments and preserving repeated header values.
- Insert the browser debug `<base>` tag into the actual HTML `<head>` element, not into a commented-out `<head>` occurrence.

## Root cause

`Request.__init__()` copied several mutable inputs defensively, but stored `cookies` directly.

`strip_url()` removed default ports with a broad string replacement across the entire netloc, so matching text inside credentials could be removed too.

`request_to_curl()` built a shell command with string interpolation and only used the first value for each header.

`open_in_browser()` tried to account for comments, but ignored the comment-stripped result before matching `<head>`.

## Validation

- `python -m pytest tests\test_http_request.py tests\test_utils_url.py tests\test_utils_request.py tests\test_utils_response.py`
- `python -m ruff check scrapy\http\request\__init__.py scrapy\utils\url.py scrapy\utils\request.py scrapy\utils\response.py tests\test_http_request.py tests\test_utils_url.py tests\test_utils_request.py tests\test_utils_response.py`
- `git diff --check`