### PR TITLE
Allow offsite image downloads in ImagesPipeline

### DIFF
--- a/scrapy/pipelines/images.py
+++ b/scrapy/pipelines/images.py
@@ -228,7 +228,14 @@ class ImagesPipeline(FilesPipeline):
             raise TypeError(
                 f"{self.images_urls_field} must be a list of URLs, got {type(urls).__name__}. "
             )
-        return [Request(u, callback=NO_CALLBACK) for u in urls]
+        return [
+            Request(
+                u,
+                callback=NO_CALLBACK,
+                meta={"allow_offsite": True},
+            )
+            for u in urls
+        ]
 
     def item_completed(
         self, results: list[FileInfoOrError], item: Any, info: MediaPipeline.SpiderInfo

--- a/tests/test_pipeline_images.py
+++ b/tests/test_pipeline_images.py
@@ -270,6 +270,17 @@ class TestImagesPipelineFieldsMixin(ABC):
         assert images == [results[0][1]]
         assert isinstance(item, self.item_class)
 
+
+    def test_media_request_allow_offsite(self, tmp_path):
+        url = "http://www.example.com/images/1.jpg"
+        item = self.item_class(name="item1", image_urls=[url])
+        pipeline = ImagesPipeline.from_crawler(
+            get_crawler(None, {"IMAGES_STORE": str(tmp_path)})
+        )
+        requests = list(pipeline.get_media_requests(item, None))
+        assert requests[0].url == url
+        assert requests[0].meta.get("allow_offsite") is True
+
     def test_item_fields_override_settings(self):
         url = "http://www.example.com/images/1.jpg"
         item = self.item_class(name="item1", custom_image_urls=[url])


### PR DESCRIPTION
## Summary

Allow image download requests generated by `ImagesPipeline` to bypass `OffsiteMiddleware` by setting `allow_offsite=True`.

## Motivation

When a spider uses `allowed_domains`, images may be hosted on external domains (e.g. CDN/media hosts).

`ImagesPipeline.get_media_requests()` currently generates requests without `allow_offsite`, which can cause media requests to be blocked.

This change keeps crawling restricted while allowing image downloads to proceed.

Closes #7544

## Changes

* Add `meta["allow_offsite"] = True` to requests generated by `ImagesPipeline`
* Add tests to verify generated media requests include `allow_offsite`

## Validation

```bash
python -m pytest tests/test_pipeline_images.py -vv
```

32 tests passed.
