### PR TITLE
Validate reversed telnet console port ranges

### DIFF
--- a/scrapy/utils/reactor.py
+++ b/scrapy/utils/reactor.py
@@ -33,6 +33,8 @@ def listen_tcp(portrange: list[int], host: str, factory: ServerFactory) -> Port:
 
     if len(portrange) > 2:
         raise ValueError(f"invalid portrange: {portrange}")
+    if len(portrange) == 2 and portrange[0] > portrange[1]:
+        raise ValueError(f"invalid portrange: {portrange}")
     if not portrange:
         return reactor.listenTCP(0, factory, interface=host)  # type: ignore[no-any-return]
     if len(portrange) == 1:

--- a/tests/test_extension_telnet.py
+++ b/tests/test_extension_telnet.py
@@ -53,3 +53,9 @@ class TestTelnetExtension:
         d = portal.login(creds, None, ITelnetProtocol)
         yield d
         console.stop_listening()
+
+    def test_invalid_reversed_portrange(self):
+        settings = {"TELNETCONSOLE_PORT": [2, 1]}
+        console = TelnetConsole(get_crawler(settings_dict=settings))
+        with pytest.raises(ValueError, match=r"invalid portrange: \[2, 1\]"):
+            console.start_listening()


### PR DESCRIPTION
A reversed `TELNETCONSOLE_PORT` range, such as `[2, 1]`, could reach `listen_tcp` and produce invalid behavior instead of failing clearly.

This change validates reversed port ranges explicitly so invalid telnet console configuration raises `ValueError`.

A test has been added to cover this scenario.
