### PR TITLE
Fix LocalCache evicting an entry when an existing key is overwritten

### DIFF
--- a/docs/news.rst
+++ b/docs/news.rst
@@ -25,6 +25,15 @@ Backward-incompatible changes
 
     (:gh:`6585`, :gh:`7731`)
 
+Bug fixes
+~~~~~~~~~
+
+-   Overwriting an existing key in the internal ``LocalCache`` class no longer
+    evicts a different entry. Among other things, this made the DNS cache
+    shrink below :setting:`DNSCACHE_SIZE` whenever the same host name was
+    resolved concurrently.
+    (:gh:`7981`)
+
 .. _release-2.17.0:
 
 Scrapy 2.17.0 (2026-07-07)

--- a/scrapy/utils/datatypes.py
+++ b/scrapy/utils/datatypes.py
@@ -177,8 +177,11 @@ class LocalCache(OrderedDict[_KT, _VT]):
         if self.limit is not None:
             if self.limit == 0:
                 return
-            while len(self) >= self.limit:
-                self.popitem(last=False)
+            # Overwriting an existing key does not add an entry, so it must not
+            # evict one either.
+            if key not in self:
+                while len(self) >= self.limit:
+                    self.popitem(last=False)
         super().__setitem__(key, value)
 
 

--- a/tests/test_utils_datatypes.py
+++ b/tests/test_utils_datatypes.py
@@ -334,6 +334,31 @@ class TestLocalCache:
         assert cache["b"] == 2
         assert cache["c"] == 3
 
+    def test_overwrite_does_not_evict(self):
+        cache: LocalCache[str, int] = LocalCache(limit=3)
+        cache["a"] = 1
+        cache["b"] = 2
+        cache["c"] = 3
+
+        cache["c"] = 30
+        cache["a"] = 10
+
+        assert len(cache) == 3
+        assert list(cache) == ["a", "b", "c"]
+        assert cache["a"] == 10
+        assert cache["b"] == 2
+        assert cache["c"] == 30
+
+    def test_overwrite_keeps_expiry_order(self):
+        cache: LocalCache[str, int] = LocalCache(limit=2)
+        cache["a"] = 1
+        cache["b"] = 2
+        cache["a"] = 10
+        # "a" was written last but added first, so it still expires first.
+        cache["c"] = 3
+        assert "a" not in cache
+        assert list(cache) == ["b", "c"]
+
     def test_cache_without_limit(self):
         maximum = 10**4
         cache: LocalCache[str, int] = LocalCache()


### PR DESCRIPTION
`LocalCache` evicts the oldest entry whenever it is full, without checking whether the key being written is already there. Overwriting a key does not add an entry, so that eviction is pure loss:

```python
>>> c = LocalCache(limit=3)
>>> c['a'], c['b'], c['c'] = 1, 2, 3
>>> c['c'] = 30          # overwrite the newest key
>>> dict(c)
{'b': 2, 'c': 30}        # 'a' is gone and the cache is down to 2
```

The cache stays shrunk after that.

`dnscache` hits this. Both resolvers only write on a miss, but concurrent requests to the same host all miss before the first one resolves and then all write, so each burst evicts unrelated hosts and the cache drifts below `DNSCACHE_SIZE`.

Fix is to skip the eviction when the key is already present. Existing keys keep their place in the expiry order, same as `OrderedDict`. Both new tests fail without the change.
