### PR TITLE
Preserve Content-Encoding header in decompressed responses

### DIFF
--- a/scrapy/downloadermiddlewares/httpcompression.py
+++ b/scrapy/downloadermiddlewares/httpcompression.py
@@ -148,8 +148,11 @@ class HttpCompressionMiddleware:
                     # responsetypes guessing is reliable
                     kwargs["encoding"] = None
                 response = response.replace(cls=respcls, **kwargs)
+                # Preserve the original Content-Encoding header so spiders
+                # can inspect the original response encoding.
                 if not content_encoding:
-                    del response.headers["Content-Encoding"]
+                    if "Content-Encoding" in response.headers:
+                        response.flags.add("body-decoded")
 
         return response
 


### PR DESCRIPTION
## Problem

The HttpCompressionMiddleware deletes the Content-Encoding header after decompressing the response body. Spiders cannot see the original content encoding of responses.

## Fix

Instead of deleting the header, add a `body-decoded` flag to the response. This lets spiders know the body was decompressed while preserving the original header for inspection.

Closes #1988