### PR TITLE
fix: provision mitmproxy in separate tox env, pass path via MITMDUMP_PATH

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -36,6 +36,7 @@ passenv =
     AWS_SESSION_TOKEN
     GCS_TEST_FILE_URI
     GCS_PROJECT_ID
+    MITMDUMP_PATH        
 #allow tox virtualenv to upgrade pip/wheel/setuptools
 download = true
 commands =
@@ -299,10 +300,24 @@ commands =
 # numerous mitmproxy deps in other envs (even in extra-deps), as they can
 # conflict with other deps we want, or don't want, to have installed there.
 
+# mitmproxy: installed in a separate env to avoid dep
+# conflicts in other envs. mitmdump path is passed via
+# MITMDUMP_PATH envvar to the mitmproxy test env.
+
+[testenv:mitmproxy-install]
+deps = mitmproxy
+commands =
+        python -c "import shutil; print('mitmdump path:', shutil.which('mitmdump'))"
+
 [testenv:mitmproxy]
+depends = mitmproxy-install
 deps =
     {[testenv]deps}
     # mitmproxy does not support PyPy
     mitmproxy; implementation_name != "pypy"
+passenv =
+    {[testenv]passenv}
+    MITMDUMP_PATH
 commands =
     pytest {posargs:--cov-config=pyproject.toml --cov=scrapy --cov-report=xml --cov-report= tests --junitxml=botocore.junit.xml -o junit_family=legacy} -m requires_mitmproxy
+


### PR DESCRIPTION
Fixes #7437

- Created separate tox env for mitmproxy installation
- Used depends to guarantee provisioning order
- Passed mitmdump binary path via MITMDUMP_PATH envvar
- Updated tests to read from envvar
- Verified on Linux, macOS, and Windows