### PR TITLE
Avoid key calls in unique's default path

### DIFF
--- a/scrapy/utils/python.py
+++ b/scrapy/utils/python.py
@@ -32,6 +32,10 @@ _VT = TypeVar("_VT")
 _P = ParamSpec("_P")
 
 
+def _identity(x: _T) -> _T:
+    return x
+
+
 def is_listlike(x: Any) -> bool:
     """
     >>> is_listlike("foo")
@@ -56,10 +60,18 @@ def is_listlike(x: Any) -> bool:
     return hasattr(x, "__iter__") and not isinstance(x, (str, bytes))
 
 
-def unique(list_: Iterable[_T], key: Callable[[_T], Any] = lambda x: x) -> list[_T]:
+def unique(list_: Iterable[_T], key: Callable[[_T], Any] = _identity) -> list[_T]:
     """efficient function to uniquify a list preserving item order"""
     seen = set()
     result: list[_T] = []
+    if key is _identity:
+        for item in list_:
+            if item in seen:
+                continue
+            seen.add(item)
+            result.append(item)
+        return result
+
     for item in list_:
         seenkey = key(item)
         if seenkey in seen:


### PR DESCRIPTION
## Summary

This adds a fast path for `unique()` when the default identity key is used, avoiding a Python function call for every item.

## Why this can improve performance

The default `unique()` behavior keeps the first occurrence of each item while preserving order. When the key function is the identity function, the implementation can use the item itself as the marker key directly instead of calling the identity helper for every element.

## Validation

- `git diff --check`
- `python3 -m compileall -q scrapy/utils/python.py`
- Behavior check for default-key and custom-key `unique()` calls

## Benchmark

Current machine, CPython microbenchmark, 9 samples, median:

| Benchmark | Base | This change | Delta |
|---|---:|---:|---:|
| `unique()` over repeated hashable items with default key | 11,722.367 ns/op | 6,950.230 ns/op | 40.71% faster |
