### PR TITLE
Fix to LocalCache with limit=0 still stores items rather than disabling the cache

### DIFF
--- a/scrapy/utils/datatypes.py
+++ b/scrapy/utils/datatypes.py
@@ -152,7 +152,9 @@ class LocalCache(OrderedDict[_KT, _VT]):
         self.limit: int | None = limit
 
     def __setitem__(self, key: _KT, value: _VT) -> None:
-        if self.limit:
+        if self.limit is not None:
+            if self.limit == 0:
+                return
             while len(self) >= self.limit:
                 self.popitem(last=False)
         super().__setitem__(key, value)

--- a/scrapy/utils/signal.py
+++ b/scrapy/utils/signal.py
@@ -125,12 +125,8 @@ def _send_catch_log_deferred(
             **named,
         )
         d.addErrback(logerror, receiver)
-        # TODO https://pylint.readthedocs.io/en/latest/user_guide/messages/warning/cell-var-from-loop.html
         d2: Deferred[tuple[TypingAny, TypingAny]] = d.addBoth(
-            lambda result: (
-                receiver,  # pylint: disable=cell-var-from-loop  # noqa: B023
-                result,
-            )
+            lambda result, recv=receiver: (recv, result)
         )
         dfds.append(d2)
 

--- a/scrapy/utils/signal.py
+++ b/scrapy/utils/signal.py
@@ -127,8 +127,8 @@ def _send_catch_log_deferred(
         d.addErrback(logerror, receiver)
 
         d2: Deferred[tuple[TypingAny, TypingAny]] = d.addBoth(
-    lambda result, recv: (recv, result), receiver
-)
+            lambda result, recv: (recv, result), receiver
+        )
 
         dfds.append(d2)
 

--- a/scrapy/utils/signal.py
+++ b/scrapy/utils/signal.py
@@ -125,9 +125,11 @@ def _send_catch_log_deferred(
             **named,
         )
         d.addErrback(logerror, receiver)
+
         d2: Deferred[tuple[TypingAny, TypingAny]] = d.addBoth(
-            lambda result, recv=receiver: (recv, result)
-        )
+    lambda result, recv: (recv, result), receiver
+)
+
         dfds.append(d2)
 
     results = yield DeferredList(dfds)

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -75,12 +75,3 @@ def test_caching_hostname_resolver_dnscache_disabled_rejects_storage():
     # dnscache should remain empty despite address being resolved
     assert "example.com" not in dnscache
     assert len(dnscache) == 0
-
-
-def test_caching_threaded_resolver_dnscache_disabled_rejects_storage():
-    # Regression test: when DNSCACHE_ENABLED=False, resolved DNS results
-    # should not be stored in dnscache even after successful resolution.
-    dnscache.limit = 0
-    dnscache["example.com"] = "1.2.3.4"
-    assert "example.com" not in dnscache
-    assert len(dnscache) == 0

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -53,3 +53,34 @@ def test_caching_hostname_resolver_no_addresses_not_cached():
     resolver.resolveHostName(Mock(), "example.com")
 
     assert "example.com" not in dnscache
+
+
+def test_caching_hostname_resolver_dnscache_disabled_rejects_storage():
+    # Regression test for LocalCache(limit=0) rejecting storage
+    # when DNSCACHE_ENABLED=False. _CachingResolutionReceiver writes
+    # directly to dnscache, so we verify nothing is stored.
+    def fake_resolve(receiver, *_):
+        receiver.resolutionBegan(Mock())
+        receiver.addressResolved(Mock())
+        receiver.resolutionComplete()
+        return receiver
+
+    reactor = Mock()
+    reactor.nameResolver.resolveHostName.side_effect = fake_resolve
+
+    # cache_size=0 simulates DNSCACHE_ENABLED=False
+    resolver = CachingHostnameResolver(reactor, cache_size=0)
+    resolver.resolveHostName(Mock(), "example.com")
+
+    # dnscache should remain empty despite address being resolved
+    assert "example.com" not in dnscache
+    assert len(dnscache) == 0
+
+
+def test_caching_threaded_resolver_dnscache_disabled_rejects_storage():
+    # Regression test: when DNSCACHE_ENABLED=False, resolved DNS results
+    # should not be stored in dnscache even after successful resolution.
+    dnscache.limit = 0
+    dnscache["example.com"] = "1.2.3.4"
+    assert "example.com" not in dnscache
+    assert len(dnscache) == 0

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -56,9 +56,7 @@ def test_caching_hostname_resolver_no_addresses_not_cached():
 
 
 def test_caching_hostname_resolver_dnscache_disabled_rejects_storage():
-    # Regression test for LocalCache(limit=0) rejecting storage
-    # when DNSCACHE_ENABLED=False. _CachingResolutionReceiver writes
-    # directly to dnscache, so we verify nothing is stored.
+
     def fake_resolve(receiver, *_):
         receiver.resolutionBegan(Mock())
         receiver.addressResolved(Mock())
@@ -68,10 +66,8 @@ def test_caching_hostname_resolver_dnscache_disabled_rejects_storage():
     reactor = Mock()
     reactor.nameResolver.resolveHostName.side_effect = fake_resolve
 
-    # cache_size=0 simulates DNSCACHE_ENABLED=False
     resolver = CachingHostnameResolver(reactor, cache_size=0)
     resolver.resolveHostName(Mock(), "example.com")
 
-    # dnscache should remain empty despite address being resolved
     assert "example.com" not in dnscache
     assert len(dnscache) == 0

--- a/tests/test_utils_datatypes.py
+++ b/tests/test_utils_datatypes.py
@@ -310,7 +310,6 @@ class TestLocalCache:
             assert cache[str(x)] == x
 
     def test_cache_with_zero_limit(self):
-        # limit=0 means cache is disabled, no items should be stored
         cache = LocalCache(limit=0)
         cache["a"] = 1
         cache["b"] = 2

--- a/tests/test_utils_datatypes.py
+++ b/tests/test_utils_datatypes.py
@@ -309,6 +309,17 @@ class TestLocalCache:
             assert str(x) in cache
             assert cache[str(x)] == x
 
+    def test_cache_with_zero_limit(self):
+        # limit=0 means cache is disabled, no items should be stored
+        cache = LocalCache(limit=0)
+        cache["a"] = 1
+        cache["b"] = 2
+        cache["c"] = 3
+        assert len(cache) == 0
+        assert "a" not in cache
+        assert "b" not in cache
+        assert "c" not in cache
+
 
 class TestLocalWeakReferencedCache:
     def test_cache_with_limit(self):


### PR DESCRIPTION
Bug:-
'LocalCache.__setitem__' checks 'if self.limit:' to enforce the size limit. With a limit=0 (cache disabled), Python has treat 0 as false,and skips the check,so it’ll go through storing an item unconditionally.
Impact of Bug:-
When 'DNSCACHE_ENABLED=False', Scrapy passes 'cache_size=0' to 'LocalCache'.Because of this bug,DNS results are cached indefinitely  leading to a memory leak on large crawls, even when caching was explicitly disabled.
FIx:-
Change 'if self.limit:' to 'if self.limit is not None:'
and Add early 'return' when 'limit=0'
