### PR TITLE
fix: preserve Proxy-Authorization header across retries in HttpxDownloadHandler

### DIFF
--- a/scrapy/core/downloader/handlers/_base_streaming.py
+++ b/scrapy/core/downloader/handlers/_base_streaming.py
@@ -279,7 +279,7 @@ class BaseStreamingDownloadHandler(BaseHttpDownloadHandler, ABC, Generic[_Respon
         if not proxy:
             return None, None
         proxy = add_http_if_no_scheme(proxy)
-        auth_header: list[bytes] | None = request.headers.pop(
+        auth_header: list[bytes] | None = request.headers.get(
             b"Proxy-Authorization", None
         )
         return proxy, auth_header[0].decode("ascii") if auth_header else None

--- a/scrapy/core/downloader/handlers/_httpx.py
+++ b/scrapy/core/downloader/handlers/_httpx.py
@@ -158,7 +158,11 @@ class HttpxDownloadHandler(_Base):
                 request.method,
                 request.url,
                 content=request.body,
-                headers=request.headers.to_tuple_list(),
+                headers=[
+                    (k, v)
+                    for k, v in request.headers.to_tuple_list()
+                    if k.lower() != b"proxy-authorization"
+                ],
                 timeout=timeout,
             ) as response:
                 yield response


### PR DESCRIPTION
Fixes #7601

Dear Scrapy maintainers,

Thank you for your continued work on Scrapy. I came across issue #7601 reported by @wRAR and have attempted a fix after analyzing the code. I would appreciate any feedback.

## Problem

`BaseStreamingDownloadHandler._extract_proxy()` uses `request.headers.pop()` to extract the `Proxy-Authorization` header, which permanently removes it from the request object. When a request fails (e.g., 503) and is retried by the retry middleware, the `Proxy-Authorization` header is no longer present on the request, causing the proxy to return 407 Proxy Authentication Required.

Reproduction (from the issue):

```
uvx --from mitmproxy mitmdump --listen-port 8080 --set proxyauth=user:pass
https_proxy=http://user:pass@127.0.0.1:8080 scrapy shell -s TWISTED_REACTOR_ENABLED=False https://httpbin.org/status/503
```

The first attempt receives 503, and the subsequent retry fails with 407 because the proxy auth header was stripped.

## Fix

Two changes, following the same pattern already used by the Twisted handler (`http11.py`):

1. **`_base_streaming.py`**: Changed `request.headers.pop()` to `request.headers.get()` in `_extract_proxy()`, so the `Proxy-Authorization` header remains on the request and is available for subsequent retries.

2. **`_httpx.py`**: In `HttpxDownloadHandler._make_request()`, filter out `Proxy-Authorization` from the headers passed to httpx, to prevent the header from being sent to the destination server. This mirrors the Twisted handler's approach at `http11.py:467`:

```python
headers=[
    (k, v)
    for k, v in request.headers.to_tuple_list()
    if k.lower() != b"proxy-authorization"
],
```

## Why both changes are needed

- Change 1 alone would leak `Proxy-Authorization` to the destination server, as the header would be included in the request passed to httpx.
- Change 2 alone would have no effect, since the header would already be removed from `request.headers` by `pop()`.
- Together, the header stays on the request for retries but is never sent to the destination server.

This approach is consistent with how the Twisted-based handler (`http11.py`) already handles this case: it reads the header with `get()` at line 429 and removes it from the outgoing headers at line 467.

Thank you for reviewing. Please let me know if there are any issues with this approach.
