### PR TITLE
fix: do not start spider request processing in the shell (#7552)

### DIFF
--- a/scrapy/shell.py
+++ b/scrapy/shell.py
@@ -29,7 +29,6 @@ from scrapy.utils.conf import get_config
 from scrapy.utils.console import DEFAULT_PYTHON_SHELLS, start_python_console
 from scrapy.utils.datatypes import SequenceExclude
 from scrapy.utils.defer import (
-    _schedule_coro,
     deferred_f_from_coro_f,
     maybe_deferred_to_future,
 )
@@ -214,7 +213,6 @@ class Shell:
         self.crawler.spider = spider
         assert self.crawler.engine
         await self.crawler.engine.open_spider_async(close_if_idle=False)
-        _schedule_coro(self.crawler.engine._start_request_processing())
         self.spider = spider
 
     def fetch(


### PR DESCRIPTION
## Description

Fixes #7552

### Root cause

When opening a spider in the interactive shell, `Shell._open_spider()` calls `engine._start_request_processing()`, which triggers the spider's `start()` / `start_requests()` method. For modern spiders with `async def start()`, this starts a full crawl—iterating over start requests, downloading pages, etc.—while the user only intended to open an interactive shell.

The engine was intentionally initialized with `_start_request_processing=False` earlier (in `scrapy.commands.shell.Command.run()`), but `_open_spider()` explicitly re-enabled it.

### Fix

Remove the `_schedule_coro(self.crawler.engine._start_request_processing())` call from `Shell._open_spider()`. The shell's `fetch()` method schedules requests via `engine.crawl()`, which works independently of `_start_request_processing()`. Spider start requests should not be processed automatically in the shell—only URLs that the user explicitly passes to `fetch()` should be crawled.

### Why this is safe

1. `engine.crawl()` (called by `Shell._schedule()`) adds a request directly to the scheduler and works without `_start_request_processing()` having been called.
2. The existing test suite (`tests/test_command_shell.py`) continues to pass, including all `fetch()` tests.
3. This is a regression from #6729 (the async `Spider.start()` feature), which added the `_start_request_processing()` call to `_open_spider()`.

### Checklist

- [x] Fix applied and syntax-verified
- [x] Unused import `_schedule_coro` removed
- [x] All existing shell tests pass

Co-authored-by: vcrab1312 <vcrab1312@users.noreply.github.com> (root cause identification)
