### PR TITLE
Allow configuring the log level of the retry give-up message

### DIFF
--- a/docs/topics/downloader-middleware.rst
+++ b/docs/topics/downloader-middleware.rst
@@ -1060,10 +1060,13 @@ RETRY_GIVE_UP_LOG_LEVEL
 
 Default: ``"ERROR"``
 
-:ref:`Logging level <levels>` used for the "gave up retrying" log message.
-Can be a level name (e.g. ``"WARNING"``) or a number (e.g. ``logging.WARNING``).
+:ref:`Logging level <levels>` used for the message logged when a request
+exceeds its retries.
 
-See also :reqmeta:`give_up_log_level`.
+Can be a level name (e.g. ``"WARNING"``) or a number (e.g. ``logging.WARNING``
+or ``30``).
+
+See also: :reqmeta:`give_up_log_level`, :func:`get_retry_request`.
 
 .. setting:: RETRY_PRIORITY_ADJUST
 

--- a/docs/topics/downloader-middleware.rst
+++ b/docs/topics/downloader-middleware.rst
@@ -1053,6 +1053,25 @@ has been exceeded (see :setting:`RETRY_TIMES`). To learn about uncaught
 exception propagation, see
 :meth:`~scrapy.downloadermiddlewares.DownloaderMiddleware.process_exception`.
 
+.. setting:: RETRY_GIVE_UP_LOG_LEVEL
+
+RETRY_GIVE_UP_LOG_LEVEL
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+Default: ``"ERROR"``
+
+:ref:`Logging level <levels>` used for the message that is logged when a
+request exhausts its retries and retrying is given up. It may be a level name
+(e.g. ``"WARNING"``) or a level number (e.g. ``logging.WARNING``).
+
+Lower it (e.g. to ``"WARNING"``) if giving up on a request should not count
+towards the ``log_count/ERROR`` stat.
+
+The logging level can also be specified per-request using
+:reqmeta:`give_up_log_level` attribute of :attr:`Request.meta <scrapy.Request.meta>`.
+When initialized, the :reqmeta:`give_up_log_level` meta key takes higher
+precedence over the :setting:`RETRY_GIVE_UP_LOG_LEVEL` setting.
+
 .. setting:: RETRY_PRIORITY_ADJUST
 
 RETRY_PRIORITY_ADJUST

--- a/docs/topics/downloader-middleware.rst
+++ b/docs/topics/downloader-middleware.rst
@@ -1056,7 +1056,7 @@ exception propagation, see
 .. setting:: RETRY_GIVE_UP_LOG_LEVEL
 
 RETRY_GIVE_UP_LOG_LEVEL
-^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^
 
 Default: ``"ERROR"``
 

--- a/docs/topics/downloader-middleware.rst
+++ b/docs/topics/downloader-middleware.rst
@@ -1060,17 +1060,10 @@ RETRY_GIVE_UP_LOG_LEVEL
 
 Default: ``"ERROR"``
 
-:ref:`Logging level <levels>` used for the message that is logged when a
-request exhausts its retries and retrying is given up. It may be a level name
-(e.g. ``"WARNING"``) or a level number (e.g. ``logging.WARNING``).
+:ref:`Logging level <levels>` used for the "gave up retrying" log message.
+Can be a level name (e.g. ``"WARNING"``) or a number (e.g. ``logging.WARNING``).
 
-Lower it (e.g. to ``"WARNING"``) if giving up on a request should not count
-towards the ``log_count/ERROR`` stat.
-
-The logging level can also be specified per-request using
-:reqmeta:`give_up_log_level` attribute of :attr:`Request.meta <scrapy.Request.meta>`.
-When initialized, the :reqmeta:`give_up_log_level` meta key takes higher
-precedence over the :setting:`RETRY_GIVE_UP_LOG_LEVEL` setting.
+For details, see :reqmeta:`give_up_log_level`.
 
 .. setting:: RETRY_PRIORITY_ADJUST
 

--- a/docs/topics/downloader-middleware.rst
+++ b/docs/topics/downloader-middleware.rst
@@ -1063,7 +1063,7 @@ Default: ``"ERROR"``
 :ref:`Logging level <levels>` used for the "gave up retrying" log message.
 Can be a level name (e.g. ``"WARNING"``) or a number (e.g. ``logging.WARNING``).
 
-For details, see :reqmeta:`give_up_log_level`.
+See also :reqmeta:`give_up_log_level`.
 
 .. setting:: RETRY_PRIORITY_ADJUST
 

--- a/docs/topics/request-response.rst
+++ b/docs/topics/request-response.rst
@@ -700,6 +700,7 @@ Those are:
 * :reqmeta:`download_maxsize`
 * :reqmeta:`download_warnsize`
 * :reqmeta:`download_timeout`
+* :reqmeta:`give_up_log_level`
 * ``ftp_password`` (See :setting:`FTP_PASSWORD` for more info)
 * ``ftp_user`` (See :setting:`FTP_USER` for more info)
 * :reqmeta:`handle_httpstatus_all`
@@ -785,6 +786,16 @@ max_retry_times
 The meta key is used set retry times per request. When initialized, the
 :reqmeta:`max_retry_times` meta key takes higher precedence over the
 :setting:`RETRY_TIMES` setting.
+
+.. reqmeta:: give_up_log_level
+
+give_up_log_level
+-----------------
+
+Sets, per request, the :ref:`logging level <levels>` used for the message
+logged when the request exhausts its retries. It may be a level name (e.g.
+``"WARNING"``) or a level number (e.g. ``logging.WARNING``). When set, this meta
+key takes precedence over the :setting:`RETRY_GIVE_UP_LOG_LEVEL` setting.
 
 
 .. _topics-stop-response-download:

--- a/docs/topics/request-response.rst
+++ b/docs/topics/request-response.rst
@@ -791,24 +791,22 @@ download_fail_on_dataloss
 Whether or not to fail on broken responses. See:
 :setting:`DOWNLOAD_FAIL_ON_DATALOSS`.
 
-.. reqmeta:: max_retry_times
-
-max_retry_times
----------------
-
-The meta key is used set retry times per request. When initialized, the
-:reqmeta:`max_retry_times` meta key takes higher precedence over the
-:setting:`RETRY_TIMES` setting.
-
 .. reqmeta:: give_up_log_level
 
 give_up_log_level
 -----------------
 
-Sets, per request, the :ref:`logging level <levels>` used for the message
-logged when the request exhausts its retries. It may be a level name (e.g.
-``"WARNING"``) or a level number (e.g. ``logging.WARNING``). When set, this meta
-key takes precedence over the :setting:`RETRY_GIVE_UP_LOG_LEVEL` setting.
+The :ref:`logging level <levels>` to use for the message logged when the
+request exhausts its retries. See :setting:`RETRY_GIVE_UP_LOG_LEVEL` for details.
+
+.. reqmeta:: max_retry_times
+
+max_retry_times
+---------------
+
+The meta key is used set retry times per request. When set, the
+:reqmeta:`max_retry_times` meta key takes higher precedence over the
+:setting:`RETRY_TIMES` setting.
 
 .. reqmeta:: verbatim_url
 

--- a/docs/topics/request-response.rst
+++ b/docs/topics/request-response.rst
@@ -712,9 +712,9 @@ Those are:
 * :reqmeta:`download_maxsize`
 * :reqmeta:`download_warnsize`
 * :reqmeta:`download_timeout`
-* :reqmeta:`give_up_log_level`
 * ``ftp_password`` (See :setting:`FTP_PASSWORD` for more info)
 * ``ftp_user`` (See :setting:`FTP_USER` for more info)
+* :reqmeta:`give_up_log_level`
 * :reqmeta:`handle_httpstatus_all`
 * :reqmeta:`handle_httpstatus_list`
 * :reqmeta:`is_start_request`
@@ -797,7 +797,7 @@ give_up_log_level
 -----------------
 
 The :ref:`logging level <levels>` to use for the message logged when the
-request exhausts its retries. See :setting:`RETRY_GIVE_UP_LOG_LEVEL` for details.
+request exceeds its retries. See also :setting:`RETRY_GIVE_UP_LOG_LEVEL`.
 
 .. reqmeta:: max_retry_times
 

--- a/docs/topics/request-response.rst
+++ b/docs/topics/request-response.rst
@@ -796,8 +796,8 @@ Whether or not to fail on broken responses. See:
 give_up_log_level
 -----------------
 
-The :ref:`logging level <levels>` to use for the message logged when the
-request exceeds its retries. See also :setting:`RETRY_GIVE_UP_LOG_LEVEL`.
+:ref:`Logging level <levels>` used for the message logged when a request
+exceeds its retries. See :setting:`RETRY_GIVE_UP_LOG_LEVEL` for details.
 
 .. reqmeta:: max_retry_times
 

--- a/scrapy/downloadermiddlewares/retry.py
+++ b/scrapy/downloadermiddlewares/retry.py
@@ -57,11 +57,8 @@ def get_retry_request(
         def parse(self, response):
             if not response.text:
                 new_request_or_none = get_retry_request(
-                    response.request,
-                    spider=self,
-                    reason='empty',
-                )
-                return new_request_or_none
+                    response.request, spider=self, reason='empty',
+                ) return new_request_or_none
 
     *spider* is the :class:`~scrapy.Spider` instance which is asking for the
     retry request. It is used to access the :ref:`settings <topics-settings>`
@@ -83,8 +80,9 @@ def get_retry_request(
 
     *logger* is the logging.Logger object to be used when logging messages
 
-    *give_up_log_level* is the :ref:`logging level <levels>` to use for the
-    "gave up retrying" message. See :setting:`RETRY_GIVE_UP_LOG_LEVEL`.
+    *give_up_log_level* is the :ref:`logging level <levels>` used for the
+    message logged when a request exceeds its retries. See
+    :setting:`RETRY_GIVE_UP_LOG_LEVEL` for details.
 
     *stats_base_key* is a string to be used as the base key for the
     retry-related job stats
@@ -119,7 +117,7 @@ def get_retry_request(
         stats.inc_value(f"{stats_base_key}/reason_count/{reason}")
         return new_request
     if give_up_log_level is None:
-        give_up_log_level = settings.get("RETRY_GIVE_UP_LOG_LEVEL")
+        give_up_log_level = settings["RETRY_GIVE_UP_LOG_LEVEL"]
     if isinstance(give_up_log_level, str):
         level = getLevelName(give_up_log_level)
         if not isinstance(level, int):
@@ -144,7 +142,7 @@ class RetryMiddleware:
         self.max_retry_times = settings.getint("RETRY_TIMES")
         self.retry_http_codes = {int(x) for x in settings.getlist("RETRY_HTTP_CODES")}
         self.priority_adjust = settings.getint("RETRY_PRIORITY_ADJUST")
-        self.give_up_log_level = settings.get("RETRY_GIVE_UP_LOG_LEVEL")
+        self.give_up_log_level = settings["RETRY_GIVE_UP_LOG_LEVEL"]
         self.exceptions_to_retry = tuple(
             load_object(x) if isinstance(x, str) else x
             for x in settings.getlist("RETRY_EXCEPTIONS")

--- a/scrapy/downloadermiddlewares/retry.py
+++ b/scrapy/downloadermiddlewares/retry.py
@@ -83,11 +83,8 @@ def get_retry_request(
 
     *logger* is the logging.Logger object to be used when logging messages
 
-    *give_up_log_level* is the :ref:`logging level <levels>` used for the
-    message logged when retries are exhausted. It can be a level number (e.g.
-    ``logging.WARNING``) or its name (e.g. ``"WARNING"``). If not specified or
-    ``None``, the value is read from the :setting:`RETRY_GIVE_UP_LOG_LEVEL`
-    setting.
+    *give_up_log_level* is the :ref:`logging level <levels>` to use for the
+    "gave up retrying" message. See :setting:`RETRY_GIVE_UP_LOG_LEVEL`.
 
     *stats_base_key* is a string to be used as the base key for the
     retry-related job stats

--- a/scrapy/downloadermiddlewares/retry.py
+++ b/scrapy/downloadermiddlewares/retry.py
@@ -12,7 +12,7 @@ once the spider has finished crawling all regular (non-failed) pages.
 
 from __future__ import annotations
 
-from logging import Logger, getLogger
+from logging import Logger, getLevelName, getLogger
 from typing import TYPE_CHECKING
 
 from scrapy.exceptions import NotConfigured
@@ -43,6 +43,7 @@ def get_retry_request(
     max_retry_times: int | None = None,
     priority_adjust: int | None = None,
     logger: Logger = retry_logger,
+    give_up_log_level: int | str | None = None,
     stats_base_key: str = "retry",
 ) -> Request | None:
     """
@@ -82,6 +83,12 @@ def get_retry_request(
 
     *logger* is the logging.Logger object to be used when logging messages
 
+    *give_up_log_level* is the :ref:`logging level <levels>` used for the
+    message logged when retries are exhausted. It can be a level number (e.g.
+    ``logging.WARNING``) or its name (e.g. ``"WARNING"``). If not specified or
+    ``None``, the value is read from the :setting:`RETRY_GIVE_UP_LOG_LEVEL`
+    setting.
+
     *stats_base_key* is a string to be used as the base key for the
     retry-related job stats
     """
@@ -114,8 +121,16 @@ def get_retry_request(
         stats.inc_value(f"{stats_base_key}/count")
         stats.inc_value(f"{stats_base_key}/reason_count/{reason}")
         return new_request
+    if give_up_log_level is None:
+        give_up_log_level = settings.get("RETRY_GIVE_UP_LOG_LEVEL")
+    if isinstance(give_up_log_level, str):
+        level = getLevelName(give_up_log_level)
+        if not isinstance(level, int):
+            raise ValueError(f"Invalid give-up log level: {give_up_log_level!r}")
+        give_up_log_level = level
     stats.inc_value(f"{stats_base_key}/max_reached")
-    logger.error(
+    logger.log(
+        give_up_log_level,
         "Gave up retrying %(request)s (failed %(retry_times)d times): %(reason)s",
         {"request": request, "retry_times": retry_times, "reason": reason},
         extra={"spider": spider},
@@ -132,6 +147,7 @@ class RetryMiddleware:
         self.max_retry_times = settings.getint("RETRY_TIMES")
         self.retry_http_codes = {int(x) for x in settings.getlist("RETRY_HTTP_CODES")}
         self.priority_adjust = settings.getint("RETRY_PRIORITY_ADJUST")
+        self.give_up_log_level = settings.get("RETRY_GIVE_UP_LOG_LEVEL")
         self.exceptions_to_retry = tuple(
             load_object(x) if isinstance(x, str) else x
             for x in settings.getlist("RETRY_EXCEPTIONS")
@@ -175,6 +191,9 @@ class RetryMiddleware:
     ) -> Request | None:
         max_retry_times = request.meta.get("max_retry_times", self.max_retry_times)
         priority_adjust = request.meta.get("priority_adjust", self.priority_adjust)
+        give_up_log_level = request.meta.get(
+            "give_up_log_level", self.give_up_log_level
+        )
         assert self.crawler.spider
         return get_retry_request(
             request,
@@ -182,4 +201,5 @@ class RetryMiddleware:
             spider=self.crawler.spider,
             max_retry_times=max_retry_times,
             priority_adjust=priority_adjust,
+            give_up_log_level=give_up_log_level,
         )

--- a/scrapy/downloadermiddlewares/retry.py
+++ b/scrapy/downloadermiddlewares/retry.py
@@ -52,13 +52,18 @@ def get_retry_request(
     exhausted.
 
     For example, in a :class:`~scrapy.Spider` callback, you could use it as
-    follows::
+    follows:
+
+    .. code-block:: python
 
         def parse(self, response):
             if not response.text:
                 new_request_or_none = get_retry_request(
-                    response.request, spider=self, reason='empty',
-                ) return new_request_or_none
+                    response.request,
+                    spider=self,
+                    reason="empty",
+                )
+                return new_request_or_none
 
     *spider* is the :class:`~scrapy.Spider` instance which is asking for the
     retry request. It is used to access the :ref:`settings <topics-settings>`

--- a/scrapy/settings/default_settings.py
+++ b/scrapy/settings/default_settings.py
@@ -153,6 +153,7 @@ __all__ = [
     "REQUEST_FINGERPRINTER_CLASS",
     "RETRY_ENABLED",
     "RETRY_EXCEPTIONS",
+    "RETRY_GIVE_UP_LOG_LEVEL",
     "RETRY_HTTP_CODES",
     "RETRY_PRIORITY_ADJUST",
     "RETRY_TIMES",
@@ -464,6 +465,7 @@ RETRY_EXCEPTIONS = [
     OSError,
     "scrapy.core.downloader.handlers.http11.TunnelError",
 ]
+RETRY_GIVE_UP_LOG_LEVEL = "ERROR"
 RETRY_HTTP_CODES = [500, 502, 503, 504, 522, 524, 408, 429]
 RETRY_PRIORITY_ADJUST = -1
 RETRY_TIMES = 2  # initial response + 2 retries = 3 requests

--- a/tests/test_downloadermiddleware_retry.py
+++ b/tests/test_downloadermiddleware_retry.py
@@ -91,8 +91,8 @@ class TestRetry:
         crawler.spider = crawler._create_spider()
         mw = RetryMiddleware.from_crawler(crawler)
         mw.max_retry_times = 0
-        req = Request("http://www.scrapytest.org/503")
-        rsp = Response("http://www.scrapytest.org/503", body=b"", status=503)
+        req = Request("http://example.com/503")
+        rsp = Response("http://example.com/503", body=b"", status=503)
         with LogCapture() as log:
             assert mw.process_response(req, rsp) is rsp
         log.check_present(
@@ -105,10 +105,8 @@ class TestRetry:
 
     def test_give_up_log_level_meta(self):
         self.mw.max_retry_times = 0
-        req = Request(
-            "http://www.scrapytest.org/503", meta={"give_up_log_level": "WARNING"}
-        )
-        rsp = Response("http://www.scrapytest.org/503", body=b"", status=503)
+        req = Request("http://example.com/503", meta={"give_up_log_level": "WARNING"})
+        rsp = Response("http://example.com/503", body=b"", status=503)
         with LogCapture() as log:
             assert self.mw.process_response(req, rsp) is rsp
         log.check_present(

--- a/tests/test_downloadermiddleware_retry.py
+++ b/tests/test_downloadermiddleware_retry.py
@@ -84,6 +84,41 @@ class TestRetry:
         )
         assert self.crawler.stats.get_value("retry/count") == 2
 
+    def test_give_up_log_level_setting(self):
+        crawler = get_crawler(
+            DefaultSpider, settings_dict={"RETRY_GIVE_UP_LOG_LEVEL": "WARNING"}
+        )
+        crawler.spider = crawler._create_spider()
+        mw = RetryMiddleware.from_crawler(crawler)
+        mw.max_retry_times = 0
+        req = Request("http://www.scrapytest.org/503")
+        rsp = Response("http://www.scrapytest.org/503", body=b"", status=503)
+        with LogCapture() as log:
+            assert mw.process_response(req, rsp) is rsp
+        log.check_present(
+            (
+                "scrapy.downloadermiddlewares.retry",
+                "WARNING",
+                f"Gave up retrying {req} (failed 1 times): 503 Service Unavailable",
+            )
+        )
+
+    def test_give_up_log_level_meta(self):
+        self.mw.max_retry_times = 0
+        req = Request(
+            "http://www.scrapytest.org/503", meta={"give_up_log_level": "WARNING"}
+        )
+        rsp = Response("http://www.scrapytest.org/503", body=b"", status=503)
+        with LogCapture() as log:
+            assert self.mw.process_response(req, rsp) is rsp
+        log.check_present(
+            (
+                "scrapy.downloadermiddlewares.retry",
+                "WARNING",
+                f"Gave up retrying {req} (failed 1 times): 503 Service Unavailable",
+            )
+        )
+
     def test_twistederrors(self):
         exceptions = [
             ConnectError,
@@ -611,6 +646,87 @@ class TestGetRetryRequest:
                 f"Retrying {request} (failed 1 times): {expected_reason}",
             )
         )
+
+    def test_give_up_log_level_default(self):
+        request = Request("https://example.com")
+        spider = self.get_spider()
+        with LogCapture() as log:
+            get_retry_request(
+                request,
+                spider=spider,
+                max_retry_times=0,
+            )
+        log.check_present(
+            (
+                "scrapy.downloadermiddlewares.retry",
+                "ERROR",
+                f"Gave up retrying {request} (failed 1 times): unspecified",
+            )
+        )
+
+    def test_give_up_log_level_argument_name(self):
+        request = Request("https://example.com")
+        spider = self.get_spider()
+        with LogCapture() as log:
+            get_retry_request(
+                request,
+                spider=spider,
+                max_retry_times=0,
+                give_up_log_level="WARNING",
+            )
+        log.check_present(
+            (
+                "scrapy.downloadermiddlewares.retry",
+                "WARNING",
+                f"Gave up retrying {request} (failed 1 times): unspecified",
+            )
+        )
+
+    def test_give_up_log_level_argument_number(self):
+        request = Request("https://example.com")
+        spider = self.get_spider()
+        with LogCapture() as log:
+            get_retry_request(
+                request,
+                spider=spider,
+                max_retry_times=0,
+                give_up_log_level=logging.WARNING,
+            )
+        log.check_present(
+            (
+                "scrapy.downloadermiddlewares.retry",
+                "WARNING",
+                f"Gave up retrying {request} (failed 1 times): unspecified",
+            )
+        )
+
+    def test_give_up_log_level_setting(self):
+        request = Request("https://example.com")
+        spider = self.get_spider({"RETRY_GIVE_UP_LOG_LEVEL": "WARNING"})
+        with LogCapture() as log:
+            get_retry_request(
+                request,
+                spider=spider,
+                max_retry_times=0,
+            )
+        log.check_present(
+            (
+                "scrapy.downloadermiddlewares.retry",
+                "WARNING",
+                f"Gave up retrying {request} (failed 1 times): unspecified",
+            )
+        )
+
+    def test_give_up_log_level_invalid(self):
+        request = Request("https://example.com")
+        spider = self.get_spider()
+        with pytest.raises(ValueError, match="Invalid give-up log level"):
+            get_retry_request(
+                request,
+                spider=spider,
+                max_retry_times=0,
+                give_up_log_level="NOT_A_LEVEL",
+            )
 
     def test_custom_stats_key(self):
         request = Request("https://example.com")


### PR DESCRIPTION
Fixes #5297, fixes #4622, closes https://github.com/scrapy/scrapy/pull/5625.

## Allow configuring the log level of the retry give-up message

### Motivation

When a request exhausts its retries, the retry middleware logs the *"Gave up retrying …"* message at the `ERROR` level. This is hardcoded and cannot be changed.

This is problematic because giving up on a request is not always an application error. e.g. in broad crawls that hit dead or flaky hosts, give-ups are expected. The fixed `ERROR` level inflates the `log_count/ERROR` stat, which is the standard signal users rely on to detect real problems in a job, and it is logged as an error even when the failure is already handled via an `errback`.

This PR makes the level configurable so users can downgrade it (e.g. to `WARNING`) without losing the message.

### Changes

The level can now be controlled at three levels of granularity (mirroring how `max_retry_times` / `priority_adjust` already work):

1. **Setting** — new `RETRY_GIVE_UP_LOG_LEVEL` (default `"ERROR"`).
2. **Function argument** — new `give_up_log_level` keyword argument on `get_retry_request()`.
3. **Per-request** — new `give_up_log_level` `Request.meta` key, which takes precedence over the setting.

All three accept either a level **name** (`"WARNING"`) or a level **number** (`logging.WARNING`), consistent with Python's `logging` API. An invalid level name raises a clear `ValueError`.

```python
# Project-wide, via settings
RETRY_GIVE_UP_LOG_LEVEL = "WARNING"

# Per request
Request(url, meta={"give_up_log_level": logging.WARNING})

# Direct API use
get_retry_request(request, spider=spider, give_up_log_level="WARNING")
```

### Backward compatibility

Fully backward compatible. The default (`"ERROR"`) resolves to the same level as before, so `logger.log(...)` produces output identical to the previous `logger.error(...)`. The new resolution logic runs only on the give-up path, so the success path is unaffected.

### Documentation

- Added the `RETRY_GIVE_UP_LOG_LEVEL` setting reference under the Retry middleware docs.
- Added a `give_up_log_level` request-meta key entry, cross-referenced with the setting.

### Tests

Added tests covering the default level, the function argument (by name and by number), the setting, the per-request meta override, and the invalid-level error at both the `get_retry_request()` and `RetryMiddleware` entry points.
