### PR TITLE
Don't evaluate annotations in get_func_args_dict() on Python 3.14+

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+import sys
 from importlib.util import find_spec
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -53,6 +54,10 @@ if not H2_ENABLED:
 
 if find_spec("httpx2") is None and find_spec("httpx") is None:
     collect_ignore.append("scrapy/core/downloader/handlers/_httpx.py")
+
+if sys.version_info < (3, 14):
+    # needs lazily evaluated annotations (PEP 649) to be importable
+    collect_ignore.append("tests/utils/lazy_annotations.py")
 
 
 def pytest_addoption(parser, pluginmanager):

--- a/docs/news.rst
+++ b/docs/news.rst
@@ -25,6 +25,21 @@ Backward-incompatible changes
 
     (:issue:`6585`, :issue:`7731`)
 
+Bug fixes
+~~~~~~~~~
+
+-   On Python 3.14 and later, loading a component whose methods are annotated
+    with objects that are only imported under :data:`typing.TYPE_CHECKING` no
+    longer raises :exc:`NameError`.
+
+    :func:`scrapy.utils.python.get_func_args_dict` now asks
+    :func:`inspect.signature` not to evaluate annotations eagerly, so
+    unresolvable ones are returned as :class:`typing.ForwardRef` objects
+    instead. This affects
+    :func:`~scrapy.utils.python.get_func_args` and middleware loading as well.
+
+    (:issue:`7796`)
+
 .. _release-2.17.0:
 
 Scrapy 2.17.0 (2026-07-07)

--- a/scrapy/utils/python.py
+++ b/scrapy/utils/python.py
@@ -178,10 +178,35 @@ def binary_is_text(data: bytes) -> bool:
     return all(c not in _BINARYCHARS for c in data)
 
 
+if sys.version_info >= (3, 14):
+
+    def _signature(func: Callable[..., Any]) -> inspect.Signature:
+        # Since Python 3.14 annotations are evaluated lazily (PEP 649, PEP 749)
+        # and the default inspect.Format.VALUE makes inspect.signature()
+        # evaluate them, which raises NameError for annotations that are only
+        # valid under typing.TYPE_CHECKING. We only need parameter names and
+        # defaults, so we ask for unresolvable annotations to be returned as
+        # typing.ForwardRef objects instead.
+        return inspect.signature(  # pylint: disable=unexpected-keyword-arg
+            func, annotation_format=inspect.Format.FORWARDREF
+        )
+
+else:
+
+    def _signature(func: Callable[..., Any]) -> inspect.Signature:
+        return inspect.signature(func)
+
+
 def get_func_args_dict(
     func: Callable[..., Any], stripself: bool = False
 ) -> Mapping[str, inspect.Parameter]:
     """Return the argument dict of a callable object.
+
+    On Python 3.14 and later, the
+    :attr:`~inspect.Parameter.annotation` of the returned
+    :class:`~inspect.Parameter` objects may be a :class:`typing.ForwardRef`
+    instead of the annotated object, e.g. for annotations that are only
+    imported under :data:`typing.TYPE_CHECKING`.
 
     .. versionadded:: 2.14
     """
@@ -190,7 +215,7 @@ def get_func_args_dict(
 
     args: Mapping[str, inspect.Parameter]
     try:
-        sig = inspect.signature(func)
+        sig = _signature(func)
     except ValueError:
         return {}
 

--- a/tests/test_downloadermiddleware.py
+++ b/tests/test_downloadermiddleware.py
@@ -16,7 +16,7 @@ from scrapy.spiders import Spider
 from scrapy.utils.defer import maybe_deferred_to_future
 from scrapy.utils.python import to_bytes
 from scrapy.utils.test import get_crawler, get_from_asyncio_queue
-from tests.utils.decorators import coroutine_test
+from tests.utils.decorators import coroutine_test, requires_lazy_annotations
 
 if TYPE_CHECKING:
     from collections.abc import AsyncGenerator
@@ -346,3 +346,25 @@ class TestDeprecatedSpiderArg(TestManagerBase):
             result = await mwman.download_async(download_func, req)
         assert result is resp
         assert not download_func.called
+
+
+@requires_lazy_annotations
+def test_middleware_with_lazy_annotations():
+    """Loading a middleware must not resolve its method annotations."""
+    from tests.utils.lazy_annotations import (  # noqa: PLC0415
+        MiddlewareWithLazyAnnotations,
+    )
+
+    crawler = get_crawler(
+        Spider,
+        {
+            "DOWNLOADER_MIDDLEWARES": {
+                "tests.utils.lazy_annotations.MiddlewareWithLazyAnnotations": 100,
+            },
+        },
+    )
+    crawler._apply_settings()
+    mwman = DownloaderMiddlewareManager.from_crawler(crawler)
+    assert any(
+        isinstance(mw, MiddlewareWithLazyAnnotations) for mw in mwman.middlewares
+    )

--- a/tests/test_utils_deprecate.py
+++ b/tests/test_utils_deprecate.py
@@ -7,7 +7,12 @@ from unittest import mock
 import pytest
 
 from scrapy.exceptions import ScrapyDeprecationWarning
-from scrapy.utils.deprecate import create_deprecated_class, update_classpath
+from scrapy.utils.deprecate import (
+    argument_is_required,
+    create_deprecated_class,
+    update_classpath,
+)
+from tests.utils.decorators import requires_lazy_annotations
 
 
 class MyWarning(UserWarning):
@@ -284,3 +289,16 @@ class TestUpdateClassPath:
     def test_returns_nonstring(self):
         for notastring in [None, True, [1, 2, 3], object()]:
             assert update_classpath(notastring) == notastring
+
+
+@requires_lazy_annotations
+def test_argument_is_required_lazy_annotations():
+    """Annotations that cannot be resolved at run time must not be an error."""
+    from tests.utils.lazy_annotations import (  # noqa: PLC0415
+        MiddlewareWithLazyAnnotations,
+    )
+
+    method = MiddlewareWithLazyAnnotations().process_exception
+    assert argument_is_required(method, "request") is True
+    assert argument_is_required(method, "spider") is False
+    assert argument_is_required(method, "missing") is False

--- a/tests/test_utils_python.py
+++ b/tests/test_utils_python.py
@@ -4,7 +4,7 @@ import functools
 import operator
 import platform
 import sys
-from typing import TYPE_CHECKING, TypeVar
+from typing import TYPE_CHECKING, ForwardRef, TypeVar
 
 import pytest
 
@@ -14,12 +14,13 @@ from scrapy.utils.python import (
     MutableAsyncChain,
     binary_is_text,
     get_func_args,
+    get_func_args_dict,
     memoizemethod_noargs,
     to_bytes,
     to_unicode,
     without_none_values,
 )
-from tests.utils.decorators import coroutine_test
+from tests.utils.decorators import coroutine_test, requires_lazy_annotations
 
 if TYPE_CHECKING:
     from collections.abc import AsyncIterator, Iterable, Mapping
@@ -188,6 +189,31 @@ def test_get_func_args():
             [],
             ["args", "kwargs"],
         ]
+
+
+@requires_lazy_annotations
+def test_get_func_args_lazy_annotations():
+    """Annotations that cannot be resolved at run time must not be an error."""
+    from tests.utils.lazy_annotations import (  # noqa: PLC0415
+        MiddlewareWithLazyAnnotations,
+        func_with_lazy_annotations,
+    )
+
+    assert get_func_args(func_with_lazy_annotations) == ["request", "spider"]
+    assert get_func_args(MiddlewareWithLazyAnnotations().process_exception) == [
+        "request",
+        "exception",
+        "spider",
+    ]
+
+
+@requires_lazy_annotations
+def test_get_func_args_dict_lazy_annotations():
+    """Unresolvable annotations are reported as forward references."""
+    from tests.utils.lazy_annotations import func_with_lazy_annotations  # noqa: PLC0415
+
+    params = get_func_args_dict(func_with_lazy_annotations)
+    assert isinstance(params["request"].annotation, ForwardRef)
 
 
 @pytest.mark.parametrize(

--- a/tests/utils/decorators.py
+++ b/tests/utils/decorators.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import sys
 from functools import wraps
 from typing import TYPE_CHECKING, Any, ParamSpec
 
@@ -14,6 +15,13 @@ if TYPE_CHECKING:
 
 
 _P = ParamSpec("_P")
+
+#: Mark a test that needs :mod:`tests.utils.lazy_annotations`, which is only
+#: importable on Python versions that evaluate annotations lazily (PEP 649).
+requires_lazy_annotations = pytest.mark.skipif(
+    sys.version_info < (3, 14),
+    reason="Lazily evaluated annotations (PEP 649) require Python 3.14+",
+)
 
 
 def inline_callbacks_test(

--- a/tests/utils/lazy_annotations.py
+++ b/tests/utils/lazy_annotations.py
@@ -1,0 +1,27 @@
+# This module deliberately does not use "from __future__ import annotations",
+# so that on Python 3.14+ its annotations are lazily evaluated as per PEP 649
+# instead of being turned into strings as per PEP 563. As it also annotates
+# objects that are only imported under TYPE_CHECKING, importing it on older
+# Python versions raises NameError, so conftest.py excludes it from collection
+# there and the tests that use it are skipped.
+# pylint: disable=used-before-assignment
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    # TC004 is exactly what this module needs to reproduce: an import that is
+    # only available to type checkers but is referenced from an annotation that
+    # is evaluated (lazily) at run time.
+    import scrapy  # noqa: TC004
+
+
+class MiddlewareWithLazyAnnotations:
+    """A middleware whose method annotations cannot be resolved at run time."""
+
+    def process_exception(
+        self, request: scrapy.Request, exception: Exception, spider=None
+    ) -> None:
+        pass
+
+
+def func_with_lazy_annotations(request: scrapy.Request, spider: scrapy.Spider) -> None:
+    pass


### PR DESCRIPTION
Resolves #7796.

## Problem

Since Python 3.14 annotations are evaluated lazily (PEP 649, PEP 749), and `inspect.signature()` evaluates them by default (`inspect.Format.VALUE`). `get_func_args_dict()` therefore raises `NameError` for callables annotated with objects that are only imported under `typing.TYPE_CHECKING`:

```python
from typing import TYPE_CHECKING

if TYPE_CHECKING:
    import scrapy


class SomeDownloaderMiddleware:
    def process_exception(self, request: scrapy.Request, exception: Exception, spider=None) -> None:
        pass
```

Loading that middleware fails, because `MiddlewareManager._check_mw_method_spider_arg()` calls `argument_is_required()`, which calls `get_func_args_dict()`.

## Fix

Pass `annotation_format=inspect.Format.FORWARDREF` on 3.14+, so unresolvable annotations come back as `typing.ForwardRef` objects instead of raising. Nothing in Scrapy reads `Parameter.annotation` — only parameter names and defaults — so this is safe for both in-tree callers (`get_func_args()` for `XmlRpcRequest`, and `argument_is_required()`). It is documented on `get_func_args_dict()` since that function is public.

## Scope

`get_spec()` has the same root cause and still fails on 3.14 (`TypeError: unsupported callable`, as `getfullargspec()` wraps the `NameError`). It is reachable through `scrapy/contracts/__init__.py`, which calls it on `request_cls.__init__`, so a `Request` subclass with `TYPE_CHECKING` annotations would hit it.

I left it out of this PR because `inspect.getfullargspec()` has no `annotation_format` parameter, so fixing it means rewriting `get_spec()` on top of `inspect.signature()` — and the two disagree on bound methods. `get_spec()`'s own doctests expect `self` in the result, which `signature()` strips. That is a behaviour change worth deciding on separately. Happy to follow up if you want it fixed, here or in another issue.

## Tests

The bug only reproduces without `from __future__ import annotations` — with it, annotations are PEP 563 strings and `signature()` never evaluates them. That means the reproducing module cannot be imported at all below 3.14, so it lives in `tests/utils/lazy_annotations.py`, is excluded from collection below 3.14 in `conftest.py` (otherwise `--doctest-modules` imports it), and its tests are skipped via a shared `requires_lazy_annotations` marker.

Four tests cover `get_func_args()`, `get_func_args_dict()` (asserting the `ForwardRef` contract), `argument_is_required()`, and building a `DownloaderMiddlewareManager` with an affected middleware. All four fail with `NameError` when the `scrapy/utils/python.py` change is reverted.

Two lint suppressions were unavoidable and are commented in place: `# pylint: disable=unexpected-keyword-arg` (pylint runs below 3.14 and does not narrow the version gate) and `# noqa: TC004` on the fixture's import, which is the exact pattern being reproduced.

Verified locally on macOS:

| Check | Result |
| --- | --- |
| `pytest scrapy tests --doctest-modules` on 3.13 | 3817 passed, 488 skipped, 19 xfailed |
| `pytest scrapy tests --doctest-modules` on 3.14 | 3822 passed, 483 skipped, 19 xfailed |
| `tox -e mypy` | clean, 465 files |
| `tox -e pylint` | clean |
| `tox -e pre-commit` | all hooks pass |
| `tox -e docs` | build succeeded |

The only pylint message on my tree is a pre-existing `useless-suppression` at `scrapy/utils/reactor.py:110`, which fires on non-Windows and is present on a clean checkout of master.

---

This PR was written entirely using an LLM. I directed it, reviewed the diff, and confirmed the verification results above on my own machine before opening this.
