### PR TITLE
Narrow _SettingsKey to str

### DIFF
--- a/scrapy/settings/__init__.py
+++ b/scrapy/settings/__init__.py
@@ -16,9 +16,9 @@ from scrapy.utils.python import global_object_name
 
 logger = getLogger(__name__)
 
-# The key types are restricted in BaseSettings._get_key() to ones supported by JSON,
-# see https://github.com/scrapy/scrapy/issues/5383.
-_SettingsKey: TypeAlias = bool | float | int | str | None
+# Setting names are always uppercase strings; non-uppercase module-level
+# variables are ignored when loading settings.
+_SettingsKey: TypeAlias = str
 
 if TYPE_CHECKING:
     from types import ModuleType
@@ -657,16 +657,9 @@ class BaseSettings(MutableMapping[_SettingsKey, Any]):
 
     def _to_dict(self) -> dict[_SettingsKey, Any]:
         return {
-            self._get_key(k): (v._to_dict() if isinstance(v, BaseSettings) else v)
+            str(k): (v._to_dict() if isinstance(v, BaseSettings) else v)
             for k, v in self.items()
         }
-
-    def _get_key(self, key_value: Any) -> _SettingsKey:
-        return (
-            key_value
-            if isinstance(key_value, (bool, float, int, str, type(None)))
-            else str(key_value)
-        )
 
     def copy_to_dict(self) -> dict[_SettingsKey, Any]:
         """

--- a/tests/test_settings/__init__.py
+++ b/tests/test_settings/__init__.py
@@ -384,15 +384,15 @@ class TestBaseSettings:
                 "TEST_STRING": "a string",
                 "TEST_LIST": [1, 2],
                 "TEST_BOOLEAN": False,
-                "TEST_BASE": BaseSettings({1: 1, 2: 2}, "project"),
-                "TEST": BaseSettings({1: 10, 3: 30}, "default"),
-                "HASNOBASE": BaseSettings({3: 3000}, "default"),
+                "TEST_BASE": BaseSettings({"A": 1, "B": 2}, "project"),
+                "TEST": BaseSettings({"A": 10, "C": 30}, "default"),
+                "HASNOBASE": BaseSettings({"C": 3000}, "default"),
             }
         )
         assert s.copy_to_dict() == {
-            "HASNOBASE": {3: 3000},
-            "TEST": {1: 10, 3: 30},
-            "TEST_BASE": {1: 1, 2: 2},
+            "HASNOBASE": {"C": 3000},
+            "TEST": {"A": 10, "C": 30},
+            "TEST_BASE": {"A": 1, "B": 2},
             "TEST_LIST": [1, 2],
             "TEST_BOOLEAN": False,
             "TEST_STRING": "a string",


### PR DESCRIPTION
setting names are always uppercase strings, so the bool|float|int|str|None union for _SettingsKey was wider than reality and looked off in the BaseSettings.get reference docs. the #5383 fix that added it only narrowed down from Any, it never meant non-str keys are actually useful.

following wRAR's review in the thread, i narrowed _SettingsKey to str, used str(k) directly in _to_dict so any stray non-str key still serializes, and dropped the now unused _get_key. also updated test_copy_to_dict which had int keys for no real reason. no typing errors and the tests pass.

closes #6958
