### PR TITLE
Keep the Proxy-Authorization header on the request across retries (fix #7601)

### DIFF
--- a/scrapy/core/downloader/handlers/_base_streaming.py
+++ b/scrapy/core/downloader/handlers/_base_streaming.py
@@ -279,9 +279,7 @@ class BaseStreamingDownloadHandler(BaseHttpDownloadHandler, ABC, Generic[_Respon
         if not proxy:
             return None, None
         proxy = add_http_if_no_scheme(proxy)
-        auth_header: list[bytes] | None = request.headers.pop(
-            b"Proxy-Authorization", None
-        )
+        auth_header: list[bytes] = request.headers.getlist(b"Proxy-Authorization")
         return proxy, auth_header[0].decode("ascii") if auth_header else None
 
     def _extract_proxy_url_with_creds(self, request: Request) -> str | None:

--- a/scrapy/core/downloader/handlers/_httpx.py
+++ b/scrapy/core/downloader/handlers/_httpx.py
@@ -153,12 +153,24 @@ class HttpxDownloadHandler(_Base):
             )
         client = self._get_client(proxy)
 
+        headers = request.headers.to_tuple_list()
+        if proxy is not None:
+            # The proxy credentials travel in the proxy URL, so keep the
+            # Proxy-Authorization header out of the request sent to the
+            # destination server. _extract_proxy() no longer pops it, so it
+            # survives on the request for retries and redirects.
+            headers = [
+                (name, value)
+                for name, value in headers
+                if name.lower() != "proxy-authorization"
+            ]
+
         try:
             async with client.stream(
                 request.method,
                 request.url,
                 content=request.body,
-                headers=request.headers.to_tuple_list(),
+                headers=headers,
                 timeout=timeout,
             ) as response:
                 yield response

--- a/tests/test_downloader_handler_httpx.py
+++ b/tests/test_downloader_handler_httpx.py
@@ -151,6 +151,28 @@ class TestHttpsProxy(TestHttpProxy):
     is_secure = True
 
 
+class TestProxyAuthHeaderRetries:
+    """Regression test for #7601: extracting the proxy credentials must not
+    drop the Proxy-Authorization header from the request, otherwise retries
+    and redirects reuse the same request and fail to authenticate."""
+
+    def test_extract_proxy_does_not_mutate_request_headers(self) -> None:
+        request = Request(
+            "https://example.com",
+            meta={"proxy": "http://proxy.example:8080"},
+            headers={"Proxy-Authorization": "Basic dXNlcjpwYXNz"},
+        )
+        proxy, auth = HttpxDownloadHandler._extract_proxy(request)
+        assert proxy == "http://proxy.example:8080"
+        assert auth == "Basic dXNlcjpwYXNz"
+        # The header must remain so a retry can re-authenticate.
+        assert request.headers.getlist(b"Proxy-Authorization") == [
+            b"Basic dXNlcjpwYXNz"
+        ]
+        # A second extraction, as happens on a retry, still yields the creds.
+        assert HttpxDownloadHandler._extract_proxy(request) == (proxy, auth)
+
+
 @pytest.mark.requires_mitmproxy
 class TestMitmProxy(HttpxDownloadHandlerMixin, TestMitmProxyBase):
     handler_supports_socks = HAS_SOCKS


### PR DESCRIPTION
Fixes #7601.

## Problem

With `HttpxDownloadHandler` (the non-Twisted handler), a request through an
authenticated proxy loses its credentials on the first retry or redirect:

```
[retry] Retrying <GET .../status/503> (failed 1 times): 503 Service Unavailable
[retry] Retrying <GET .../status/503> (failed 2 times): 407 Proxy Authentication Required
[retry] Gave up retrying <GET .../status/503> (failed 3 times): 407 Proxy Authentication Required
```

The first attempt authenticates, the second does not.

## Cause

`BaseStreamingDownloadHandler._extract_proxy()` read the proxy credentials
with `request.headers.pop("Proxy-Authorization")`. The `pop` mutated the
shared `Request` object. Retries and redirects reuse that same request, so
on the second attempt the header is already gone, no credentials are added
to the proxy URL, and the proxy answers 407.

## Fix

- `_extract_proxy()` now reads the header with `getlist()` instead of
  `pop()`, so the request keeps its `Proxy-Authorization` header and later
  attempts can authenticate again.
- The httpx handler is what previously relied on the `pop` to avoid sending
  the proxy header to the destination server. It now drops
  `Proxy-Authorization` from the outgoing headers when a proxy is in use, so
  the credentials still never reach the destination. The existing
  `test_dont_leak_proxy_authorization_header` continues to cover that.

## Tests

Added `TestProxyAuthHeaderRetries.test_extract_proxy_does_not_mutate_request_headers`,
which checks that extracting the proxy keeps the header on the request and
that a second extraction (as on a retry) still returns the credentials. The
test fails against the old `pop`-based code and passes with the fix. The
existing proxy tests still pass.
