### PR TITLE
Preserve HTTPX proxy auth across retries

### DIFF
--- a/scrapy/core/downloader/handlers/_base_streaming.py
+++ b/scrapy/core/downloader/handlers/_base_streaming.py
@@ -279,9 +279,7 @@ class BaseStreamingDownloadHandler(BaseHttpDownloadHandler, ABC, Generic[_Respon
         if not proxy:
             return None, None
         proxy = add_http_if_no_scheme(proxy)
-        auth_header: list[bytes] | None = request.headers.pop(
-            b"Proxy-Authorization", None
-        )
+        auth_header: list[bytes] = request.headers.getlist(b"Proxy-Authorization")
         return proxy, auth_header[0].decode("ascii") if auth_header else None
 
     def _extract_proxy_url_with_creds(self, request: Request) -> str | None:

--- a/scrapy/core/downloader/handlers/_httpx.py
+++ b/scrapy/core/downloader/handlers/_httpx.py
@@ -152,13 +152,18 @@ class HttpxDownloadHandler(_Base):
                 f"SOCKS proxy support in {type(self).__name__} requires the 'httpx[socks]' extra to be installed."
             )
         client = self._get_client(proxy)
+        headers = request.headers.to_tuple_list()
+        if proxy:
+            request_headers = Headers(request.headers, encoding=request.headers.encoding)
+            request_headers.pop(b"Proxy-Authorization", None)
+            headers = request_headers.to_tuple_list()
 
         try:
             async with client.stream(
                 request.method,
                 request.url,
                 content=request.body,
-                headers=request.headers.to_tuple_list(),
+                headers=headers,
                 timeout=timeout,
             ) as response:
                 yield response

--- a/tests/test_downloader_handler_httpx.py
+++ b/tests/test_downloader_handler_httpx.py
@@ -146,6 +146,53 @@ class TestHttpsWithCrawler(TestHttpWithCrawler):
 class TestHttpProxy(HttpxDownloadHandlerMixin, TestHttpProxyBase):
     expected_http_proxy_request_body = b"http://example.com/"
 
+    @coroutine_test
+    async def test_proxy_auth_header_preserved_for_retries(self) -> None:
+        class Stream:
+            async def __aenter__(self) -> None:
+                return None
+
+            async def __aexit__(self, *args: object) -> None:
+                return None
+
+        class Client:
+            def __init__(self) -> None:
+                self.headers: list[tuple[str, str]] | None = None
+                self.proxy: str | None = None
+
+            def stream(self, *args: Any, **kwargs: Any) -> Stream:
+                self.headers = kwargs["headers"]
+                return Stream()
+
+        request = Request(
+            "http://example.com/",
+            headers={
+                "Proxy-Authorization": "Basic dXNlcjpwYXNz",
+                "X-Test": "test",
+            },
+            meta={"proxy": "http://proxy.example:3128"},
+        )
+        client = Client()
+        handler: Any = HttpxDownloadHandler.__new__(HttpxDownloadHandler)
+        handler._proxy_auth_encoding = "latin-1"
+
+        def get_client(proxy: str | None) -> Client:
+            client.proxy = proxy
+            return client
+
+        handler._get_client = get_client
+
+        async with handler._make_request(request, timeout=1.0):
+            pass
+
+        assert client.proxy == "http://user:pass@proxy.example:3128"
+        assert client.headers == [("X-Test", "test")]
+        assert request.headers[b"Proxy-Authorization"] == b"Basic dXNlcjpwYXNz"
+        assert (
+            handler._extract_proxy_url_with_creds(request)
+            == "http://user:pass@proxy.example:3128"
+        )
+
 
 class TestHttpsProxy(TestHttpProxy):
     is_secure = True


### PR DESCRIPTION
## Summary
- Preserve `Proxy-Authorization` on the Scrapy request when `HttpxDownloadHandler` extracts proxy credentials, so retry and redirect request copies keep proxy auth.
- Continue stripping `Proxy-Authorization` from the headers passed to httpx when a proxy is used, relying on the proxy URL credentials instead.
- Add a regression test for preserving proxy auth while not forwarding it as a request header.

Fixes #7601

## Tests
- `uv run --with ruff ruff check scrapy/core/downloader/handlers/_base_streaming.py scrapy/core/downloader/handlers/_httpx.py tests/test_downloader_handler_httpx.py`
- `uv run --with pytest --with pytest-twisted --with httpx --with testfixtures --with pexpect --with pyftpdlib --with pygments --with sybil python -m pytest tests/test_downloader_handler_httpx.py -q`
- `git diff --check`
