### PR TITLE
Fix cell-var-from-loop bug in _send_catch_log_deferred

### DIFF
--- a/scrapy/utils/signal.py
+++ b/scrapy/utils/signal.py
@@ -125,12 +125,8 @@ def _send_catch_log_deferred(
             **named,
         )
         d.addErrback(logerror, receiver)
-        # TODO https://pylint.readthedocs.io/en/latest/user_guide/messages/warning/cell-var-from-loop.html
         d2: Deferred[tuple[TypingAny, TypingAny]] = d.addBoth(
-            lambda result: (
-                receiver,  # pylint: disable=cell-var-from-loop  # noqa: B023
-                result,
-            )
+            lambda result, recv=receiver: (recv, result)
         )
         dfds.append(d2)
 

--- a/scrapy/utils/signal.py
+++ b/scrapy/utils/signal.py
@@ -127,8 +127,8 @@ def _send_catch_log_deferred(
         d.addErrback(logerror, receiver)
 
         d2: Deferred[tuple[TypingAny, TypingAny]] = d.addBoth(
-    lambda result, recv: (recv, result), receiver
-)
+            lambda result, recv: (recv, result), receiver
+        )
 
         dfds.append(d2)
 

--- a/scrapy/utils/signal.py
+++ b/scrapy/utils/signal.py
@@ -125,9 +125,11 @@ def _send_catch_log_deferred(
             **named,
         )
         d.addErrback(logerror, receiver)
+
         d2: Deferred[tuple[TypingAny, TypingAny]] = d.addBoth(
-            lambda result, recv=receiver: (recv, result)
-        )
+    lambda result, recv: (recv, result), receiver
+)
+
         dfds.append(d2)
 
     results = yield DeferredList(dfds)


### PR DESCRIPTION
Lambda in _send_catch_log_deferred was capturing receiver by reference in a for-loop. Thus, every callback could end up pointing to the last receiver in the loop, not to their own.

Fixed by passing receiver as an extra positional argument to addBoth which would capture the value at the iteration safely.
d.addBoth(lambda result, recv: (recv, result), receiver)

Removes also the TODO comment and the pylint/noqa suppressions that were suppressing the warning instead of fixing it.

Test with: pytest tests/testutilssignal.py -v (10 passed)