### PR TITLE
Keep the scheduler's active.json up to date while the job runs

### DIFF
--- a/docs/news.rst
+++ b/docs/news.rst
@@ -25,6 +25,29 @@ Backward-incompatible changes
 
     (:gh:`6585`, :gh:`7731`)
 
+New features
+~~~~~~~~~~~~
+
+-   :class:`~scrapy.pqueues.ScrapyPriorityQueue` and
+    :class:`~scrapy.pqueues.DownloaderAwarePriorityQueue` have a new ``state()``
+    method, which returns the same value as ``close()`` without closing the
+    queue, and a new ``state_version`` property, which changes whenever
+    ``state()`` starts returning a different value.
+    (:gh:`7978`)
+
+Bug fixes
+~~~~~~~~~
+
+-   :class:`~scrapy.core.scheduler.Scheduler` now keeps the ``active.json``
+    file of the :ref:`job directory <topics-jobs>` up to date as the job runs,
+    instead of only writing it when the job stops. Previously, a job that
+    stopped abruptly left that file missing or stale, and resuming it silently
+    ignored every request that its disk queues had written to disk.
+
+    The file is also written through a temporary file now, so that a crash
+    while writing it cannot leave a truncated file behind.
+    (:gh:`4106`, :gh:`7978`)
+
 .. _release-2.17.0:
 
 Scrapy 2.17.0 (2026-07-07)

--- a/docs/topics/jobs.rst
+++ b/docs/topics/jobs.rst
@@ -153,9 +153,8 @@ Where:
 
 -   :class:`~scrapy.core.scheduler.Scheduler` creates the ``requests.queue/``
     directory and the ``active.json`` file, the latter containing the state
-    data returned by :meth:`DownloaderAwarePriorityQueue.close()
-    <scrapy.pqueues.DownloaderAwarePriorityQueue.close>` the last time the job
-    was paused.
+    data of :class:`~scrapy.pqueues.DownloaderAwarePriorityQueue`, kept up to
+    date as the job runs.
 
 -   :class:`~scrapy.pqueues.DownloaderAwarePriorityQueue` creates the
     ``{hostname}-{hash}`` directories.

--- a/scrapy/core/scheduler.py
+++ b/scrapy/core/scheduler.py
@@ -236,8 +236,10 @@ class Scheduler(BaseScheduler):
         representation of the state (``startprios``) of
         :setting:`SCHEDULER_PRIORITY_QUEUE`.
 
-        The file is generated whenever the job stops (cleanly) and is loaded
-        when resuming the job.
+        The file is rewritten whenever that state changes, and when the job
+        stops, and is loaded when resuming the job. Rewriting it as the job
+        runs means that a job that stops abruptly can still be resumed from
+        whatever its queues managed to write to disk.
 
     -   Instantiates the configured :setting:`SCHEDULER_PRIORITY_QUEUE` with
         ``requests.queue/`` as persistence directory (*key*) and
@@ -348,6 +350,9 @@ class Scheduler(BaseScheduler):
         self.spider: Spider = spider
         self.mqs: ScrapyPriorityQueue = self._mq()
         self.dqs: ScrapyPriorityQueue | None = self._dq() if self.dqdir else None
+        self._dqs_state_version: int | None = (
+            self.dqs.state_version if self.dqs is not None else None
+        )
         return self.df.open()
 
     def close(self, reason: str) -> Deferred[None] | None:
@@ -359,6 +364,7 @@ class Scheduler(BaseScheduler):
             state = self.dqs.close()
             assert isinstance(self.dqdir, str)
             self._write_dqs_state(self.dqdir, state)
+            self._dqs_state_version = self.dqs.state_version
         return self.df.close(reason)
 
     def enqueue_request(self, request: Request) -> bool:
@@ -433,6 +439,7 @@ class Scheduler(BaseScheduler):
             assert self.stats is not None
             self.stats.inc_value("scheduler/unserializable")
             return False
+        self._sync_dqs_state()
         return True
 
     def _mqpush(self, request: Request) -> None:
@@ -440,8 +447,26 @@ class Scheduler(BaseScheduler):
 
     def _dqpop(self) -> Request | None:
         if self.dqs is not None:
-            return self.dqs.pop()
+            request = self.dqs.pop()
+            self._sync_dqs_state()
+            return request
         return None
+
+    def _sync_dqs_state(self) -> None:
+        """Persist the state of the disk queue if it changed since last time.
+
+        The state only changes when an internal queue is created or drained, so
+        most requests do not trigger a write. Checking
+        ``ScrapyPriorityQueue.state_version`` keeps the common case, where
+        nothing changed, out of the (linear) cost of building the state.
+        """
+        assert self.dqs is not None
+        assert self.dqdir is not None
+        version = self.dqs.state_version
+        if version == self._dqs_state_version:
+            return
+        self._write_dqs_state(self.dqdir, self.dqs.state())
+        self._dqs_state_version = version
 
     def _mq(self) -> ScrapyPriorityQueue:
         """Create a new priority queue instance, with in-memory storage"""
@@ -494,5 +519,11 @@ class Scheduler(BaseScheduler):
             return json.load(f)
 
     def _write_dqs_state(self, dqdir: str, state: Any) -> None:
-        with Path(dqdir, "active.json").open("w", encoding="utf-8") as f:
+        # Write to a temporary file in the same directory and rename it over
+        # the old one, so that a crash mid-write cannot leave a truncated
+        # active.json behind.
+        path = Path(dqdir, "active.json")
+        tmp_path = path.with_suffix(".json.tmp")
+        with tmp_path.open("w", encoding="utf-8") as f:
             json.dump(state, f)
+        tmp_path.replace(path)

--- a/scrapy/pqueues.py
+++ b/scrapy/pqueues.py
@@ -134,6 +134,7 @@ class ScrapyPriorityQueue:
         self.queues: dict[int, QueueProtocol] = {}
         self._start_queues: dict[int, QueueProtocol] = {}
         self.curprio: int | None = None
+        self._state_version: int = 0
         self.init_prios(startprios)
 
     def init_prios(self, startprios: Iterable[int]) -> None:
@@ -179,10 +180,12 @@ class ScrapyPriorityQueue:
         if is_start_request and self._start_queue_cls:
             if priority not in self._start_queues:
                 self._start_queues[priority] = self._sqfactory(priority)
+                self._state_version += 1
             q = self._start_queues[priority]
         else:
             if priority not in self.queues:
                 self.queues[priority] = self.qfactory(priority)
+                self._state_version += 1
             q = self.queues[priority]
         q.push(request)  # this may fail (eg. serialization error)
         if self.curprio is None or priority < self.curprio:
@@ -198,6 +201,7 @@ class ScrapyPriorityQueue:
                 m = q.pop()
                 if not q:
                     del self.queues[self.curprio]
+                    self._state_version += 1
                     q.close()
                     if not self._start_queues:
                         self._update_curprio()
@@ -211,6 +215,7 @@ class ScrapyPriorityQueue:
                     m = q.pop()
                     if not q:
                         del self._start_queues[self.curprio]
+                        self._state_version += 1
                         q.close()
                         self._update_curprio()
                     return m
@@ -243,13 +248,32 @@ class ScrapyPriorityQueue:
         # Protocols can't declare optional members
         return cast("Request", queue.peek())  # type: ignore[attr-defined]
 
+    @property
+    def state_version(self) -> int:
+        """A number that changes whenever :meth:`state` starts returning a
+        different value.
+
+        Callers that persist :meth:`state` can compare this against the value
+        they saw last to find out whether they need to persist it again,
+        without having to build the state itself, which is *O(priorities)*.
+        """
+        return self._state_version
+
+    def state(self) -> list[int]:
+        """Return the priorities with a non-discarded internal queue, sorted.
+
+        This is the same value that :meth:`close` returns, but the queue stays
+        usable, so that callers that persist this value can keep it up to date
+        while the queue is still in use.
+        """
+        return sorted({*self.queues, *self._start_queues})
+
     def close(self) -> list[int]:
-        active: set[int] = set()
+        active = self.state()
         for queues in (self.queues, self._start_queues):
-            for p, q in queues.items():
-                active.add(p)
+            for q in queues.values():
                 q.close()
-        return list(active)
+        return active
 
     def __len__(self) -> int:
         return (
@@ -357,6 +381,7 @@ class DownloaderAwarePriorityQueue:
 
         self.pqueues: dict[str, ScrapyPriorityQueue] = {}  # slot -> priority queue
         self._last_selected_slot: str | None = None
+        self._state_version: int = 0
         if slot_startprios:
             for slot, startprios in slot_startprios.items():
                 self.pqueues[slot] = self.pqfactory(slot, startprios)
@@ -407,9 +432,13 @@ class DownloaderAwarePriorityQueue:
 
         slot = self._next_slot(stats, update_state=True)
         queue = self.pqueues[slot]
+        queue_version = queue.state_version
         request = queue.pop()
+        if queue.state_version != queue_version:
+            self._state_version += 1
         if len(queue) == 0:
             del self.pqueues[slot]
+            self._state_version += 1
             if self.key:
                 # Reclaim the slot directory; rmdir leaves it alone if the
                 # downstream queues did not remove all their files.
@@ -421,8 +450,12 @@ class DownloaderAwarePriorityQueue:
         slot = self._downloader_interface.get_slot_key(request)
         if slot not in self.pqueues:
             self.pqueues[slot] = self.pqfactory(slot)
+            self._state_version += 1
         queue = self.pqueues[slot]
+        queue_version = queue.state_version
         queue.push(request)
+        if queue.state_version != queue_version:
+            self._state_version += 1
 
     def peek(self) -> Request | None:
         """Returns the next object to be returned by :meth:`pop`,
@@ -438,9 +471,32 @@ class DownloaderAwarePriorityQueue:
         queue = self.pqueues[slot]
         return queue.peek()
 
+    @property
+    def state_version(self) -> int:
+        """A number that changes whenever :meth:`state` starts returning a
+        different value.
+
+        Callers that persist :meth:`state` can compare this against the value
+        they saw last to find out whether they need to persist it again,
+        without having to build the state itself, which is *O(slots)*.
+        """
+        return self._state_version
+
+    def state(self) -> dict[str, list[int]]:
+        """Return the state of the priority queue of every active slot.
+
+        This is the same value that :meth:`close` returns, but the queue stays
+        usable, so that callers that persist this value can keep it up to date
+        while the queue is still in use.
+        """
+        return {slot: queue.state() for slot, queue in self.pqueues.items()}
+
     def close(self) -> dict[str, list[int]]:
-        active = {slot: queue.close() for slot, queue in self.pqueues.items()}
+        active = self.state()
+        for queue in self.pqueues.values():
+            queue.close()
         self.pqueues.clear()
+        self._state_version += 1
         return active
 
     def __len__(self) -> int:

--- a/tests/test_pqueues.py
+++ b/tests/test_pqueues.py
@@ -101,6 +101,43 @@ class TestPriorityQueue:
         assert queue2.pop().url == req.url
         queue2.close()
 
+    def test_state_matches_close(self):
+        temp_dir = tempfile.mkdtemp()
+        queue = build_from_crawler(
+            ScrapyPriorityQueue, self.crawler, FifoMemoryQueue, temp_dir
+        )
+        assert queue.state() == []
+        queue.push(Request("https://example.org/1", priority=1))
+        queue.push(Request("https://example.org/2", priority=2))
+        state = queue.state()
+        assert state == [-2, -1]
+        assert len(queue) == 2
+        assert queue.close() == state
+
+    def test_state_version(self):
+        temp_dir = tempfile.mkdtemp()
+        queue = build_from_crawler(
+            ScrapyPriorityQueue, self.crawler, FifoMemoryQueue, temp_dir
+        )
+        version = queue.state_version
+
+        queue.push(Request("https://example.org/1", priority=1))
+        assert queue.state_version != version
+        version = queue.state_version
+
+        # Same priority, so no new internal queue and no state change.
+        queue.push(Request("https://example.org/2", priority=1))
+        assert queue.state_version == version
+
+        queue.pop()
+        assert queue.state_version == version
+
+        # The last request of the internal queue, which is then discarded.
+        queue.pop()
+        assert queue.state_version != version
+        assert queue.state() == []
+        queue.close()
+
     def test_queue_push_pop_priorities(self):
         temp_dir = tempfile.mkdtemp()
         queue = build_from_crawler(
@@ -251,6 +288,46 @@ class TestDownloaderAwarePriorityQueue:
 
         popped = self.queue.pop()
         assert popped.url == req_b.url
+
+    def test_state_matches_close(self):
+        assert self.queue.state() == {}
+        req = Request("https://example.org/")
+        req.meta[Downloader.DOWNLOAD_SLOT] = "example-slot"
+        self.queue.push(req)
+        state = self.queue.state()
+        assert state == {"example-slot": [0]}
+        assert len(self.queue) == 1
+        assert self.queue.close() == state
+
+    def test_state_version(self):
+        def request(url, slot, priority=0):
+            req = Request(url, priority=priority)
+            req.meta[Downloader.DOWNLOAD_SLOT] = slot
+            return req
+
+        version = self.queue.state_version
+
+        self.queue.push(request("https://example.org/1", "slot-a"))
+        assert self.queue.state_version != version
+        version = self.queue.state_version
+
+        # Same slot and priority, so no state change.
+        self.queue.push(request("https://example.org/2", "slot-a"))
+        assert self.queue.state_version == version
+
+        # A new priority within a known slot is a state change too.
+        self.queue.push(request("https://example.org/3", "slot-a", priority=1))
+        assert self.queue.state_version != version
+        version = self.queue.state_version
+
+        self.queue.push(request("https://example.org/4", "slot-b"))
+        assert self.queue.state_version != version
+        version = self.queue.state_version
+
+        while self.queue.pop() is not None:
+            pass
+        assert self.queue.state_version != version
+        assert self.queue.state() == {}
 
     def test_contains(self):
         req = Request("https://example.org/")

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
+import json
 import warnings
 from abc import ABC, abstractmethod
 from contextlib import AbstractAsyncContextManager, asynccontextmanager
-from typing import TYPE_CHECKING
-from unittest.mock import Mock
+from typing import TYPE_CHECKING, Any
+from unittest.mock import Mock, patch
 
 import pytest
 
@@ -211,6 +212,73 @@ class TestMigration:
                 "scrapy.pqueues.DownloaderAwarePriorityQueue", tmp_path
             ):
                 pass
+
+
+class TestActiveJson:
+    """The scheduler keeps ``active.json`` up to date while the job runs,
+    rather than only writing it when the job stops, so that a job that stops
+    abruptly does not lose track of its disk queues.
+    """
+
+    @staticmethod
+    def read(jobdir: Path) -> Any:
+        path = jobdir / "requests.queue" / "active.json"
+        return json.loads(path.read_text(encoding="utf-8"))
+
+    @coroutine_test
+    async def test_written_before_close(self, tmp_path: Path) -> None:
+        async with create_scheduler(
+            "scrapy.pqueues.ScrapyPriorityQueue", tmp_path
+        ) as scheduler:
+            for url, priority in _PRIORITIES:
+                scheduler.enqueue_request(Request(url, priority=priority))
+            assert self.read(tmp_path) == sorted(-p for _, p in _PRIORITIES)
+
+    @coroutine_test
+    async def test_written_before_close_downloader_aware(self, tmp_path: Path) -> None:
+        async with create_scheduler(
+            "scrapy.pqueues.DownloaderAwarePriorityQueue", tmp_path
+        ) as scheduler:
+            for url, slot in _URLS_WITH_SLOTS:
+                request = Request(url)
+                request.meta[Downloader.DOWNLOAD_SLOT] = slot
+                scheduler.enqueue_request(request)
+            assert self.read(tmp_path) == {"a": [0], "b": [0], "c": [0]}
+
+    @coroutine_test
+    async def test_updated_as_queues_drain(self, tmp_path: Path) -> None:
+        async with create_scheduler(
+            "scrapy.pqueues.ScrapyPriorityQueue", tmp_path
+        ) as scheduler:
+            for url in _URLS:
+                scheduler.enqueue_request(Request(url))
+            assert self.read(tmp_path) == [0]
+
+            while scheduler.has_pending_requests():
+                scheduler.next_request()
+            assert self.read(tmp_path) == []
+
+    @coroutine_test
+    async def test_written_only_when_the_state_changes(self, tmp_path: Path) -> None:
+        async with create_scheduler(
+            "scrapy.pqueues.ScrapyPriorityQueue", tmp_path
+        ) as scheduler:
+            with patch.object(
+                scheduler, "_write_dqs_state", wraps=scheduler._write_dqs_state
+            ) as write_dqs_state:
+                for url in _URLS:
+                    scheduler.enqueue_request(Request(url))
+                # All these requests share a priority, so they all land in the
+                # same internal queue, and only its creation is a state change.
+                assert write_dqs_state.call_count == 1
+
+    @coroutine_test
+    async def test_no_temporary_file_left_behind(self, tmp_path: Path) -> None:
+        async with create_scheduler(
+            "scrapy.pqueues.ScrapyPriorityQueue", tmp_path
+        ) as scheduler:
+            scheduler.enqueue_request(Request("http://foo.com/a"))
+            assert not list((tmp_path / "requests.queue").glob("*.tmp"))
 
 
 def _is_scheduling_fair(enqueued_slots: list[str], dequeued_slots: list[str]) -> bool:


### PR DESCRIPTION
Part of #7978, and the part of #4106 that does not depend on #7877.

## The problem

`active.json` is only written by `Scheduler.close()`. When a job stops any other way — a crash, a second Ctrl-C, a power loss — the file is left missing, or holding the state of an earlier run.

On resume `_read_dqs_state()` then returns `()`, `init_prios()` gets nothing, and the scheduler starts with an empty disk queue. The priority bucket directories under `requests.queue/` are still sitting there with requests in them, but nothing points at them anymore, so they are silently ignored.

## The change

`ScrapyPriorityQueue` and `DownloaderAwarePriorityQueue` get:

- `state()`, which returns the same value `close()` returns, without closing anything.
- `state_version`, a number that changes whenever `state()` would start returning a different value.

The scheduler writes `active.json` whenever `state_version` moves. That only happens when an internal queue is created or drained, and, for the downloader-aware queue, when a slot appears or disappears, so a normal crawl does a handful of writes rather than one per request.

The file is also written to a temporary file in the same directory and renamed over the old one now, so a crash while writing it cannot leave a truncated `active.json` behind.

Behaviour on a clean stop does not change: the file ends up with the same contents it has today.

## Why `state_version` and not just comparing `state()`

My first attempt had the scheduler call `state()` on every enqueue and dequeue and compare it against the last value it wrote. That is fine for `ScrapyPriorityQueue`, whose state is one entry per priority, but `DownloaderAwarePriorityQueue` is the default and its state is one entry per pending slot:

```
   100 slots: push 0.39us   state()   17.54us
  1000 slots: push 0.38us   state()  168.62us
 10000 slots: push 0.40us   state() 1781.60us
```

On a broad crawl that turns a 0.4µs push into a 1.8ms one. Comparing an integer keeps the check O(1) and leaves `state()` to run only when the file is about to be written. Measured that way, `Scheduler.enqueue_request` into an existing slot stays flat at ~9.4µs for 100, 1000 and 10000 pending slots, against ~10.4µs on master.

## What this does not do

It does not make a crashed job resumable on its own. queuelib's disk queues still write their own size metadata only on `close()`, so the queue files are the next problem, and that is what #7877 is about. This change stops the scheduler from discarding the state that did survive.

## Two calls I made

- No `fsync`. Without syncing the directory entry a power loss can still lose the rename. That looked like a rounding error next to losing the queue files themselves, but I am happy to add it.
- Unconditional, rather than gated behind a setting. The cost is low enough that an opt-in knob did not seem worth it. If you would rather the crash-tolerant path be strictly opt-in from the start, I will gate it.

## Tests

`TestActiveJson` in `tests/test_scheduler.py` covers the file being written before `close()` for both priority queue classes, being updated as the queues drain, being written once for a batch of same-priority requests instead of once per request, and leaving no temporary file behind. `tests/test_pqueues.py` covers `state()` matching `close()` and the `state_version` semantics for both classes.

Eight of the nine new tests fail without the change. The ninth is the temporary file check, which is a regression guard.
