### PR TITLE
Keep a slash before the query when the path is empty

### DIFF
--- a/docs/news.rst
+++ b/docs/news.rst
@@ -3,6 +3,14 @@
 Release notes
 =============
 
+Unreleased
+----------
+
+-   A :class:`~scrapy.Request` URL with a host and a query or fragment but no
+    path now keeps a ``/`` before the query, so the request line sent to the
+    server is ``/?...`` instead of ``?...``. Some servers reject the latter
+    with a 400. (:issue:`6574`)
+
 .. _release-2.16.0:
 
 Scrapy 2.16.0 (2026-05-19)

--- a/scrapy/http/request/__init__.py
+++ b/scrapy/http/request/__init__.py
@@ -19,6 +19,7 @@ from typing import (
     TypeVar,
     overload,
 )
+from urllib.parse import urlsplit, urlunsplit
 
 from w3lib.url import safe_url_string
 
@@ -263,6 +264,18 @@ class Request(object_ref):
             self._url = url
         else:
             self._url = safe_url_string(url, self.encoding)
+            # an http(s) url with a host and a query or fragment but no path
+            # ends up with an empty path, which makes the request line start
+            # with "?..." and breaks servers that expect "/?...". put the "/"
+            # back, same as w3lib's safe_download_url does. see #6574.
+            parts = urlsplit(self._url)
+            if (
+                parts.scheme in ("http", "https")
+                and parts.netloc
+                and not parts.path
+                and (parts.query or parts.fragment)
+            ):
+                self._url = urlunsplit(parts._replace(path="/"))
 
         if (
             "://" not in self._url

--- a/tests/test_downloader_handlers_http_base.py
+++ b/tests/test_downloader_handlers_http_base.py
@@ -822,6 +822,25 @@ class TestHttpBase(ABC):
             response = await download_handler.download_request(request)
         assert response.body == path.encode()
 
+    @coroutine_test
+    async def test_empty_path_with_query(self, mockserver: MockServer) -> None:
+        # #6574: a url with a query but no path used to produce a request line
+        # of "?url=x" which servers reject with a 400. it should be "/?url=x".
+        base = mockserver.url("", is_secure=self.is_secure)
+        request = Request(base + "/uri?url=x")
+        assert request.url == base + "/uri?url=x"
+        async with self.get_dh() as download_handler:
+            response = await download_handler.download_request(request)
+        assert response.body == b"/uri?url=x"
+
+        # the host-only-with-query case the issue is about: the server must see
+        # a leading slash in the request line.
+        request = Request(base + "?url=x")
+        assert request.url == base + "/?url=x"
+        async with self.get_dh() as download_handler:
+            response = await download_handler.download_request(request)
+        assert response.status == 200
+
 
 class TestHttpsBase(TestHttpBase):
     is_secure = True

--- a/tests/test_http_request.py
+++ b/tests/test_http_request.py
@@ -97,6 +97,17 @@ class TestRequest:
         r = self.request_class(url="http://www.scrapy.org/path")
         assert r.url == "http://www.scrapy.org/path"
 
+    def test_url_empty_path_with_query(self):
+        # #6574: a host with a query but no path should keep a "/" so the
+        # request line is "/?..." and not "?...".
+        r = self.request_class(url="http://127.0.0.1:9000?url=x")
+        assert r.url == "http://127.0.0.1:9000/?url=x"
+        r = self.request_class(url="http://example.com#frag")
+        assert r.url == "http://example.com/#frag"
+        # no query or fragment, leave it alone
+        r = self.request_class(url="http://example.com")
+        assert r.url == "http://example.com"
+
     def test_url_quoting(self):
         r = self.request_class(url="http://www.scrapy.org/blank%20space")
         assert r.url == "http://www.scrapy.org/blank%20space"


### PR DESCRIPTION
a request to something like http://host:9000?url=x was getting turned into a request line of "?url=x" with no leading slash, and some servers just reject that with a 400 and never see the request. now when theres a host and a query or fragment but no path, i put a / in before the query, same thing w3lib's safe_download_url already does. left verbatim urls alone.

added a test on the request url and one on the actual request line the server sees. tests pass. closes #6574
