### PR TITLE
Merge repeated curl -d/--data options in Request.from_curl()

### DIFF
--- a/scrapy/utils/curl.py
+++ b/scrapy/utils/curl.py
@@ -23,6 +23,11 @@ class DataAction(argparse.Action):
     ) -> None:
         value = str(values)
         value = value.removeprefix("$")
+        # curl merges repeated -d/--data/--data-raw options into a single body
+        # joined with "&"; mirror that instead of keeping only the last one.
+        previous = getattr(namespace, self.dest, None)
+        if previous is not None:
+            value = f"{previous}&{value}"
         setattr(namespace, self.dest, value)
 
 

--- a/tests/test_utils_curl.py
+++ b/tests/test_utils_curl.py
@@ -163,6 +163,39 @@ class TestCurlToRequestKwargs:
         }
         self._test_command(curl_command, expected_result)
 
+    def test_post_data_multiple(self):
+        # curl merges repeated -d/--data/--data-raw options into a single body
+        # joined with "&"; scrapy must do the same, not keep only the last one.
+        curl_command = "curl 'https://www.example.org/' -d 'a=1' -d 'b=2' -d 'c=3'"
+        expected_result = {
+            "method": "POST",
+            "url": "https://www.example.org/",
+            "body": "a=1&b=2&c=3",
+        }
+        self._test_command(curl_command, expected_result)
+
+    def test_post_data_multiple_mixed_flag_names(self):
+        curl_command = (
+            "curl 'https://www.example.org/' --data 'a=1' --data-raw 'b=2' -d 'c=3'"
+        )
+        expected_result = {
+            "method": "POST",
+            "url": "https://www.example.org/",
+            "body": "a=1&b=2&c=3",
+        }
+        self._test_command(curl_command, expected_result)
+
+    def test_post_data_multiple_with_string_prefix(self):
+        # The leading "$" left by bash $'...' quoting is stripped per option,
+        # before the values are merged.
+        curl_command = "curl 'https://www.example.org/' -d $'a=1' -d $'b=2'"
+        expected_result = {
+            "method": "POST",
+            "url": "https://www.example.org/",
+            "body": "a=1&b=2",
+        }
+        self._test_command(curl_command, expected_result)
+
     def test_explicit_get_with_data(self):
         curl_command = "curl httpbin.org/anything -X GET --data asdf"
         expected_result = {


### PR DESCRIPTION
No linked issue — found while reading `scrapy/utils/curl.py`.

## Summary

`Request.from_curl()` silently drops all but the last `-d`/`--data`/`--data-raw` value when a curl command repeats them.

curl merges repeated data options into a single body joined with `&`. From the curl man page (`-d, --data`):

> If any of these options is used more than once on the same command line, the data pieces specified are merged with a separating &-symbol. Thus, using `-d name=daniel -d skill=lousy` would generate a post chunk that looks like `name=daniel&skill=lousy`.

But scrapy's `DataAction` uses a single-value action, so it keeps only the last one:

```python
>>> from scrapy.utils.curl import curl_to_request_kwargs
>>> curl_to_request_kwargs("curl -d 'a=1' -d 'b=2' https://example.org")["body"]
'b=2'          # 'a=1' is lost; real curl sends 'a=1&b=2'
```

Verified against real curl 7.87. This bites anyone converting a hand-written or tool-generated curl command with multiple `-d` flags into a Scrapy request.

## Fix

Accumulate repeated values with `&` in `DataAction`, mirroring curl. This covers the whole class: `-H`/`--header` and `-b`/`--cookie` already accumulate via `action="append"`; `-d`/`--data`/`--data-raw` (all mapped to `DataAction`) was the only repeatable data flag that didn't.

```python
>>> curl_to_request_kwargs("curl -d 'a=1' -d 'b=2' https://example.org")["body"]
'a=1&b=2'
```

The per-value `$`-prefix stripping (from `$'...'` shell quoting) still applies to each option before the merge.

## Tests

Adds three cases to `tests/test_utils_curl.py` — repeated `-d`, mixed `-d`/`--data`/`--data-raw`, and repeated with `$`-prefix quoting. They fail on the current code and pass with the fix; the full `test_utils_curl.py` suite passes and `ruff` check + format are clean.
