### PR TITLE
Broader sweep of stale module-level docstrings (#7699)

### DIFF
--- a/scrapy/commands/shell.py
+++ b/scrapy/commands/shell.py
@@ -1,9 +1,3 @@
-"""
-Scrapy Shell
-
-See documentation in docs/topics/shell.rst
-"""
-
 from __future__ import annotations
 
 import asyncio

--- a/scrapy/core/downloader/middleware.py
+++ b/scrapy/core/downloader/middleware.py
@@ -1,9 +1,3 @@
-"""
-Downloader Middleware manager
-
-See documentation in docs/topics/downloader-middleware.rst
-"""
-
 from __future__ import annotations
 
 import warnings

--- a/scrapy/core/spidermw.py
+++ b/scrapy/core/spidermw.py
@@ -1,9 +1,3 @@
-"""
-Spider Middleware manager
-
-See documentation in docs/topics/spider-middleware.rst
-"""
-
 from __future__ import annotations
 
 import logging

--- a/scrapy/downloadermiddlewares/defaultheaders.py
+++ b/scrapy/downloadermiddlewares/defaultheaders.py
@@ -1,9 +1,3 @@
-"""
-DefaultHeaders downloader middleware
-
-See documentation in docs/topics/downloader-middleware.rst
-"""
-
 from __future__ import annotations
 
 from typing import TYPE_CHECKING

--- a/scrapy/downloadermiddlewares/downloadtimeout.py
+++ b/scrapy/downloadermiddlewares/downloadtimeout.py
@@ -1,9 +1,3 @@
-"""
-Download timeout middleware
-
-See documentation in docs/topics/downloader-middleware.rst
-"""
-
 from __future__ import annotations
 
 from typing import TYPE_CHECKING

--- a/scrapy/downloadermiddlewares/httpauth.py
+++ b/scrapy/downloadermiddlewares/httpauth.py
@@ -1,9 +1,3 @@
-"""
-HTTP basic auth downloader middleware
-
-See documentation in docs/topics/downloader-middleware.rst
-"""
-
 from __future__ import annotations
 
 import warnings

--- a/scrapy/extension.py
+++ b/scrapy/extension.py
@@ -1,9 +1,3 @@
-"""
-The Extension Manager
-
-See documentation in docs/topics/extensions.rst
-"""
-
 from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any

--- a/scrapy/extensions/closespider.py
+++ b/scrapy/extensions/closespider.py
@@ -1,9 +1,3 @@
-"""CloseSpider is an extension that forces spiders to be closed after certain
-conditions are met.
-
-See documentation in docs/topics/extensions.rst
-"""
-
 from __future__ import annotations
 
 import logging

--- a/scrapy/extensions/debug.py
+++ b/scrapy/extensions/debug.py
@@ -1,9 +1,3 @@
-"""
-Extensions for debugging Scrapy
-
-See documentation in docs/topics/extensions.rst
-"""
-
 from __future__ import annotations
 
 import contextlib

--- a/scrapy/extensions/feedexport.py
+++ b/scrapy/extensions/feedexport.py
@@ -1,9 +1,3 @@
-"""
-Feed Exports extension
-
-See documentation in docs/topics/feed-exports.rst
-"""
-
 from __future__ import annotations
 
 import asyncio

--- a/scrapy/extensions/memdebug.py
+++ b/scrapy/extensions/memdebug.py
@@ -1,9 +1,3 @@
-"""
-MemoryDebugger extension
-
-See documentation in docs/topics/extensions.rst
-"""
-
 from __future__ import annotations
 
 import gc

--- a/scrapy/extensions/memusage.py
+++ b/scrapy/extensions/memusage.py
@@ -1,9 +1,3 @@
-"""
-MemoryUsage extension
-
-See documentation in docs/topics/extensions.rst
-"""
-
 from __future__ import annotations
 
 import logging

--- a/scrapy/extensions/telnet.py
+++ b/scrapy/extensions/telnet.py
@@ -1,9 +1,3 @@
-"""
-Scrapy Telnet Console extension
-
-See documentation in docs/topics/telnetconsole.rst
-"""
-
 from __future__ import annotations
 
 import binascii

--- a/scrapy/http/request/__init__.py
+++ b/scrapy/http/request/__init__.py
@@ -1,10 +1,3 @@
-"""
-This module implements the Request class which is used to represent HTTP
-requests in Scrapy.
-
-See documentation in docs/topics/request-response.rst
-"""
-
 from __future__ import annotations
 
 import inspect

--- a/scrapy/http/request/form.py
+++ b/scrapy/http/request/form.py
@@ -1,10 +1,3 @@
-"""
-This module implements the FormRequest class which is a more convenient class
-(than Request) to generate Requests based on form data.
-
-See documentation in docs/topics/request-response.rst
-"""
-
 from __future__ import annotations
 
 from collections.abc import Iterable

--- a/scrapy/http/request/json_request.py
+++ b/scrapy/http/request/json_request.py
@@ -1,10 +1,3 @@
-"""
-This module implements the JsonRequest class which is a more convenient class
-(than Request) to generate JSON Requests.
-
-See documentation in docs/topics/request-response.rst
-"""
-
 from __future__ import annotations
 
 import copy

--- a/scrapy/http/request/rpc.py
+++ b/scrapy/http/request/rpc.py
@@ -1,10 +1,3 @@
-"""
-This module implements the XmlRpcRequest class which is a more convenient class
-(that Request) to generate xml-rpc requests.
-
-See documentation in docs/topics/request-response.rst
-"""
-
 from __future__ import annotations
 
 import xmlrpc.client as xmlrpclib

--- a/scrapy/http/response/__init__.py
+++ b/scrapy/http/response/__init__.py
@@ -1,10 +1,3 @@
-"""
-This module implements the Response class which is used to represent HTTP
-responses in Scrapy.
-
-See documentation in docs/topics/request-response.rst
-"""
-
 from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, AnyStr, TypeVar, overload

--- a/scrapy/http/response/html.py
+++ b/scrapy/http/response/html.py
@@ -1,11 +1,3 @@
-"""
-This module implements the :class:`HtmlResponse` class which is used as a
-content type marker by :class:`~scrapy.selector.Selector` and can be used in
-``isinstance()`` checks.
-
-See documentation in docs/topics/request-response.rst
-"""
-
 from scrapy.http.response.text import TextResponse
 
 

--- a/scrapy/http/response/json.py
+++ b/scrapy/http/response/json.py
@@ -1,10 +1,3 @@
-"""
-This module implements the JsonResponse class that is used when the response
-has a JSON MIME type in its Content-Type header.
-
-See documentation in docs/topics/request-response.rst
-"""
-
 from scrapy.http.response.text import TextResponse
 
 

--- a/scrapy/http/response/text.py
+++ b/scrapy/http/response/text.py
@@ -1,10 +1,3 @@
-"""
-This module implements the TextResponse class which adds encoding handling and
-discovering (through HTTP headers) to base Response class.
-
-See documentation in docs/topics/request-response.rst
-"""
-
 from __future__ import annotations
 
 import json

--- a/scrapy/http/response/xml.py
+++ b/scrapy/http/response/xml.py
@@ -1,11 +1,3 @@
-"""
-This module implements the :class:`XmlResponse` class which is used as a
-content type marker by :class:`~scrapy.selector.Selector` and can be used in
-``isinstance()`` checks.
-
-See documentation in docs/topics/request-response.rst
-"""
-
 from scrapy.http.response.text import TextResponse
 
 

--- a/scrapy/item.py
+++ b/scrapy/item.py
@@ -1,9 +1,3 @@
-"""
-Scrapy Item
-
-See documentation in docs/topics/items.rst
-"""
-
 from __future__ import annotations
 
 from abc import ABCMeta

--- a/scrapy/loader/__init__.py
+++ b/scrapy/loader/__init__.py
@@ -1,9 +1,3 @@
-"""
-Item Loader
-
-See documentation in docs/topics/loaders.rst
-"""
-
 from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any

--- a/scrapy/pipelines/__init__.py
+++ b/scrapy/pipelines/__init__.py
@@ -1,9 +1,3 @@
-"""
-Item pipeline
-
-See documentation in docs/topics/item-pipeline.rst
-"""
-
 from __future__ import annotations
 
 import asyncio

--- a/scrapy/shell.py
+++ b/scrapy/shell.py
@@ -1,9 +1,3 @@
-"""Scrapy Shell
-
-See documentation in docs/topics/shell.rst
-
-"""
-
 from __future__ import annotations
 
 import asyncio

--- a/scrapy/spidermiddlewares/depth.py
+++ b/scrapy/spidermiddlewares/depth.py
@@ -1,9 +1,3 @@
-"""
-Depth Spider Middleware
-
-See documentation in docs/topics/spider-middleware.rst
-"""
-
 from __future__ import annotations
 
 import logging

--- a/scrapy/spidermiddlewares/httperror.py
+++ b/scrapy/spidermiddlewares/httperror.py
@@ -1,9 +1,3 @@
-"""
-HttpError Spider Middleware
-
-See documentation in docs/topics/spider-middleware.rst
-"""
-
 from __future__ import annotations
 
 import logging

--- a/scrapy/spidermiddlewares/urllength.py
+++ b/scrapy/spidermiddlewares/urllength.py
@@ -1,9 +1,3 @@
-"""
-Url Length Spider Middleware
-
-See documentation in docs/topics/spider-middleware.rst
-"""
-
 from __future__ import annotations
 
 import logging

--- a/scrapy/spiders/__init__.py
+++ b/scrapy/spiders/__init__.py
@@ -1,9 +1,3 @@
-"""
-Base class for Scrapy spiders
-
-See documentation in docs/topics/spiders.rst
-"""
-
 from __future__ import annotations
 
 import logging

--- a/scrapy/spiders/crawl.py
+++ b/scrapy/spiders/crawl.py
@@ -1,10 +1,3 @@
-"""
-This modules implements the CrawlSpider which is the recommended spider to use
-for scraping typical websites that requires crawling pages.
-
-See documentation in docs/topics/spiders.rst
-"""
-
 from __future__ import annotations
 
 import copy

--- a/scrapy/spiders/feed.py
+++ b/scrapy/spiders/feed.py
@@ -1,10 +1,3 @@
-"""
-This module implements the XMLFeedSpider which is the recommended spider to use
-for scraping from an XML feed.
-
-See documentation in docs/topics/spiders.rst
-"""
-
 from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any


### PR DESCRIPTION
Follow-up to my previous commit on this branch, which only got through 3 files and said a broader sweep was still needed. This finishes that sweep.

Same deal as before: these modules had a module-level docstring that just repeats the module/class name and says "see docs/topics/whatever.rst" - no extra info, just noise above the imports. Removed 28 more of them.

Before deleting each one I went and checked that nothing was actually getting lost:

html.py/xml.py mention that HtmlResponse/XmlResponse act as a "content type marker" for Selector - that's already explained on scrapy.Selector itself (which docs/topics/selectors.rst pulls in via autoclass), so it's not going anywhere.
CrawlSpider, XMLFeedSpider and CSVFeedSpider all have their own writeups in docs/topics/spiders.rst that go into more detail than the module docstrings ever did.
CloseSpider's blurb is already covered in docs/topics/extensions.rst.
Ran ruff and the tests for everything touched (item, http request/response, spider, crawl spider, the downloader/spider middlewares affected, pipelines, telnet extension, feedexport) and it's all green.

Ref #7699