### PR TITLE
fix(ftp): close FTP client and protocol on all code paths

### DIFF
--- a/scrapy/core/downloader/handlers/ftp.py
+++ b/scrapy/core/downloader/handlers/ftp.py
@@ -108,18 +108,22 @@ class FTPDownloadHandler(BaseDownloadHandler):
         client: FTPClient = await maybe_deferred_to_future(
             creator.connectTCP(parsed_url.hostname, parsed_url.port or 21)
         )
-        filepath = unquote(parsed_url.path)
-        protocol = ReceivedDataProtocol(request.meta.get("ftp_local_filename"))
         try:
-            await maybe_deferred_to_future(client.retrieveFile(filepath, protocol))
-        except CommandFailed as e:
-            message = str(e)
-            if m := _CODE_RE.search(message):
-                ftpcode = m.group()
-                httpcode = self.CODE_MAPPING.get(ftpcode, self.CODE_MAPPING["default"])
-                return Response(url=request.url, status=httpcode, body=message.encode())
-            raise
-        protocol.close()
+            filepath = unquote(parsed_url.path)
+            protocol = ReceivedDataProtocol(request.meta.get("ftp_local_filename"))
+            try:
+                await maybe_deferred_to_future(client.retrieveFile(filepath, protocol))
+            except CommandFailed as e:
+                protocol.close()
+                message = str(e)
+                if m := _CODE_RE.search(message):
+                    ftpcode = m.group()
+                    httpcode = self.CODE_MAPPING.get(ftpcode, self.CODE_MAPPING["default"])
+                    return Response(url=request.url, status=httpcode, body=message.encode())
+                raise
+            protocol.close()
+        finally:
+            await maybe_deferred_to_future(client.quit())
         headers = {"local filename": protocol.filename or b"", "size": protocol.size}
         body = protocol.filename or protocol.body.read()
         respcls = responsetypes.from_args(url=request.url, body=body)


### PR DESCRIPTION
## Description

`FTPDownloadHandler.download_request` creates `FTPClient` instances
but never closes them, relying on garbage collection to clean up
the underlying TCP connections.

Additionally, the `ReceivedDataProtocol` was not closed in the
`CommandFailed` exception path, potentially leaking file handles
or memory buffers.

Fixes #7602

## Changes

- Wrap download logic in `try/finally` to always call `client.quit()`
- Add `protocol.close()` in the `CommandFailed` exception path
