### PR TITLE
Remove stale module-level docstring from scrapy.mail

### DIFF
--- a/scrapy/mail.py
+++ b/scrapy/mail.py
@@ -1,9 +1,3 @@
-"""
-Mail sending helpers
-
-See documentation in docs/topics/email.rst
-"""
-
 from __future__ import annotations
 
 import logging


### PR DESCRIPTION
## Summary

Removes the outdated module-level docstring from `scrapy.mail`.

The removed docstring referenced `docs/topics/email.rst`, which no longer exists, and duplicated information that is no longer useful.

Refs #7699