### PR TITLE
Close the FTP control connection and response buffer after each request

### DIFF
--- a/scrapy/core/downloader/handlers/ftp.py
+++ b/scrapy/core/downloader/handlers/ftp.py
@@ -84,6 +84,10 @@ class FTPDownloadHandler(BaseDownloadHandler):
         "default": 503,
     }
 
+    #: The FTP client of the most recent request, kept so the control
+    #: connection can be closed (see ``download_request``).
+    client: FTPClient
+
     def __init__(self, crawler: Crawler):
         if not crawler.settings.getbool("TWISTED_REACTOR_ENABLED"):
             raise NotConfigured(f"{type(self).__name__} requires a Twisted reactor.")
@@ -105,7 +109,7 @@ class FTPDownloadHandler(BaseDownloadHandler):
         creator = ClientCreator(
             reactor, FTPClient, user, password, passive=passive_mode
         )
-        client: FTPClient = await maybe_deferred_to_future(
+        self.client = client = await maybe_deferred_to_future(
             creator.connectTCP(parsed_url.hostname, parsed_url.port or 21)
         )
         filepath = unquote(parsed_url.path)
@@ -119,7 +123,12 @@ class FTPDownloadHandler(BaseDownloadHandler):
                 httpcode = self.CODE_MAPPING.get(ftpcode, self.CODE_MAPPING["default"])
                 return Response(url=request.url, status=httpcode, body=message.encode())
             raise
-        protocol.close()
+        finally:
+            # Always release the response buffer and the control connection,
+            # including on the CommandFailed/error paths above.
+            protocol.close()
+            if client.transport is not None:
+                client.transport.loseConnection()
         headers = {"local filename": protocol.filename or b"", "size": protocol.size}
         body = protocol.filename or protocol.body.read()
         respcls = responsetypes.from_args(url=request.url, body=body)

--- a/tests/test_downloader_handler_twisted_ftp.py
+++ b/tests/test_downloader_handler_twisted_ftp.py
@@ -6,13 +6,14 @@ from abc import ABC, abstractmethod
 from pathlib import Path
 from tempfile import mkstemp
 from typing import TYPE_CHECKING, Any
+from unittest.mock import patch
 
 import pytest
 from pytest_twisted import async_yield_fixture
 from twisted.cred import checkers, credentials, portal
 
 from scrapy import Spider
-from scrapy.core.downloader.handlers.ftp import FTPDownloadHandler
+from scrapy.core.downloader.handlers.ftp import FTPDownloadHandler, ReceivedDataProtocol
 from scrapy.crawler import Crawler
 from scrapy.exceptions import NotConfigured
 from scrapy.http import HtmlResponse, Request, Response
@@ -108,6 +109,38 @@ class TestFTPBase(ABC):
         r = await dh.download_request(request)
         assert r.status == 404
         assert r.body == b"['550 nonexistent.txt: No such file or directory.']"
+
+    @deferred_f_from_coro_f
+    async def test_ftp_download_closes_connection(
+        self, server_url: str, dh: FTPDownloadHandler
+    ) -> None:
+        request = Request(url=server_url + "file.txt", meta=self.req_meta)
+        await dh.download_request(request)
+        # The control connection is released rather than left for the GC.
+        assert dh.client.transport is not None
+        assert dh.client.transport.disconnecting
+
+    @deferred_f_from_coro_f
+    async def test_ftp_download_closes_connection_on_error(
+        self, server_url: str, dh: FTPDownloadHandler
+    ) -> None:
+        request = Request(url=server_url + "nonexistent.txt", meta=self.req_meta)
+        r = await dh.download_request(request)
+        assert r.status == 404
+        # The connection is released on the error path too.
+        assert dh.client.transport is not None
+        assert dh.client.transport.disconnecting
+
+    @deferred_f_from_coro_f
+    async def test_ftp_download_closes_protocol_on_error(
+        self, server_url: str, dh: FTPDownloadHandler
+    ) -> None:
+        request = Request(url=server_url + "nonexistent.txt", meta=self.req_meta)
+        with patch.object(ReceivedDataProtocol, "close", autospec=True) as mock_close:
+            r = await dh.download_request(request)
+        assert r.status == 404
+        # The response buffer is closed even when the download fails.
+        mock_close.assert_called_once()
 
     @deferred_f_from_coro_f
     async def test_ftp_local_filename(


### PR DESCRIPTION
Fixes #7602.

`FTPDownloadHandler.download_request()` opens an `FTPClient` control connection and a `ReceivedDataProtocol` (which owns a `BytesIO` or an open file when `ftp_local_filename` is set), but:

- the control connection was never closed, so it was left to be reclaimed by the garbage collector at some non-deterministic later time; and
- `protocol.close()` ran only on the success path, so a failed (`CommandFailed`) download leaked the file handle / buffer.

Both resources are now released in a `finally` block, so the success, 404/`CommandFailed`, and re-raised-error paths all clean up. The control connection is closed via `client.transport.loseConnection()`, matching the existing teardown helper in the FTP tests, and the handler keeps a reference to the most recent client on `self.client` (which the test `dh` fixture already expected).

### Tests
Added three regression tests (run for both the authenticated and anonymous FTP cases):
- `test_ftp_download_closes_connection` — the connection is released after a successful download;
- `test_ftp_download_closes_connection_on_error` — and after a 404;
- `test_ftp_download_closes_protocol_on_error` — `ReceivedDataProtocol.close()` is called even when the download fails.

All six fail on `master` and pass with the fix; the existing FTP tests (20 total) stay green, and `ruff` and `mypy` are clean.