### PR TITLE
Fix feed export batches only closing at spider shutdown

### DIFF
--- a/docs/news.rst
+++ b/docs/news.rst
@@ -198,6 +198,13 @@ Improvements
 Bug fixes
 ~~~~~~~~~
 
+-   :class:`~scrapy.extensions.feedexport.FeedExporter` now finalizes and
+    uploads each feed export batch as soon as it fills up, instead of only
+    when the spider closes. This bug affected every batch, including
+    batches other than the last one, regardless of how long the crawl
+    continued to run afterward.
+    (:issue:`7730`)
+
 -   :class:`~scrapy.core.downloader.handlers._httpx.HttpxDownloadHandler` no
     longer ignores proxy credentials for redirected or retried requests.
     (:issue:`7601`, :issue:`7630`)

--- a/scrapy/extensions/feedexport.py
+++ b/scrapy/extensions/feedexport.py
@@ -475,7 +475,7 @@ class FeedExporter:
         self.feeds = {}
         self.slots: list[FeedSlot] = []
         self.filters: dict[str, ItemFilter] = {}
-        self._pending_close_coros: list[Coroutine[Any, Any, None]] = []
+        self._pending_close_coros: list[Coroutine[Any, Any, None] | Deferred[None]] = []
 
         if not self.settings["FEEDS"] and not self.settings["FEED_URI"]:
             raise NotConfigured
@@ -525,6 +525,19 @@ class FeedExporter:
             if not self._exporter_supported(feed_options["format"]):
                 raise NotConfigured
 
+    def _schedule_close_coro(
+        self, coro: Coroutine[Any, Any, None]
+    ) -> asyncio.Task[None] | Deferred[None]:
+        """Eagerly schedule (and start executing) a slot-closing
+        coroutine right away, returning an object that's already
+        running under whichever reactor is active, rather than a bare
+        coroutine object, which does nothing on its own until awaited
+        or wrapped as a task/Deferred. See GH #7730.
+        """
+        if is_asyncio_available():
+            return asyncio.ensure_future(coro)
+        return Deferred.fromCoroutine(coro)
+
     def open_spider(self, spider: Spider) -> None:
         for uri, feed_options in self.feeds.items():
             uri_params = self._get_uri_params(spider, feed_options["uri_params"])
@@ -540,17 +553,18 @@ class FeedExporter:
 
     async def close_spider(self, spider: Spider) -> None:
         self._pending_close_coros.extend(
-            self._close_slot(slot, spider) for slot in self.slots
+            self._schedule_close_coro(self._close_slot(slot, spider))
+            for slot in self.slots
         )
 
         if self._pending_close_coros:
             if is_asyncio_available():
                 await asyncio.wait(
-                    [asyncio.create_task(coro) for coro in self._pending_close_coros]
+                    cast("list[asyncio.Task[None]]", self._pending_close_coros)
                 )
             else:
                 await DeferredList(
-                    deferred_from_coro(coro) for coro in self._pending_close_coros
+                    cast("list[Deferred[None]]", self._pending_close_coros)
                 )
 
         # Send FEED_EXPORTER_CLOSED signal
@@ -652,7 +666,18 @@ class FeedExporter:
                 uri_params = self._get_uri_params(
                     spider, self.feeds[slot.uri_template]["uri_params"], slot
                 )
-                self._pending_close_coros.append(self._close_slot(slot, spider))
+                # Eagerly schedule (and start executing) the close/upload
+                # for this filled batch right away, rather than merely
+                # appending the coroutine object to a list: a bare
+                # coroutine object does nothing on its own until awaited
+                # or wrapped as a task/Deferred, so without this, every
+                # batch's storage upload and exporter finalization was
+                # effectively delayed until close_spider() ran at the very
+                # end of the crawl, regardless of how many batches filled
+                # up along the way. See GH #7730.
+                self._pending_close_coros.append(
+                    self._schedule_close_coro(self._close_slot(slot, spider))
+                )
                 slots.append(
                     self._start_new_batch(
                         batch_id=slot.batch_id + 1,

--- a/tests/test_feedexport_batch.py
+++ b/tests/test_feedexport_batch.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import asyncio
+import contextlib
 import csv
 import json
 import marshal
@@ -221,6 +223,59 @@ class TestBatchDeliveries(TestFeedExportBase):
         crawler = get_crawler(settings_dict=settings)
         with pytest.raises(NotConfigured):
             FeedExporter(crawler)
+
+    @coroutine_test
+    async def test_item_scraped_schedules_batch_close_immediately(self):
+        """
+        Regression test for
+        https://github.com/scrapy/scrapy/issues/7730
+
+        item_scraped() must actually schedule (start executing) a
+        filled batch's storage upload and exporter finalization right
+        away, not merely construct a coroutine object and leave it
+        dormant in _pending_close_coros until close_spider() finally
+        awaits it at the very end of the crawl. A bare coroutine
+        object does nothing on its own until it's awaited or wrapped
+        as a task/Deferred, so previously every batch's close was
+        effectively delayed until the crawl fully finished, regardless
+        of how many batches filled up along the way.
+        """
+        settings = {
+            "FEEDS": {
+                self._random_temp_filename()
+                / "jl"
+                / self._file_mark: {
+                    "format": "jl",
+                    "batch_item_count": 1,
+                },
+            },
+        }
+        crawler = get_crawler(settings_dict=settings)
+        spider = crawler._create_spider("testspider")
+        crawler.spider = spider
+
+        exporter = FeedExporter(crawler)
+        exporter.open_spider(spider)
+        try:
+            assert exporter._pending_close_coros == []
+
+            # batch_item_count=1, so a single scraped item immediately
+            # fills and should close a batch.
+            exporter.item_scraped({"a": 1}, spider)
+
+            assert len(exporter._pending_close_coros) == 1
+            scheduled = exporter._pending_close_coros[0]
+            # The entry must already be an actively-scheduled task
+            # (pending or done), not a bare, never-started coroutine
+            # object.
+            assert not asyncio.iscoroutine(scheduled)
+            if isinstance(scheduled, asyncio.Task):
+                assert not scheduled.cancelled()
+                await scheduled
+        finally:
+            for slot in exporter.slots:
+                with contextlib.suppress(Exception):
+                    await exporter._close_slot(slot, spider)
 
     @coroutine_test
     async def test_export_no_items_not_store_empty(self):


### PR DESCRIPTION
Fixes #7730.

`item_scraped()` (a synchronous signal handler) constructed a coroutine to close and finalize a filled batch, but only appended that bare coroutine object to `self._pending_close_coros`. A coroutine object does nothing on its own until it's awaited or wrapped as a task/Deferred; it only actually ran once `close_spider()` finally awaited everything in that list at the very end of the crawl. This meant every batch's storage upload (`FeedStorage.store()`) and exporter finalization (`finish_exporting()`) was silently delayed until the spider fully closed, regardless of how many batches filled up while the crawl was still ongoing -- exactly as diagnosed in the issue, including the exact mechanism the reporter identified.

**Fix**: add a small helper, `_schedule_close_coro()`, that eagerly schedules (and starts executing) a slot-closing coroutine right away using whichever native primitive matches the active reactor: `asyncio.ensure_future()` when the asyncio reactor is installed, or `Deferred.fromCoroutine()` for the plain Twisted reactor (both already proven, existing mechanisms Scrapy relies on elsewhere -- this reuses the same approach `deferred_from_coro()` already takes internally, rather than inventing new scheduling logic). Use this helper both at the per-batch close point in `item_scraped()` and for the final, still-open slots in `close_spider()`, so `_pending_close_coros` consistently holds already-scheduled objects (`asyncio.Task` or `Deferred`) that `close_spider()` can still correctly await in full at the end, without re-wrapping them.

**Testing**: verified with real, end-to-end crawls using a custom feed storage that records wall-clock timestamps when each batch is stored, matching the reporter's own suggested verification method: with the original code, all batches closed at the exact same instant (spider close time), regardless of how long the crawl actually took; with the fix, batches close incrementally, spread out over time to match when each one actually filled up. Verified this for both the asyncio reactor (Scrapy's default) and the plain Twisted reactor path (directly unit-testing `_schedule_close_coro()`'s `Deferred.fromCoroutine` branch, confirming it starts the coroutine's body executing immediately without any external `await`, since `CrawlerProcess` doesn't support fully disabling the reactor to run a full crawl under it in my sandbox).

Added a regression test exercising `item_scraped()` directly against a real `FeedExporter`/`Crawler`, confirming the entry it adds to `_pending_close_coros` is already an actively-scheduled task rather than a dormant, never-started coroutine object (also confirmed by the exact `RuntimeWarning: coroutine was never awaited` the original code produces). I confirmed the test fails with the original code and passes with the fix. Ran the full existing `test_feedexport_batch.py` suite (10 passed: 9 baseline + 1 new) and the broader feedexport/signals/engine/scheduler test suites (113 passed total), no regressions.
