### PR TITLE
Quote arguments in request_to_curl()

### DIFF
--- a/docs/news.rst
+++ b/docs/news.rst
@@ -238,6 +238,12 @@ Bug fixes
     :func:`scrapy.utils.request.request_to_curl`.
     (:issue:`7603`, :issue:`7675`, :issue:`7684`)
 
+-   :func:`scrapy.utils.request.request_to_curl` now quotes the arguments of
+    the command it builds, so a URL containing ``&``, or a body or header
+    value containing whitespace or a quote, no longer breaks the command or
+    changes the value.
+    (:issue:`7825`)
+
 -   Fixed :class:`scrapy.resolver.CachingThreadedResolver` not disabling the
     cache when :setting:`DNSCACHE_ENABLED` is set to ``False``.
     (:issue:`7663`)

--- a/scrapy/utils/request.py
+++ b/scrapy/utils/request.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 import hashlib
 import json
 import logging
+import shlex
 from typing import TYPE_CHECKING, Any, Protocol
 from urllib.parse import urlunparse
 from weakref import WeakKeyDictionary
@@ -231,15 +232,16 @@ def request_to_curl(request: Request) -> str:
     :param request: Request object to be converted
     :return: string containing the curl command
     """
-    method = request.method
+    args: list[str] = ["curl", "-X", request.method, request.url]
 
-    data = f"--data-raw '{request.body.decode('utf-8')}'" if request.body else ""
+    if request.body:
+        args += ["--data-raw", request.body.decode("utf-8")]
 
-    headers = " ".join(
-        f"-H '{k.decode()}: {v[0].decode()}'" for k, v in request.headers.items()
-    )
-
-    url = request.url
+    args += [
+        arg
+        for k, v in request.headers.items()
+        for arg in ("-H", f"{k.decode()}: {v[0].decode()}")
+    ]
 
     cookie_list: list[VerboseCookie] = _to_verbose_cookies(request.cookies)
     pairs = [
@@ -247,7 +249,10 @@ def request_to_curl(request: Request) -> str:
         for c in cookie_list
         if (decoded := _decode_cookie(c, request)) is not None
     ]
-    cookies = f"--cookie '{'; '.join(pairs)}'" if pairs else ""
+    if pairs:
+        args += ["--cookie", "; ".join(pairs)]
 
-    curl_cmd = f"curl -X {method} {url} {data} {headers} {cookies}".strip()
-    return " ".join(curl_cmd.split())
+    # shlex.join is the inverse of the shlex.split that curl_to_request_kwargs
+    # uses, so values keep any quotes, whitespace and shell metacharacters they
+    # contain instead of splitting the command or silently changing the value.
+    return shlex.join(args)

--- a/tests/test_utils_request.py
+++ b/tests/test_utils_request.py
@@ -417,7 +417,7 @@ class TestRequestToCurl:
         )
         expected_curl_command = (
             "curl -X POST https://www.httpbin.org/post"
-            " --data-raw '{\"foo\": \"bar\"}' --cookie 'foo=bar'"
+            ' --data-raw \'{"foo": "bar"}\' --cookie foo=bar'
         )
         self._test_request(request_object, expected_curl_command)
 
@@ -430,7 +430,7 @@ class TestRequestToCurl:
         )
         expected_curl_command = (
             "curl -X POST https://www.httpbin.org/post"
-            " --data-raw '{\"foo\": \"bar\"}' --cookie 'foo=bar'"
+            ' --data-raw \'{"foo": "bar"}\' --cookie foo=bar'
         )
         self._test_request(request_object, expected_curl_command)
 
@@ -451,7 +451,7 @@ class TestRequestToCurl:
         )
         expected_curl_command = (
             "curl -X POST https://www.httpbin.org/post"
-            " --data-raw '{\"foo\": \"bar\"}' --cookie 'foo=bar'"
+            ' --data-raw \'{"foo": "bar"}\' --cookie foo=bar'
         )
         self._test_request(request_object, expected_curl_command)
 
@@ -472,9 +472,65 @@ class TestRequestToCurl:
         )
         expected_curl_command = (
             "curl -X POST https://www.httpbin.org/post"
-            " --data-raw '{\"foo\": \"bar\"}' --cookie 'foo=1'"
+            ' --data-raw \'{"foo": "bar"}\' --cookie foo=1'
         )
         self._test_request(request_object, expected_curl_command)
+
+    def test_url_with_two_query_parameters(self) -> None:
+        # An unquoted & ends the command in a shell: everything after it is
+        # parsed as a separate command.
+        request_object = Request("https://www.example.com/?a=1&b=2")
+        expected_curl_command = "curl -X GET 'https://www.example.com/?a=1&b=2'"
+        self._test_request(request_object, expected_curl_command)
+
+    def test_body_keeps_whitespace(self) -> None:
+        request_object = Request(
+            "https://www.example.com",
+            method="POST",
+            body='{"a":  "b  c"}',
+        )
+        expected_curl_command = (
+            'curl -X POST https://www.example.com --data-raw \'{"a":  "b  c"}\''
+        )
+        self._test_request(request_object, expected_curl_command)
+
+    def test_body_keeps_newlines(self) -> None:
+        request_object = Request(
+            "https://www.example.com", method="POST", body="line1\nline2"
+        )
+        expected_curl_command = (
+            "curl -X POST https://www.example.com --data-raw 'line1\nline2'"
+        )
+        self._test_request(request_object, expected_curl_command)
+
+    def test_body_with_single_quote(self) -> None:
+        request_object = Request("https://www.example.com", method="POST", body="it's")
+        expected_curl_command = (
+            "curl -X POST https://www.example.com --data-raw 'it'\"'\"'s'"
+        )
+        self._test_request(request_object, expected_curl_command)
+
+    def test_header_keeps_whitespace(self) -> None:
+        request_object = Request("https://www.example.com", headers={"X-Note": "a  b"})
+        expected_curl_command = "curl -X GET https://www.example.com -H 'X-Note: a  b'"
+        self._test_request(request_object, expected_curl_command)
+
+    @pytest.mark.parametrize(
+        "request_object",
+        [
+            Request("https://www.example.com/?a=1&b=2"),
+            Request("https://www.example.com", method="POST", body='{"a":  "b  c"}'),
+            Request("https://www.example.com", method="POST", body="line1\nline2"),
+            Request("https://www.example.com", method="POST", body="it's"),
+            Request("https://www.example.com", headers={"X-Note": "a  b"}),
+        ],
+    )
+    def test_round_trip(self, request_object: Request) -> None:
+        # to_curl documents itself as the inverse of from_curl.
+        parsed = Request.from_curl(request_object.to_curl())
+        assert parsed.url == request_object.url
+        assert parsed.method == request_object.method
+        assert parsed.body == request_object.body
 
     def test_request_to_curl_method(self) -> None:
         request_object = Request(


### PR DESCRIPTION
`request_to_curl()` interpolates the URL, body, headers and cookies straight into a format string, then finishes with `" ".join(curl_cmd.split())`. Neither step is safe, so the command it returns isn't always a faithful copy of the request — and sometimes isn't runnable at all.

The clearest case is a URL with two query parameters:

```pycon
>>> Request("https://www.example.com/?a=1&b=2").to_curl()
'curl -X GET https://www.example.com/?a=1&b=2'
```

`&` is a shell control operator, so that command doesn't fetch the URL. bash cuts it in half and backgrounds the first part:

```console
$ echo curl -X GET https://www.example.com/?a=1&b=2
curl -X GET https://www.example.com/?a=1
```

PowerShell rejects it outright ("The ampersand (&) character is not allowed"). Since query strings with more than one parameter are the normal case, most `to_curl()` output for real requests is affected.

The whitespace collapsing is quieter but worse, because it changes data rather than breaking loudly. Runs of spaces and any newlines inside the body or a header value are replaced with single spaces:

```pycon
>>> r = Request("https://www.example.com", method="POST", body='{"a":  "b  c"}')
>>> Request.from_curl(r.to_curl()).body
b'{"a": "b c"}'
```

And a single quote in the body produces unbalanced quotes, so the command can't be parsed:

```pycon
>>> r = Request("https://www.example.com", method="POST", body="it's")
>>> r.to_curl()
'curl -X POST https://www.example.com --data-raw \'it\'s\''
>>> Request.from_curl(r.to_curl())
ValueError: No closing quotation
```

`Request.to_curl()` documents itself as the inverse of `from_curl()`, so those last two are contract violations you can assert on directly.

## Fix

Collect the arguments in a list and return `shlex.join(args)`. That's the exact inverse of the `shlex.split()` that `curl_to_request_kwargs()` already uses for the other direction, and it only quotes what needs quoting, so simple cases look the same as before. Dropping the `split()`/`join()` also means empty sections no longer need collapsing — they're simply never appended.

Four existing cookie expectations lose their surrounding quotes, because `shlex.quote("foo=bar")` correctly leaves it alone. `--cookie foo=bar` and `--cookie 'foo=bar'` are the same command; the tests were pinning incidental quoting. Everything else in `TestRequestToCurl` passes untouched, including the JSON body and header cases, since `shlex.quote` picks the same quoting the old f-strings hardcoded.

## Tests

Added cases for the ampersand URL, whitespace and newlines in a body, a single quote in a body, whitespace in a header value, and a parametrised round trip through `from_curl()` — which is the property the docstring promises. With `scrapy/utils/request.py` reverted, 12 of them fail; the round trip failures are the informative ones:

```
assert b'{"a": "b c}' == b'{"a":  "b  c"}'
AssertionError: assert b'line1 line2' == b'line1\nline2'
ValueError: No closing quotation
```

One thing worth noting: the round trip does *not* catch the ampersand case, because `shlex.split()` doesn't treat `&` specially — only a real shell does. That one is pinned by the expected-string test instead.

`tests/test_utils_request.py` and `tests/test_http_request.py` pass (97), and ruff, ruff-format and mypy are clean on the changed files.

While in here I noticed the header loop only emits `v[0]`, so a multi-valued header loses everything after the first value. That felt like a separate decision to me, so I left it alone — happy to include it if you'd like.

This has been the behaviour since `request_to_curl()` was added in 2.9.0; the new `Request.to_curl()` method just makes it easier to reach. I'll add a news entry once this has a number, unless you'd rather fold it into the existing `request_to_curl` bullet.
