### PR TITLE
Handle query strings in sitemap URLs

### DIFF
--- a/scrapy/spiders/sitemap.py
+++ b/scrapy/spiders/sitemap.py
@@ -6,6 +6,7 @@ import re
 # Iterable is needed at the run time for the SitemapSpider._parse_sitemap() annotation
 from collections.abc import AsyncIterator, Iterable, Sequence  # noqa: TC003
 from typing import TYPE_CHECKING, Any, cast
+from urllib.parse import urlparse
 
 from scrapy.http import Request, Response, XmlResponse
 from scrapy.spiders import Spider
@@ -145,7 +146,8 @@ class SitemapSpider(Spider):
         # without actually being a .xml.gz file in the first place,
         # merely XML gzip-compressed on the fly,
         # in other word, here, we have plain XML
-        if response.url.endswith(".xml") or response.url.endswith(".xml.gz"):
+        sitemap_path = urlparse(response.url).path
+        if sitemap_path.endswith((".xml", ".xml.gz")):
             return response.body
         return None
 

--- a/tests/test_spider_sitemap.py
+++ b/tests/test_spider_sitemap.py
@@ -60,6 +60,14 @@ class TestSitemapSpider(TestSpider):
         r = TextResponse(url="http://www.example.com/sitemap.xml", body=self.BODY)
         self.assertSitemapBody(r, self.BODY)
 
+    @pytest.mark.parametrize("url", [
+        "http://www.example.com/sitemap.xml?from=1&to=2",
+        "http://www.example.com/sitemap.xml.gz?from=1&to=2",
+    ])
+    def test_get_sitemap_body_xml_url_with_query(self, url: str):
+        r = TextResponse(url=url, body=self.BODY)
+        self.assertSitemapBody(r, self.BODY)
+
     def test_get_sitemap_body_xml_url_compressed(self):
         r = Response(
             url="http://www.example.com/sitemap.xml.gz",


### PR DESCRIPTION
Resolves #6293.

## Summary
- Check the parsed URL path when deciding whether a plain response body should be treated as a sitemap.
- Keep query strings from preventing .xml and .xml.gz sitemap URLs from being parsed.
- Add regression coverage for sitemap URLs with query parameters.

## Tests
- python -m pytest tests/test_spider_sitemap.py -q
- python -m ruff check scrapy/spiders/sitemap.py tests/test_spider_sitemap.py
- git diff --check
