### PR TITLE
Fix rel_has_nofollow to be case-insensitive per HTML spec

### DIFF
--- a/scrapy/utils/misc.py
+++ b/scrapy/utils/misc.py
@@ -162,7 +162,7 @@ def md5sum(file: IO[bytes]) -> str:
 
 def rel_has_nofollow(rel: str | None) -> bool:
     """Return True if link rel attribute has nofollow type"""
-    return rel is not None and "nofollow" in rel.replace(",", " ").split()
+    return rel is not None and "nofollow" in rel.lower().replace(",", " ").split()
 
 
 class SupportsFromCrawler(Protocol[_T_co, _P]):

--- a/tests/test_utils_misc/__init__.py
+++ b/tests/test_utils_misc/__init__.py
@@ -160,3 +160,8 @@ class TestUtilsMisc:
         assert rel_has_nofollow("nofollowfoo") is False
         assert rel_has_nofollow("foonofollow") is False
         assert rel_has_nofollow("ugc,  ,  nofollow") is True
+        # rel attribute values are ASCII case-insensitive per the HTML spec
+        assert rel_has_nofollow("NoFollow") is True
+        assert rel_has_nofollow("NOFOLLOW") is True
+        assert rel_has_nofollow("UGC NoFollow") is True
+        assert rel_has_nofollow("ugc,NoFollow") is True


### PR DESCRIPTION
## Bug

The HTML specification states that link type keywords such as `nofollow`
are [ASCII case-insensitive](https://html.spec.whatwg.org/multipage/links.html#link-type-nofollow).
However, `rel_has_nofollow` performs a case-sensitive check, so a page
with `rel="NoFollow"` or `rel="NOFOLLOW"` is incorrectly treated as a
follow link and Scrapy will crawl it when it should not.

## Fix

Add `.lower()` before the token split in `scrapy/utils/misc.py`:

```python
# before
return rel is not None and "nofollow" in rel.replace(",", " ").split()
# after
return rel is not None and "nofollow" in rel.lower().replace(",", " ").split()
```

## Verification

```
pytest tests/test_utils_misc/ -k nofollow -v
# 1 passed
```

All 15 tests in `tests/test_utils_misc/` pass. The link extractor nofollow
test also passes.

> Note: This fix was developed with AI assistance.