### PR TITLE
Let SitemapSpider rediscover sitemap entries on resume

### DIFF
--- a/scrapy/spiders/sitemap.py
+++ b/scrapy/spiders/sitemap.py
@@ -55,7 +55,7 @@ class SitemapSpider(Spider):
 
     async def start(self) -> AsyncIterator[Any]:
         for url in self.sitemap_urls:
-            yield Request(url, self._parse_sitemap)
+            yield Request(url, self._parse_sitemap, dont_filter=True)
 
     def sitemap_filter(
         self, entries: Iterable[dict[str, Any]]
@@ -69,7 +69,10 @@ class SitemapSpider(Spider):
     def _parse_sitemap(self, response: Response) -> Iterable[Request]:
         if response.url.endswith("/robots.txt"):
             urls = list(sitemap_urls_from_robots(response.body, base_url=response.url))
-            return (Request(url, callback=self._parse_sitemap) for url in urls)
+            return (
+                Request(url, callback=self._parse_sitemap, dont_filter=True)
+                for url in urls
+            )
 
         body = self._get_sitemap_body(response)
         if not body:
@@ -84,7 +87,10 @@ class SitemapSpider(Spider):
 
         if s.type == "sitemapindex":
             urls = list(self._get_urls_from_sitemapindex(self.sitemap_filter(s)))
-            return (Request(loc, callback=self._parse_sitemap) for loc in urls)
+            return (
+                Request(loc, callback=self._parse_sitemap, dont_filter=True)
+                for loc in urls
+            )
 
         if s.type == "urlset":
             url_callback_pairs = list(

--- a/tests/test_spider_sitemap.py
+++ b/tests/test_spider_sitemap.py
@@ -102,12 +102,15 @@ Sitemap: /sitemap-relative-url.xml
 
         r = TextResponse(url="http://www.example.com/robots.txt", body=robots)
         spider = self.spider_class("example.com")
-        assert [req.url for req in spider._parse_sitemap(r)] == [
+        requests = list(spider._parse_sitemap(r))
+
+        assert [req.url for req in requests] == [
             "http://example.com/sitemap.xml",
             "http://example.com/sitemap-product-index.xml",
             "http://example.com/sitemap-uppercase.xml",
             "http://www.example.com/sitemap-relative-url.xml",
         ]
+        assert all(req.dont_filter for req in requests)
 
     def test_get_sitemap_urls_from_robotstxt_skips_invalid_utf8_urls(self):
         robots = (
@@ -246,15 +249,18 @@ Sitemap: /sitemap-relative-url.xml
 
         r = TextResponse(url="http://www.example.com/sitemap.xml", body=sitemap)
         spider = self.spider_class("example.com")
-        assert [req.url for req in spider._parse_sitemap(r)] == [
+        requests = list(spider._parse_sitemap(r))
+
+        assert [req.url for req in requests] == [
             "http://www.example.com/sitemap1.xml",
             "http://www.example.com/sitemap2.xml",
         ]
+        assert all(req.dont_filter for req in requests)
 
         spider = FilteredSitemapSpider("example.com")
-        assert [req.url for req in spider._parse_sitemap(r)] == [
-            "http://www.example.com/sitemap2.xml"
-        ]
+        requests = list(spider._parse_sitemap(r))
+        assert [req.url for req in requests] == ["http://www.example.com/sitemap2.xml"]
+        assert all(req.dont_filter for req in requests)
 
     @pytest.mark.parametrize(
         ("rule", "result"),
@@ -496,5 +502,5 @@ Sitemap: /sitemap-relative-url.xml
         assert len(requests) == 1
         request = requests[0]
         assert request.url == "https://toscrape.com/sitemap.xml"
-        assert request.dont_filter is False
+        assert request.dont_filter is True
         assert request.callback == spider._parse_sitemap


### PR DESCRIPTION
## Summary
- make `SitemapSpider.start()` requests bypass the dupefilter, matching the default `Spider.start()` behavior for start URLs
- make sitemap discovery requests from `robots.txt` and sitemap indexes bypass the dupefilter
- keep final URL requests from URL sets filtered as before

Fixes #4479.

## Rationale

With `JOBDIR`, sitemap discovery URLs such as `robots.txt` and sitemap index files can already be present in `requests.seen` when a crawl is resumed. If those discovery requests are filtered, the spider can finish before rediscovering the URL set.

This keeps duplicate filtering for the actual URLs discovered from URL sets, while allowing the sitemap discovery chain to run again on resume.

## Tests
- `py -3.14 -m pytest tests/test_spider_sitemap.py::TestSitemapSpider::test_sitemap_urls tests/test_spider_sitemap.py::TestSitemapSpider::test_get_sitemap_urls_from_robotstxt tests/test_spider_sitemap.py::TestSitemapSpider::test_sitemapindex_filter -q`
- `py -3.14 -m pytest tests/test_spider_sitemap.py -q`
- `py -3.14 -m py_compile scrapy/spiders/sitemap.py tests/test_spider_sitemap.py`
- `git diff --check`