### PR TITLE
Do not fail to disable a component with an unimportable path

### DIFF
--- a/docs/news.rst
+++ b/docs/news.rst
@@ -25,6 +25,16 @@ Backward-incompatible changes
 
     (:issue:`6585`, :issue:`7731`)
 
+Bug fixes
+~~~~~~~~~
+
+-   Disabling a component whose import path cannot be imported, e.g. a
+    component removed from a later Scrapy version, no longer raises
+    :exc:`ModuleNotFoundError` while resolving :ref:`component priority
+    dictionaries <component-priority-dictionaries>`. This bug was introduced in
+    Scrapy 2.15.0.
+    (:issue:`7820`)
+
 .. _release-2.17.0:
 
 Scrapy 2.17.0 (2026-07-07)

--- a/scrapy/settings/__init__.py
+++ b/scrapy/settings/__init__.py
@@ -366,7 +366,7 @@ class BaseSettings(MutableMapping[str, Any]):
         def normalize_key(key: Any) -> Any:
             try:
                 loaded_key = load_object(key)
-            except (NameError, TypeError, ValueError):
+            except (ImportError, NameError, TypeError, ValueError):
                 loaded_key = key
             else:
                 import_path = global_object_name(loaded_key)

--- a/tests/test_settings/__init__.py
+++ b/tests/test_settings/__init__.py
@@ -428,6 +428,9 @@ class TestBaseSettings:
             pytest.param(1, TypeError, id="type-error"),
             pytest.param("foo", ValueError, id="value-error"),
             pytest.param("csv.gz", NameError, id="name-error"),
+            pytest.param(
+                "nonexistent.module.Component", ImportError, id="import-error"
+            ),
         ],
     )
     def test_get_component_priority_dict_with_base_handles_load_object_exceptions(
@@ -445,6 +448,20 @@ class TestBaseSettings:
 
         assert isinstance(value, BaseSettings)
         assert dict(value) == {key: 1}
+
+    def test_get_component_priority_dict_with_base_disable_unimportable_key(self):
+        """Disabling a component whose module cannot be imported, e.g. one
+        removed from a later Scrapy version, must not break settings
+        resolution."""
+        settings = BaseSettings(
+            {
+                "FOO_BASE": BaseSettings({"csv.excel": 1}),
+                "FOO": BaseSettings({"nonexistent.module.Component": None}),
+            }
+        )
+        value = settings.get_component_priority_dict_with_base("FOO")
+
+        assert dict(value) == {"csv.excel": 1}
 
     def test_get_component_priority_dict_with_base_override_none_by_type(self):
         settings = BaseSettings()


### PR DESCRIPTION
Fixes #7820.

## Problem

`BaseSettings.get_component_priority_dict_with_base()` normalizes **every** key of a component priority dictionary by calling `load_object()` on it, including keys whose value is `None` — i.e. components the user is explicitly disabling.

`normalize_key()` guards against `(NameError, TypeError, ValueError)`, which are the three exceptions `load_object()` raises itself, but not against the `ImportError` raised by the `import_module()` call inside it. So a stale entry disabling a component whose module no longer exists aborts settings resolution:

```python
from scrapy.settings import Settings

s = Settings()
s.set("EXTENSIONS", {"scrapy.webservice.WebService": None}, priority="cmdline")
s.get_component_priority_dict_with_base("EXTENSIONS")
# ModuleNotFoundError: No module named 'scrapy.webservice'
```

The failure surfaces inside a Deferred via `_apply_settings` → `ExtensionManager.from_crawler`, so in practice the spider appears to hang on download when it has in fact never started.

The current behaviour is also internally inconsistent: a key naming a missing *attribute* of an existing module (`"scrapy.extensions.corestats.NoSuchThing"`) is tolerated via the `NameError` branch, while a key naming a missing *module* crashes. Both are the same class of unresolvable key.

## Fix

Add `ImportError` to the guard. An unimportable key then falls back to its raw string form, and because its value is `None` it is dropped by the existing `if v is not None` filter, so disabling by import path keeps working.

Note that the alternative of skipping normalization for `None`-valued keys does **not** work: normalization to the canonical import path is exactly what makes a `None` override match the corresponding key in `<NAME>_BASE`. Skipping it would silently re-enable every default component the user meant to turn off.

### This does not hide genuine import errors

For *enabled* components (value not `None`) the key survives settings resolution as a string, and `MiddlewareManager.from_crawler()` calls `load_object()` on it again, catching only `NotConfigured`. A bad import path therefore still fails loudly there, with a message that names the component. Widening the guard in `normalize_key()` only changes behaviour for entries that were about to be discarded anyway.

`ImportError` was chosen over a bare `except Exception` (as suggested in the issue) deliberately: `except Exception` would also swallow failures from modules that exist but raise at import time, e.g. a user extension with a broken top-level import, which today produce a useful traceback.

## Affected versions

The issue reports this as a 2.17 regression, but it goes back further. `git show 06fb87f7b:scrapy/settings/__init__.py` shows the same `normalize_key()`/`load_object()` logic already inside `getwithbase()` in **2.15.0** (with the guard spelled `(AttributeError, TypeError, ValueError)`). It moved to `get_component_priority_dict_with_base()` in 2.16.0 (#7449). 2.14.0 had a plain three-line `getwithbase()` with no `load_object()` call, which matches the "worked on ≤2.14" part of the report. The release note says 2.15.0 accordingly.

## Tests

- Added an `import-error` case to the existing `test_get_component_priority_dict_with_base_handles_load_object_exceptions`, which already parametrizes the other three tolerated exceptions.
- Added `test_get_component_priority_dict_with_base_disable_unimportable_key` covering the reported scenario: a `None`-valued unimportable key must not break resolution of the rest of the dictionary.

Both fail on `master` and pass with the fix. `tests/test_settings`, `tests/test_middleware.py`, `tests/test_downloadermiddleware.py`, `tests/test_spidermiddleware.py` and `tests/test_utils_misc` pass (191 passed, 1 xfailed), and `ruff` 0.15.20 check/format are clean.

## Open question for maintainers

@AdrianAtZyte raised on the issue that silently accepting an unresolvable disable could hide a user mistake, e.g. a component that moved between `SPIDER_MIDDLEWARES` and `DOWNLOADER_MIDDLEWARES` in a newer version. That seems worth addressing, but as a separate change — logging a warning when a `None`-valued key cannot be resolved would alter log output for every project carrying a stale entry, and it should not block fixing the crash. Happy to add it here instead if you would prefer them together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
