### PR TITLE
Normalize empty URL paths before query strings

### DIFF
--- a/scrapy/http/request/__init__.py
+++ b/scrapy/http/request/__init__.py
@@ -8,6 +8,7 @@ See documentation in docs/topics/request-response.rst
 from __future__ import annotations
 
 import inspect
+from urllib.parse import urlsplit, urlunsplit
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -263,6 +264,9 @@ class Request(object_ref):
             self._url = url
         else:
             self._url = safe_url_string(url, self.encoding)
+            parts = urlsplit(self._url)
+            if parts.netloc and not parts.path and parts.query:
+                self._url = urlunsplit(parts._replace(path="/"))
 
         if (
             "://" not in self._url

--- a/tests/test_http_request.py
+++ b/tests/test_http_request.py
@@ -100,6 +100,16 @@ class TestRequest:
         r = self.request_class(url="http://www.scrapy.org/path")
         assert r.url == "http://www.scrapy.org/path"
 
+    def test_url_empty_path_with_query(self):
+        r = self.request_class(url="http://www.scrapy.org?foo=bar")
+        assert r.url == "http://www.scrapy.org/?foo=bar"
+
+        r = self.request_class(
+            url="http://www.scrapy.org?foo=bar",
+            meta={"verbatim_url": True},
+        )
+        assert r.url == "http://www.scrapy.org?foo=bar"
+
     def test_url_quoting(self):
         r = self.request_class(url="http://www.scrapy.org/blank%20space")
         assert r.url == "http://www.scrapy.org/blank%20space"


### PR DESCRIPTION
## Summary
- Normalize request URLs like `http://host?foo=bar` to `http://host/?foo=bar` so HTTP clients send a valid origin-form path.
- Preserve `meta={"verbatim_url": True}` behavior for callers that explicitly opt out of URL normalization.

Closes #6574.

## Tests
- Red: `python -m pytest tests/test_http_request.py::TestRequest::test_url_empty_path_with_query -q` failed before the fix with `http://www.scrapy.org?foo=bar` missing `/`.
- Green: `python -m pytest tests/test_http_request.py::TestRequest::test_url_empty_path_with_query -q`
- `python -m pytest tests/test_http_request.py -q`