### PR TITLE
Preserve original Content-Encoding header in response after decompression

### DIFF
--- a/scrapy/downloadermiddlewares/httpcompression.py
+++ b/scrapy/downloadermiddlewares/httpcompression.py
@@ -112,6 +112,7 @@ class HttpCompressionMiddleware:
         if request.method == "HEAD":
             return response
         content_encoding = response.headers.getlist("Content-Encoding")
+        original_content_encoding = response.headers.get("Content-Encoding")
         if content_encoding:
             max_size = request.meta.get("download_maxsize", self._max_size)
             warn_size = request.meta.get("download_warnsize", self._warn_size)
@@ -152,8 +153,10 @@ class HttpCompressionMiddleware:
                 # responsetypes guessing is reliable
                 kwargs["encoding"] = None
             response = response.replace(cls=respcls, **kwargs)
-            if not content_encoding:
-                del response.headers["Content-Encoding"]
+            if original_content_encoding:
+                response.headers["Content-Encoding"] = original_content_encoding
+            else:
+                response.headers.pop("Content-Encoding", None)
         return response
 
     def _handle_encoding(


### PR DESCRIPTION
Fix #1988

Keep the original Content-Encoding header value in the response after decompression so that spiders can see all original response headers.

Currently, after decompression, the Content-Encoding header is either set to the remaining unsupported encodings or deleted entirely. This change preserves the original header value.