### PR TITLE
Preserve Proxy-Authorization header across retries in HttpxDownloadHandler

### DIFF
--- a/scrapy/core/downloader/handlers/_base_streaming.py
+++ b/scrapy/core/downloader/handlers/_base_streaming.py
@@ -274,15 +274,24 @@ class BaseStreamingDownloadHandler(BaseHttpDownloadHandler, ABC, Generic[_Respon
         Proxy-Authorization header.
 
         This is useful for handlers that take the proxy headers separately.
+
+        The extracted auth header is cached in request.meta so it survives
+        retries — popping it from headers on the first call would otherwise
+        cause the retry to lose proxy credentials.
         """
         proxy: str | None = request.meta.get("proxy")
         if not proxy:
             return None, None
         proxy = add_http_if_no_scheme(proxy)
-        auth_header: list[bytes] | None = request.headers.pop(
-            b"Proxy-Authorization", None
-        )
-        return proxy, auth_header[0].decode("ascii") if auth_header else None
+        auth_header: str | None = request.meta.get("_proxy_auth_header")
+        if auth_header is None:
+            auth_bytes: list[bytes] | None = request.headers.pop(
+                b"Proxy-Authorization", None
+            )
+            if auth_bytes:
+                auth_header = auth_bytes[0].decode("ascii")
+                request.meta["_proxy_auth_header"] = auth_header
+        return proxy, auth_header
 
     def _extract_proxy_url_with_creds(self, request: Request) -> str | None:
         """Return the proxy URL with the userinfo added based on the

--- a/tests/test_downloader_handler_httpx.py
+++ b/tests/test_downloader_handler_httpx.py
@@ -159,3 +159,58 @@ class TestMitmProxy(HttpxDownloadHandlerMixin, TestMitmProxyBase):
 @pytest.mark.requires_internet
 class TestRealWebsite(HttpxDownloadHandlerMixin, TestRealWebsiteBase):
     pass
+
+
+class TestProxyAuthRetry:
+    """Test that proxy auth header is preserved across retries.
+
+    Regression test for: _extract_proxy() used request.headers.pop()
+    which permanently removed the Proxy-Authorization header. On retry
+    the header was gone, causing 407 Proxy Authentication Required.
+    """
+
+    def test_extract_proxy_preserves_auth_on_retry(self) -> None:
+        from scrapy.core.downloader.handlers._base_streaming import (
+            BaseStreamingDownloadHandler,
+        )
+
+        request = Request(
+            "http://example.com",
+            meta={"proxy": "http://proxy.example.com:8080"},
+            headers={"Proxy-Authorization": "Basic dXNlcjpwYXNz"},
+        )
+        # First call should extract the auth from headers
+        proxy1, auth1 = BaseStreamingDownloadHandler._extract_proxy(request)
+        assert proxy1 == "http://proxy.example.com:8080"
+        assert auth1 == "Basic dXNlcjpwYXNz"
+        # Header should be removed from request after first call
+        assert b"Proxy-Authorization" not in request.headers
+        # Second call (simulating retry) should still return the auth
+        proxy2, auth2 = BaseStreamingDownloadHandler._extract_proxy(request)
+        assert proxy2 == "http://proxy.example.com:8080"
+        assert auth2 == "Basic dXNlcjpwYXNz"
+        # Auth should be cached in meta
+        assert request.meta["_proxy_auth_header"] == "Basic dXNlcjpwYXNz"
+
+    def test_extract_proxy_no_auth_header(self) -> None:
+        from scrapy.core.downloader.handlers._base_streaming import (
+            BaseStreamingDownloadHandler,
+        )
+
+        request = Request(
+            "http://example.com",
+            meta={"proxy": "http://proxy.example.com:8080"},
+        )
+        proxy, auth = BaseStreamingDownloadHandler._extract_proxy(request)
+        assert proxy == "http://proxy.example.com:8080"
+        assert auth is None
+
+    def test_extract_proxy_no_proxy(self) -> None:
+        from scrapy.core.downloader.handlers._base_streaming import (
+            BaseStreamingDownloadHandler,
+        )
+
+        request = Request("http://example.com")
+        proxy, auth = BaseStreamingDownloadHandler._extract_proxy(request)
+        assert proxy is None
+        assert auth is None


### PR DESCRIPTION
`BaseStreamingDownloadHandler._extract_proxy()` uses `request.headers.pop()` to extract the Proxy-Authorization header, which permanently removes it from the request. On retry the header is gone, so the retry hits the proxy without credentials and fails with 407 Proxy Authentication Required.

The fix caches the extracted auth in `request.meta["_proxy_auth_header"]` so it survives retries. The first call pops the header (keeping backward compat), stores the value in meta, and subsequent calls read from meta.

Added unit tests for: auth preservation across retry (two calls on same request), no auth header, and no proxy.

Fixes #7601