### PR TITLE
fix: prevent scrapy shell from starting full crawl (#7552)

### DIFF
--- a/scrapy/shell.py
+++ b/scrapy/shell.py
@@ -214,7 +214,7 @@ class Shell:
         self.crawler.spider = spider
         assert self.crawler.engine
         await self.crawler.engine.open_spider_async(close_if_idle=False)
-        _schedule_coro(self.crawler.engine._start_request_processing())
+        # _schedule_coro(self.crawler.engine._start_request_processing())
         self.spider = spider
 
     def fetch(


### PR DESCRIPTION
### Description

This PR fixes a bug where invoking the `scrapy shell` command inside a project automatically triggers a full spider crawl instead of just fetching the single requested URL (issue #7552).

**The Root Cause:**
During recent refactorings (specifically in #6729 and #7395), an internal call to `self.crawler.engine._start_request_processing()` was introduced inside the `Shell._open_spider()` method. This inadvertently started the execution of the entire spider engine (including calling the spider's `start()` method and processing subsequent requests), rather than preserving the shell as an isolated REPL environment for inspecting a single response.

**The Solution:**
As investigated and suggested by @vcrab1312 in the issue discussion, removing the `_start_request_processing()` scheduling from `Shell._open_spider()` stops the unintended full crawl. The shell now successfully opens, fetches the single target URL, and presents the interactive prompt cleanly without being flooded by subsequent crawler logs.

### Steps to Test

1. Inside a Scrapy project with a configured spider that implements a custom `start()` method yielding multiple requests, run:
   `scrapy shell <URL>`
2. Prior to this PR, after fetching the target URL, the engine would continue crawling all other requests from the spider.
3. With this PR applied, the shell stops immediately at the `>>>` prompt after the initial fetch, as expected.
4. All dedicated shell tests (`tests/test_command_shell.py`) pass successfully.

### Checklist:

- [x] A minimal reproducible example of the bug is provided in the original issue.
- [x] I have tested this code locally and all relevant tests passed.
- [x] This code contains no backwards-incompatible changes.