### PR TITLE
docs: clarify asyncio checks in component initialization

### DIFF
--- a/docs/news.rst
+++ b/docs/news.rst
@@ -265,6 +265,11 @@ Bug fixes
 Documentation
 ~~~~~~~~~~~~~
 
+-   Clarified that :func:`scrapy.utils.asyncio.is_asyncio_available` and
+    :func:`scrapy.utils.reactorless.is_reactorless` should not be called from a
+    component ``__init__()`` method, before the asyncio event loop is running.
+    (:issue:`7812`)
+
 -   Mentioned :doc:`scrapy-lint <scrapy-lint:index>` in the docs.
     (:issue:`4421`, :issue:`7627`)
 

--- a/docs/topics/asyncio.rst
+++ b/docs/topics/asyncio.rst
@@ -119,7 +119,14 @@ Enforcing asyncio as a requirement
 If you are writing a :ref:`component <topics-components>` that requires asyncio
 to work, use :func:`scrapy.utils.asyncio.is_asyncio_available` to
 :ref:`enforce it as a requirement <enforce-component-requirements>`. For
-example:
+example, from a method that runs after the crawler has started:
+
+.. warning::
+    Do not call ``is_asyncio_available()`` or ``is_reactorless()`` from a
+    component ``__init__()`` method. Components are initialized before the
+    asyncio event loop is running, so the result may be incorrect. During
+    initialization, use the :class:`~scrapy.crawler.Crawler` instance and its
+    settings instead.
 
 .. code-block:: python
 
@@ -127,7 +134,7 @@ example:
 
 
     class MyComponent:
-        def __init__(self):
+        def process_item(self, item):
             if not is_asyncio_available():
                 raise ValueError(
                     f"{MyComponent.__qualname__} requires the asyncio support. "


### PR DESCRIPTION
## Purpose
Clarify that `is_asyncio_available()` and `is_reactorless()` are runtime checks and are not reliable from a component `__init__()` method before the event loop starts. The example now runs from a post-start method and points initialization code to the `Crawler` instance and its settings.

## References
Closes #7812

## Verification
- `python -m compileall -q scrapy`
- `python -m sphinx -b html --keep-going docs _build/docs` (build succeeded; one pre-existing `sphinx-llms-txt` warning about `settings.rst`)
- `git diff --check`