### PR TITLE
Document scrape_response output change in 2.13 notes

### DIFF
--- a/docs/news.rst
+++ b/docs/news.rst
@@ -1695,6 +1695,11 @@ Backward-incompatible changes
     ``process_start_requests()`` has been replaced by ``process_start()``.
     (:issue:`6729`)
 
+-   ``scrapy.core.spidermw.SpiderMiddlewareManager.scrape_response()``, which
+    is intended for internal use, now returns a deferred whose result is a
+    ``MutableAsyncChain`` instead of the previous callback output shape.
+    (:issue:`6787`)
+
 -   The now-deprecated ``start_requests()`` method, when it returns an iterable
     instead of being defined as a generator, is now executed *after* the
     :ref:`scheduler <topics-scheduler>` instance has been created.


### PR DESCRIPTION
## Summary
- document the Scrapy 2.13 `SpiderMiddlewareManager.scrape_response()` output change in the backward-incompatible changes section
- note that the internal method now resolves to a `MutableAsyncChain`

Fixes #6787.

## Verification
- `git diff --check`
- `rg -n 'scrape_response\(\)|MutableAsyncChain|issue:6787' docs/news.rst`

I could not run a local RST parse in the existing Scrapy Python 3.13 venv because `docutils` is not installed there.
