### PR TITLE
Expose asyncio availability during component initialization

### DIFF
--- a/docs/topics/asyncio.rst
+++ b/docs/topics/asyncio.rst
@@ -117,24 +117,27 @@ Enforcing asyncio as a requirement
 ==================================
 
 If you are writing a :ref:`component <topics-components>` that requires asyncio
-to work, use :func:`scrapy.utils.asyncio.is_asyncio_available` to
-:ref:`enforce it as a requirement <enforce-component-requirements>`. For
-example:
+to work, check :attr:`scrapy.crawler.Crawler.asyncio_enabled` during component
+initialization to :ref:`enforce it as a requirement
+<enforce-component-requirements>`. For example:
 
 .. code-block:: python
 
-    from scrapy.utils.asyncio import is_asyncio_available
-
-
     class MyComponent:
-        def __init__(self):
-            if not is_asyncio_available():
+        @classmethod
+        def from_crawler(cls, crawler):
+            if not crawler.asyncio_enabled:
                 raise ValueError(
                     f"{MyComponent.__qualname__} requires the asyncio support. "
                     f"Make sure you have configured the asyncio reactor in the "
                     f"TWISTED_REACTOR setting. See the asyncio documentation "
                     f"of Scrapy for more information."
                 )
+            return cls()
+
+In code that runs after component initialization and does not have access to a
+:class:`~scrapy.crawler.Crawler` instance, use
+:func:`scrapy.utils.asyncio.is_asyncio_available` instead.
 
 .. autofunction:: scrapy.utils.asyncio.is_asyncio_available
 .. autofunction:: scrapy.utils.reactor.is_asyncio_reactor_installed

--- a/scrapy/crawler.py
+++ b/scrapy/crawler.py
@@ -99,6 +99,13 @@ class _LateAttribute(Generic[_T]):
 
 
 class Crawler:
+    asyncio_enabled: _LateAttribute[bool] = _LateAttribute()
+    """Whether asyncio support is enabled for this crawler.
+
+    This attribute is available during component initialization.
+
+    .. versionadded:: VERSION
+    """
     engine: _LateAttribute[ExecutionEngine] = _LateAttribute()
     extensions: _LateAttribute[ExtensionManager] = _LateAttribute()
     logformatter: _LateAttribute[LogFormatter] = _LateAttribute()
@@ -133,6 +140,7 @@ class Crawler:
 
         self.spider: Spider | None = None
 
+        self._asyncio_enabled: bool | None = None
         self._engine: ExecutionEngine | None = None
         self._extensions: ExtensionManager | None = None
         self._logformatter: LogFormatter | None = None
@@ -200,6 +208,7 @@ class Crawler:
             logger.debug("Not using a Twisted reactor")
             self._apply_reactorless_default_settings()
 
+        self.asyncio_enabled = not use_reactor or is_asyncio_reactor_installed()
         self.extensions = build_from_crawler(ExtensionManager, self)
         self.settings.freeze()
 

--- a/tests/AsyncCrawlerProcess/asyncio_enabled_no_reactor.py
+++ b/tests/AsyncCrawlerProcess/asyncio_enabled_no_reactor.py
@@ -4,9 +4,13 @@ from scrapy.utils.reactor import is_asyncio_reactor_installed
 
 
 class ReactorCheckExtension:
-    def __init__(self):
+    @classmethod
+    def from_crawler(cls, crawler):
         if not is_asyncio_reactor_installed():
             raise RuntimeError("ReactorCheckExtension requires the asyncio reactor.")
+        if not crawler.asyncio_enabled:
+            raise RuntimeError("Crawler did not report asyncio support.")
+        return cls()
 
 
 class NoRequestsSpider(scrapy.Spider):

--- a/tests/AsyncCrawlerProcess/asyncio_enabled_reactor.py
+++ b/tests/AsyncCrawlerProcess/asyncio_enabled_reactor.py
@@ -30,9 +30,13 @@ if not is_asyncio_reactor_installed():
 
 
 class ReactorCheckExtension:
-    def __init__(self):
+    @classmethod
+    def from_crawler(cls, crawler):
         if not is_asyncio_reactor_installed():
             raise RuntimeError("ReactorCheckExtension requires the asyncio reactor.")
+        if not crawler.asyncio_enabled:
+            raise RuntimeError("Crawler did not report asyncio support.")
+        return cls()
 
 
 class NoRequestsSpider(scrapy.Spider):

--- a/tests/AsyncCrawlerProcess/reactorless_simple.py
+++ b/tests/AsyncCrawlerProcess/reactorless_simple.py
@@ -3,6 +3,14 @@ from scrapy.crawler import AsyncCrawlerProcess
 from scrapy.utils.reactorless import is_reactorless
 
 
+class AsyncioCheckExtension:
+    @classmethod
+    def from_crawler(cls, crawler):
+        if not crawler.asyncio_enabled:
+            raise RuntimeError("Crawler did not report asyncio support.")
+        return cls()
+
+
 class NoRequestsSpider(scrapy.Spider):
     name = "no_request"
 
@@ -12,7 +20,12 @@ class NoRequestsSpider(scrapy.Spider):
         yield
 
 
-process = AsyncCrawlerProcess(settings={"TWISTED_REACTOR_ENABLED": False})
+process = AsyncCrawlerProcess(
+    settings={
+        "TWISTED_REACTOR_ENABLED": False,
+        "EXTENSIONS": {AsyncioCheckExtension: 0},
+    }
+)
 
 process.crawl(NoRequestsSpider)
 process.start()

--- a/tests/CrawlerProcess/asyncio_enabled_no_reactor.py
+++ b/tests/CrawlerProcess/asyncio_enabled_no_reactor.py
@@ -4,9 +4,13 @@ from scrapy.utils.reactor import is_asyncio_reactor_installed
 
 
 class ReactorCheckExtension:
-    def __init__(self):
+    @classmethod
+    def from_crawler(cls, crawler):
         if not is_asyncio_reactor_installed():
             raise RuntimeError("ReactorCheckExtension requires the asyncio reactor.")
+        if not crawler.asyncio_enabled:
+            raise RuntimeError("Crawler did not report asyncio support.")
+        return cls()
 
 
 class NoRequestsSpider(scrapy.Spider):

--- a/tests/CrawlerProcess/asyncio_enabled_reactor.py
+++ b/tests/CrawlerProcess/asyncio_enabled_reactor.py
@@ -38,11 +38,15 @@ if not is_asyncio_reactor_installed():
 
 
 class ReactorCheckExtension:
-    def __init__(self):
+    @classmethod
+    def from_crawler(cls, crawler):
         if not is_asyncio_reactor_installed():
             raise RuntimeError("ReactorCheckExtension requires the asyncio reactor.")
+        if not crawler.asyncio_enabled:
+            raise RuntimeError("Crawler did not report asyncio support.")
         if not is_asyncio_available():
             raise RuntimeError("ReactorCheckExtension requires asyncio support.")
+        return cls()
 
 
 class NoRequestsSpider(scrapy.Spider):

--- a/tests/CrawlerProcess/reactor_select.py
+++ b/tests/CrawlerProcess/reactor_select.py
@@ -7,6 +7,14 @@ from scrapy.crawler import CrawlerProcess
 selectreactor.install()
 
 
+class AsyncioCheckExtension:
+    @classmethod
+    def from_crawler(cls, crawler):
+        if crawler.asyncio_enabled:
+            raise RuntimeError("Crawler unexpectedly reported asyncio support.")
+        return cls()
+
+
 class NoRequestsSpider(scrapy.Spider):
     name = "no_request"
 
@@ -15,7 +23,7 @@ class NoRequestsSpider(scrapy.Spider):
         yield
 
 
-process = CrawlerProcess(settings={})
+process = CrawlerProcess(settings={"EXTENSIONS": {AsyncioCheckExtension: 0}})
 
 d = process.crawl(NoRequestsSpider)
 d.addErrback(log.err)

--- a/tests/test_crawler.py
+++ b/tests/test_crawler.py
@@ -76,7 +76,13 @@ class TestCrawler:
 
     @pytest.mark.parametrize(
         "attr",
-        ["extensions", "logformatter", "request_fingerprinter", "stats"],
+        [
+            "asyncio_enabled",
+            "extensions",
+            "logformatter",
+            "request_fingerprinter",
+            "stats",
+        ],
     )
     def test_late_attr_before_apply_settings(self, attr: str) -> None:
         crawler = get_raw_crawler(DefaultSpider)


### PR DESCRIPTION
Closes #7812.

## Summary

Components are initialized immediately after `Crawler._apply_settings()` selects and verifies the runtime mode. At that point, `is_asyncio_available()` can still depend on loop state that is not available to extension initialization, even though the crawler already knows whether it will use asyncio.

This change exposes that resolved state as `Crawler.asyncio_enabled` before the extension manager is created. Components can now enforce an asyncio requirement from `from_crawler()` without probing a loop that has not started. The asyncio documentation now recommends the crawler attribute during component initialization and keeps `is_asyncio_available()` for later code without crawler access.

The regression coverage checks the attribute during extension construction with an asyncio reactor, reactorless mode, and a non-asyncio reactor. It also verifies the attribute keeps the existing late-initialization contract.

## Verification

- `python -m pytest tests/test_crawler.py::TestCrawler::test_late_attr_before_apply_settings tests/test_crawler_subprocess.py::TestCrawlerProcessSubprocess::test_asyncio_enabled_no_reactor tests/test_crawler_subprocess.py::TestCrawlerProcessSubprocess::test_asyncio_enabled_reactor tests/test_crawler_subprocess.py::TestCrawlerProcessSubprocess::test_reactor_select tests/test_crawler_subprocess.py::TestAsyncCrawlerProcessSubprocess::test_asyncio_enabled_no_reactor tests/test_crawler_subprocess.py::TestAsyncCrawlerProcessSubprocess::test_asyncio_enabled_reactor tests/test_crawler_subprocess.py::TestAsyncCrawlerProcessSubprocess::test_reactorless_simple -q --tb=short --timeout=30` (11 passed)
- `ruff check` and `ruff format --check` on the changed Python files
- `sphinx-lint docs/topics/asyncio.rst`
- `python -m sphinx --keep-going -b html docs .docs-build-local` (completed; one unrelated `sphinx-llms-txt` missing-include warning)
- `git diff --check`
