### PR TITLE
Fix FTPDownloadHandler not closing FTP connection after download

### DIFF
--- a/scrapy/core/downloader/handlers/ftp.py
+++ b/scrapy/core/downloader/handlers/ftp.py
@@ -113,15 +113,22 @@ class FTPDownloadHandler(BaseDownloadHandler):
         try:
             await maybe_deferred_to_future(client.retrieveFile(filepath, protocol))
         except CommandFailed as e:
+            protocol.close()
             message = str(e)
             if m := _CODE_RE.search(message):
                 ftpcode = m.group()
                 httpcode = self.CODE_MAPPING.get(ftpcode, self.CODE_MAPPING["default"])
                 return Response(url=request.url, status=httpcode, body=message.encode())
             raise
-        protocol.close()
-        headers = {"local filename": protocol.filename or b"", "size": protocol.size}
-        body = protocol.filename or protocol.body.read()
-        respcls = responsetypes.from_args(url=request.url, body=body)
-        # hints for Headers-related types may need to be fixed to not use AnyStr
-        return respcls(url=request.url, status=200, body=body, headers=headers)  # type: ignore[arg-type]
+        else:
+            protocol.close()
+            headers = {"local filename": protocol.filename or b"", "size": protocol.size}
+            body = protocol.filename or protocol.body.read()
+            respcls = responsetypes.from_args(url=request.url, body=body)
+            # hints for Headers-related types may need to be fixed to not use AnyStr
+            return respcls(url=request.url, status=200, body=body, headers=headers)  # type: ignore[arg-type]
+        finally:
+            try:
+                await maybe_deferred_to_future(client.quit())
+            except Exception:
+                pass


### PR DESCRIPTION
## Summary

Closes #7602

`FTPDownloadHandler.download_request()` creates an `FTPClient` but never calls `client.quit()` to close the FTP control connection. This is a resource leak — the connection stays open until the server times it out.

There was also a secondary bug: the `except CommandFailed` path did not call `protocol.close()`. For local-filename downloads this leaves a file handle open until GC.

## Changes

Refactored the try/except block to `try/except/else/finally`:

- `except CommandFailed` — now calls `protocol.close()` before the error-response logic
- `else` (success path) — `protocol.close()` moved here (was called unconditionally before, which would have run even on exception before this fix)
- `finally` — calls `await maybe_deferred_to_future(client.quit())` unconditionally; any exception from `quit()` is suppressed so it doesn't mask the original error

```python
try:
    await maybe_deferred_to_future(client.retrieveFile(filepath, protocol))
except CommandFailed as e:
    protocol.close()
    ...
else:
    protocol.close()
    ...
finally:
    try:
        await maybe_deferred_to_future(client.quit())
    except Exception:
        pass
```

## Why this is not a duplicate

```bash
gh pr list --repo scrapy/scrapy --state open --search "7602 in:body"
gh pr list --repo scrapy/scrapy --state open --search "ftp quit"
```

No existing open PR addresses this issue.

## AI assistance

This PR was developed with AI assistance (Claude). The submitting human has reviewed every changed line and understands the fix end-to-end.