### PR TITLE
Schedule feed export batches to close as soon as they fill up

### DIFF
--- a/scrapy/extensions/feedexport.py
+++ b/scrapy/extensions/feedexport.py
@@ -13,7 +13,7 @@ import re
 import sys
 import warnings
 from abc import ABC, abstractmethod
-from collections.abc import Callable, Coroutine
+from collections.abc import Callable
 from datetime import datetime, timezone
 from pathlib import Path, PureWindowsPath
 from tempfile import NamedTemporaryFile
@@ -475,7 +475,7 @@ class FeedExporter:
         self.feeds = {}
         self.slots: list[FeedSlot] = []
         self.filters: dict[str, ItemFilter] = {}
-        self._pending_close_coros: list[Coroutine[Any, Any, None]] = []
+        self._pending_close_futures: list[asyncio.Task[None] | Deferred[None]] = []
 
         if not self.settings["FEEDS"] and not self.settings["FEED_URI"]:
             raise NotConfigured
@@ -539,22 +539,28 @@ class FeedExporter:
             )
 
     async def close_spider(self, spider: Spider) -> None:
-        self._pending_close_coros.extend(
-            self._close_slot(slot, spider) for slot in self.slots
-        )
+        for slot in self.slots:
+            self._schedule_close_slot(slot, spider)
 
-        if self._pending_close_coros:
+        if self._pending_close_futures:
             if is_asyncio_available():
-                await asyncio.wait(
-                    [asyncio.create_task(coro) for coro in self._pending_close_coros]
-                )
+                await asyncio.wait(self._pending_close_futures)
             else:
-                await DeferredList(
-                    deferred_from_coro(coro) for coro in self._pending_close_coros
-                )
+                await DeferredList(self._pending_close_futures)
 
         # Send FEED_EXPORTER_CLOSED signal
         await self.crawler.signals.send_catch_log_async(signals.feed_exporter_closed)
+
+    def _schedule_close_slot(self, slot: FeedSlot, spider: Spider) -> None:
+        # Schedule the slot to close (and its batch to be finalized/uploaded)
+        # right away instead of merely recording the coroutine, so that
+        # mid-crawl batches are delivered as soon as they fill up instead of
+        # only when the whole crawl finishes (see GH #7730).
+        coro = self._close_slot(slot, spider)
+        if is_asyncio_available():
+            self._pending_close_futures.append(asyncio.create_task(coro))
+        else:
+            self._pending_close_futures.append(deferred_from_coro(coro))
 
     @staticmethod
     def _get_file(slot_: FeedSlot) -> IO[bytes]:
@@ -652,7 +658,7 @@ class FeedExporter:
                 uri_params = self._get_uri_params(
                     spider, self.feeds[slot.uri_template]["uri_params"], slot
                 )
-                self._pending_close_coros.append(self._close_slot(slot, spider))
+                self._schedule_close_slot(slot, spider)
                 slots.append(
                     self._start_new_batch(
                         batch_id=slot.batch_id + 1,

--- a/tests/test_feedexport_batch.py
+++ b/tests/test_feedexport_batch.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import csv
 import json
 import marshal
@@ -381,6 +382,40 @@ class TestBatchDeliveries(TestFeedExportBase):
         assert crawler.stats
         assert "feedexport/success_count/FileFeedStorage" in crawler.stats.get_stats()
         assert crawler.stats.get_value("feedexport/success_count/FileFeedStorage") == 12
+
+    @coroutine_test
+    async def test_batch_closed_without_waiting_for_spider_close(self):
+        """Regression test for GH #7730.
+
+        A full batch must be scheduled to close (and its file finalized)
+        as soon as it fills up. Previously, the closing coroutine was only
+        recorded in a plain list and never actually scheduled to run until
+        close_spider() wrapped and awaited it, so every batch ended up
+        being finalized/uploaded all at once at the end of the crawl
+        instead of as each batch filled up.
+        """
+        settings = {
+            "FEEDS": {
+                self._random_temp_filename() / "%(batch_id)d": {"format": "json"},
+            },
+            "FEED_EXPORT_BATCH_ITEM_COUNT": 1,
+        }
+        crawler = get_crawler(settings_dict=settings)
+        exporter = FeedExporter(crawler)
+        spider = Spider("test")
+        exporter.open_spider(spider)
+
+        exporter.item_scraped({"foo": "bar"}, spider)
+        assert exporter._pending_close_futures, "batch rollover should schedule a close"
+
+        # Give the event loop a chance to run already-scheduled work.
+        # close_spider() is deliberately never called here: the batch
+        # should already be finalized without it.
+        await asyncio.sleep(0.05)
+
+        written = [p for p in Path(self.temp_dir).rglob("*") if p.is_file()]
+        assert written, "batch was not finalized until spider close"
+        assert json.loads(written[0].read_text()) == [{"foo": "bar"}]
 
     @pytest.mark.requires_boto3
     @inline_callbacks_test


### PR DESCRIPTION
Fixes #7730

### Problem

`FeedExporter.item_scraped()` only recorded the `_close_slot()` coroutine for a full batch in a plain list (`_pending_close_coros`). That coroutine was never actually scheduled to run — it sat inert until `close_spider()` wrapped every pending coroutine in a task/deferred and awaited them all together. As a result, every batch was finalized and uploaded all at once at the very end of the crawl, instead of as each batch filled up, contradicting the "delayed file delivery" behavior documented for `FEED_EXPORT_BATCH_ITEM_COUNT`.

### Fix

Introduced `_schedule_close_slot()`, which immediately wraps the closing coroutine in `asyncio.create_task()` (or `deferred_from_coro()` under the Twisted reactor) so it starts running right away. Both the mid-crawl batch-rollover path (`item_scraped`) and the end-of-crawl path (`close_spider`) now go through this same helper, and `close_spider()` just awaits the already-scheduled futures instead of creating tasks from raw, unstarted coroutines.

### Testing

Added `test_batch_closed_without_waiting_for_spider_close` in `tests/test_feedexport_batch.py`, which fills a batch via a direct `item_scraped()` call, yields control once, and asserts the batch file is already on disk — without ever calling `close_spider()`. I verified this test fails with an `AttributeError` against the pre-fix code (confirming it actually exercises the bug) and passes with the fix. Full `test_feedexport.py` + `test_feedexport_batch.py` suites pass (58 tests).