### PR TITLE
Move scrapy.utils.benchserver to scrapy.utils._benchserver (#7766)

### DIFF
--- a/scrapy/commands/bench.py
+++ b/scrapy/commands/bench.py
@@ -36,7 +36,7 @@ class Command(ScrapyCommand):
 
 class _BenchServer:
     def __enter__(self) -> None:
-        pargs = [sys.executable, "-u", "-m", "scrapy.utils.benchserver"]
+        pargs = [sys.executable, "-u", "-m", "scrapy.utils._benchserver"]
         self.proc = subprocess.Popen(  # noqa: S603
             pargs, stdout=subprocess.PIPE, env=get_testenv()
         )

--- a/scrapy/utils/_benchserver.py
+++ b/scrapy/utils/_benchserver.py
@@ -1,0 +1,48 @@
+import random
+from typing import Any
+from urllib.parse import urlencode
+
+from twisted.web.resource import Resource
+from twisted.web.server import Request, Site
+
+
+class Root(Resource):
+    isLeaf = True
+
+    def getChild(self, path: str, request: Request) -> Resource:
+        return self
+
+    def render(self, request: Request) -> bytes:
+        total = _getarg(request, b"total", 100, int)
+        show = _getarg(request, b"show", 10, int)
+        nlist = [random.randint(1, total) for _ in range(show)]  # noqa: S311
+        request.write(b"<html><head></head><body>")
+        assert request.args is not None
+        args = request.args.copy()
+        for nl in nlist:
+            args["n"] = nl
+            argstr = urlencode(args, doseq=True)
+            request.write(f"<a href='/follow?{argstr}'>follow {nl}</a><br>".encode())
+        request.write(b"</body></html>")
+        return b""
+
+
+def _getarg(
+    request: Request, name: bytes, default: Any = None, type_: type = str
+) -> Any:
+    return type_(request.args[name][0]) if name in request.args else default
+
+
+if __name__ == "__main__":
+    from twisted.internet import reactor
+
+    root = Root()  # type: ignore[no-untyped-call]
+    factory = Site(root)
+    httpPort = reactor.listenTCP(8998, Site(root))
+
+    def _print_listening() -> None:
+        httpHost = httpPort.getHost()
+        print(f"Bench server at http://{httpHost.host}:{httpHost.port}")
+
+    reactor.callWhenRunning(_print_listening)
+    reactor.run()

--- a/scrapy/utils/benchserver.py
+++ b/scrapy/utils/benchserver.py
@@ -1,10 +1,13 @@
 import warnings
 
 from scrapy.exceptions import ScrapyDeprecationWarning
-from scrapy.utils._benchserver import *  # noqa: F403
+from scrapy.utils._benchserver import main
 
 warnings.warn(
-    "scrapy.utils.benchserver is deprecated, use scrapy.utils._benchserver instead.",
+    "scrapy.utils.benchserver is deprecated.",
     category=ScrapyDeprecationWarning,
     stacklevel=2,
 )
+
+if __name__ == "__main__":
+    main()

--- a/scrapy/utils/benchserver.py
+++ b/scrapy/utils/benchserver.py
@@ -1,48 +1,10 @@
-import random
-from typing import Any
-from urllib.parse import urlencode
+import warnings
 
-from twisted.web.resource import Resource
-from twisted.web.server import Request, Site
+from scrapy.exceptions import ScrapyDeprecationWarning
+from scrapy.utils._benchserver import *  # noqa: F403
 
-
-class Root(Resource):
-    isLeaf = True
-
-    def getChild(self, path: str, request: Request) -> Resource:
-        return self
-
-    def render(self, request: Request) -> bytes:
-        total = _getarg(request, b"total", 100, int)
-        show = _getarg(request, b"show", 10, int)
-        nlist = [random.randint(1, total) for _ in range(show)]  # noqa: S311
-        request.write(b"<html><head></head><body>")
-        assert request.args is not None
-        args = request.args.copy()
-        for nl in nlist:
-            args["n"] = nl
-            argstr = urlencode(args, doseq=True)
-            request.write(f"<a href='/follow?{argstr}'>follow {nl}</a><br>".encode())
-        request.write(b"</body></html>")
-        return b""
-
-
-def _getarg(
-    request: Request, name: bytes, default: Any = None, type_: type = str
-) -> Any:
-    return type_(request.args[name][0]) if name in request.args else default
-
-
-if __name__ == "__main__":
-    from twisted.internet import reactor
-
-    root = Root()  # type: ignore[no-untyped-call]
-    factory = Site(root)
-    httpPort = reactor.listenTCP(8998, Site(root))
-
-    def _print_listening() -> None:
-        httpHost = httpPort.getHost()
-        print(f"Bench server at http://{httpHost.host}:{httpHost.port}")
-
-    reactor.callWhenRunning(_print_listening)
-    reactor.run()
+warnings.warn(
+    "scrapy.utils.benchserver is deprecated, use scrapy.utils._benchserver instead.",
+    category=ScrapyDeprecationWarning,
+    stacklevel=2,
+)


### PR DESCRIPTION
Refactor `scrapy.utils.benchserver` to internal `scrapy.utils._benchserver`.

### Changes Made
* Renamed `scrapy/utils/benchserver.py` implementation to `scrapy/utils/_benchserver.py`.
* Updated module invocation in `scrapy/commands/bench.py`.
* Added a deprecation warning stub in `scrapy/utils/benchserver.py` for backwards compatibility.

Part of #7766