### PR TITLE
fix: FTPDownloadHandler not closing FTP connections after download

### DIFF
--- a/scrapy/core/downloader/handlers/ftp.py
+++ b/scrapy/core/downloader/handlers/ftp.py
@@ -119,7 +119,10 @@ class FTPDownloadHandler(BaseDownloadHandler):
                 httpcode = self.CODE_MAPPING.get(ftpcode, self.CODE_MAPPING["default"])
                 return Response(url=request.url, status=httpcode, body=message.encode())
             raise
-        protocol.close()
+        finally:
+            protocol.close()
+            assert client.transport
+            client.transport.loseConnection()
         headers = {"local filename": protocol.filename or b"", "size": protocol.size}
         body = protocol.filename or protocol.body.read()
         respcls = responsetypes.from_args(url=request.url, body=body)

--- a/tests/test_downloader_handler_twisted_ftp.py
+++ b/tests/test_downloader_handler_twisted_ftp.py
@@ -205,3 +205,83 @@ def test_not_configured_without_reactor() -> None:
     crawler = Crawler(Spider, {"TWISTED_REACTOR_ENABLED": False})
     with pytest.raises(NotConfigured):
         FTPDownloadHandler.from_crawler(crawler)
+
+
+class TestFTPCleanup(TestFTPBase):
+    def _create_files(self, root: Path) -> None:
+        userdir = root / self.username
+        userdir.mkdir()
+        for filename, content in self.test_files:
+            (userdir / filename).write_bytes(content)
+
+    def _get_factory(self, root):
+        from twisted.protocols.ftp import FTPFactory, FTPRealm
+
+        realm = FTPRealm(anonymousRoot=str(root), userHome=str(root))
+        p = portal.Portal(realm)
+        users_checker = checkers.InMemoryUsernamePasswordDatabaseDontUse()
+        users_checker.addUser(self.username, self.password)
+        p.registerChecker(users_checker, credentials.IUsernamePassword)
+        return FTPFactory(portal=p)
+
+    @deferred_f_from_coro_f
+    async def test_lose_connection_called_on_success(
+        self, server_url: str
+    ) -> None:
+        from unittest.mock import patch
+
+        from scrapy.core.downloader.handlers.ftp import ReceivedDataProtocol
+
+        lose_calls: list[bool] = []
+        close_calls: list[bool] = []
+        original_close = ReceivedDataProtocol.close
+
+        def tracking_close(self):
+            close_calls.append(True)
+            original_close(self)
+
+        with patch.object(ReceivedDataProtocol, "close", tracking_close), patch(
+            "twisted.internet.tcp.Client.loseConnection"
+        ) as mock_lose:
+            mock_lose.side_effect = lambda: lose_calls.append(True)
+            crawler = get_crawler()
+            dh = build_from_crawler(FTPDownloadHandler, crawler)
+            request = Request(
+                url=server_url + "file.txt",
+                meta={"ftp_user": "scrapy", "ftp_password": "passwd"},
+            )
+            r = await dh.download_request(request)
+            assert r.status == 200
+            assert close_calls, "protocol.close() was not called"
+            assert lose_calls, "transport.loseConnection() was not called"
+
+    @deferred_f_from_coro_f
+    async def test_lose_connection_called_on_error(
+        self, server_url: str
+    ) -> None:
+        from unittest.mock import patch
+
+        from scrapy.core.downloader.handlers.ftp import ReceivedDataProtocol
+
+        lose_calls: list[bool] = []
+        close_calls: list[bool] = []
+        original_close = ReceivedDataProtocol.close
+
+        def tracking_close(self):
+            close_calls.append(True)
+            original_close(self)
+
+        with patch.object(ReceivedDataProtocol, "close", tracking_close), patch(
+            "twisted.internet.tcp.Client.loseConnection"
+        ) as mock_lose:
+            mock_lose.side_effect = lambda: lose_calls.append(True)
+            crawler = get_crawler()
+            dh = build_from_crawler(FTPDownloadHandler, crawler)
+            request = Request(
+                url=server_url + "nonexistent.txt",
+                meta={"ftp_user": "scrapy", "ftp_password": "passwd"},
+            )
+            r = await dh.download_request(request)
+            assert r.status == 404
+            assert close_calls, "protocol.close() was not called on error"
+            assert lose_calls, "transport.loseConnection() was not called on error"


### PR DESCRIPTION
## Problem Situation

FTPDownloadHandler.download_request() creates FTPClient instances but never closes the control connection after the transfer completes or fails. The except CommandFailed path also never calls protocol.close(), which could leave an open file handle for local-filename downloads.

## Approach

Add a finally block to ensure cleanup happens in all code paths:

1. Move protocol.close() into the finally block so ReceivedDataProtocol resources are released in all paths
2. Add client.transport.loseConnection() in the finally block to close the TCP connection

## Why I Am Confident

This follows the standard Twisted pattern for closing protocol connections. The finally block ensures cleanup happens regardless of success or failure. Tests verify that both protocol.close() and transport.loseConnection() are called on both success and error paths.

## Risks

Minimal - this is adding cleanup that was missing, not changing existing behavior.

## User-Visible Behavior Changes

None - this is a resource leak fix that doesn't change observable behavior for users.

## Verification

- All existing FTP tests pass (22 tests)
- New tests verify cleanup is called on both success and error paths

Closes scrapy/scrapy#7602