### PR TITLE
Honor DOWNLOADER_CLIENT_TLS_CIPHERS=None to use Twisted defaults (#7499)

### DIFF
--- a/scrapy/core/downloader/contextfactory.py
+++ b/scrapy/core/downloader/contextfactory.py
@@ -74,8 +74,15 @@ class _ScrapyClientContextFactory(BrowserLikePolicyForHTTPS):
         super().__init__(*args, **kwargs)  # type: ignore[no-untyped-call]
         self._ssl_method: int = method
         self.tls_verbose_logging: bool = tls_verbose_logging  # unused
-        self.tls_ciphers: AcceptableCiphers
-        if tls_ciphers:
+        self.tls_ciphers: AcceptableCiphers | None
+        if tls_ciphers is None:
+            # Explicit None means: defer to Twisted's defaults. The
+            # acceptableCiphers kwarg will be omitted entirely when building
+            # CertificateOptions, so twisted.internet._sslverify.defaultCiphers
+            # applies. Twisted's defaults exclude weaker suites that
+            # OpenSSL's "DEFAULT" still permits.
+            self.tls_ciphers = None
+        elif tls_ciphers:
             self.tls_ciphers = AcceptableCiphers.fromOpenSSLCipherString(tls_ciphers)
         else:
             self.tls_ciphers = DEFAULT_CIPHERS
@@ -93,6 +100,23 @@ class _ScrapyClientContextFactory(BrowserLikePolicyForHTTPS):
             "DOWNLOADER_CLIENT_TLS_VERBOSE_LOGGING"
         )
         tls_ciphers: str | None = crawler.settings["DOWNLOADER_CLIENT_TLS_CIPHERS"]
+        if tls_ciphers == "DEFAULT":
+            # See gh-7499. The implicit default of "DEFAULT" hides Twisted's
+            # stricter defaultCiphers (which excludes weak suites that
+            # OpenSSL's "DEFAULT" still permits). Users should explicitly
+            # choose either a cipher string or None to opt into Twisted's
+            # defaults. In a future major, the implicit default is intended
+            # to become None.
+            warnings.warn(
+                'The implicit default of DOWNLOADER_CLIENT_TLS_CIPHERS="DEFAULT" '
+                "is deprecated and will change to None in a future Scrapy release, "
+                "which will defer to Twisted's stricter defaultCiphers. Set "
+                "DOWNLOADER_CLIENT_TLS_CIPHERS explicitly to either a cipher "
+                "string (to preserve current behavior) or None (to opt in to "
+                "Twisted's defaults now).",
+                ScrapyDeprecationWarning,
+                stacklevel=2,
+            )
         verify_certificates = crawler.settings.getbool("DOWNLOAD_VERIFY_CERTIFICATES")
         return cls(  # type: ignore[misc]
             *args,
@@ -109,11 +133,13 @@ class _ScrapyClientContextFactory(BrowserLikePolicyForHTTPS):
 
     def _get_cert_options(self) -> CertificateOptions:
         with _filter_method_warning():
-            return _ScrapyCertificateOptions(
-                method=self._ssl_method,
-                fixBrokenPeers=True,
-                acceptableCiphers=self.tls_ciphers,
-            )
+            kwargs: dict[str, Any] = {
+                "method": self._ssl_method,
+                "fixBrokenPeers": True,
+            }
+            if self.tls_ciphers is not None:
+                kwargs["acceptableCiphers"] = self.tls_ciphers
+            return _ScrapyCertificateOptions(**kwargs)
 
     # should be removed together with ScrapyClientContextFactory
     def getContext(
@@ -139,12 +165,12 @@ class _ScrapyClientContextFactory(BrowserLikePolicyForHTTPS):
         # Otherwise use the normal Twisted function.
         # Note that this doesn't use self._get_context().
         with _filter_method_warning():
+            extra: dict[str, Any] = {"method": self._ssl_method}
+            if self.tls_ciphers is not None:
+                extra["acceptableCiphers"] = self.tls_ciphers
             return optionsForClientTLS(  # type: ignore[no-any-return]
                 hostname=hostname.decode("ascii"),
-                extraCertificateOptions={
-                    "method": self._ssl_method,
-                    "acceptableCiphers": self.tls_ciphers,
-                },
+                extraCertificateOptions=extra,
             )
 
 

--- a/tests/test_core_downloader.py
+++ b/tests/test_core_downloader.py
@@ -234,6 +234,76 @@ class TestContextFactoryTLSMethod(TestContextFactoryBase):
         await self._assert_factory_works(server_url, client_context_factory)
 
 
+class TestContextFactoryTLSCiphers:
+    """Coverage for DOWNLOADER_CLIENT_TLS_CIPHERS, including the explicit-None
+    semantic added for gh-7499.
+    """
+
+    def test_default_string_yields_parsed_ciphers(self) -> None:
+        """The default setting value of "DEFAULT" parses to an
+        AcceptableCiphers, preserving prior behavior.
+        """
+        crawler = get_crawler()
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", ScrapyDeprecationWarning)
+            factory = _load_context_factory_from_settings(crawler)
+        assert factory.tls_ciphers is not None
+
+    def test_explicit_string_is_parsed(self) -> None:
+        crawler = get_crawler(
+            settings_dict={"DOWNLOADER_CLIENT_TLS_CIPHERS": "HIGH:!aNULL:!MD5"}
+        )
+        factory = _load_context_factory_from_settings(crawler)
+        assert factory.tls_ciphers is not None
+
+    def test_explicit_none_defers_to_twisted_defaults(self) -> None:
+        """Setting to None must defer to Twisted's defaultCiphers.
+
+        Before gh-7499, an explicit None silently fell back to scrapy's
+        DEFAULT_CIPHERS, which is OpenSSL's "DEFAULT". Twisted's defaults
+        are stricter (they exclude weaker suites like RC4 and export-grade).
+        """
+        crawler = get_crawler(settings_dict={"DOWNLOADER_CLIENT_TLS_CIPHERS": None})
+        factory = _load_context_factory_from_settings(crawler)
+        assert factory.tls_ciphers is None
+
+    def test_explicit_none_does_not_pass_acceptable_ciphers(self) -> None:
+        """When tls_ciphers is None, acceptableCiphers must not be passed to
+        CertificateOptions so Twisted's defaults apply.
+        """
+        crawler = get_crawler(settings_dict={"DOWNLOADER_CLIENT_TLS_CIPHERS": None})
+        factory = _load_context_factory_from_settings(crawler)
+        # _get_cert_options should not raise and should return a usable
+        # CertificateOptions even though acceptableCiphers was omitted.
+        opts = factory._get_cert_options()
+        assert opts is not None
+
+    def test_default_value_emits_deprecation_warning(self) -> None:
+        """The implicit default of "DEFAULT" is deprecated in favor of an
+        explicit choice (a cipher string or None).
+        """
+        crawler = get_crawler()
+        with pytest.warns(
+            ScrapyDeprecationWarning,
+            match=r"DOWNLOADER_CLIENT_TLS_CIPHERS.*deprecated",
+        ):
+            _load_context_factory_from_settings(crawler)
+
+    def test_explicit_none_does_not_warn(self) -> None:
+        crawler = get_crawler(settings_dict={"DOWNLOADER_CLIENT_TLS_CIPHERS": None})
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", ScrapyDeprecationWarning)
+            _load_context_factory_from_settings(crawler)
+
+    def test_explicit_string_does_not_warn(self) -> None:
+        crawler = get_crawler(
+            settings_dict={"DOWNLOADER_CLIENT_TLS_CIPHERS": "HIGH:!aNULL:!MD5"}
+        )
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", ScrapyDeprecationWarning)
+            _load_context_factory_from_settings(crawler)
+
+
 @coroutine_test
 async def test_fetch_deprecated_spider_arg():
     class CustomDownloader(Downloader):


### PR DESCRIPTION
Closes #7499.

Setting `DOWNLOADER_CLIENT_TLS_CIPHERS` to `None` was supposed to defer to Twisted's `defaultCiphers`, but it fell back to `scrapy.core.downloader.tls.DEFAULT_CIPHERS` (which is OpenSSL's `"DEFAULT"`), so an explicit `None` was indistinguishable from the default and you couldn't opt into the stricter Twisted set.

When `tls_ciphers` is `None` I now omit the `acceptableCiphers` kwarg entirely from `CertificateOptions` / `optionsForClientTLS`, so Twisted's defaults apply. Twisted's `defaultCiphers` exclude weaker suites (RC4, export-grade) that OpenSSL's `"DEFAULT"` still permits, so this is a real hardening knob, not just an API cleanup. A plain string is still parsed as before, and an empty string still falls back to scrapy's `DEFAULT_CIPHERS`.

I also added a `ScrapyDeprecationWarning` when the setting is the implicit `"DEFAULT"`, nudging toward an explicit choice ahead of a future major where the default could flip to `None`. If you'd rather land the `None` fix without the deprecation for now, I can drop that part.

7 unit tests in `tests/test_core_downloader.py` cover the None path, the explicit-string path, the deprecation warning firing, and it not firing when set explicitly.
