### PR TITLE
Deprecate ScrapyCommand.help()

### DIFF
--- a/scrapy/commands/__init__.py
+++ b/scrapy/commands/__init__.py
@@ -68,10 +68,16 @@ class ScrapyCommand(ABC):
         return self.short_desc()
 
     def help(self) -> str:
-        """An extensive help for the command. It will be shown when using the
-        "help" command. It can contain newlines since no post-formatting will
-        be applied to its contents.
+        """An extensive help for the command.
+
+        Deprecated: this method is no longer called by Scrapy (there is no
+        ``help`` command), so overriding or calling it has no effect.
         """
+        warnings.warn(
+            "ScrapyCommand.help() is deprecated and is no longer used by Scrapy.",
+            ScrapyDeprecationWarning,
+            stacklevel=2,
+        )
         return self.long_desc()
 
     def add_options(self, parser: argparse.ArgumentParser) -> None:

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -12,6 +12,7 @@ import pytest
 import scrapy
 from scrapy.cmdline import _pop_command_name, _print_unknown_command_msg
 from scrapy.commands import ScrapyCommand, ScrapyHelpFormatter, view
+from scrapy.exceptions import ScrapyDeprecationWarning
 from scrapy.settings import Settings
 from scrapy.utils.reactor import _asyncio_reactor_path
 from tests.utils.cmdline import call, proc
@@ -45,6 +46,10 @@ class TestCommandSettings:
         self.command.process_options(args, opts)
         assert isinstance(self.command.settings["FEEDS"], scrapy.settings.BaseSettings)
         assert dict(self.command.settings["FEEDS"]) == json.loads(feeds_json)
+
+    def test_help_is_deprecated(self):
+        with pytest.warns(ScrapyDeprecationWarning, match="help"):
+            self.command.help()
 
     def test_help_formatter(self):
         formatter = ScrapyHelpFormatter(prog="scrapy")


### PR DESCRIPTION
As noted in #7626, `ScrapyCommand.help()` is dead code: there is no `help` command, Scrapy never calls the method, and none of the built-in commands override it. The docstring also points at a `"help" command` that does not exist.

This deprecates the method by emitting a `ScrapyDeprecationWarning` when it is called (matching the existing `set_crawler()` deprecation in the same file) and rewrites the docstring to say it is no longer used. I kept the change to `scrapy/commands/__init__.py` only — happy to also warn when a custom command overrides it (via `method_is_overridden`) if you would prefer that route, but starting with the simpler "deprecate calling it" since that is unambiguous.

Added a test that asserts calling `help()` warns.

Closes #7626