### PR TITLE
Fix get_base_url/get_meta_refresh ignoring <base href> beyond 4096 chars

### DIFF
--- a/scrapy/utils/response.py
+++ b/scrapy/utils/response.py
@@ -28,7 +28,7 @@ _baseurl_cache: WeakKeyDictionary[Response, str] = WeakKeyDictionary()
 def get_base_url(response: TextResponse) -> str:
     """Return the base url of the given response, joined with the response url"""
     if response not in _baseurl_cache:
-        text = response.text[0:4096]
+        text = response.text
         _baseurl_cache[response] = html.get_base_url(
             text, response.url, response.encoding
         )
@@ -46,7 +46,7 @@ def get_meta_refresh(
 ) -> tuple[None, None] | tuple[float, str]:
     """Parse the http-equiv refresh parameter from the given response"""
     if response not in _metaref_cache:
-        text = response.text[0:4096]
+        text = response.text
         _metaref_cache[response] = html.get_meta_refresh(
             text, get_base_url(response), response.encoding, ignore_tags=ignore_tags
         )

--- a/tests/test_utils_response.py
+++ b/tests/test_utils_response.py
@@ -321,3 +321,21 @@ def test_open_in_browser_raises_for_unsupported_response_type():
     response = Response("http://www.example.com", body=b"binary")
     with pytest.raises(TypeError):
         open_in_browser(response, _openfunc=lambda _: True)
+
+
+def test_get_base_url_beyond_4096_chars():
+    """get_base_url must find <base href> even when it appears after
+    the first 4096 characters of the response body.
+
+    Regression test for https://github.com/scrapy/scrapy/issues/3017
+    """
+    # Build a body where the base tag is past the 4096-char mark by
+    # padding with an HTML comment before the <head>.
+    padding = "<!-- " + "x" * 4100 + " -->"
+    body = (
+        f"<html>{padding}"
+        f'<head><base href="http://www.example.com/img/"></head>'
+        f"<body>content</body></html>"
+    ).encode()
+    resp = HtmlResponse("http://www.example.com", body=body)
+    assert get_base_url(resp) == "http://www.example.com/img/"


### PR DESCRIPTION
## Bug

`scrapy.utils.response.get_base_url` and `get_meta_refresh` both truncate the response text to the first **4096 characters** before searching for `<base href>` / `<meta http-equiv=refresh>`. When the base tag appears after that offset (e.g. the page has a large inline script, lengthy comment block, or heavy whitespace before `<head>`), Scrapy silently falls back to the response URL as the base URL. This produces wrong absolute links and mis-resolved relative URLs in the link extractor, `response.urljoin()`, and `FormRequest`.

Reported in #3017.

## Fix

Remove the `[0:4096]` slice so the full response text is searched. Results are still cached per-response via `WeakKeyDictionary`, so the performance cost is bounded to a single regex pass over the document—which is what w3lib already does internally.

## Verification

New regression test added to `tests/test_utils_response.py`:

```
tests/test_utils_response.py::test_get_base_url_beyond_4096_chars
```

RED (before fix):
```
FAILED - AssertionError: assert 'http://www.example.com' == 'http://www.example.com/img/'
```

GREEN (after fix):
```
27 passed in 0.63s
```

Existing test suite also passes:
```
tests/test_linkextractors.py   38 passed
tests/test_http_response_text.py  253 passed
```

Closes #3017