### PR TITLE
Give cross-domain redirects their own download slot

### DIFF
--- a/scrapy/core/downloader/__init__.py
+++ b/scrapy/core/downloader/__init__.py
@@ -160,6 +160,10 @@ class Downloader:
     # passed as download_func into self.middleware.download() in self.fetch()
     async def _enqueue_request(self, request: Request) -> Response:
         key, slot = self._get_slot(request)
+        if self.DOWNLOAD_SLOT not in request.meta:
+            # Remember that we picked the slot, rather than the user, so that
+            # RedirectMiddleware knows it may recompute it for a new URL.
+            request.meta["_auto_download_slot"] = True
         request.meta[self.DOWNLOAD_SLOT] = key
         slot.active.add(request)
         self.signals.send_catch_log(

--- a/scrapy/downloadermiddlewares/redirect.py
+++ b/scrapy/downloadermiddlewares/redirect.py
@@ -129,6 +129,13 @@ class BaseRedirectMiddleware:
             cls=None,
             cookies=None,
         )
+        if redirect_request.meta.pop("_auto_download_slot", None):
+            # The download slot was assigned by the downloader from the URL of
+            # source_request, so it must not carry over to a different URL. The
+            # downloader assigns a new one, which is the same slot when the
+            # domain does not change.
+            redirect_request.meta.pop("download_slot", None)
+
         if "_scheme_proxy" in redirect_request.meta:
             source_request_scheme = urlparse_cached(source_request).scheme
             redirect_request_scheme = urlparse_cached(redirect_request).scheme

--- a/tests/test_downloadermiddleware_redirect.py
+++ b/tests/test_downloadermiddleware_redirect.py
@@ -319,6 +319,30 @@ class TestRedirectMiddleware(TestRedirectBase):
         )
         _test_passthrough(Request(url, meta={"handle_httpstatus_all": True}))
 
+    def test_downloader_assigned_slot_dropped_on_new_domain(self):
+        req = Request("http://a.example/")
+        req.meta["download_slot"] = "a.example"
+        req.meta["_auto_download_slot"] = True
+        r = self.mw.process_response(req, self.get_response(req, "http://b.example/"))
+        assert "download_slot" not in r.meta
+        assert "_auto_download_slot" not in r.meta
+
+    def test_downloader_assigned_slot_dropped_on_same_domain(self):
+        # The downloader recomputes the same slot from the URL, so dropping it
+        # unconditionally keeps same-domain redirects on the same slot.
+        req = Request("http://a.example/one")
+        req.meta["download_slot"] = "a.example"
+        req.meta["_auto_download_slot"] = True
+        r = self.mw.process_response(
+            req, self.get_response(req, "http://a.example/two")
+        )
+        assert "download_slot" not in r.meta
+
+    def test_user_assigned_slot_kept(self):
+        req = Request("http://a.example/", meta={"download_slot": "custom"})
+        r = self.mw.process_response(req, self.get_response(req, "http://b.example/"))
+        assert r.meta["download_slot"] == "custom"
+
     def test_latin1_location(self):
         req = Request("http://scrapytest.org/first")
         latin1_location = "/ação".encode("latin1")  # HTTP historically supports latin1

--- a/tests/test_downloaderslotssettings.py
+++ b/tests/test_downloaderslotssettings.py
@@ -54,6 +54,29 @@ class DownloaderSlotsSettingsTestSpider(MetaSpider):
         self.times[slot].append(time.time())
 
 
+class RedirectSlotSpider(MetaSpider):
+    """Follows a redirect to a different host name for the same server."""
+
+    name = "redirect_slot"
+
+    def __init__(self, *args: Any, **kwargs: Any):
+        super().__init__(*args, **kwargs)
+        assert self.mockserver
+        self.slots: list[str] = []
+
+    async def start(self):
+        # 127.0.0.1 and localhost are different host names, so they get
+        # different download slots, while pointing at the same mock server.
+        target = self.mockserver.url("/text").replace("127.0.0.1", "localhost")
+        yield Request(
+            self.mockserver.url(f"/redirect-to?goto={target}"),
+            callback=self.parse,
+        )
+
+    def parse(self, response):
+        self.slots.append(response.meta["download_slot"])
+
+
 class TestCrawl:
     @classmethod
     def setup_class(cls):
@@ -63,6 +86,12 @@ class TestCrawl:
     @classmethod
     def teardown_class(cls):
         cls.mockserver.__exit__(None, None, None)
+
+    @inline_callbacks_test
+    def test_redirect_to_other_host_changes_slot(self):
+        crawler = get_crawler(RedirectSlotSpider)
+        yield crawler.crawl(mockserver=self.mockserver)
+        assert crawler.spider.slots == ["localhost"]
 
     @inline_callbacks_test
     def test_delay(self):


### PR DESCRIPTION
The downloader writes the slot it picked into `request.meta["download_slot"]`
(`Downloader._enqueue_request`), and `_build_redirect_request` copies meta over
to the redirected request. So after a redirect to another domain,
`get_slot_key()` finds the inherited value and keeps using the *first* domain's
slot — `CONCURRENT_REQUESTS_PER_DOMAIN`, `DOWNLOAD_DELAY` and AutoThrottle all
end up applied as if the whole chain belonged to one domain.

Closes #2141.

The tricky part is that a user-set `download_slot` lives at the same meta key,
and that one clearly should survive a redirect. So the downloader now marks the
slot as its own when it's the one filling the key, and the redirect middleware
drops it on that basis. No hostname comparison needed — the downloader just
recomputes from the new URL, which gives back the same slot when the domain
didn't change.

The private `_auto_download_slot` key follows what `_scheme_proxy` already does
a few lines below in the same method, so hopefully it doesn't feel out of place.

Tests:

- three in `test_downloadermiddleware_redirect.py` — slot dropped on a new
  domain, dropped (and recomputed identically) on the same domain, user-set slot
  left alone
- one crawl in `test_downloaderslotssettings.py` that redirects from `127.0.0.1`
  to `localhost` on the same mock server, so the two hostnames give genuinely
  different slots, and asserts the callback sees `localhost`

The redirect ones and the crawl one all fail on master and pass with the fix.
`ruff check`, `ruff format` and the rest of pre-commit are clean, and the
related modules (redirect, metarefresh, downloader, slots, scheduler, pqueues,
downloadermiddleware, engine) pass: 266 passed, 3 skipped.

One thing I left out: no `docs/news.rst` entry, since `download_slot` has no
prose docs beyond the reqmeta list entry and I wasn't sure whether you prefer
contributors to add release notes. Happy to add one.
