### PR TITLE
Add a leading slash to request URLs with a host and query/fragment but no path

### DIFF
--- a/scrapy/http/request/__init__.py
+++ b/scrapy/http/request/__init__.py
@@ -19,6 +19,7 @@ from typing import (
     TypeVar,
     overload,
 )
+from urllib.parse import urlsplit, urlunsplit
 
 from w3lib.url import safe_url_string
 
@@ -263,6 +264,18 @@ class Request(object_ref):
             self._url = url
         else:
             self._url = safe_url_string(url, self.encoding)
+            # An http(s) URL with a host and a query or fragment but no path
+            # keeps an empty path, so the request line starts with "?..." and
+            # some servers reject it with a 400. Put the "/" back, the same
+            # normalization w3lib's safe_download_url applies. See #6574.
+            parts = urlsplit(self._url)
+            if (
+                parts.scheme in ("http", "https")
+                and parts.netloc
+                and not parts.path
+                and (parts.query or parts.fragment)
+            ):
+                self._url = urlunsplit(parts._replace(path="/"))
 
         if (
             "://" not in self._url

--- a/tests/test_http_request.py
+++ b/tests/test_http_request.py
@@ -100,6 +100,21 @@ class TestRequest:
         r = self.request_class(url="http://www.scrapy.org/path")
         assert r.url == "http://www.scrapy.org/path"
 
+    def test_url_empty_path_with_query(self):
+        # #6574: an http(s) url with a host and a query or fragment but no path
+        # must keep a leading "/" so the request line is "/?..." and not "?...",
+        # which some servers reject with a 400.
+        r = self.request_class(url="http://www.scrapy.org?url=x")
+        assert r.url == "http://www.scrapy.org/?url=x"
+        r = self.request_class(url="http://www.scrapy.org#frag")
+        assert r.url == "http://www.scrapy.org/#frag"
+        # a host with no query or fragment is left unchanged
+        r = self.request_class(url="http://www.scrapy.org")
+        assert r.url == "http://www.scrapy.org"
+        # an existing path is untouched
+        r = self.request_class(url="http://www.scrapy.org/p?url=x")
+        assert r.url == "http://www.scrapy.org/p?url=x"
+
     def test_url_quoting(self):
         r = self.request_class(url="http://www.scrapy.org/blank%20space")
         assert r.url == "http://www.scrapy.org/blank%20space"


### PR DESCRIPTION
Fixes #6574.

## Problem

A `Request` URL with a host and a query (or fragment) but no path keeps an empty path after `safe_url_string`, so the HTTP request line is sent as `?url=x HTTP/1.1` instead of `/?url=x HTTP/1.1`. Some servers reject the former with a 400 and the request never reaches the application:

```python
>>> Request("http://127.0.0.1:9000?url=x").url
'http://127.0.0.1:9000?url=x'   # request line: "?url=x HTTP/1.1" -> 400
```

This matches @Laerte's analysis on the issue: `safe_url_string` (unlike `safe_download_url`) doesn't restore the `/`.

## Fix

In `Request._set_url`, after `safe_url_string`, if an http(s) URL has a host, an empty path, and a query or fragment, put the `/` back — the same normalization `w3lib.url.safe_download_url` applies:

```python
>>> Request("http://127.0.0.1:9000?url=x").url
'http://127.0.0.1:9000/?url=x'
```

URLs that already have a path, and hosts with neither a query nor a fragment (e.g. `http://example.com`), are left unchanged — the downloader already turns a bare host into a `/` request line, and not touching those avoids changing URL identity/dedup for the common case.

## Tests

Added `test_url_empty_path_with_query` (passes with the fix, fails without it). The full `test_http_request.py`, `test_utils_url.py`, `test_utils_request.py`, and `test_http_response.py` suites pass (228 passed locally), so request fingerprinting and URL utils are unaffected.

## A question for you

@wRAR noted on the issue that #1133 is related and "there could be a general solution for both." This PR is the **narrow, targeted** fix @Laerte pointed at (mirroring `safe_download_url`). If you'd rather solve #1133 and this together with a more general normalization (e.g. pushing the `/` handling into `safe_url_string` upstream in w3lib), I'm happy to take that direction instead — just let me know which you'd prefer.

I also left `docs/news.rst` untouched since recent merged PRs don't add per-PR entries; happy to add a release note if you'd like one.
