### PR TITLE
Fix HTTP request target for empty URL path

### DIFF
--- a/scrapy/core/downloader/handlers/http11.py
+++ b/scrapy/core/downloader/handlers/http11.py
@@ -10,7 +10,7 @@ from functools import partial
 from io import BytesIO
 from time import monotonic
 from typing import TYPE_CHECKING, Any, TypedDict, TypeVar, cast
-from urllib.parse import urldefrag, urlparse
+from urllib.parse import urldefrag, urlparse, urlunparse
 
 from twisted.internet import ssl
 from twisted.internet.defer import Deferred, succeed
@@ -71,6 +71,13 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 _T = TypeVar("_T")
+
+
+def _url_with_root_path(url: str) -> str:
+    parsed = urlparse(url)
+    if parsed.netloc and not parsed.path:
+        return urlunparse(parsed._replace(path="/"))
+    return url
 
 
 class _ResultT(TypedDict):
@@ -468,7 +475,7 @@ class _ScrapyAgent:
         start_time = monotonic()
         d: Deferred[IResponse] = agent.request(
             method,
-            to_bytes(url, encoding="ascii"),
+            to_bytes(_url_with_root_path(url), encoding="ascii"),
             headers,
             cast("IBodyProducer", bodyproducer),
         )

--- a/tests/test_downloader_handler_twisted_http11.py
+++ b/tests/test_downloader_handler_twisted_http11.py
@@ -6,9 +6,10 @@ import sys
 from typing import TYPE_CHECKING, Any
 
 import pytest
+from twisted.internet.defer import Deferred
 
-from scrapy import Spider
-from scrapy.core.downloader.handlers.http11 import HTTP11DownloadHandler
+from scrapy import Request, Spider
+from scrapy.core.downloader.handlers.http11 import HTTP11DownloadHandler, _ScrapyAgent
 from scrapy.crawler import Crawler
 from scrapy.exceptions import NotConfigured
 from tests.utils.bases.download_handlers_http import (
@@ -52,6 +53,20 @@ def test_not_configured_without_reactor() -> None:
     crawler = Crawler(Spider, {"TWISTED_REACTOR_ENABLED": False})
     with pytest.raises(NotConfigured):
         HTTP11DownloadHandler.from_crawler(crawler)
+
+
+def test_download_request_adds_root_path_before_query(mocker) -> None:
+    crawler = Crawler(Spider, {"TWISTED_REACTOR_ENABLED": True})
+    scrapy_agent = _ScrapyAgent(contextFactory=mocker.Mock(), crawler=crawler)
+    agent = mocker.Mock()
+    agent.request.return_value = Deferred()
+    mocker.patch.object(scrapy_agent, "_get_agent", return_value=agent)
+
+    scrapy_agent.download_request(Request("http://127.0.0.1:9000?url=www.example.com"))
+
+    assert agent.request.call_args.args[1] == (
+        b"http://127.0.0.1:9000/?url=www.example.com"
+    )
 
 
 class TestHttp(HTTP11DownloadHandlerMixin, TestHttpBase):


### PR DESCRIPTION
## Summary
- add a root path when sending absolute HTTP URLs with an empty path and a query string
- cover URLs like `http://127.0.0.1:9000?url=www.example.com` so Twisted sends `/?...` instead of `?...`

Fixes #6574.

## Tests
- `py -3.14 -m pytest tests/test_downloader_handler_twisted_http11.py::test_download_request_adds_root_path_before_query -q`
- `py -3.14 -m pytest tests/test_downloader_handler_twisted_http11.py::TestHttp::test_verbatim_url tests/test_downloader_handler_twisted_http11.py::TestHttp::test_download_with_maxsize tests/test_downloader_handler_twisted_http11.py::TestHttp::test_download_with_warnsize -q`
- `py -3.14 -m py_compile scrapy/core/downloader/handlers/http11.py tests/test_downloader_handler_twisted_http11.py`
- `git diff --check`