### PR TITLE
fix: schedule _close_slot coroutine immediately when batch completes

### DIFF
--- a/scrapy/extensions/feedexport.py
+++ b/scrapy/extensions/feedexport.py
@@ -486,6 +486,7 @@ class FeedExporter:
         self.slots: list[FeedSlot] = []
         self.filters: dict[str, ItemFilter] = {}
         self._pending_close_coros: list[Coroutine[Any, Any, None]] = []
+        self._pending_close_tasks: list = []
 
         if not self.settings["FEEDS"] and not self.settings["FEED_URI"]:
             raise NotConfigured
@@ -549,19 +550,19 @@ class FeedExporter:
             )
 
     async def close_spider(self, spider: Spider) -> None:
-        self._pending_close_coros.extend(
-            self._close_slot(slot, spider) for slot in self.slots
-        )
-
-        if self._pending_close_coros:
+        # Close remaining slots
+        for slot in self.slots:
+            close_coro = self._close_slot(slot, spider)
             if is_asyncio_available():
-                await asyncio.wait(
-                    [asyncio.create_task(coro) for coro in self._pending_close_coros]
-                )
+                self._pending_close_tasks.append(asyncio.create_task(close_coro))
             else:
-                await DeferredList(
-                    deferred_from_coro(coro) for coro in self._pending_close_coros
-                )
+                self._pending_close_tasks.append(deferred_from_coro(close_coro))
+
+        if self._pending_close_tasks:
+            if is_asyncio_available():
+                await asyncio.wait(self._pending_close_tasks)
+            else:
+                await DeferredList(self._pending_close_tasks)
 
         # Send FEED_EXPORTER_CLOSED signal
         await self.crawler.signals.send_catch_log_async(signals.feed_exporter_closed)
@@ -662,7 +663,11 @@ class FeedExporter:
                 uri_params = self._get_uri_params(
                     spider, self.feeds[slot.uri_template]["uri_params"], slot
                 )
-                self._pending_close_coros.append(self._close_slot(slot, spider))
+                close_coro = self._close_slot(slot, spider)
+                if is_asyncio_available():
+                    self._pending_close_tasks.append(asyncio.create_task(close_coro))
+                else:
+                    self._pending_close_tasks.append(deferred_from_coro(close_coro))
                 slots.append(
                     self._start_new_batch(
                         batch_id=slot.batch_id + 1,


### PR DESCRIPTION
## Summary

Fixes #7730

When `FEED_EXPORT_BATCH_ITEM_COUNT` is set, batches are finalized at spider close instead of when the batch is full. This is because `item_scraped()` adds the `_close_slot` coroutine to `_pending_close_coros` but never schedules it — it only runs in `close_spider()`.

## Fix

Schedule the coroutine immediately via `asyncio.create_task()` (or `deferred_from_coro` for Twisted) when a batch completes, and track the resulting tasks/deferreds in a new `_pending_close_tasks` list. `close_spider()` now also adds remaining slots to the same task list and waits for all.

## Changes

- Added `_pending_close_tasks` list to track scheduled tasks/deferreds
- In `item_scraped()`: schedule `_close_slot` immediately when batch completes instead of appending to pending coroutines list
- In `close_spider()`: schedule remaining slots and wait for all tasks

## Testing

Verified that batches are now finalized immediately when the batch item count is reached, not at spider close.

Closes #7730
