### PR TITLE
fix: preserve %-format specifiers in pathlib.Path feed URIs (#6425)

### DIFF
--- a/scrapy/extensions/feedexport.py
+++ b/scrapy/extensions/feedexport.py
@@ -467,8 +467,9 @@ class FeedExporter:
                 stacklevel=2,
             )
             uri = self.settings["FEED_URI"]
-            # handle pathlib.Path objects
-            uri = str(uri) if not isinstance(uri, Path) else uri.absolute().as_uri()
+            # handle pathlib.Path objects; use str() instead of as_uri() to
+            # preserve %-format specifiers (as_uri() would URL-encode % → %25)
+            uri = str(uri) if not isinstance(uri, Path) else str(uri.absolute())
             feed_options = {"format": self.settings["FEED_FORMAT"]}
             self.feeds[uri] = feed_complete_default_values_from_settings(
                 feed_options, self.settings
@@ -478,11 +479,12 @@ class FeedExporter:
 
         # 'FEEDS' setting takes precedence over 'FEED_URI'
         for settings_uri, feed_options in self.settings.getdict("FEEDS").items():
-            # handle pathlib.Path objects
+            # handle pathlib.Path objects; use str() instead of as_uri() to
+            # preserve %-format specifiers (as_uri() would URL-encode % → %25)
             uri = (
                 str(settings_uri)
                 if not isinstance(settings_uri, Path)
-                else settings_uri.absolute().as_uri()
+                else str(settings_uri.absolute())
             )
             self.feeds[uri] = feed_complete_default_values_from_settings(
                 feed_options, self.settings

--- a/tests/test_feedexport.py
+++ b/tests/test_feedexport.py
@@ -1404,3 +1404,33 @@ class TestFeedExportInit:
         crawler = get_crawler(settings_dict=settings)
         exporter = FeedExporter.from_crawler(crawler)
         assert isinstance(exporter, FeedExporter)
+
+    def test_pathlib_with_uri_format_specifiers(self):
+        """Path objects with %-format specifiers must not be URL-encoded.
+
+        as_uri() encodes '%' as '%25', which breaks the ``uri % uri_params``
+        interpolation in open_spider() with a TypeError/KeyError.  The fix is
+        to use str(path.absolute()) instead of path.absolute().as_uri().
+        See https://github.com/scrapy/scrapy/issues/6425
+        """
+        with tempfile.TemporaryDirectory() as tmpdir:
+            feed_path = Path(tmpdir) / "%(name)s.json"
+            settings = {
+                "FEEDS": {
+                    feed_path: {
+                        "format": "json",
+                    },
+                },
+            }
+            crawler = get_crawler(settings_dict=settings)
+            exporter = FeedExporter.from_crawler(crawler)
+            assert isinstance(exporter, FeedExporter)
+
+            spider = scrapy.Spider("myspider")
+            spider.crawler = crawler
+            # This must not raise TypeError/KeyError from broken %-formatting
+            exporter.open_spider(spider)
+
+            assert len(exporter.slots) == 1
+            expected_uri = str(feed_path.absolute()).replace("%(name)s", "myspider")
+            assert exporter.slots[0].uri == expected_uri


### PR DESCRIPTION
## Summary

- Using a `pathlib.Path` with %-format specifiers (e.g. `%(name)s`, `%(time)s`) as a `FEEDS` key caused a `KeyError` in `open_spider()` because `as_uri()` URL-encodes `%` as `%25`, breaking `uri % uri_params` interpolation
- Fix: use `str(path.absolute())` instead of `path.absolute().as_uri()` — `FileFeedStorage` already accepts plain path strings

## Changes

- `scrapy/extensions/feedexport.py`: replace `path.absolute().as_uri()` with `str(path.absolute())` in both the legacy `FEED_URI` branch and the main `FEEDS` loop
- `tests/test_feedexport.py`: add `test_pathlib_with_uri_format_specifiers` asserting correct URI interpolation with a `Path` containing `%(name)s`

Fixes #6425