### PR TITLE
Add Windows note for 'python -m scrapy' alternative in tutorial

### DIFF
--- a/docs/intro/tutorial.rst
+++ b/docs/intro/tutorial.rst
@@ -53,6 +53,11 @@ directory where you'd like to store your code and run::
 
     scrapy startproject tutorial
 
+.. note::
+
+   On Windows, if the ``scrapy`` command is not recognized, run it as a
+   Python module instead: ``python -m scrapy startproject tutorial``.
+
 This will create a ``tutorial`` directory with the following contents::
 
     tutorial/


### PR DESCRIPTION
## What
Adds a note in the "Creating a project" section of the tutorial explaining
that Windows users can run `python -m scrapy startproject tutorial` if the
`scrapy` command isn't recognized on their system PATH.

## Why
Closes #7306

The tutorial introduces the `scrapy` command without mentioning the
`python -m scrapy` alternative, which is useful for Windows users who may
not have Scripts added to PATH.

## Testing
Built docs locally with `sphinx-build -b html . _build/html` — build
succeeded with no new warnings introduced by this change.