### PR TITLE
Forward coalesced bytes after HTTP proxy CONNECT response

### DIFF
--- a/scrapy/core/downloader/handlers/http11.py
+++ b/scrapy/core/downloader/handlers/http11.py
@@ -221,16 +221,21 @@ class _TunnelingTCP4ClientEndpoint(TCP4ClientEndpoint):
         # see https://github.com/scrapy/scrapy/issues/2491
         if b"\r\n\r\n" not in self._connectBuffer:
             return
+        idx = self._connectBuffer.find(b"\r\n\r\n")
+        extra_data = self._connectBuffer[idx + 4 :]
         self._protocol.dataReceived = self._protocolDataReceived  # type: ignore[method-assign]
         respm = _TunnelingTCP4ClientEndpoint._responseMatcher.match(self._connectBuffer)
         if respm and int(respm.group("status")) == 200:
             # set proper Server Name Indication extension
             sslOptions = self._contextFactory.creatorForNetloc(  # type: ignore[call-arg,misc]
-                self._tunneledHost,  # type: ignore[arg-type]
+                self._tunneledHost,
                 self._tunneledPort,
             )
             self._protocol.transport.startTLS(sslOptions, self._protocolFactory)
             self._tunnelReadyDeferred.callback(self._protocol)
+            if extra_data:
+                # forward any coalesced data received with the connect response
+                self._protocolDataReceived(bytes(extra_data))
         else:
             extra: Any
             if respm:

--- a/tests/test_downloader_handler_twisted_http11.py
+++ b/tests/test_downloader_handler_twisted_http11.py
@@ -4,11 +4,18 @@ from __future__ import annotations
 
 import sys
 from typing import TYPE_CHECKING, Any
+from unittest.mock import MagicMock
 
 import pytest
+from twisted.internet.protocol import Protocol
+from twisted.python.failure import Failure
 
 from scrapy import Spider
-from scrapy.core.downloader.handlers.http11 import HTTP11DownloadHandler
+from scrapy.core.downloader.handlers.http11 import (
+    HTTP11DownloadHandler,
+    TunnelError,
+    _TunnelingTCP4ClientEndpoint,
+)
 from scrapy.crawler import Crawler
 from scrapy.exceptions import NotConfigured
 from tests.test_downloader_handlers_http_base import (
@@ -117,3 +124,69 @@ class TestRealWebsite(HTTP11DownloadHandlerMixin, TestRealWebsiteBase):
     @property
     def platform_cert_store_works(self) -> bool:
         return sys.platform != "win32"
+
+
+def test_tunneling_endpoint_coalesced_bytes() -> None:
+    reactor = MagicMock()
+    context_factory = MagicMock()
+    endpoint = _TunnelingTCP4ClientEndpoint(
+        reactor=reactor,
+        host="example.com",
+        port=443,
+        proxyConf=("proxy.example.com", 8080, None),
+        contextFactory=context_factory,
+    )
+    endpoint._protocolFactory = MagicMock()
+
+    protocol = Protocol()
+    transport = MagicMock()
+    protocol.transport = transport
+
+    received: list[bytes] = []
+
+    def mock_data_received(data: bytes) -> None:
+        received.append(data)
+
+    protocol.dataReceived = mock_data_received  # type: ignore[method-assign]
+
+    endpoint.requestTunnel(protocol)
+
+    coalesced_data = b"HTTP/1.1 200 Connection established\r\n\r\n\x16\x03\x01\x00\xfa"
+    protocol.dataReceived(coalesced_data)
+
+    assert received == [b"\x16\x03\x01\x00\xfa"]
+
+
+def test_tunneling_endpoint_non_200_response() -> None:
+    reactor = MagicMock()
+    context_factory = MagicMock()
+    endpoint = _TunnelingTCP4ClientEndpoint(
+        reactor=reactor,
+        host="example.com",
+        port=443,
+        proxyConf=("proxy.example.com", 8080, None),
+        contextFactory=context_factory,
+    )
+    endpoint._protocolFactory = MagicMock()
+
+    protocol = Protocol()
+    transport = MagicMock()
+    protocol.transport = transport
+
+    received: list[bytes] = []
+
+    def mock_data_received(data: bytes) -> None:
+        received.append(data)
+
+    protocol.dataReceived = mock_data_received  # type: ignore[method-assign]
+
+    endpoint.requestTunnel(protocol)
+
+    coalesced_data = b"HTTP/1.1 407 Proxy Authentication Required\r\n\r\n"
+    protocol.dataReceived(coalesced_data)
+
+    assert received == []
+    assert endpoint._tunnelReadyDeferred.called
+    failure = endpoint._tunnelReadyDeferred.result
+    assert isinstance(failure, Failure)
+    assert failure.check(TunnelError)


### PR DESCRIPTION
### Summary
Fixes a critical bug where Scrapy discards coalesced TLS bytes received in the same TCP packet as the HTTP proxy's `200 Connection established` response headers. This causes the subsequent TLS handshake to silently hang or fail.

## Changes
* Sliced and preserved coalesced bytes following the proxy's `\r\n\r\n` boundary in [http11.py](file:///H:/PRs/scrapy/scrapy/core/downloader/handlers/http11.py).
* Forwarded the preserved extra bytes to the protocol's restored `dataReceived` callback after TLS wrapping.
* Added regression coverage in [test_downloader_handler_twisted_http11.py](file:///H:/PRs/scrapy/tests/test_downloader_handler_twisted_http11.py) for both successful proxy CONNECT responses with coalesced bytes and non-200 responses.

## Testing
pytest tests/test_downloader_handler_twisted_http11.py