### PR TITLE
Add Request.to_curl() (#7743)

### DIFF
--- a/docs/topics/request-response.rst
+++ b/docs/topics/request-response.rst
@@ -260,6 +260,8 @@ Request objects
 
     .. automethod:: from_curl
 
+    .. automethod:: to_curl
+
     .. automethod:: to_dict
 
 

--- a/scrapy/http/request/__init__.py
+++ b/scrapy/http/request/__init__.py
@@ -387,6 +387,20 @@ class Request(object_ref):
         request_kwargs.update(kwargs)
         return cls(**request_kwargs)
 
+    def to_curl(self) -> str:
+        """Return a string with a `cURL <https://curl.se/>`_ command equivalent
+        to this request.
+
+        Inverse of :meth:`from_curl`. See also
+        :func:`scrapy.utils.request.request_to_curl`.
+
+        .. versionadded:: VERSION
+        """
+        # Imported here to avoid a circular import.
+        from scrapy.utils.request import request_to_curl  # noqa: PLC0415
+
+        return request_to_curl(self)
+
     def to_dict(self, *, spider: scrapy.Spider | None = None) -> dict[str, Any]:
         """Return a dictionary containing the Request's data.
 

--- a/tests/test_utils_request.py
+++ b/tests/test_utils_request.py
@@ -475,3 +475,14 @@ class TestRequestToCurl:
             " --data-raw '{\"foo\": \"bar\"}' --cookie 'foo=1'"
         )
         self._test_request(request_object, expected_curl_command)
+
+    def test_request_to_curl_method(self) -> None:
+        request_object = Request(
+            "https://www.httpbin.org/post",
+            method="POST",
+            body=json.dumps({"foo": "bar"}),
+        )
+        expected_curl_command = (
+            'curl -X POST https://www.httpbin.org/post --data-raw \'{"foo": "bar"}\''
+        )
+        assert request_object.to_curl() == expected_curl_command

--- a/tests/utils/bases/http_request.py
+++ b/tests/utils/bases/http_request.py
@@ -6,6 +6,7 @@ import pytest
 
 from scrapy.http import Headers, Request
 from scrapy.http.request import NO_CALLBACK
+from scrapy.utils.request import request_to_curl
 
 
 class TestRequestBase(ABC):
@@ -488,3 +489,11 @@ class TestRequestBase(ABC):
                 'curl -X PATCH "http://example.org" --foo -z',
                 ignore_unknown_options=False,
             )
+
+    def test_to_curl(self):
+        # Note: more curated tests regarding curl conversion are in
+        # `test_utils_request.py`
+        r = self.request_class(
+            "http://www.example.com/", method="POST", body=b"foo=bar"
+        )
+        assert r.to_curl() == request_to_curl(r)


### PR DESCRIPTION
Adds Request.to_curl() as the inverse of Request.from_curl(), following the wrapper approach suggested in the issue thread. The method delegates to the existing scrapy.utils.request.request_to_curl() so the conversion logic stays in one place.

The import is inside the method to avoid a circular import, since scrapy.utils.request imports Request. The shared test compares against request_to_curl() instead of a fixed string because subclasses like JsonRequest add default headers, so the exact output differs per class.

Includes a docs entry, a versionadded directive, and tests: a shared test that runs for all Request subclasses and an exact output test in TestRequestToCurl.

Verified locally with pytest on the affected test files, pre-commit and mypy.

Resolves #7743, closes #7746.
