### PR TITLE
Fix strip_url() removing default port from password.

### DIFF
--- a/docs/news.rst
+++ b/docs/news.rst
@@ -237,6 +237,10 @@ Bug fixes
     tag when adding the ``<base>`` tag.
     (:issue:`7459`)
 
+-   Fixed :func:`scrapy.utils.url.strip_url` removing default ports from
+    passwords when ``strip_credentials=False``.
+    (:issue:`7604`)
+
 Documentation
 ~~~~~~~~~~~~~
 

--- a/docs/news.rst
+++ b/docs/news.rst
@@ -237,10 +237,6 @@ Bug fixes
     tag when adding the ``<base>`` tag.
     (:issue:`7459`)
 
--   Fixed :func:`scrapy.utils.url.strip_url` removing default ports from
-    passwords when ``strip_credentials=False``.
-    (:issue:`7604`)
-
 Documentation
 ~~~~~~~~~~~~~
 

--- a/scrapy/utils/url.py
+++ b/scrapy/utils/url.py
@@ -140,10 +140,8 @@ def strip_url(
         }
     ):
         port_suffix = f":{parsed_url.port}"
-        userinfo, sep, host = netloc.rpartition("@")
-        if host.endswith(port_suffix):
-            host = host[: -len(port_suffix)]
-        netloc = f"{userinfo}{sep}{host}"
+        if netloc.endswith(port_suffix):
+            netloc = netloc[: -len(port_suffix)]
 
     return urlunparse(
         (

--- a/scrapy/utils/url.py
+++ b/scrapy/utils/url.py
@@ -139,7 +139,11 @@ def strip_url(
             ("ftp", 21),
         }
     ):
-        netloc = netloc.replace(f":{parsed_url.port}", "")
+        port_suffix = f":{parsed_url.port}"
+        userinfo, sep, host = netloc.rpartition("@")
+        if host.endswith(port_suffix):
+            host = host[: -len(port_suffix)]
+        netloc = f"{userinfo}{sep}{host}"
 
     return urlunparse(
         (

--- a/scrapy/utils/url.py
+++ b/scrapy/utils/url.py
@@ -140,8 +140,7 @@ def strip_url(
         }
     ):
         port_suffix = f":{parsed_url.port}"
-        if netloc.endswith(port_suffix):
-            netloc = netloc[: -len(port_suffix)]
+        netloc = netloc.removesuffix(port_suffix)
 
     return urlunparse(
         (

--- a/tests/test_utils_url.py
+++ b/tests/test_utils_url.py
@@ -346,6 +346,18 @@ class TestStripUrl:
                 "ftp://username:password@www.example.com:221/file.txt",
                 "ftp://username:password@www.example.com:221/file.txt",
             ),
+            (
+                "http://user:80@www.example.com:80/index.html",
+                "http://user:80@www.example.com/index.html",
+            ),
+            (
+                "https://user:443@www.example.com:443/index.html",
+                "https://user:443@www.example.com/index.html",
+            ),
+            (
+                "ftp://user:21@www.example.com:21/file.txt",
+                "ftp://user:21@www.example.com/file.txt",
+            ),
         ],
     )
     def test_default_ports(self, url: str, expected: str) -> None:


### PR DESCRIPTION
### summary
fixes `strip_url()` stripping default ports from passwords when `strip_credentials=False`.

```python
strip_url("http://user:80@example.com:80/p", strip_credentials=False)
# before: 'http://user@example.com/p'
# after:  'http://user:80@example.com/p'
```
fixes #7604

### root cause

`netloc.replace(f":{parsed_url.port}", "")` is a global substring replace and matches `:80` inside `user:password@` too.

### fix

split netloc on the rightmost `@` with `rpartition("@")` and strip the `:port` suffix from the host side only.

### changes

- `scrapy/utils/url.py` — strip default port from host only
- `tests/test_utils_url.py` — regression tests for passwords `80`, `443`, `21`
- `docs/news.rst` — bug fix entry

### test plan

```
pytest tests/test_utils_url.py
pytest tests/test_spidermiddleware_referer.py
```

edge cases verified: no credentials, non-default ports, IPv6 with and without credentials, `strip_credentials=True` path.