### PR TITLE
Fix asyncio requirement check during component initialization

### DIFF
--- a/docs/topics/asyncio.rst
+++ b/docs/topics/asyncio.rst
@@ -119,6 +119,9 @@ Enforcing asyncio as a requirement
 If you are writing a :ref:`component <topics-components>` that requires asyncio
 to work, use :func:`scrapy.utils.asyncio.is_asyncio_available` to
 :ref:`enforce it as a requirement <enforce-component-requirements>`. For
+components initialized from a :class:`~scrapy.crawler.Crawler`, check
+:setting:`TWISTED_REACTOR_ENABLED` first, because in reactorless mode the
+asyncio event loop is not running yet during component initialization. For
 example:
 
 .. code-block:: python
@@ -127,14 +130,19 @@ example:
 
 
     class MyComponent:
-        def __init__(self):
-            if not is_asyncio_available():
+        @classmethod
+        def from_crawler(cls, crawler):
+            if (
+                crawler.settings.getbool("TWISTED_REACTOR_ENABLED")
+                and not is_asyncio_available()
+            ):
                 raise ValueError(
                     f"{MyComponent.__qualname__} requires the asyncio support. "
                     f"Make sure you have configured the asyncio reactor in the "
                     f"TWISTED_REACTOR setting. See the asyncio documentation "
                     f"of Scrapy for more information."
                 )
+            return cls()
 
 .. autofunction:: scrapy.utils.asyncio.is_asyncio_available
 .. autofunction:: scrapy.utils.reactor.is_asyncio_reactor_installed


### PR DESCRIPTION
## Summary

- update the component example to use `from_crawler()` so that settings are available during initialization
- check `TWISTED_REACTOR_ENABLED` before calling `is_asyncio_available()` in reactorless mode
- document why the event-loop helper cannot be called unconditionally at that stage

Resolves #7812

## Testing

- `.venv/bin/tox -e docs`
- `.venv/bin/tox -e docs-tests`
- `.venv/bin/tox -e pre-commit -- --files docs/topics/asyncio.rst`

This PR was written entirely using an LLM.
