### PR TITLE
Fix image store ACL settings for S3 and GCS

### DIFF
--- a/scrapy/pipelines/images.py
+++ b/scrapy/pipelines/images.py
@@ -18,8 +18,13 @@ from itemadapter import ItemAdapter
 from scrapy.exceptions import NotConfigured, ScrapyDeprecationWarning
 from scrapy.http import Request, Response
 from scrapy.http.request import NO_CALLBACK
-from scrapy.pipelines.files import FileException, FilesPipeline, GCSFilesStore, S3FilesStore, _md5sum
-from scrapy.settings import BaseSettings
+from scrapy.pipelines.files import (
+    FileException,
+    FilesPipeline,
+    GCSFilesStore,
+    S3FilesStore,
+    _md5sum,
+)
 from scrapy.utils.defer import ensure_awaitable
 from scrapy.utils.python import to_bytes
 
@@ -34,6 +39,7 @@ if TYPE_CHECKING:
 
     from scrapy.crawler import Crawler
     from scrapy.pipelines.media import FileInfoOrError, MediaPipeline
+    from scrapy.settings import BaseSettings
 
 
 class ImageException(FileException):

--- a/scrapy/pipelines/images.py
+++ b/scrapy/pipelines/images.py
@@ -135,6 +135,8 @@ class ImagesPipeline(FilesPipeline):
 
     @classmethod
     def _update_stores(cls, settings: BaseSettings) -> None:
+        super()._update_stores(settings)
+
         s3store: type[S3FilesStore] = cast(
             "type[S3FilesStore]", cls.STORE_SCHEMES["s3"]
         )

--- a/scrapy/pipelines/images.py
+++ b/scrapy/pipelines/images.py
@@ -11,14 +11,15 @@ import hashlib
 import warnings
 from contextlib import suppress
 from io import BytesIO
-from typing import TYPE_CHECKING, Any, ClassVar
+from typing import TYPE_CHECKING, Any, ClassVar, cast
 
 from itemadapter import ItemAdapter
 
 from scrapy.exceptions import NotConfigured, ScrapyDeprecationWarning
 from scrapy.http import Request, Response
 from scrapy.http.request import NO_CALLBACK
-from scrapy.pipelines.files import FileException, FilesPipeline, _md5sum
+from scrapy.pipelines.files import FileException, FilesPipeline, GCSFilesStore, S3FilesStore, _md5sum
+from scrapy.settings import BaseSettings
 from scrapy.utils.defer import ensure_awaitable
 from scrapy.utils.python import to_bytes
 
@@ -127,13 +128,15 @@ class ImagesPipeline(FilesPipeline):
         return await self.image_downloaded(response, request, info, item=item)
 
     @classmethod
-    def _update_stores(cls, settings):
-        super()._update_stores(settings)
-
-        s3store = cls.STORE_SCHEMES["s3"]
+    def _update_stores(cls, settings: BaseSettings) -> None:
+        s3store: type[S3FilesStore] = cast(
+            "type[S3FilesStore]", cls.STORE_SCHEMES["s3"]
+        )
         s3store.POLICY = settings["IMAGES_STORE_S3_ACL"]
 
-        gcs_store = cls.STORE_SCHEMES["gs"]
+        gcs_store: type[GCSFilesStore] = cast(
+            "type[GCSFilesStore]", cls.STORE_SCHEMES["gs"]
+        )
         gcs_store.POLICY = settings["IMAGES_STORE_GCS_ACL"] or None
 
     async def image_downloaded(

--- a/scrapy/pipelines/images.py
+++ b/scrapy/pipelines/images.py
@@ -126,6 +126,16 @@ class ImagesPipeline(FilesPipeline):
     ) -> str:
         return await self.image_downloaded(response, request, info, item=item)
 
+    @classmethod
+    def _update_stores(cls, settings):
+        super()._update_stores(settings)
+
+        s3store = cls.STORE_SCHEMES["s3"]
+        s3store.POLICY = settings["IMAGES_STORE_S3_ACL"]
+
+        gcs_store = cls.STORE_SCHEMES["gs"]
+        gcs_store.POLICY = settings["IMAGES_STORE_GCS_ACL"] or None
+
     async def image_downloaded(
         self,
         response: Response,

--- a/tests/test_pipeline_images.py
+++ b/tests/test_pipeline_images.py
@@ -15,6 +15,7 @@ from itemadapter import ItemAdapter
 from scrapy.http import Request, Response
 from scrapy.item import Field, Item
 from scrapy.pipelines.images import ImageException, ImagesPipeline
+from scrapy.pipelines.files import GCSFilesStore, S3FilesStore
 from scrapy.utils.test import get_crawler
 
 try:
@@ -540,6 +541,44 @@ class TestImagesPipelineCustomSettings:
         for pipe_attr, settings_attr in self.img_cls_attribute_names:
             expected_value = settings.get(settings_attr)
             assert getattr(pipeline_cls, pipe_attr.lower()) == expected_value
+
+    def test_images_store_s3_acl_setting_used(self, tmp_path):
+        old_policy = S3FilesStore.POLICY
+
+        try:
+            crawler = get_crawler(
+                None,
+                {
+                    "IMAGES_STORE": tmp_path,
+                    "IMAGES_STORE_S3_ACL": "public-read",
+                    "FILES_STORE_S3_ACL": "private",
+                },
+            )
+
+            ImagesPipeline.from_crawler(crawler)
+
+            assert S3FilesStore.POLICY == "public-read"
+        finally:
+            S3FilesStore.POLICY = old_policy
+
+    def test_images_store_gcs_acl_setting_used(self, tmp_path):
+        old_policy = GCSFilesStore.POLICY
+
+        try:
+            crawler = get_crawler(
+                None,
+                {
+                    "IMAGES_STORE": tmp_path,
+                    "IMAGES_STORE_GCS_ACL": "authenticatedRead",
+                    "FILES_STORE_GCS_ACL": "",
+                },
+            )
+
+            ImagesPipeline.from_crawler(crawler)
+
+            assert GCSFilesStore.POLICY == "authenticatedRead"
+        finally:
+            GCSFilesStore.POLICY = old_policy
 
 
 def _create_image(format_, *a, **kw):

--- a/tests/test_pipeline_images.py
+++ b/tests/test_pipeline_images.py
@@ -14,8 +14,8 @@ from itemadapter import ItemAdapter
 
 from scrapy.http import Request, Response
 from scrapy.item import Field, Item
-from scrapy.pipelines.images import ImageException, ImagesPipeline
 from scrapy.pipelines.files import GCSFilesStore, S3FilesStore
+from scrapy.pipelines.images import ImageException, ImagesPipeline
 from scrapy.utils.test import get_crawler
 
 try:


### PR DESCRIPTION
Fixes #7597

## Description

This change restores support for the `IMAGES_STORE_S3_ACL` and `IMAGES_STORE_GCS_ACL` settings in `ImagesPipeline`.

Issue #7597 identified a regression introduced in 2ad5f0c where image-specific ACL settings were no longer applied. As a result, image stores would use the corresponding file store ACL settings instead.

This change updates `ImagesPipeline` to apply:

* `IMAGES_STORE_S3_ACL` to `S3FilesStore`
* `IMAGES_STORE_GCS_ACL` to `GCSFilesStore`

## Tests

Added regression tests to verify that:

* `IMAGES_STORE_S3_ACL` is applied to `S3FilesStore`
* `IMAGES_STORE_GCS_ACL` is applied to `GCSFilesStore`

These tests fail without the fix and pass with the fix applied.