### PR TITLE
Fix request_to_curl handling of verbose cookies dictionaries

### DIFF
--- a/scrapy/utils/request.py
+++ b/scrapy/utils/request.py
@@ -180,9 +180,9 @@ def _get_method(obj: Any, name: Any) -> Any:
 
 
 def _cookie_value_to_unicode(value: str | bytes | float) -> str:
-    if isinstance(value, (bytes, str)):
-        return to_unicode(value)
-    return to_unicode(str(value))
+    if isinstance(value, bytes):
+        return value.decode()
+    return str(value)
 
 
 def request_to_curl(request: Request) -> str:

--- a/scrapy/utils/request.py
+++ b/scrapy/utils/request.py
@@ -202,7 +202,7 @@ def request_to_curl(request: Request) -> str:
             cookies = f"--cookie '{cookie}'"
         elif isinstance(request.cookies, list):
             cookie = "; ".join(
-                f"{to_unicode(c['name'])}={to_unicode(c['value'])}"
+                f"{to_unicode(str(c['name']))}={to_unicode(str(c['value']))}"
                 if "name" in c and "value" in c
                 else f"{next(iter(c.keys()))}={next(iter(c.values()))}"
                 for c in request.cookies

--- a/scrapy/utils/request.py
+++ b/scrapy/utils/request.py
@@ -202,7 +202,7 @@ def request_to_curl(request: Request) -> str:
             cookies = f"--cookie '{cookie}'"
         elif isinstance(request.cookies, list):
             cookie = "; ".join(
-                f"{c['name']}={c['value']}"
+                f"{to_unicode(c['name'])}={to_unicode(c['value'])}"
                 if "name" in c and "value" in c
                 else f"{next(iter(c.keys()))}={next(iter(c.values()))}"
                 for c in request.cookies

--- a/scrapy/utils/request.py
+++ b/scrapy/utils/request.py
@@ -202,7 +202,9 @@ def request_to_curl(request: Request) -> str:
             cookies = f"--cookie '{cookie}'"
         elif isinstance(request.cookies, list):
             cookie = "; ".join(
-                f"{next(iter(c.keys()))}={next(iter(c.values()))}"
+                f"{c['name']}={c['value']}"
+                if "name" in c and "value" in c
+                else f"{next(iter(c.keys()))}={next(iter(c.values()))}"
                 for c in request.cookies
             )
             cookies = f"--cookie '{cookie}'"

--- a/scrapy/utils/request.py
+++ b/scrapy/utils/request.py
@@ -179,7 +179,7 @@ def _get_method(obj: Any, name: Any) -> Any:
         raise ValueError(f"Method {name!r} not found in: {obj}") from None
 
 
-def _cookie_value_to_unicode(value: str | bytes | float | int) -> str:
+def _cookie_value_to_unicode(value: str | bytes | float) -> str:
     if isinstance(value, (bytes, str)):
         return to_unicode(value)
     return to_unicode(str(value))

--- a/scrapy/utils/request.py
+++ b/scrapy/utils/request.py
@@ -179,6 +179,12 @@ def _get_method(obj: Any, name: Any) -> Any:
         raise ValueError(f"Method {name!r} not found in: {obj}") from None
 
 
+def _cookie_value_to_unicode(value: str | bytes | float | int) -> str:
+    if isinstance(value, (bytes, str)):
+        return to_unicode(value)
+    return to_unicode(str(value))
+
+
 def request_to_curl(request: Request) -> str:
     """
     Converts a :class:`~scrapy.Request` object to a curl command.
@@ -202,7 +208,7 @@ def request_to_curl(request: Request) -> str:
             cookies = f"--cookie '{cookie}'"
         elif isinstance(request.cookies, list):
             cookie = "; ".join(
-                f"{to_unicode(str(c['name']))}={to_unicode(str(c['value']))}"
+                f"{_cookie_value_to_unicode(c['name'])}={_cookie_value_to_unicode(c['value'])}"
                 if "name" in c and "value" in c
                 else f"{next(iter(c.keys()))}={next(iter(c.values()))}"
                 for c in request.cookies

--- a/tests/test_utils_request.py
+++ b/tests/test_utils_request.py
@@ -434,3 +434,24 @@ class TestRequestToCurl:
             " --data-raw '{\"foo\": \"bar\"}' --cookie 'foo=bar'"
         )
         self._test_request(request_object, expected_curl_command)
+
+    def test_cookies_list_verbose_non_string_value(self):
+        request_object = Request(
+            "https://www.httpbin.org/post",
+            method="POST",
+            cookies=[
+                {
+                    "name": "foo",
+                    "value": 1,
+                    "domain": "example.com",
+                    "path": "/",
+                    "secure": True,
+                }
+            ],
+            body=json.dumps({"foo": "bar"}),
+        )
+        expected_curl_command = (
+            "curl -X POST https://www.httpbin.org/post"
+            " --data-raw '{\"foo\": \"bar\"}' --cookie 'foo=1'"
+        )
+        self._test_request(request_object, expected_curl_command)

--- a/tests/test_utils_request.py
+++ b/tests/test_utils_request.py
@@ -413,3 +413,24 @@ class TestRequestToCurl:
             " --data-raw '{\"foo\": \"bar\"}' --cookie 'foo=bar'"
         )
         self._test_request(request_object, expected_curl_command)
+
+    def test_cookies_list_verbose(self):
+        request_object = Request(
+            "https://www.httpbin.org/post",
+            method="POST",
+            cookies=[
+                {
+                    "name": "foo",
+                    "value": "bar",
+                    "domain": "example.com",
+                    "path": "/",
+                    "secure": True,
+                }
+            ],
+            body=json.dumps({"foo": "bar"}),
+        )
+        expected_curl_command = (
+            "curl -X POST https://www.httpbin.org/post"
+            " --data-raw '{\"foo\": \"bar\"}' --cookie 'foo=bar'"
+        )
+        self._test_request(request_object, expected_curl_command)

--- a/tests/test_utils_request.py
+++ b/tests/test_utils_request.py
@@ -420,8 +420,8 @@ class TestRequestToCurl:
             method="POST",
             cookies=[
                 {
-                    "name": "foo",
-                    "value": "bar",
+                    "name": b"foo",
+                    "value": b"bar",
                     "domain": "example.com",
                     "path": "/",
                     "secure": True,


### PR DESCRIPTION
Fix `request_to_curl()` handling of list form cookies that use the documented verbose cookie format.

Previously, verbose cookies such as:

``` python
cookies=[
    {
        "name": "foo",
        "value": "bar",
        "domain": "example.com",
        "path": "/",
        "secure": True,
    }
]
```

rendered as:

```
--cookie 'name=foo'
```

instead of:

```
--cookie 'foo=bar'
```

This change uses the `"name"` and `"value"` fields when present, while preserving the existing behavior for generic single-entry cookie dictionaries.

Added a test case and verified that all the relevant test cases pass locally.