### PR TITLE
Document cb_kwargs/meta deep-copy when JOBDIR is set

### DIFF
--- a/docs/topics/jobs.rst
+++ b/docs/topics/jobs.rst
@@ -104,6 +104,15 @@ If you wish to log the requests that couldn't be serialized, you can set the
 :setting:`SCHEDULER_DEBUG` setting to ``True`` in the project's settings page.
 It is ``False`` by default.
 
+.. note:: Because requests are serialized with :mod:`pickle`, the objects you
+    store on a request, such as the values of its
+    :attr:`~scrapy.Request.cb_kwargs` and :attr:`~scrapy.Request.meta`
+    dictionaries, are deep-copied when the request is written to and later read
+    back from the job directory. As a result, the callback receives a *copy* of
+    those objects rather than the original ones, and changes made to the copy are
+    not reflected in the original object. Keep this in mind if you rely on
+    sharing mutable state through ``cb_kwargs`` or ``meta``.
+
 .. _job-dir-contents:
 
 Job directory contents

--- a/docs/topics/request-response.rst
+++ b/docs/topics/request-response.rst
@@ -188,6 +188,13 @@ Request objects
         ``failure.request.cb_kwargs`` in the request's errback. For more information,
         see :ref:`errback-cb_kwargs`.
 
+        .. note:: When :setting:`JOBDIR` is set, requests are serialized to disk
+            with :mod:`pickle` (see :ref:`request-serialization`). As a result,
+            the callback receives a deep copy of any object stored in
+            ``cb_kwargs``, so mutating such an object in the callback does not
+            affect the original. Avoid relying on shared mutable state passed
+            through ``cb_kwargs`` in that case.
+
     .. attribute:: Request.meta
        :value: {}
 


### PR DESCRIPTION
Closes #6120

## Why

When `JOBDIR` is set, the scheduler persists requests to disk and serializes them with `pickle` (via `PickleLifoDiskQueue`). Because of this round trip, the objects stored in a request's `cb_kwargs` (and `meta`) are **deep-copied**: the callback receives copies rather than the original objects, so mutating them in the callback does not affect the originals.

This is easy to miss — enabling `JOBDIR` is a one-line change, and previously working code that relies on sharing mutable state through `cb_kwargs` can silently start behaving differently. The behavior was not mentioned anywhere in the docs.

## Changes

- **docs/topics/jobs.rst** – add a note to the *Request serialization* section explaining that `cb_kwargs`/`meta` values are deep-copied across the job directory round trip.
- **docs/topics/request-response.rst** – add a short cross-referenced caution to the `Request.cb_kwargs` attribute docs.

Docs-only change. Built locally with Sphinx; the new notes render correctly and introduce no new warnings.