### PR TITLE
Use client.bucket() in GCSFeedStorage so object-level GCS permissions suffice

### DIFF
--- a/scrapy/extensions/feedexport.py
+++ b/scrapy/extensions/feedexport.py
@@ -340,7 +340,7 @@ class GCSFeedStorage(BlockingFeedStorage):
             from google.cloud.storage import Client  # noqa: PLC0415
 
             client = Client(project=self.project_id)
-            bucket = client.get_bucket(self.bucket_name)
+            bucket = client.bucket(self.bucket_name)
             blob = bucket.blob(self.blob_name)
             blob.upload_from_file(file, predefined_acl=self.acl)
         finally:

--- a/tests/test_feedexport_storages.py
+++ b/tests/test_feedexport_storages.py
@@ -524,7 +524,7 @@ class TestGCSFeedStorage:
 
             f.seek.assert_called_once_with(0)
             m.assert_called_once_with(project=project_id)
-            client_mock.get_bucket.assert_called_once_with("mybucket")
+            client_mock.bucket.assert_called_once_with("mybucket")
             bucket_mock.blob.assert_called_once_with("export.csv")
             blob_mock.upload_from_file.assert_called_once_with(f, predefined_acl=acl)
             f.close.assert_called_once_with()
@@ -548,7 +548,7 @@ class TestGCSFeedStorage:
 
             f.seek.assert_called_once_with(0)
             m.assert_called_once_with(project=project_id)
-            client_mock.get_bucket.assert_called_once_with("mybucket")
+            client_mock.bucket.assert_called_once_with("mybucket")
             bucket_mock.blob.assert_called_once_with("export.csv")
             blob_mock.upload_from_file.assert_called_once_with(f, predefined_acl=acl)
             f.close.assert_called_once_with()

--- a/tests/utils/cloud.py
+++ b/tests/utils/cloud.py
@@ -14,7 +14,6 @@ def mock_google_cloud_storage() -> tuple[Any, Any, Any]:
 
     bucket_mock = mock.create_autospec(Bucket)
     client_mock.bucket.return_value = bucket_mock
-    client_mock.get_bucket.return_value = bucket_mock
 
     blob_mock = mock.create_autospec(Blob)
     bucket_mock.blob.return_value = blob_mock


### PR DESCRIPTION
Resolves https://github.com/scrapy/scrapy/issues/5475.