### PR TITLE
docs: clarify LOG_FILE with multiple spiders

### DIFF
--- a/docs/topics/settings.rst
+++ b/docs/topics/settings.rst
@@ -361,6 +361,14 @@ All of these settings, except for :setting:`ASYNCIO_EVENT_LOOP`, are only used
 when the Twisted reactor is used, i.e. when :setting:`TWISTED_REACTOR_ENABLED`
 is ``True``.
 
+Logging settings
+----------------
+
+:setting:`LOG_FILE` is a global logging setting. It can be defined from a
+spider, but when multiple spiders run in the same process, for example with
+:class:`~scrapy.crawler.CrawlerProcess`, it cannot be used as a per-spider log
+destination through :attr:`~scrapy.Spider.custom_settings`.
+
 .. _topics-settings-ref:
 
 Built-in settings reference
@@ -1459,6 +1467,12 @@ LOG_FILE
 Default: ``None``
 
 File name to use for logging output. If ``None``, standard error will be used.
+
+This is a global logging setting. When running multiple spiders in the same
+process, for example with :class:`~scrapy.crawler.CrawlerProcess`,
+:setting:`LOG_FILE` cannot be used as a per-spider log destination through
+:attr:`~scrapy.Spider.custom_settings`. See :ref:`topics-logging-settings` for
+more information about logging configuration.
 
 .. setting:: LOG_FILE_APPEND
 


### PR DESCRIPTION
Fixes #6909

## Summary
- Document `LOG_FILE` as a global logging setting in the special settings section.
- Add the same limitation to the `LOG_FILE` reference entry for users reading the settings list directly.

## Verification
- `python -m sphinx -W -b dummy docs C:\Users\14692\Documents\Codex\2026-06-24\issue-openpr-review-aireview-commit-pr\work\builds\scrapy-docs-dummy`
- `git diff --check`