### PR TITLE
Fix request_to_curl() corrupting dict cookies with bytes keys/values

### DIFF
--- a/scrapy/utils/request.py
+++ b/scrapy/utils/request.py
@@ -213,7 +213,7 @@ def request_to_curl(request: Request) -> str:
             cookie = "; ".join(
                 f"{_cookie_value_to_unicode(c['name'])}={_cookie_value_to_unicode(c['value'])}"
                 if "name" in c and "value" in c
-                else f"{next(iter(c.keys()))}={next(iter(c.values()))}"
+                else f"{_cookie_value_to_unicode(next(iter(c.keys())))}={_cookie_value_to_unicode(next(iter(c.values())))}"
                 for c in request.cookies
             )
             cookies = f"--cookie '{cookie}'"

--- a/scrapy/utils/request.py
+++ b/scrapy/utils/request.py
@@ -204,7 +204,10 @@ def request_to_curl(request: Request) -> str:
     cookies = ""
     if request.cookies:
         if isinstance(request.cookies, dict):
-            cookie = "; ".join(f"{k}={v}" for k, v in request.cookies.items())
+            cookie = "; ".join(
+                f"{_cookie_value_to_unicode(k)}={_cookie_value_to_unicode(v)}"
+                for k, v in request.cookies.items()
+            )
             cookies = f"--cookie '{cookie}'"
         elif isinstance(request.cookies, list):
             cookie = "; ".join(

--- a/tests/test_utils_request.py
+++ b/tests/test_utils_request.py
@@ -401,6 +401,19 @@ class TestRequestToCurl:
         )
         self._test_request(request_object, expected_curl_command)
 
+    def test_cookies_dict_bytes(self):
+        request_object = Request(
+            "https://www.httpbin.org/post",
+            method="POST",
+            cookies={b"foo": b"bar"},
+            body=json.dumps({"foo": "bar"}),
+        )
+        expected_curl_command = (
+            "curl -X POST https://www.httpbin.org/post"
+            " --data-raw '{\"foo\": \"bar\"}' --cookie 'foo=bar'"
+        )
+        self._test_request(request_object, expected_curl_command)
+
     def test_cookies_list(self):
         request_object = Request(
             "https://www.httpbin.org/post",

--- a/tests/test_utils_request.py
+++ b/tests/test_utils_request.py
@@ -468,3 +468,16 @@ class TestRequestToCurl:
             " --data-raw '{\"foo\": \"bar\"}' --cookie 'foo=1'"
         )
         self._test_request(request_object, expected_curl_command)
+
+    def test_cookies_list_bytes_nonstandard_key(self):
+        request_object = Request(
+            "https://www.httpbin.org/post",
+            method="POST",
+            cookies=[{b"foo": b"bar"}],
+            body=json.dumps({"foo": "bar"}),
+        )
+        expected_curl_command = (
+            "curl -X POST https://www.httpbin.org/post"
+            " --data-raw '{\"foo\": \"bar\"}' --cookie 'foo=bar'"
+        )
+        self._test_request(request_object, expected_curl_command)


### PR DESCRIPTION
`request_to_curl()` renders dict cookies whose keys/values are bytes as their literal repr (`b'k'=b'v'`) in the emitted curl command, producing a broken command.

PR #7603 made the list-cookie branch bytes-safe but did not mirror the same handling to the dict branch. This applies the identical decoding there. Existing tests green (29 passed).