### PR TITLE
Time out hanging tests in the VCS dependencies job

### DIFF
--- a/.github/workflows/tests-vcs-deps.yml
+++ b/.github/workflows/tests-vcs-deps.yml
@@ -16,8 +16,11 @@ jobs:
   tests:
     name: tests
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     env:
-      PYTEST_ADDOPTS: -n auto --no-cov
+      # A development branch of a dependency can make a test hang forever, so
+      # tests get a time limit here that they do not need elsewhere.
+      PYTEST_ADDOPTS: -n auto --no-cov --timeout=120
       TOXENV: vcs-deps
       UV_PYTHON_PREFERENCE: only-system
     steps:

--- a/tox.ini
+++ b/tox.ini
@@ -44,6 +44,7 @@ deps =
     pygments
     pytest
     pytest-cov >= 7.0.0
+    pytest-timeout
     pytest-xdist
     sybil >= 1.3.0  # https://github.com/cjw296/sybil/issues/20#issuecomment-605433422
     pytest-twisted >= 1.14.3

--- a/tox.ini
+++ b/tox.ini
@@ -215,7 +215,8 @@ deps =
 #
 # Pillow and uvloop build from source, and need the libjpeg headers and
 # autotools respectively. robotexclusionrulesparser has no public repository,
-# so it stays at its latest release.
+# and PyDispatcher has seen no commit since 2023-10-23, so they stay at their
+# latest release.
 commands_pre =
     uv pip install --python {envpython} --no-deps --reinstall \
         git+https://github.com/twisted/twisted \
@@ -236,7 +237,6 @@ commands_pre =
         git+https://github.com/john-kurkowski/tldextract \
         git+https://github.com/scrapy/w3lib \
         git+https://github.com/zopefoundation/zope.interface \
-        git+https://github.com/mcfletch/pydispatcher \
         git+https://github.com/boto/boto3 \
         git+https://github.com/bpython/bpython \
         git+https://github.com/google/brotli \


### PR DESCRIPTION
https://github.com/scrapy/scrapy/actions/workflows/tests-vcs-deps.yml currently hags, this should help in the future.

An LLM found 2 issues:

-   The hang was apparently caused by a regression in pydispatcher. Since pydispatcher is dead and [we might drop it](https://github.com/scrapy/scrapy/pull/7942), I have stopped installing its VCS version.
-   https://github.com/scrapy/w3lib/pull/298