### PR TITLE
Fix CaseInsensitiveDict.copy() sharing state with the original

### DIFF
--- a/scrapy/utils/datatypes.py
+++ b/scrapy/utils/datatypes.py
@@ -135,9 +135,18 @@ class CaseInsensitiveDict(collections.UserDict[str | bytes, Any]):
     # UserDict.copy() shallow-copies the instance, which would share self._keys
     # between the copy and the original.
     def __copy__(self) -> Self:
-        return self.__class__(self)
+        new = self.__class__()
+        new.data = self.data.copy()
+        new._keys = self._keys.copy()
+        return new
 
     copy = __copy__
+
+    # UserDict.__ior__ updates self.data directly, which would leave self._keys
+    # out of date.
+    def __ior__(self, other: Any) -> Self:  # type: ignore[override,misc]
+        self.update(other)
+        return self
 
     def _normkey(self, key: str | bytes) -> str | bytes:
         return key

--- a/scrapy/utils/datatypes.py
+++ b/scrapy/utils/datatypes.py
@@ -132,6 +132,13 @@ class CaseInsensitiveDict(collections.UserDict[str | bytes, Any]):
     def __repr__(self) -> str:
         return f"<{self.__class__.__name__}: {super().__repr__()}>"
 
+    # UserDict.copy() shallow-copies the instance, which would share self._keys
+    # between the copy and the original.
+    def __copy__(self) -> Self:
+        return self.__class__(self)
+
+    copy = __copy__
+
     def _normkey(self, key: str | bytes) -> str | bytes:
         return key
 

--- a/tests/test_utils_datatypes.py
+++ b/tests/test_utils_datatypes.py
@@ -229,6 +229,28 @@ class TestCaseInsensitiveDict(TestCaseInsensitiveDictBase):
         assert isinstance(iterkeys, Iterator)
         assert list(iterkeys) == ["AsDf", "FoO"]
 
+    def test_copy_keeps_values(self):
+        class MyDict(self.dict_class):
+            def _normvalue(self, value):
+                return value + 1
+
+        d = MyDict({"key": 1})
+        for copied in (copy.copy(d), d.copy()):
+            assert copied["key"] == 2
+
+    def test_ior(self):
+        d = self.dict_class({"header1": "value1"})
+        d |= {"HEADER1": "value2", "header2": "value3"}
+        assert len(d) == 2
+        assert d["HeAdEr1"] == "value2"
+        assert d["HeAdEr2"] == "value3"
+
+    def test_ior_mapping(self):
+        d = self.dict_class({"header1": "value1"})
+        d |= self.dict_class({"HEADER1": "value2"})
+        assert len(d) == 1
+        assert d["HeAdEr1"] == "value2"
+
 
 @pytest.mark.filterwarnings("ignore::scrapy.exceptions.ScrapyDeprecationWarning")
 class TestCaselessDict(TestCaseInsensitiveDictBase):

--- a/tests/test_utils_datatypes.py
+++ b/tests/test_utils_datatypes.py
@@ -204,6 +204,15 @@ class TestCaseInsensitiveDictBase(ABC):
         assert h1.get("header1") == h3.get("header1")
         assert h1.get("header1") == h3.get("HEADER1")
 
+    def test_copy_is_independent(self):
+        h1 = self.dict_class({"header1": "value1", "header2": "value2"})
+        for h2 in (copy.copy(h1), h1.copy()):
+            del h2["header1"]
+            h2["header3"] = "value3"
+            assert "header1" in h1
+            assert "header3" not in h1
+            assert dict(h1) == {"header1": "value1", "header2": "value2"}
+
 
 class TestCaseInsensitiveDict(TestCaseInsensitiveDictBase):
     dict_class = CaseInsensitiveDict  # type: ignore[assignment]


### PR DESCRIPTION
## Bug

`CaseInsensitiveDict` keeps a second dict, `_keys`, mapping the lowercased key to the key as stored. Two inherited `UserDict` methods don't know about it:

`copy()` shallow-copies the instance, so the copy and the original share that same `_keys` dict. Changing one is then visible in the other:

```pycon
>>> d = CaseInsensitiveDict({"A": "1"})
>>> c = d.copy()
>>> del c["A"]
>>> "A" in d
False
>>> d.data
{'A': '1'}
```

Adding a key goes the other way: after `c["C"] = "3"`, `"C" in d` is True but `d["C"]` raises `KeyError`, and so does `dict(d)`.

`__ior__` does `self.data |= other`, bypassing `__setitem__`, so `_keys` never learns about the new keys:

```pycon
>>> d = CaseInsensitiveDict({"header1": "value1"})
>>> d |= {"HEADER1": "value2"}
>>> len(d)
2
>>> d["header1"]
'value1'
```

`Headers.to_unicode_dict()` returns one of these, so `response.headers.to_unicode_dict()` is the likely way to run into either.

## Fix

`__copy__`/`copy` build a new instance from copies of `data` and `_keys`, so nothing is shared and the values aren't put through `_normvalue` a second time.

`__ior__` delegates to `update()`, so `|=` goes through `__setitem__`.

The original copy test is in the shared base class, so it covers `CaselessDict` too (which already passed it). The three added tests are `CaseInsensitiveDict`-specific — `CaselessDict` has the same `|=` and re-normalising-copy behaviour, which I've asked about in the comments rather than widening this PR into the deprecated class.
