### PR TITLE
Fix log counter crawler scoping

### DIFF
--- a/scrapy/utils/log.py
+++ b/scrapy/utils/log.py
@@ -237,9 +237,25 @@ class LogCounterHandler(logging.Handler):
         self.crawler: Crawler = crawler
 
     def emit(self, record: logging.LogRecord) -> None:
+        if not self._record_is_from_crawler(record):
+            return
         sname = f"log_count/{record.levelname}"
         assert self.crawler.stats
         self.crawler.stats.inc_value(sname)
+
+    def _record_is_from_crawler(self, record: logging.LogRecord) -> bool:
+        record_crawler = getattr(record, "crawler", None)
+        if record_crawler is not None:
+            return record_crawler is self.crawler
+
+        record_spider = getattr(record, "spider", None)
+        if record_spider is not None:
+            return (
+                getattr(record_spider, "crawler", None) is self.crawler
+                or record_spider is self.crawler.spider
+            )
+
+        return True
 
 
 def logformatter_adapter(

--- a/tests/test_utils_log.py
+++ b/tests/test_utils_log.py
@@ -99,6 +99,38 @@ class TestLogCounterHandler:
         assert crawler.stats
         assert crawler.stats.get_value("log_count/ERROR") == 1
 
+    def test_accepted_current_crawler(
+        self, crawler: Crawler, logger: logging.Logger
+    ) -> None:
+        logger.error("test log msg", extra={"crawler": crawler})
+        assert crawler.stats
+        assert crawler.stats.get_value("log_count/ERROR") == 1
+
+    def test_ignored_other_crawler(
+        self, crawler: Crawler, logger: logging.Logger
+    ) -> None:
+        other_crawler = get_crawler(settings_dict={"LOG_LEVEL": "WARNING"})
+        logger.error("test log msg", extra={"crawler": other_crawler})
+        assert crawler.stats
+        assert crawler.stats.get_value("log_count/ERROR") is None
+
+    def test_accepted_current_spider(
+        self, crawler: Crawler, logger: logging.Logger
+    ) -> None:
+        spider = crawler._create_spider()
+        logger.error("test log msg", extra={"spider": spider})
+        assert crawler.stats
+        assert crawler.stats.get_value("log_count/ERROR") == 1
+
+    def test_ignored_other_spider(
+        self, crawler: Crawler, logger: logging.Logger
+    ) -> None:
+        other_crawler = get_crawler(settings_dict={"LOG_LEVEL": "WARNING"})
+        other_spider = other_crawler._create_spider()
+        logger.error("test log msg", extra={"spider": other_spider})
+        assert crawler.stats
+        assert crawler.stats.get_value("log_count/ERROR") is None
+
     def test_filtered_out_level(self, crawler: Crawler, logger: logging.Logger) -> None:
         logger.debug("test log msg")
         assert crawler.stats


### PR DESCRIPTION
## Summary
- skip log counter updates for records explicitly scoped to a different crawler or spider
- keep existing behavior for records without crawler/spider metadata
- add regression coverage for crawler-scoped and spider-scoped log records

Closes #1362

## Tests
- `.venv/bin/python -m pytest tests/test_utils_log.py::TestLogCounterHandler -q`
- `.venv/bin/python -m pytest tests/test_utils_log.py tests/test_crawler.py::TestCrawlerLogging -q`
- `.venv/bin/ruff check scrapy/utils/log.py tests/test_utils_log.py`
- `.venv/bin/ruff format --check scrapy/utils/log.py tests/test_utils_log.py`

This PR was written entirely using an LLM.