### PR TITLE
Document start_time and finish_time stats (#6351)

### DIFF
--- a/docs/topics/stats.rst
+++ b/docs/topics/stats.rst
@@ -84,6 +84,17 @@ Get all stats:
 
 .. skip: end
 
+Timing
+------
+
+'time_start'
+    A date and time object used for recording when the crawl starts.
+
+'time_finish'
+    A date and time object used for recording when crwal finishes. 
+
+
+
 Available Stats Collectors
 ==========================
 


### PR DESCRIPTION
Resolves #6351

The Stats Collection page documents the Stats Collector API but does not
describe the stats Scrapy produces. This adds a short "Built-in stats
reference" section documenting the start_time and finish_time stats as a
starting point.