### PR TITLE
docs: quote pip extras install examples

### DIFF
--- a/docs/intro/install.rst
+++ b/docs/intro/install.rst
@@ -258,7 +258,7 @@ has a version of pyOpenSSL that your version of Twisted does not support.
 To install a version of pyOpenSSL that your version of Twisted supports,
 reinstall Twisted with the :code:`tls` extra option::
 
-    pip install twisted[tls]
+    pip install 'twisted[tls]'
 
 For details, see `Issue #2473 <https://github.com/scrapy/scrapy/issues/2473>`_.
 


### PR DESCRIPTION
## Summary
- Quote `pip install` examples that include extras.

## Why
- Shells such as zsh can expand unquoted bracket expressions before `pip` receives them.

## Scope
- Files changed:
- `docs/intro/install.rst`
- This does not change dependencies or runtime behavior.

## Testing
- `git diff --check`

## Maintainer Fit
- Small install-command correctness fix.
- Duplicate PR search terms checked: `quote pip extras`, `quote optional dependency`, `zsh pip install extras`, `pip extras install examples`