### PR TITLE
Preserve feed URI params for Path keys

### DIFF
--- a/scrapy/extensions/feedexport.py
+++ b/scrapy/extensions/feedexport.py
@@ -34,6 +34,10 @@ from scrapy.utils.ftp import ftp_store_file
 from scrapy.utils.misc import build_from_crawler, load_object
 from scrapy.utils.python import without_none_values
 
+_FEED_URI_PARAM_RE = re.compile(
+    r"%25%28(?P<key>[A-Za-z_][A-Za-z0-9_]*)%29(?P<format>[-+#0-9 .hlL]*[diouxXeEfFgGcrs])"
+)
+
 if TYPE_CHECKING:
     from _typeshed import OpenBinaryMode
 
@@ -46,6 +50,21 @@ if TYPE_CHECKING:
 
 
 logger = logging.getLogger(__name__)
+
+
+def _path_to_feed_uri_template(path: Path) -> str:
+    uri = path.absolute().as_uri()
+    placeholders: list[str] = []
+
+    def replace_placeholder(match: re.Match[str]) -> str:
+        placeholders.append(f"%({match['key']}){match['format']}")
+        return f"__scrapy_feed_uri_param_{len(placeholders) - 1}__"
+
+    uri = _FEED_URI_PARAM_RE.sub(replace_placeholder, uri)
+    uri = uri.replace("%", "%%")
+    for index, placeholder in enumerate(placeholders):
+        uri = uri.replace(f"__scrapy_feed_uri_param_{index}__", placeholder)
+    return uri
 
 UriParamsCallableT: TypeAlias = Callable[
     [dict[str, Any], Spider], dict[str, Any] | None
@@ -471,7 +490,9 @@ class FeedExporter:
             )
             uri = self.settings["FEED_URI"]
             # handle pathlib.Path objects
-            uri = str(uri) if not isinstance(uri, Path) else uri.absolute().as_uri()
+            uri = (
+                str(uri) if not isinstance(uri, Path) else _path_to_feed_uri_template(uri)
+            )
             feed_options = {"format": self.settings["FEED_FORMAT"]}
             self.feeds[uri] = feed_complete_default_values_from_settings(
                 feed_options, self.settings
@@ -485,7 +506,7 @@ class FeedExporter:
             uri = (
                 str(settings_uri)
                 if not isinstance(settings_uri, Path)
-                else settings_uri.absolute().as_uri()
+                else _path_to_feed_uri_template(settings_uri)
             )
             self.feeds[uri] = feed_complete_default_values_from_settings(
                 feed_options, self.settings

--- a/tests/test_feedexport.py
+++ b/tests/test_feedexport.py
@@ -1404,3 +1404,21 @@ class TestFeedExportInit:
         crawler = get_crawler(settings_dict=settings)
         exporter = FeedExporter.from_crawler(crawler)
         assert isinstance(exporter, FeedExporter)
+
+    def test_pathlib_uri_params(self, tmp_path: Path):
+        feed_uri = tmp_path / "output dir" / "%(name)s.json"
+        settings = {
+            "FEEDS": {
+                feed_uri: {
+                    "format": "json",
+                },
+            },
+        }
+        crawler = get_crawler(settings_dict=settings)
+        exporter = FeedExporter.from_crawler(crawler)
+        spider = Spider("example")
+        spider.crawler = crawler
+
+        exporter.open_spider(spider)
+
+        assert exporter.slots[0].uri.endswith("/output%20dir/example.json")


### PR DESCRIPTION
Fixes #6425.

When a `pathlib.Path` key in `FEEDS` contains feed URI parameters such as `%(name)s`, `Path.as_uri()` percent-encodes the placeholder before `FeedExporter.open_spider()` applies URI params. The encoded `%25...` sequence then breaks old-style string formatting.

This keeps URI placeholders format-ready while still escaping other percent-encoded path characters before the URI template is formatted.

Checks run:
- `PYTHONPATH=. python -m pytest tests/test_feedexport.py::TestFeedExportInit::test_pathlib_uri_params tests/test_feedexport.py::TestFeedExportInit::test_absolute_pathlib_as_uri tests/test_feedexport.py::TestFeedExportInit::test_relative_pathlib_as_uri tests/test_feedexport_uri_params.py -q`
- `python -m ruff check scrapy/extensions/feedexport.py tests/test_feedexport.py`
- `git diff --check`