### PR TITLE
Change`_schedule_coro` usage to custom task tracker

### DIFF
--- a/scrapy/commands/parse.py
+++ b/scrapy/commands/parse.py
@@ -10,14 +10,16 @@ from itemadapter import ItemAdapter
 from twisted.internet.defer import Deferred, maybeDeferred
 from w3lib.url import is_url
 
+from scrapy import signals
 from scrapy.commands import BaseRunSpiderCommand
 from scrapy.exceptions import UsageError
 from scrapy.http import Request, Response
 from scrapy.utils import display
 from scrapy.utils.asyncgen import collect_asyncgen
-from scrapy.utils.defer import _schedule_coro, aiter_errback, deferred_from_coro
+from scrapy.utils.defer import aiter_errback, deferred_from_coro
 from scrapy.utils.log import failure_to_exc_info
 from scrapy.utils.misc import arg_to_iter
+from scrapy.utils.python import _current_async_backend_tracker_factory
 from scrapy.utils.spider import spidercls_for_request
 
 if TYPE_CHECKING:
@@ -268,6 +270,11 @@ class Command(BaseRunSpiderCommand):
         assert self.spidercls
         self.crawler_process.crawl(self.spidercls, **opts.spargs)
         self.pcrawler = next(iter(self.crawler_process.crawlers))
+        self._tracker = _current_async_backend_tracker_factory()
+        self.pcrawler.signals.connect(self._tracker.drain, signal=signals.spider_closed)
+        self.pcrawler.signals.connect(
+            self._tracker.drain, signal=signals.engine_stopped
+        )
         self.crawler_process.start()
 
         if not self.first_response:
@@ -285,7 +292,7 @@ class Command(BaseRunSpiderCommand):
             itemproc = self.pcrawler.engine.scraper.itemproc
             if hasattr(itemproc, "process_item_async"):
                 for item in items:
-                    _schedule_coro(itemproc.process_item_async(item))
+                    self._tracker.schedule(itemproc.process_item_async(item))
             else:
                 for item in items:
                     itemproc.process_item(item, spider)

--- a/scrapy/commands/parse.py
+++ b/scrapy/commands/parse.py
@@ -270,11 +270,6 @@ class Command(BaseRunSpiderCommand):
         assert self.spidercls
         self.crawler_process.crawl(self.spidercls, **opts.spargs)
         self.pcrawler = next(iter(self.crawler_process.crawlers))
-        self._tracker = _current_async_backend_tracker_factory()
-        self.pcrawler.signals.connect(self._tracker.drain, signal=signals.spider_closed)
-        self.pcrawler.signals.connect(
-            self._tracker.drain, signal=signals.engine_stopped
-        )
         self.crawler_process.start()
 
         if not self.first_response:
@@ -291,6 +286,14 @@ class Command(BaseRunSpiderCommand):
             assert self.pcrawler.engine
             itemproc = self.pcrawler.engine.scraper.itemproc
             if hasattr(itemproc, "process_item_async"):
+                if not getattr(self, "_tracker", None):
+                    self._tracker = _current_async_backend_tracker_factory()
+                    self.pcrawler.signals.connect(
+                        self._tracker.drain, signal=signals.spider_closed
+                    )
+                    self.pcrawler.signals.connect(
+                        self._tracker.drain, signal=signals.engine_stopped
+                    )
                 for item in items:
                     self._tracker.schedule(itemproc.process_item_async(item))
             else:

--- a/scrapy/core/downloader/__init__.py
+++ b/scrapy/core/downloader/__init__.py
@@ -23,12 +23,15 @@ from scrapy.utils.asyncio import (
 from scrapy.utils.decorators import _warn_spider_arg
 from scrapy.utils.defer import (
     _defer_sleep_async,
-    _schedule_coro,
     deferred_from_coro,
     maybe_deferred_to_future,
 )
 from scrapy.utils.deprecate import warn_on_deprecated_spider_attribute
 from scrapy.utils.httpobj import urlparse_cached
+from scrapy.utils.python import (
+    _BackgroundTaskTracker,
+    _current_async_backend_tracker_factory,
+)
 
 if TYPE_CHECKING:
     from collections.abc import Generator
@@ -120,6 +123,7 @@ class Downloader:
         self.per_slot_settings: dict[str, dict[str, Any]] = self.settings.getdict(
             "DOWNLOAD_SLOTS"
         )
+        self._tracker: _BackgroundTaskTracker | None = None
 
     @inlineCallbacks
     @_warn_spider_arg
@@ -193,6 +197,14 @@ class Downloader:
             slot.active.remove(request)
 
     def _process_queue(self, slot: Slot) -> None:
+        if self._tracker is None:
+            self._tracker = _current_async_backend_tracker_factory()
+            self.crawler.signals.connect(
+                self._tracker.drain, signal=signals.spider_closed
+            )
+            self.crawler.signals.connect(
+                self._tracker.drain, signal=signals.engine_stopped
+            )
         if slot.latercall:
             # block processing until slot.latercall is called
             return
@@ -210,7 +222,7 @@ class Downloader:
         while slot.queue and slot.free_transfer_slots() > 0:
             slot.lastseen = now
             request, queue_dfd = slot.queue.popleft()
-            _schedule_coro(self._wait_for_download(slot, request, queue_dfd))
+            self._tracker.schedule(self._wait_for_download(slot, request, queue_dfd))
             # prevent burst if inter-request delays were configured
             if delay:
                 self._process_queue(slot)

--- a/scrapy/core/engine.py
+++ b/scrapy/core/engine.py
@@ -43,7 +43,11 @@ from scrapy.utils.defer import (
 from scrapy.utils.deprecate import argument_is_required
 from scrapy.utils.log import failure_to_exc_info, logformatter_adapter
 from scrapy.utils.misc import build_from_crawler, load_object
-from scrapy.utils.python import global_object_name
+from scrapy.utils.python import (
+    _BackgroundTaskTracker,
+    _current_async_backend_tracker_factory,
+    global_object_name,
+)
 from scrapy.utils.reactor import CallLaterOnce
 
 if TYPE_CHECKING:
@@ -130,6 +134,7 @@ class ExecutionEngine:
             asyncio.Future[None] | Deferred[None] | None
         ) = None
         downloader_cls: type[Downloader] = load_object(self.settings["DOWNLOADER"])
+        self._tracker: _BackgroundTaskTracker | None = None
         try:
             self.scheduler_cls: type[BaseScheduler] = self._get_scheduler_class(
                 crawler.settings
@@ -151,6 +156,13 @@ class ExecutionEngine:
             if hasattr(self, "downloader"):
                 self.downloader.close()
             raise
+
+    def _init_tracker(self) -> None:
+        if self._tracker is None:
+            self._tracker = _current_async_backend_tracker_factory()
+            self.crawler.signals.connect(
+                self._tracker.drain, signal=signals.engine_stopped
+            )
 
     def _get_scheduler_class(self, settings: BaseSettings) -> type[BaseScheduler]:
         scheduler_cls: type[BaseScheduler] = load_object(settings["SCHEDULER"])
@@ -178,6 +190,7 @@ class ExecutionEngine:
 
         .. versionadded:: 2.14
         """
+        self._init_tracker()
         if self._starting:
             raise RuntimeError("Engine already running")
         self.start_time = time()
@@ -219,6 +232,9 @@ class ExecutionEngine:
         if not self._starting:
             raise RuntimeError("Engine not running")
 
+        if self._tracker:
+            await self._tracker.drain()
+
         self.running = self._starting = False
         self._stopping = True
         if self._start_request_processing_awaitable is not None:
@@ -251,6 +267,9 @@ class ExecutionEngine:
         Gracefully close the execution engine.
         If it has already been started, stop it. In all cases, close the spider and the downloader.
         """
+        if self._tracker:
+            await self._tracker.drain()
+
         if self.running:
             await self.stop_async()  # will also close spider and downloader
         elif self.spider is not None:
@@ -291,7 +310,8 @@ class ExecutionEngine:
                 self.crawl(item_or_request)
             else:
                 assert self._slot is not None
-                _schedule_coro(
+                assert self._tracker
+                self._tracker.schedule(
                     self.scraper.start_itemproc_async(item_or_request, response=None)
                 )
                 self._slot.nextcall.schedule()
@@ -528,6 +548,7 @@ class ExecutionEngine:
         return deferred_from_coro(self.open_spider_async(close_if_idle=close_if_idle))
 
     async def open_spider_async(self, *, close_if_idle: bool = True) -> None:
+        self._init_tracker()
         assert self.crawler.spider
         if self._slot is not None:
             raise RuntimeError(
@@ -565,6 +586,7 @@ class ExecutionEngine:
         (at least) once again. A handler can raise CloseSpider to provide a custom closing reason.
         """
         assert self.spider is not None  # typing
+
         expected_ex = (DontCloseSpider, CloseSpider)
         res = self.signals.send_catch_log(
             signals.spider_idle, spider=self.spider, dont_log=expected_ex

--- a/scrapy/core/scraper.py
+++ b/scrapy/core/scraper.py
@@ -37,7 +37,11 @@ from scrapy.utils.defer import (
 from scrapy.utils.deprecate import method_is_overridden
 from scrapy.utils.log import failure_to_exc_info, logformatter_adapter
 from scrapy.utils.misc import load_object, warn_on_generator_with_return_value
-from scrapy.utils.python import global_object_name
+from scrapy.utils.python import (
+    _BackgroundTaskTracker,
+    _current_async_backend_tracker_factory,
+    global_object_name,
+)
 from scrapy.utils.spider import iterate_spider_output
 
 if TYPE_CHECKING:
@@ -122,6 +126,7 @@ class Scraper:
         self.signals: SignalManager = crawler.signals
         assert crawler.logformatter
         self.logformatter: LogFormatter = crawler.logformatter
+        self._tracker: _BackgroundTaskTracker | None = None
 
     def _check_deprecated_itemproc_method(self, method: str) -> None:
         itemproc_cls = type(self.itemproc)
@@ -165,6 +170,15 @@ class Scraper:
 
         .. versionadded:: 2.14
         """
+        if not self._tracker:
+            self._tracker = _current_async_backend_tracker_factory()
+            self.crawler.signals.connect(
+                self._tracker.drain, signal=signals.spider_closed
+            )
+            self.crawler.signals.connect(
+                self._tracker.drain, signal=signals.engine_stopped
+            )
+
         self.slot = Slot(self.crawler.settings.getint("SCRAPER_SLOT_MAX_ACTIVE_SIZE"))
         if not self.crawler.spider:
             raise RuntimeError(
@@ -194,6 +208,8 @@ class Scraper:
             raise RuntimeError("Scraper slot not assigned")
         self.slot.closing = Deferred()
         self._check_if_closing()
+        if self._tracker:
+            await self._tracker.drain()
         await maybe_deferred_to_future(self.slot.closing)
         if self._itemproc_has_async["close_spider"]:
             await self.itemproc.close_spider_async()
@@ -237,9 +253,12 @@ class Scraper:
 
     def _scrape_next(self) -> None:
         assert self.slot is not None  # typing
+        assert self._tracker
         while self.slot.queue:
             result, request, queue_dfd = self.slot.next_response_request_deferred()
-            _schedule_coro(self._wait_for_processing(result, request, queue_dfd))
+            self._tracker.schedule(
+                self._wait_for_processing(result, request, queue_dfd)
+            )
 
     async def _scrape(self, result: Response | Failure, request: Request) -> None:
         """Handle the downloaded response or failure through the spider callback/errback."""

--- a/scrapy/utils/asyncio.py
+++ b/scrapy/utils/asyncio.py
@@ -311,3 +311,19 @@ async def run_in_thread(
     from scrapy.utils.defer import maybe_deferred_to_future  # noqa: PLC0415
 
     return await maybe_deferred_to_future(deferToThread(func, *args, **kwargs))
+
+
+class _AsyncioTaskTracker:
+    __slots__ = ("__weakref__", "_tracking")
+
+    def __init__(self) -> None:
+        self._tracking: set[asyncio.Task[Any]] = set()
+
+    def schedule(self, coro: Coroutine[Any, Any, Any]) -> None:
+        t = asyncio.get_running_loop().create_task(coro)
+        self._tracking.add(t)
+        t.add_done_callback(self._tracking.discard)
+
+    async def drain(self) -> None:
+        while self._tracking:
+            await asyncio.wait(self._tracking)

--- a/scrapy/utils/defer.py
+++ b/scrapy/utils/defer.py
@@ -579,3 +579,22 @@ def ensure_awaitable(o: _T | Awaitable[_T], _warn: str | None = None) -> Awaitab
         return o
 
     return coro()
+
+
+class _DeferredTracker:
+    __slots__ = ("__weakref__", "_tracking")
+
+    def __init__(self) -> None:
+        self._tracking: set[Deferred[Any]] = set()
+
+    def _discard(self, _result: Any, d: Deferred[Any]) -> None:
+        self._tracking.discard(d)
+
+    def schedule(self, coro: Coroutine[Any, Any, Any]) -> None:
+        d = Deferred.fromCoroutine(coro)
+        self._tracking.add(d)
+        d.addBoth(self._discard, d)
+
+    async def drain(self) -> None:
+        while self._tracking:
+            await maybe_deferred_to_future(DeferredList(self._tracking))

--- a/scrapy/utils/python.py
+++ b/scrapy/utils/python.py
@@ -10,10 +10,18 @@ import re
 import sys
 import warnings
 import weakref
-from collections.abc import AsyncIterator, Iterable, Mapping
+from collections.abc import AsyncIterator, Coroutine, Iterable, Mapping
 from functools import partial, wraps
 from itertools import chain
-from typing import TYPE_CHECKING, Any, Concatenate, ParamSpec, TypeVar, overload
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Concatenate,
+    ParamSpec,
+    Protocol,
+    TypeVar,
+    overload,
+)
 
 from scrapy.exceptions import ScrapyDeprecationWarning
 from scrapy.utils.asyncgen import as_async_generator
@@ -375,3 +383,21 @@ def _iter_exc_causes(exc: BaseException) -> Iterable[BaseException]:
         seen.add(id(cur))
         yield cur
         cur = cur.__cause__ or cur.__context__
+
+
+class _BackgroundTaskTracker(Protocol):
+    def schedule(self, coro: Coroutine[Any, Any, Any]) -> None: ...
+    async def drain(self) -> None: ...
+
+
+def _current_async_backend_tracker_factory() -> _BackgroundTaskTracker:
+    from scrapy.utils.asyncio import (  # noqa: PLC0415
+        _AsyncioTaskTracker,
+        is_asyncio_available,
+    )
+
+    if is_asyncio_available():
+        return _AsyncioTaskTracker()
+    from scrapy.utils.defer import _DeferredTracker  # noqa: PLC0415
+
+    return _DeferredTracker()


### PR DESCRIPTION
Another way to solve the problem of prematurely destroying async tasks (#7029)

It's more invasive to the codebase than #7757, but also slightly more correct, since we now have proper control over when and where to wait for tasks to complete.

What I don't like:
- In the `parse` command, finalization relies solely on signals; I don't know where to explicitly call `await self._tracker.drain()` there
- In all the classes where I've used it, I can't initialize it in `__init__` because those objects are created before the asyncio loop/reactor is created. Maybe, these classes, IMO, are in need of some `__async_init__`/`__aenter__` mechanism.
- This doesn't completely eliminate calls to `_schedule_coro`, and I haven't seen a proper solution other than coloring many functions and callbacks as `async def`

What I'd like to do:
- add tests that fail on master and pass on this branch, to ensure that all these changes actually fix something and aren't just theoretical
- maybe change CrawlerRunner's own task tracking set to this
- collect feedback on the implementation
