### PR TITLE
docs: clarify asyncio component initialization checks

### DIFF
--- a/docs/topics/asyncio.rst
+++ b/docs/topics/asyncio.rst
@@ -118,23 +118,35 @@ Enforcing asyncio as a requirement
 
 If you are writing a :ref:`component <topics-components>` that requires asyncio
 to work, use :func:`scrapy.utils.asyncio.is_asyncio_available` to
-:ref:`enforce it as a requirement <enforce-component-requirements>`. For
-example:
+:ref:`enforce it as a requirement <enforce-component-requirements>`. Do not
+call it from a component ``__init__`` method, because components are created
+before the reactor or event loop is initialized. Instead, check the configured
+settings there. For example:
 
 .. code-block:: python
 
     from scrapy.utils.asyncio import is_asyncio_available
 
+    ASYNCIO_REACTOR = "twisted.internet.asyncioreactor.AsyncioSelectorReactor"
+
 
     class MyComponent:
-        def __init__(self):
-            if not is_asyncio_available():
+        def __init__(self, crawler):
+            settings = crawler.settings
+            if (
+                settings.getbool("TWISTED_REACTOR_ENABLED")
+                and settings["TWISTED_REACTOR"] != ASYNCIO_REACTOR
+            ):
                 raise ValueError(
                     f"{MyComponent.__qualname__} requires the asyncio support. "
                     f"Make sure you have configured the asyncio reactor in the "
                     f"TWISTED_REACTOR setting. See the asyncio documentation "
                     f"of Scrapy for more information."
                 )
+
+        def some_callback(self):
+            if not is_asyncio_available():
+                raise ValueError("asyncio support is not available")
 
 .. autofunction:: scrapy.utils.asyncio.is_asyncio_available
 .. autofunction:: scrapy.utils.reactor.is_asyncio_reactor_installed


### PR DESCRIPTION
## Summary

Clarifies the documented asyncio requirement check for components created during crawler setup.

- explains that `is_asyncio_available()` cannot be called from component `__init__`, because the reactor or event loop is not initialized yet;
- shows how initialization code can inspect `TWISTED_REACTOR_ENABLED` and `TWISTED_REACTOR` through the crawler settings;
- retains `is_asyncio_available()` for callbacks that run after initialization.

Resolves #7812.

## Verification

- `PATH="$PWD/.venv/bin:$PATH" .venv/bin/tox -e docs,docs-tests,pre-commit`
  - documentation build passed
  - documentation tests: 565 passed
  - all pre-commit hooks passed
- `git diff --check`

I used an AI to help prepare this contribution.
