### PR TITLE
Warn when CsvItemExporter silently drops fields (fixes #4002)

### DIFF
--- a/scrapy/exporters.py
+++ b/scrapy/exporters.py
@@ -5,6 +5,7 @@ Item Exporters are used to export/serialize items into different formats.
 from __future__ import annotations
 
 import csv
+import logging
 import marshal
 import pickle
 import pprint
@@ -14,6 +15,8 @@ from io import BytesIO, TextIOWrapper
 from typing import TYPE_CHECKING, Any
 from xml.sax.saxutils import XMLGenerator
 from xml.sax.xmlreader import AttributesImpl
+
+logger = logging.getLogger(__name__)
 
 from itemadapter import ItemAdapter, is_item
 
@@ -245,6 +248,8 @@ class CsvItemExporter(BaseItemExporter):
         self.csv_writer = csv.writer(self.stream, **self._kwargs)
         self._headers_not_written = True
         self._join_multivalued = join_multivalued
+        # Track field names we have already warned about to emit each warning once.
+        self._fields_warned: set[str] = set()
 
     def serialize_field(
         self, field: Mapping[str, Any] | Field, name: str, value: Any
@@ -264,6 +269,26 @@ class CsvItemExporter(BaseItemExporter):
         if self._headers_not_written:
             self._headers_not_written = False
             self._write_headers_and_set_fields_to_export(item)
+
+        # Warn once per field name that is present in the item but absent from
+        # fields_to_export (which was fixed from the first item).  Without this
+        # warning the data is silently lost, which is very hard to debug.
+        if self.fields_to_export is not None:
+            if isinstance(self.fields_to_export, Mapping):
+                exported_fields = set(self.fields_to_export.keys())
+            else:
+                exported_fields = set(self.fields_to_export)
+            item_fields = set(ItemAdapter(item).field_names())
+            newly_dropped = item_fields - exported_fields - self._fields_warned
+            if newly_dropped:
+                logger.warning(
+                    "CsvItemExporter is dropping field(s) %s because they "
+                    "were not present in the first exported item. "
+                    "Use the fields_to_export option to make the column set "
+                    "explicit and avoid silent data loss.",
+                    sorted(newly_dropped),
+                )
+                self._fields_warned.update(newly_dropped)
 
         fields = self._get_serialized_fields(item, default_value="", include_empty=True)
         values = list(self._build_row(x for _, x in fields))

--- a/tests/test_exporters.py
+++ b/tests/test_exporters.py
@@ -382,6 +382,69 @@ class TestCsvItemExporter(TestBaseItemExporter):
         )
 
 
+    def test_warn_on_dropped_field(self):
+        """A warning is emitted once when a subsequent item introduces a field
+        that was absent from the first item (issue #4002)."""
+        import logging
+
+        class _Capture(logging.Handler):
+            def __init__(self):
+                super().__init__()
+                self.records: list = []
+
+            def emit(self, record):
+                self.records.append(record)
+
+        output = BytesIO()
+        ie = CsvItemExporter(output)
+        ie.start_exporting()
+        ie.export_item({"name": "Alice"})
+
+        handler = _Capture()
+        exporter_log = logging.getLogger("scrapy.exporters")
+        exporter_log.addHandler(handler)
+        try:
+            ie.export_item({"name": "Bob", "age": 30})
+            # Third item has the same extra field — must NOT emit a second warning.
+            ie.export_item({"name": "Carol", "age": 25})
+        finally:
+            exporter_log.removeHandler(handler)
+
+        ie.finish_exporting()
+        # Exactly one warning for the single dropped field.
+        assert len(handler.records) == 1
+        assert handler.records[0].levelno == logging.WARNING
+        assert "age" in handler.records[0].getMessage()
+
+    def test_no_warn_when_fields_match(self):
+        """No warning is emitted when every exported item has the same fields."""
+        import logging
+
+        class _Capture(logging.Handler):
+            def __init__(self):
+                super().__init__()
+                self.records: list = []
+
+            def emit(self, record):
+                self.records.append(record)
+
+        output = BytesIO()
+        ie = CsvItemExporter(output)
+        ie.start_exporting()
+
+        handler = _Capture()
+        exporter_log = logging.getLogger("scrapy.exporters")
+        exporter_log.addHandler(handler)
+        try:
+            ie.export_item({"name": "Alice", "age": 22})
+            ie.export_item({"name": "Bob", "age": 30})
+        finally:
+            exporter_log.removeHandler(handler)
+
+        ie.finish_exporting()
+        assert len(handler.records) == 0
+
+
 class TestCsvItemExporterDataclass(TestCsvItemExporter):
     item_class = MyDataClass
     custom_field_item_class = CustomFieldDataclass


### PR DESCRIPTION
## What this fixes

Closes #4002.

When `CsvItemExporter` writes its CSV header from the **first exported item**, any field that appears in a **later item** but not in that first item is silently discarded. This is very difficult to debug because the output file looks valid — the data is just gone.

## Reproducing the problem

```python
from io import BytesIO
from scrapy.exporters import CsvItemExporter

out = BytesIO()
ie = CsvItemExporter(out)
ie.start_exporting()
ie.export_item({"name": "Alice"})           # sets header: name
ie.export_item({"name": "Bob", "age": 30})  # age silently dropped
ie.finish_exporting()

print(out.getvalue())
# b'name
Alice
Bob
'  <-- age is gone, no indication
```

## What this PR does

Emits a **single** `WARNING` log message the first time each unknown field name is encountered, naming the dropped field and pointing to `fields_to_export` as the explicit fix:

```
WARNING scrapy.exporters: CsvItemExporter is dropping field(s) ['age'] because
they were not present in the first exported item. Use the fields_to_export
option to make the column set explicit and avoid silent data loss.
```

The warning fires **once per unique field name** — not once per item — so it does not flood logs in long crawls.

## Changes

| File | Change |
|---|---|
| `scrapy/exporters.py` | Add `import logging` + module logger; track warned fields in `_fields_warned: set[str]`; emit warning in `export_item` |
| `tests/test_exporters.py` | `test_warn_on_dropped_field` — verifies one warning per field, not repeated; `test_no_warn_when_fields_match` — verifies no noise on consistent items |

## Tests

All 17 existing `TestCsvItemExporter` tests pass, plus the 2 new ones.
