### PR TITLE
Remove stale module docstrings

### DIFF
--- a/scrapy/loader/__init__.py
+++ b/scrapy/loader/__init__.py
@@ -1,9 +1,3 @@
-"""
-Item Loader
-
-See documentation in docs/topics/loaders.rst
-"""
-
 from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any

--- a/scrapy/pipelines/images.py
+++ b/scrapy/pipelines/images.py
@@ -1,9 +1,3 @@
-"""
-Images Pipeline
-
-See documentation in topics/media-pipeline.rst
-"""
-
 from __future__ import annotations
 
 import functools

--- a/scrapy/selector/unified.py
+++ b/scrapy/selector/unified.py
@@ -1,7 +1,3 @@
-"""
-XPath selectors based on lxml
-"""
-
 from __future__ import annotations
 
 from typing import Any

--- a/scrapy/shell.py
+++ b/scrapy/shell.py
@@ -1,9 +1,3 @@
-"""Scrapy Shell
-
-See documentation in docs/topics/shell.rst
-
-"""
-
 from __future__ import annotations
 
 import asyncio

--- a/scrapy/utils/url.py
+++ b/scrapy/utils/url.py
@@ -1,8 +1,3 @@
-"""
-This module contains general purpose URL functions not found in the standard
-library.
-"""
-
 from __future__ import annotations
 
 import re


### PR DESCRIPTION
## Summary
- remove stale module-level docstrings that only point to existing docs or provide generic module summaries
- keep the cleanup limited to modules where no unique guidance needed to be moved into docs

Refs #7699.

## Tests
- `git diff --check`
- `PYTHONPYCACHEPREFIX=/Volumes/STOREJET/Documents/OSC/.pycache-scrapy-cleanup python3 -m compileall -q scrapy/shell.py scrapy/loader/__init__.py scrapy/pipelines/images.py scrapy/selector/unified.py scrapy/utils/url.py`
- `PYTHONPATH=/Volumes/STOREJET/Documents/OSC/repos/scrapy /Volumes/STOREJET/Documents/OSC/repos/scrapy-empty-path-url/.venv-codex313/bin/python -c "import scrapy.shell, scrapy.loader, scrapy.pipelines.images, scrapy.selector.unified, scrapy.utils.url; print('imports ok')"`