### PR TITLE
Log ignored responses exceeding DOWNLOAD_MAXSIZE

### DIFF
--- a/scrapy/downloadermiddlewares/httpcompression.py
+++ b/scrapy/downloadermiddlewares/httpcompression.py
@@ -123,12 +123,14 @@ class HttpCompressionMiddleware:
                     response.body, content_encoding, max_size
                 )
             except _DecompressionMaxSizeExceeded as e:
-                raise IgnoreRequest(
+                msg = (
                     f"Ignored response {response} because its body "
                     f"({len(response.body)} B compressed, "
                     f"{e.decompressed_size} B decompressed so far) exceeded "
                     f"DOWNLOAD_MAXSIZE ({max_size} B) during decompression."
-                ) from e
+                )
+                logger.warning(msg)
+                raise IgnoreRequest(msg) from e
             if len(response.body) < warn_size <= len(decoded_body):
                 logger.warning(
                     f"{response} body size after decompression "

--- a/tests/test_downloadermiddleware_httpcompression.py
+++ b/tests/test_downloadermiddleware_httpcompression.py
@@ -538,23 +538,9 @@ class TestHttpCompression:
         mw.open_spider(spider)
 
         response = self._getresponse(f"bomb-{compression_id}")  # 11_511_612 B
-        with (
-            LogCapture(
-                "scrapy.downloadermiddlewares.httpcompression",
-                propagate=False,
-                level=WARNING,
-            ) as log,
-            pytest.raises(IgnoreRequest) as exc_info,
-        ):
+        with pytest.raises(IgnoreRequest) as exc_info:
             mw.process_response(response.request, response)
         assert exc_info.value.__cause__.decompressed_size < 1_100_000
-        log.check(
-            (
-                "scrapy.downloadermiddlewares.httpcompression",
-                "WARNING",
-                str(exc_info.value),
-            ),
-        )
 
     def test_compression_bomb_setting_br(self):
         _skip_if_no_br()
@@ -571,6 +557,32 @@ class TestHttpCompression:
         _skip_if_no_zstd()
 
         self._test_compression_bomb_setting("zstd")
+
+    def test_compression_bomb_setting_logs_warning(
+        self, caplog: pytest.LogCaptureFixture
+    ):
+        settings = {"DOWNLOAD_MAXSIZE": 1_000_000}
+        crawler = get_crawler(Spider, settings_dict=settings)
+        spider = crawler._create_spider("scrapytest.org")
+        mw = HttpCompressionMiddleware.from_crawler(crawler)
+        mw.open_spider(spider)
+
+        response = self._getresponse("bomb-gzip")  # 11_511_612 B
+        with (
+            caplog.at_level(
+                WARNING, logger="scrapy.downloadermiddlewares.httpcompression"
+            ),
+            pytest.raises(IgnoreRequest) as exc_info,
+        ):
+            mw.process_response(response.request, response)
+        assert exc_info.value.__cause__.decompressed_size < 1_100_000
+        assert caplog.record_tuples == [
+            (
+                "scrapy.downloadermiddlewares.httpcompression",
+                WARNING,
+                str(exc_info.value),
+            )
+        ]
 
     def _test_compression_bomb_spider_attr(self, compression_id):
         class DownloadMaxSizeSpider(Spider):

--- a/tests/test_downloadermiddleware_httpcompression.py
+++ b/tests/test_downloadermiddleware_httpcompression.py
@@ -558,9 +558,7 @@ class TestHttpCompression:
 
         self._test_compression_bomb_setting("zstd")
 
-    def test_compression_bomb_setting_logs_warning(
-        self, caplog: pytest.LogCaptureFixture
-    ):
+    def test_compression_bomb_setting_logs_warning(self, caplog):
         settings = {"DOWNLOAD_MAXSIZE": 1_000_000}
         crawler = get_crawler(Spider, settings_dict=settings)
         spider = crawler._create_spider("scrapytest.org")
@@ -568,6 +566,7 @@ class TestHttpCompression:
         mw.open_spider(spider)
 
         response = self._getresponse("bomb-gzip")  # 11_511_612 B
+        caplog.clear()
         with (
             caplog.at_level(
                 WARNING, logger="scrapy.downloadermiddlewares.httpcompression"
@@ -575,7 +574,6 @@ class TestHttpCompression:
             pytest.raises(IgnoreRequest) as exc_info,
         ):
             mw.process_response(response.request, response)
-        assert exc_info.value.__cause__.decompressed_size < 1_100_000
         assert caplog.record_tuples == [
             (
                 "scrapy.downloadermiddlewares.httpcompression",

--- a/tests/test_downloadermiddleware_httpcompression.py
+++ b/tests/test_downloadermiddleware_httpcompression.py
@@ -538,9 +538,23 @@ class TestHttpCompression:
         mw.open_spider(spider)
 
         response = self._getresponse(f"bomb-{compression_id}")  # 11_511_612 B
-        with pytest.raises(IgnoreRequest) as exc_info:
+        with (
+            LogCapture(
+                "scrapy.downloadermiddlewares.httpcompression",
+                propagate=False,
+                level=WARNING,
+            ) as log,
+            pytest.raises(IgnoreRequest) as exc_info,
+        ):
             mw.process_response(response.request, response)
         assert exc_info.value.__cause__.decompressed_size < 1_100_000
+        log.check(
+            (
+                "scrapy.downloadermiddlewares.httpcompression",
+                "WARNING",
+                str(exc_info.value),
+            ),
+        )
 
     def test_compression_bomb_setting_br(self):
         _skip_if_no_br()


### PR DESCRIPTION
Compressed responses that exceed DOWNLOAD_MAXSIZE during decompression were being ignored without any log output. This logs the IgnoreRequest message as a warning before raising, and adds a regression check for that path.

Fixes #6616.