### PR TITLE
Dedupe the submit button against list formdata in FormRequest.from_response

### DIFF
--- a/scrapy/http/request/form.py
+++ b/scrapy/http/request/form.py
@@ -245,7 +245,7 @@ def _get_inputs(
 
     if not dont_click:
         clickable = _get_clickable(clickdata, form)
-        if clickable and clickable[0] not in formdata and clickable[0] is not None:
+        if clickable and clickable[0] not in formdata_keys and clickable[0] is not None:
             values.append(clickable)
 
     formdata_items = formdata.items() if isinstance(formdata, dict) else formdata

--- a/tests/test_http_request_form.py
+++ b/tests/test_http_request_form.py
@@ -499,6 +499,39 @@ class TestFormRequest(TestRequest):
         fs = _qs(req)
         assert fs[b"clickme"] == [b"two"]
 
+    def test_from_response_override_clickable_formdata_list(self):
+        # formdata as a list of (key, value) tuples (documented as equivalent to
+        # a dict) must dedupe the submit button the same way; otherwise the form's
+        # default submit value leaks in alongside the override.
+        response = _buildresponse(
+            """<form><input type="submit" name="clickme" value="one"> </form>"""
+        )
+        req = self.request_class.from_response(
+            response, formdata=[("clickme", "two")], clickdata={"name": "clickme"}
+        )
+        assert _qs(req)[b"clickme"] == [b"two"]
+
+    def test_from_response_override_auto_clicked_submit_formdata_list(self):
+        # Same class of bug without clickdata: the auto-selected submit must be
+        # overridden by a list formdata entry, not duplicated.
+        response = _buildresponse(
+            """<form method="post">"""
+            """<input type="submit" name="clickme" value="one"></form>"""
+        )
+        req = self.request_class.from_response(response, formdata=[("clickme", "two")])
+        assert _qs(req)[b"clickme"] == [b"two"]
+
+    def test_from_response_submit_kept_with_unrelated_formdata_list(self):
+        # A list formdata that does not name the submit must not suppress it.
+        response = _buildresponse(
+            """<form method="post">"""
+            """<input type="submit" name="clickme" value="one"></form>"""
+        )
+        req = self.request_class.from_response(response, formdata=[("extra", "x")])
+        fs = _qs(req)
+        assert fs[b"clickme"] == [b"one"]
+        assert fs[b"extra"] == [b"x"]
+
     def test_from_response_dont_click(self):
         response = _buildresponse(
             """<form action="get.php" method="GET">


### PR DESCRIPTION
No linked issue — found while reading `scrapy/http/request/form.py`.

## Summary

`FormRequest.from_response()` fails to suppress the form's own submit button when `formdata` is passed as a list of `(key, value)` tuples instead of a dict — even though the docstring documents the two as equivalent ("a dictionary (or iterable of `(key, value)` tuples)").

The clickable de-dup in `_get_inputs` tests the raw `formdata`:

```python
if clickable and clickable[0] not in formdata and clickable[0] is not None:
    values.append(clickable)
```

When `formdata` is a dict, `name not in formdata` checks keys (correct). When it's a list of tuples, it compares the name *string* against `(key, value)` *tuples* — always true — so the form's default submit value is emitted **in addition to** the caller's override:

```python
# <form><input type="submit" name="clickme" value="one"></form>
FormRequest.from_response(resp, formdata=[("clickme", "two")], clickdata={"name": "clickme"})
# body: clickme=one&clickme=two    (dict formdata correctly gives just clickme=two)
```

The regular-input de-dup on the line right above already does this correctly, against `formdata_keys` (which normalizes both a dict and a list of tuples).

## Fix

Dedup the clickable against `formdata_keys` instead of the raw `formdata`, matching the sibling check so both container types behave the same. `formdata_keys` is already in scope.

## Tests

Adds three cases to `tests/test_http_request_form.py` covering the class: a list `formdata` overriding the submit via `clickdata`, the same via the auto-selected submit (no `clickdata`), and a list `formdata` that does *not* name the submit (which must keep it). They fail on the current code and pass with the fix; the full `test_http_request_form.py` suite (126 tests) passes and `ruff` check + format are clean.
