### PR TITLE
Fix data loss warning in CsvItemExporter (fixes #4002)

### DIFF
--- a/scrapy/exporters.py
+++ b/scrapy/exporters.py
@@ -18,14 +18,14 @@ from xml.sax.xmlreader import AttributesImpl
 
 from itemadapter import ItemAdapter, is_item
 
-logger = logging.getLogger(__name__)
-
 from scrapy.item import Field, Item
 from scrapy.utils.python import is_listlike, to_bytes, to_unicode
 from scrapy.utils.serialize import ScrapyJSONEncoder
 
 if TYPE_CHECKING:
     from json import JSONEncoder
+
+logger = logging.getLogger(__name__)
 
 __all__ = [
     "BaseItemExporter",

--- a/scrapy/exporters.py
+++ b/scrapy/exporters.py
@@ -5,6 +5,7 @@ Item Exporters are used to export/serialize items into different formats.
 from __future__ import annotations
 
 import csv
+import logging
 import marshal
 import pickle
 import pprint
@@ -16,6 +17,8 @@ from xml.sax.saxutils import XMLGenerator
 from xml.sax.xmlreader import AttributesImpl
 
 from itemadapter import ItemAdapter, is_item
+
+logger = logging.getLogger(__name__)
 
 from scrapy.item import Field, Item
 from scrapy.utils.python import is_listlike, to_bytes, to_unicode
@@ -245,6 +248,7 @@ class CsvItemExporter(BaseItemExporter):
         self.csv_writer = csv.writer(self.stream, **self._kwargs)
         self._headers_not_written = True
         self._join_multivalued = join_multivalued
+        self._data_loss_warned = False
 
     def serialize_field(
         self, field: Mapping[str, Any] | Field, name: str, value: Any
@@ -264,6 +268,16 @@ class CsvItemExporter(BaseItemExporter):
         if self._headers_not_written:
             self._headers_not_written = False
             self._write_headers_and_set_fields_to_export(item)
+
+        if not self._data_loss_warned and self.fields_to_export is not None:
+            item_fields = set(ItemAdapter(item).field_names())
+            if not item_fields <= set(self.fields_to_export):
+                logger.warning(
+                    "Data loss detected when exporting items. "
+                    "To avoid this, explicitly set the FEED_EXPORT_FIELDS setting. "
+                    "This message won't be shown for further items."
+                )
+                self._data_loss_warned = True
 
         fields = self._get_serialized_fields(item, default_value="", include_empty=True)
         values = list(self._build_row(x for _, x in fields))

--- a/tests/test_exporters.py
+++ b/tests/test_exporters.py
@@ -1,5 +1,6 @@
 import dataclasses
 import json
+import logging
 import marshal
 import pickle
 import re
@@ -385,6 +386,58 @@ class TestCsvItemExporter(TestBaseItemExporter):
 class TestCsvItemExporterDataclass(TestCsvItemExporter):
     item_class = MyDataClass
     custom_field_item_class = CustomFieldDataclass
+
+
+class TestCsvItemExporterDataLossWarning:
+    """Tests for the data-loss warning in CsvItemExporter (Issue #4002)."""
+
+    def test_warning_on_extra_fields(self, caplog):
+        """A warning must be logged when an item has fields not in the header."""
+        output = BytesIO()
+        ie = CsvItemExporter(output)
+        ie.start_exporting()
+        ie.export_item({"name": "John", "age": "22"})
+        with caplog.at_level(logging.WARNING, logger="scrapy.exporters"):
+            ie.export_item({"name": "Jane", "age": "25", "city": "NYC"})
+        ie.finish_exporting()
+        assert "Data loss detected" in caplog.text
+        assert "FEED_EXPORT_FIELDS" in caplog.text
+
+    def test_no_warning_on_subset_fields(self, caplog):
+        """No warning when an item has fewer fields than the header."""
+        output = BytesIO()
+        ie = CsvItemExporter(output)
+        ie.start_exporting()
+        ie.export_item({"name": "John", "age": "22"})
+        with caplog.at_level(logging.WARNING, logger="scrapy.exporters"):
+            ie.export_item({"name": "Jane"})
+        ie.finish_exporting()
+        assert "Data loss detected" not in caplog.text
+
+    def test_warning_only_once(self, caplog):
+        """The warning must only be emitted once per exporter instance."""
+        output = BytesIO()
+        ie = CsvItemExporter(output)
+        ie.start_exporting()
+        ie.export_item({"name": "John", "age": "22"})
+        with caplog.at_level(logging.WARNING, logger="scrapy.exporters"):
+            ie.export_item({"name": "Jane", "age": "25", "city": "NYC"})
+            ie.export_item({"name": "Bob", "age": "30", "country": "US"})
+        ie.finish_exporting()
+        assert caplog.text.count("Data loss detected") == 1
+
+    def test_no_warning_when_fields_to_export_covers_all(self, caplog):
+        """No warning when FEED_EXPORT_FIELDS is set and covers all item fields."""
+        output = BytesIO()
+        ie = CsvItemExporter(
+            output, fields_to_export=["name", "age", "city"]
+        )
+        ie.start_exporting()
+        with caplog.at_level(logging.WARNING, logger="scrapy.exporters"):
+            ie.export_item({"name": "John", "age": "22"})
+            ie.export_item({"name": "Jane", "age": "25", "city": "NYC"})
+        ie.finish_exporting()
+        assert "Data loss detected" not in caplog.text
 
 
 class TestXmlItemExporter(TestBaseItemExporter):

--- a/tests/test_exporters.py
+++ b/tests/test_exporters.py
@@ -429,9 +429,7 @@ class TestCsvItemExporterDataLossWarning:
     def test_no_warning_when_fields_to_export_covers_all(self, caplog):
         """No warning when FEED_EXPORT_FIELDS is set and covers all item fields."""
         output = BytesIO()
-        ie = CsvItemExporter(
-            output, fields_to_export=["name", "age", "city"]
-        )
+        ie = CsvItemExporter(output, fields_to_export=["name", "age", "city"])
         ie.start_exporting()
         with caplog.at_level(logging.WARNING, logger="scrapy.exporters"):
             ie.export_item({"name": "John", "age": "22"})


### PR DESCRIPTION
Fixes https://github.com/scrapy/scrapy/issues/4002, closes #4053.

## Summary

Scrapy's `CsvItemExporter` determines CSV column headers from the first item it exports. If subsequent items contain new fields not present in the first item, those fields are silently dropped — causing unintentional data loss with no warning.

This PR adds a one-time `logger.warning()` to `CsvItemExporter.export_item()` that fires when data loss is detected, advising the user to set the `FEED_EXPORT_FIELDS` setting.

This supersedes the stalled PR #4053, incorporating all maintainer-requested changes from that review.  

## Changes

**`scrapy/exporters.py`**
- Added `import logging` and module-level `logger`
- Added `self._data_loss_warned = False` flag in `CsvItemExporter.__init__`
- Added data-loss detection in `export_item()` using subset operator (`<=`)
- Warning fires only once per exporter instance
- Gracefully handles `fields_to_export=None` (when `include_headers_line=False`)

**`tests/test_exporters.py`**
- Added `TestCsvItemExporterDataLossWarning` with 4 test cases:
  - Warning fires on extra fields (superset of header)
  - No warning on subset fields (fewer fields than header)
  - Warning emitted only once per session
  - No warning when `fields_to_export` covers all item fields

## Maintainer Review Feedback Addressed (from PR #4053)

| Reviewer | Request | How Addressed |
|----------|---------|---------------|
| @ejulio | Use subset check, not exact match | Used `item_fields <= set(self.fields_to_export)` |
| @elacuesta | Warning must tell user how to fix | Message says: "explicitly set the FEED_EXPORT_FIELDS setting" |
| @Gallaecio | Don't duplicate flag assignment (DRY) | Flag set once, outside nested conditionals |
| General | Warn only once | Guarded by `self._data_loss_warned` flag |

## Test Results

All 156 tests in `test_exporters.py` pass (152 existing + 4 new).
