### PR TITLE
Add Request.to_curl() as the inverse of Request.from_curl() - (#7743)

### DIFF
--- a/docs/topics/request-response.rst
+++ b/docs/topics/request-response.rst
@@ -257,6 +257,8 @@ Request objects
 
     .. automethod:: from_curl
 
+    .. automethod:: to_curl
+
     .. automethod:: to_dict
 
 

--- a/scrapy/http/request/__init__.py
+++ b/scrapy/http/request/__init__.py
@@ -381,6 +381,16 @@ class Request(object_ref):
         request_kwargs.update(kwargs)
         return cls(**request_kwargs)
 
+    def to_curl(self) -> str:
+        """Return a string with a cURL command equivalent to this request.
+
+        Inverse of :meth:`from_curl`. See also
+        :func:`scrapy.utils.request.request_to_curl`.
+        """
+        from scrapy.utils.request import request_to_curl
+
+        return request_to_curl(self)
+
     def to_dict(self, *, spider: scrapy.Spider | None = None) -> dict[str, Any]:
         """Return a dictionary containing the Request's data.
 

--- a/tests/test_http_request.py
+++ b/tests/test_http_request.py
@@ -406,6 +406,19 @@ class TestRequest:
         with pytest.raises(RuntimeError):
             NO_CALLBACK()
 
+    def test_to_curl(self):
+        request = self.request_class(
+            "https://www.httpbin.org/post",
+            method="POST",
+            headers={"Content-Type": "application/json"},
+            body='{"foo": "bar"}',
+        )
+        assert request.to_curl() == (
+            "curl -X POST https://www.httpbin.org/post"
+            ' --data-raw \'{"foo": "bar"}\''
+            " -H 'Content-Type: application/json'"
+        )
+
     def test_from_curl(self):
         # Note: more curated tests regarding curl conversion are in
         # `test_utils_curl.py`


### PR DESCRIPTION
## Summary
- Add `Request.to_curl()` as a convenience wrapper around `scrapy.utils.request.request_to_curl()`
- Document the new method in the Request API reference
- Add a test verifying the generated cURL command for a POST request with headers and body

## Motivation
`Request.from_curl()` already exists, but converting a request back to a cURL command requires importing `request_to_curl()` from `scrapy.utils.request`. A `to_curl()` method makes this easier to discover when debugging spiders (e.g. from `inspect_response()`).

Resolves #7743, closes #7802.

## Test plan
- [x] `pytest tests/test_http_request.py::TestRequest::test_to_curl`