### PR TITLE
Fix sitemap tag crash in utils/sitemap.py

### DIFF
--- a/scrapy/utils/sitemap.py
+++ b/scrapy/utils/sitemap.py
@@ -99,6 +99,8 @@ class Sitemap:
     def _get_tag_name(elem: lxml.etree._Element) -> str:
         if TYPE_CHECKING:
             assert isinstance(elem.tag, str)
+        if not isinstance(elem.tag, str):
+            return ""
         _, _, localname = elem.tag.partition("}")
         return localname or elem.tag
 


### PR DESCRIPTION
Fix crash in sitemap tag parsing in utils/sitemap.py

This change fixes an issue where sitemap tag parsing could crash due to improper handling of certain input values.

Changes:
- Added missing safety check in sitemap tag parsing logic

No breaking changes.

Tests:
- Existing test suite passes locally (tox not run in this case, but recommended)
