### PR TITLE
Fix the check for sync ITEM_PROCESSOR methods.

### DIFF
--- a/scrapy/core/scraper.py
+++ b/scrapy/core/scraper.py
@@ -125,7 +125,7 @@ class Scraper:
 
     def _check_deprecated_itemproc_method(self, method: str) -> None:
         itemproc_cls = type(self.itemproc)
-        if not hasattr(self.itemproc, f"{method}_async()"):
+        if not hasattr(self.itemproc, f"{method}_async"):
             warnings.warn(
                 f"{global_object_name(itemproc_cls)} doesn't define a {method}_async() method,"
                 f" this is deprecated and the method will be required in future Scrapy versions.",

--- a/scrapy/core/scraper.py
+++ b/scrapy/core/scraper.py
@@ -125,7 +125,7 @@ class Scraper:
 
     def _check_deprecated_itemproc_method(self, method: str) -> None:
         itemproc_cls = type(self.itemproc)
-        if not hasattr(self.itemproc, "process_item_async"):
+        if not hasattr(self.itemproc, f"{method}_async()"):
             warnings.warn(
                 f"{global_object_name(itemproc_cls)} doesn't define a {method}_async() method,"
                 f" this is deprecated and the method will be required in future Scrapy versions.",


### PR DESCRIPTION
I checked that a modified `tests.test_pipelines.TestCustomPipelineManager.test_integration_no_async_not_subclass()` fails with master but passes with this but I don't want to copypaste it to a new test just for this.