### PR TITLE
Deprecate PeriodicLog.multiplier instead of removing it altogether

### DIFF
--- a/scrapy/extensions/periodic_log.py
+++ b/scrapy/extensions/periodic_log.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
 import logging
+import warnings
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any
 
 from scrapy import Spider, signals
-from scrapy.exceptions import NotConfigured
+from scrapy.exceptions import NotConfigured, ScrapyDeprecationWarning
 from scrapy.utils.asyncio import AsyncioLoopingCall, create_looping_call
 from scrapy.utils.serialize import ScrapyJSONEncoder
 
@@ -38,6 +39,7 @@ class PeriodicLog:
     ):
         self.stats: StatsCollector = stats
         self.interval: float = interval
+        self._multiplier: float = 60.0 / interval
         self.task: AsyncioLoopingCall | LoopingCall | None = None
         self.encoder: JSONEncoder = ScrapyJSONEncoder(sort_keys=True, indent=4)
         self.ext_stats_enabled: bool = bool(ext_stats)
@@ -55,6 +57,24 @@ class PeriodicLog:
             ext_delta.get("exclude", ()) if ext_delta else ()
         )
         self.ext_timing_enabled: bool = ext_timing_enabled
+
+    @property
+    def multiplier(self) -> float:
+        warnings.warn(
+            "The PeriodicLog.multiplier attribute is deprecated.",
+            ScrapyDeprecationWarning,
+            stacklevel=2,
+        )
+        return self._multiplier
+
+    @multiplier.setter
+    def multiplier(self, value: float) -> None:
+        warnings.warn(
+            "The PeriodicLog.multiplier attribute is deprecated.",
+            ScrapyDeprecationWarning,
+            stacklevel=2,
+        )
+        self._multiplier = value
 
     @classmethod
     def from_crawler(cls, crawler: Crawler) -> Self:

--- a/tests/test_extension_periodic_log.py
+++ b/tests/test_extension_periodic_log.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING, Any
 
 import pytest
 
-from scrapy.exceptions import NotConfigured
+from scrapy.exceptions import NotConfigured, ScrapyDeprecationWarning
 from scrapy.extensions.periodic_log import PeriodicLog
 from scrapy.utils.misc import build_from_crawler
 from scrapy.utils.test import get_crawler
@@ -249,3 +249,17 @@ class TestPeriodicLog:
         assert data["time"]["log_interval_real"] >= 0
         assert data["time"]["elapsed"] >= 0
         assert data["time"]["start_time"] <= data["time"]["utcnow"]
+
+    def test_multiplier_deprecated(self) -> None:
+        crawler = get_crawler(
+            MetaSpider,
+            {"PERIODIC_LOG_TIMING_ENABLED": True, "LOGSTATS_INTERVAL": 30},
+        )
+        crawler._apply_settings()
+        ext = build_from_crawler(PeriodicLog, crawler)
+        with pytest.warns(ScrapyDeprecationWarning):
+            assert ext.multiplier == 2.0
+        with pytest.warns(ScrapyDeprecationWarning):
+            ext.multiplier = 3.0
+        with pytest.warns(ScrapyDeprecationWarning):
+            assert ext.multiplier == 3.0


### PR DESCRIPTION
To minimize backward-incompatible changes in [2.18](https://github.com/scrapy/scrapy/pull/7969).