### PR TITLE
Upgrade the minimum queuelib to 1.6.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ dependencies = [
     "parsel>=1.5.0",
     "protego>=0.1.15",
     "pyOpenSSL>=22.0.0",
-    "queuelib>=1.4.2",
+    "queuelib>=1.6.1",
     "service_identity>=23.1.0",
     "tldextract",
     "w3lib>=1.17.0",

--- a/tox.ini
+++ b/tox.ini
@@ -143,7 +143,7 @@ deps =
     lxml==4.6.4
     parsel==1.5.0
     pyOpenSSL==22.0.0
-    queuelib==1.4.2
+    queuelib==1.6.1
     service_identity==23.1.0
     w3lib==1.17.0
     zope.interface==5.1.0
@@ -261,7 +261,7 @@ deps =
     lxml==5.3.2
     parsel==1.5.0
     pyOpenSSL==24.3.0
-    queuelib==1.4.2
+    queuelib==1.6.1
     service_identity==23.1.0
     # w3lib 1.17 fails to import on PyPy 3.11 because its encoding regex uses
     # an inline flag placement that Python 3.11 treats as an error: global


### PR DESCRIPTION
Split off from https://github.com/scrapy/scrapy/pull/6931.

1.6.1 introduces `peek()` support.