### PR TITLE
Fix FTPDownloadHandler connection leak

### DIFF
--- a/scrapy/core/downloader/handlers/ftp.py
+++ b/scrapy/core/downloader/handlers/ftp.py
@@ -114,12 +114,17 @@ class FTPDownloadHandler(BaseDownloadHandler):
             await maybe_deferred_to_future(client.retrieveFile(filepath, protocol))
         except CommandFailed as e:
             message = str(e)
+            # Close protocol and client on error to prevent resource leaks
+            protocol.close()
+            client.transport.loseConnection()
             if m := _CODE_RE.search(message):
                 ftpcode = m.group()
                 httpcode = self.CODE_MAPPING.get(ftpcode, self.CODE_MAPPING["default"])
                 return Response(url=request.url, status=httpcode, body=message.encode())
             raise
         protocol.close()
+        # Close the FTP client connection to prevent resource leaks
+        client.transport.loseConnection()
         headers = {"local filename": protocol.filename or b"", "size": protocol.size}
         body = protocol.filename or protocol.body.read()
         respcls = responsetypes.from_args(url=request.url, body=body)


### PR DESCRIPTION
## Description

This PR fixes a resource leak in `FTPDownloadHandler.download_request()` where `FTPClient` instances are created but never closed.

### Problem

The `download_request()` method:
1. Creates an `FTPClient` instance via `ClientCreator`
2. Creates a `ReceivedDataProtocol` instance
3. Never closes the `FTPClient` connection after use
4. Doesn't close the `ReceivedDataProtocol` in the error path

This leads to resource leaks, especially when downloading many files.

### Solution

This fix ensures proper cleanup:
1. Close the FTP client connection after successful file retrieval using `client.transport.loseConnection()`
2. Close both the protocol and client connection in the error path to prevent leaks

### Changes

```python
# Before (error path):
except CommandFailed as e:
    message = str(e)
    if m := _CODE_RE.search(message):
        # ...
    raise

# After (error path):
except CommandFailed as e:
    message = str(e)
    # Close protocol and client on error to prevent resource leaks
    protocol.close()
    client.transport.loseConnection()
    if m := _CODE_RE.search(message):
        # ...
    raise

# Before (success path):
protocol.close()
headers = {"local filename": protocol.filename or b"", "size": protocol.size}

# After (success path):
protocol.close()
# Close the FTP client connection to prevent resource leaks
client.transport.loseConnection()
headers = {"local filename": protocol.filename or b"", "size": protocol.size}
```

### References

- Fixes #7602

Co-Authored-By: Claude <noreply@anthropic.com>