### PR TITLE
Accept 2xx responses in FilesPipeline media downloads (#1615)

### DIFF
--- a/docs/news.rst
+++ b/docs/news.rst
@@ -6,6 +6,16 @@ Release notes
 Scrapy VERSION (unreleased)
 ---------------------------
 
+Bug fixes
+~~~~~~~~~
+
+-   :class:`~scrapy.pipelines.files.FilesPipeline` and
+    :class:`~scrapy.pipelines.images.ImagesPipeline` now accept any successful
+    HTTP ``2xx`` response when downloading media, not only ``200 OK``. This
+    fixes downloads that fail when servers return ``201 Created`` for
+    on-the-fly generated files.
+    (:issue:`1615`)
+
 Backward-incompatible changes
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/scrapy/pipelines/files.py
+++ b/scrapy/pipelines/files.py
@@ -623,7 +623,8 @@ class FilesPipeline(MediaPipeline):
     ) -> FileInfo:
         referer = referer_str(request)
 
-        if response.status != 200:
+        # Accept any 2xx response (e.g. 201 Created for on-the-fly media).
+        if not 200 <= response.status < 300:
             logger.warning(
                 "File (code: %(status)s): Error downloading file from "
                 "%(request)s referred in <%(referer)s>",

--- a/scrapy/pipelines/media.py
+++ b/scrapy/pipelines/media.py
@@ -238,8 +238,8 @@ class MediaPipeline(ABC):
             #
             # What happens when the media_downloaded callback raises an
             # exception, for example a FileException('download-error') when
-            # the Response status code is not 200 OK, is that the original
-            # StopIteration exception (which in turn contains the failed
+            # the Response status code is not a successful 2xx code, is that the
+            # original StopIteration exception (which in turn contains the failed
             # Response and by extension, the original Request) gets encapsulated
             # within the FileException context.
             #

--- a/tests/test_pipeline_files.py
+++ b/tests/test_pipeline_files.py
@@ -24,6 +24,7 @@ from scrapy.exceptions import NotConfigured
 from scrapy.http import Request, Response
 from scrapy.item import Field, Item
 from scrapy.pipelines.files import (
+    FileException,
     FilesPipeline,
     FSFilesStore,
     FTPFilesStore,
@@ -273,6 +274,49 @@ class TestFilesPipeline:
         path = Path(self.tempdir) / result["files"][0]["path"]
         assert path.exists()
         assert path.read_bytes() == b"data"
+
+    @pytest.mark.parametrize("status", [200, 201, 202, 203])
+    @coroutine_test
+    async def test_media_downloaded_accepts_successful_status(
+        self, status: int
+    ) -> None:
+        item_url = f"http://example.com/file-{status}.pdf"
+        request = _prepare_request_object(item_url)
+        response = Response(item_url, status=status, body=b"data")
+
+        result = await self.pipeline.media_downloaded(
+            response, request, self.pipeline.spiderinfo
+        )
+
+        assert result["status"] == "downloaded"
+        path = Path(self.tempdir) / result["path"]
+        assert path.exists()
+        assert path.read_bytes() == b"data"
+
+    @coroutine_test
+    async def test_media_downloaded_rejects_empty_successful_status(self) -> None:
+        item_url = "http://example.com/empty.pdf"
+        request = _prepare_request_object(item_url)
+        response = Response(item_url, status=204, body=b"")
+
+        with pytest.raises(FileException, match="empty-content"):
+            await self.pipeline.media_downloaded(
+                response, request, self.pipeline.spiderinfo
+            )
+
+    @pytest.mark.parametrize("status", [301, 302, 400, 404, 500])
+    @coroutine_test
+    async def test_media_downloaded_rejects_unsuccessful_status(
+        self, status: int
+    ) -> None:
+        item_url = f"http://example.com/file-{status}.pdf"
+        request = _prepare_request_object(item_url)
+        response = Response(item_url, status=status, body=b"data")
+
+        with pytest.raises(FileException, match="download-error"):
+            await self.pipeline.media_downloaded(
+                response, request, self.pipeline.spiderinfo
+            )
 
     def test_file_path_from_item(self):
         """

--- a/tests/test_pipeline_images.py
+++ b/tests/test_pipeline_images.py
@@ -16,7 +16,9 @@ from scrapy.http import Request, Response
 from scrapy.item import Field, Item
 from scrapy.pipelines.files import GCSFilesStore, S3FilesStore
 from scrapy.pipelines.images import ImageException, ImagesPipeline
+from scrapy.utils.spider import DefaultSpider
 from scrapy.utils.test import get_crawler
+from tests.utils.decorators import coroutine_test
 
 try:
     from PIL import Image
@@ -34,8 +36,10 @@ else:
 class TestImagesPipeline:
     def setup_method(self):
         self.tempdir = mkdtemp()
-        crawler = get_crawler()
-        self.pipeline = ImagesPipeline(self.tempdir, crawler=crawler)
+        crawler = get_crawler(DefaultSpider, settings_dict={"IMAGES_STORE": self.tempdir})
+        crawler.spider = crawler._create_spider()
+        self.pipeline = ImagesPipeline.from_crawler(crawler)
+        self.pipeline.open_spider()
 
     def teardown_method(self):
         rmtree(self.tempdir)
@@ -176,6 +180,22 @@ class TestImagesPipeline:
         thumb_path, _, thumb_buf = next(get_images_gen)
         assert thumb_path == "thumbs/small/3fd165099d8e71b8a48b2683946e64dbfad8b52d.jpg"
         assert orig_thumb_buf.getvalue() == thumb_buf.getvalue()
+
+    @coroutine_test
+    async def test_media_downloaded_accepts_created_response(self) -> None:
+        self.pipeline.min_width = 0
+        self.pipeline.min_height = 0
+        _, buf = _create_image("JPEG", "RGB", (50, 50), (0, 0, 0))
+        url = "https://dev.mydeco.com/mydeco.gif"
+        request = Request(url)
+        response = Response(url=url, status=201, body=buf.getvalue())
+
+        result = await self.pipeline.media_downloaded(
+            response, request, self.pipeline.spiderinfo
+        )
+
+        assert result["status"] == "downloaded"
+        assert result["path"] == "full/3fd165099d8e71b8a48b2683946e64dbfad8b52d.jpg"
 
     def test_get_transposed_images(self):
         orig_im = Image.new("RGB", (2, 2), (0, 0, 0))


### PR DESCRIPTION
## Summary

- `FilesPipeline.media_downloaded()` previously only accepted HTTP `200 OK`, so media downloads failed when servers returned other successful statuses such as `201 Created` (common for on-the-fly generated files).
- It now accepts any successful HTTP `2xx` response. Empty bodies are still rejected as before.
- Added regression tests for `FilesPipeline` and `ImagesPipeline`, plus a release note entry.

Fixes #1615.

## Test plan

- [x] `pytest tests/test_pipeline_files.py::TestFilesPipeline tests/test_pipeline_images.py::TestImagesPipeline`
- [x] Confirm a media URL that returns `201 Created` with a non-empty body is stored successfully
- [x] Confirm non-2xx responses (e.g. `404`, `302`) still raise `FileException("download-error")`
- [x] Confirm empty `2xx` responses (e.g. `204`) still raise `FileException("empty-content")`