### PR TITLE
Fix check exit code for bootstrap errors

### DIFF
--- a/scrapy/commands/check.py
+++ b/scrapy/commands/check.py
@@ -14,7 +14,9 @@ from scrapy.utils.misc import load_object, set_environ
 
 
 class TextTestResult(_TextTestResult):
-    def printSummary(self, start: float, stop: float) -> None:
+    def printSummary(
+        self, start: float, stop: float, *, bootstrap_failed: bool = False
+    ) -> None:
         write = self.stream.write
         writeln = self.stream.writeln
 
@@ -26,13 +28,15 @@ class TextTestResult(_TextTestResult):
         writeln()
 
         infos = []
-        if not self.wasSuccessful():
+        if not self.wasSuccessful() or bootstrap_failed:
             write("FAILED")
             failed, errored = map(len, (self.failures, self.errors))
             if failed:
                 infos.append(f"failures={failed}")
             if errored:
                 infos.append(f"errors={errored}")
+            if bootstrap_failed:
+                infos.append("bootstrap errors")
         else:
             write("OK")
 
@@ -116,7 +120,12 @@ class Command(ScrapyCommand):
                 start_time = time.monotonic()
                 self.crawler_process.start()
                 stop = time.monotonic()
+                bootstrap_failed = self.crawler_process.bootstrap_failed is True
 
                 result.printErrors()
-                result.printSummary(start_time, stop)
-                self.exitcode = int(not result.wasSuccessful())
+                result.printSummary(
+                    start_time,
+                    stop,
+                    bootstrap_failed=bootstrap_failed,
+                )
+                self.exitcode = int(bootstrap_failed or not result.wasSuccessful())

--- a/tests/test_command_check.py
+++ b/tests/test_command_check.py
@@ -130,6 +130,52 @@ class CheckSpider(scrapy.Spider):
         """
         self._test_contract(proj_path, parse_def=parse_def)
 
+    def test_check_returns_error_code_on_bootstrap_failure(
+        self, proj_path: Path
+    ) -> None:
+        (proj_path / self.project_name / "middlewares.py").write_text(
+            """
+class BrokenMiddleware:
+    def __init__(self):
+        raise RuntimeError("broken middleware")
+            """,
+            encoding="utf-8",
+        )
+        spider = proj_path / self.project_name / "spiders" / "checkspider.py"
+        spider.write_text(
+            f"""
+import scrapy
+
+class CheckSpider(scrapy.Spider):
+    name = '{self.spider_name}'
+    start_urls = ['data:,']
+
+    custom_settings = {{
+        "DOWNLOAD_DELAY": 0,
+        "SPIDER_MIDDLEWARES": {{
+            "{self.project_name}.middlewares.BrokenMiddleware": 100,
+        }},
+    }}
+
+    def parse(self, response, **cb_kwargs):
+        \"\"\"
+        @url data:,
+        @returns items 0 0
+        \"\"\"
+        return
+        yield
+            """,
+            encoding="utf-8",
+        )
+
+        for args in ((), ("-s", "TWISTED_REACTOR=")):
+            returncode, _, stderr = proc(
+                "check", self.spider_name, *args, cwd=proj_path
+            )
+
+            assert returncode == 1
+            assert "FAILED (bootstrap errors)" in stderr
+
     def test_printSummary_with_unsuccessful_test_result_without_errors_and_without_failures(
         self,
     ) -> None:
@@ -143,6 +189,17 @@ class CheckSpider(scrapy.Spider):
         with patch.object(result.stream, "write") as mock_write:
             result.printSummary(start_time, stop_time)
             mock_write.assert_has_calls([call("FAILED"), call("\n")])
+
+    def test_printSummary_with_bootstrap_failure(self) -> None:
+        result = TextTestResult(MagicMock(), descriptions=False, verbosity=1)
+        start_time = 1.0
+        stop_time = 2.0
+        result.testsRun = 0
+        result.failures = []
+        result.errors = []
+        with patch.object(result.stream, "writeln") as mock_write:
+            result.printSummary(start_time, stop_time, bootstrap_failed=True)
+            mock_write.assert_called_with(" (bootstrap errors)")
 
     def test_printSummary_with_unsuccessful_test_result_with_only_failures(
         self,

--- a/tests/test_command_crawl.py
+++ b/tests/test_command_crawl.py
@@ -143,3 +143,34 @@ class MySpider(scrapy.Spider):
         assert "[myspider] DEBUG: It works!" in log
         assert "Not using a Twisted reactor" in log
         assert "Spider closed (finished)" in log
+
+    def test_middleware_bootstrap_failure_exit_code(self, proj_path: Path) -> None:
+        (proj_path / self.project_name / "middlewares.py").write_text(
+            """
+class BrokenMiddleware:
+    def __init__(self):
+        raise RuntimeError("broken middleware")
+            """,
+            encoding="utf-8",
+        )
+        spider_code = f"""
+import scrapy
+
+class MySpider(scrapy.Spider):
+    name = 'myspider'
+    custom_settings = {{
+        "SPIDER_MIDDLEWARES": {{
+            "{self.project_name}.middlewares.BrokenMiddleware": 100,
+        }},
+    }}
+
+    async def start(self):
+        return
+        yield
+"""
+
+        for args in ((), ("-s", "TWISTED_REACTOR=")):
+            returncode, _, stderr = self.crawl(spider_code, proj_path, args=args)
+
+            assert returncode == 1
+            assert "broken middleware" in stderr


### PR DESCRIPTION
Closes #4292.

## Summary

- Make `scrapy check` treat crawler bootstrap failures as command failures.
- Show `FAILED (bootstrap errors)` instead of `OK` when contract crawling cannot start.
- Add regression coverage for middleware bootstrap failures in both `scrapy check` and `scrapy crawl`.

## Tests

- `python -m pytest tests/test_command_check.py tests/test_command_crawl.py -q`
- `python -m ruff check scrapy/commands/check.py tests/test_command_check.py tests/test_command_crawl.py`

This PR was written entirely using an LLM.