### PR TITLE
Normalize query-only HTTP/1.1 URLs

### DIFF
--- a/scrapy/core/downloader/handlers/http11.py
+++ b/scrapy/core/downloader/handlers/http11.py
@@ -460,6 +460,9 @@ class _ScrapyAgent:
 
         # request details
         url = urldefrag(request.url)[0]
+        parsed_url = urlparse(url)
+        if not parsed_url.path and (parsed_url.params or parsed_url.query):
+            url = parsed_url._replace(path="/").geturl()
         method = to_bytes(request.method)
         headers = TxHeaders(request.headers)
         if isinstance(agent, _TunnelingAgent):

--- a/tests/mockserver/http.py
+++ b/tests/mockserver/http.py
@@ -91,6 +91,8 @@ class Root(resource.Resource):
         return self
 
     def render(self, request):
+        if request.args.get(b"echo_uri") == [b"1"]:
+            return request.uri
         return b"Scrapy mock HTTP server\n"
 
 

--- a/tests/test_downloader_handlers_http_base.py
+++ b/tests/test_downloader_handlers_http_base.py
@@ -114,6 +114,15 @@ class TestHttpBase(ABC):
         assert response.body == b"Works"
 
     @coroutine_test
+    async def test_download_with_query_and_no_path(
+        self, mockserver: MockServer
+    ) -> None:
+        request = Request(f"{mockserver.url('', is_secure=self.is_secure)}?echo_uri=1")
+        async with self.get_dh() as download_handler:
+            response = await download_handler.download_request(request)
+        assert response.body == b"/?echo_uri=1"
+
+    @coroutine_test
     async def test_download_head(self, mockserver: MockServer) -> None:
         request = Request(
             mockserver.url("/text", is_secure=self.is_secure), method="HEAD"


### PR DESCRIPTION
## Summary
- normalize HTTP/1.1 request URLs that have a query but no path
- add a regression test that verifies the server receives `/?...`

## Root cause
Twisted's HTTP/1.1 agent forwards a query-only target as `?query`. HTTP/1.1 origin-form requests require a path, while Scrapy's HTTP/2 implementation already normalizes this case.

Fixes #6574

## Validation
- `python -m pytest tests/test_downloader_handler_twisted_http11.py -k 'query_and_no_path' -q`
- `python -m compileall -q scrapy/core/downloader/handlers/http11.py tests/mockserver/http.py tests/test_downloader_handlers_http_base.py`
- `git diff --check`

The complete HTTP/1.1 handler suite exceeded the local two-minute run limit.

