### PR TITLE
Retry responses whose body cannot be decompressed

### DIFF
--- a/docs/topics/downloader-middleware.rst
+++ b/docs/topics/downloader-middleware.rst
@@ -706,6 +706,17 @@ HttpCompressionMiddleware
    This middleware also supports decoding `zstd-compressed`_ responses with
    the :ref:`zstd <extras>` extra.
 
+   A body that cannot be decompressed, e.g. one truncated in transit, makes
+   this middleware retry the request, counting the retry under the
+   ``httpcompression/retry`` stats keys. Set the :reqmeta:`dont_retry` request
+   meta key to disable that, and see :setting:`RETRY_TIMES` for the number of
+   retries. Once retries are exhausted the response is dropped with an
+   :exc:`~scrapy.exceptions.IgnoreRequest` exception.
+
+   Note that decompression happens in ``process_response()``, so these retries
+   cannot come from :class:`RetryMiddleware`, whose ``process_exception()``
+   method only sees download handler and ``process_request()`` errors.
+
 .. _brotli: https://www.ietf.org/rfc/rfc7932.txt
 .. _zstd-compressed: https://www.ietf.org/rfc/rfc8478.txt
 

--- a/scrapy/downloadermiddlewares/httpcompression.py
+++ b/scrapy/downloadermiddlewares/httpcompression.py
@@ -7,10 +7,12 @@ from logging import getLogger
 from typing import TYPE_CHECKING, Any
 
 from scrapy import Request, Spider, signals
+from scrapy.downloadermiddlewares.retry import get_retry_request
 from scrapy.exceptions import IgnoreRequest, NotConfigured, ScrapyDeprecationWarning
 from scrapy.http import Response, TextResponse
 from scrapy.responsetypes import responsetypes
 from scrapy.utils._compression import (
+    _DECOMPRESSION_ERRORS,
     _DecompressionMaxSizeExceeded,
     _inflate,
     _unbrotli,
@@ -19,6 +21,7 @@ from scrapy.utils._compression import (
 from scrapy.utils.decorators import _warn_spider_arg
 from scrapy.utils.deprecate import warn_on_deprecated_spider_attribute
 from scrapy.utils.gz import gunzip
+from scrapy.utils.python import global_object_name
 
 if TYPE_CHECKING:
     # typing.Self requires Python 3.11
@@ -54,10 +57,12 @@ class HttpCompressionMiddleware:
                 stacklevel=2,
             )
             self.stats = stats
+            self.crawler = None
             self._max_size = 1073741824
             self._warn_size = 33554432
             return
         self.stats = crawler.stats
+        self.crawler = crawler
         self._max_size = crawler.settings.getint("DOWNLOAD_MAXSIZE")
         self._warn_size = crawler.settings.getint("DOWNLOAD_WARNSIZE")
         crawler.signals.connect(self.open_spider, signals.spider_opened)
@@ -108,6 +113,8 @@ class HttpCompressionMiddleware:
                 )
                 logger.warning(msg)
                 raise IgnoreRequest(msg) from e
+            except _DECOMPRESSION_ERRORS as e:
+                return self._handle_decompression_error(request, response, e)
             if len(response.body) < warn_size <= len(decoded_body):
                 logger.warning(
                     f"{response} body size after decompression "
@@ -135,6 +142,35 @@ class HttpCompressionMiddleware:
             if not content_encoding:
                 del response.headers["Content-Encoding"]
         return response
+
+    def _handle_decompression_error(
+        self, request: Request, response: Response, exception: Exception
+    ) -> Request:
+        """Retry *request*, whose body could not be decompressed.
+
+        A body that fails to decompress is usually a body that was truncated in
+        transit, so it is worth requesting again. Decompression happens in
+        process_response(), and exceptions raised there do not reach the
+        process_exception() method of RetryMiddleware, so the retry is requested
+        here instead.
+        """
+        reason = f"decompression error ({global_object_name(type(exception))})"
+        if (
+            self.crawler
+            and self.crawler.spider
+            and not request.meta.get("dont_retry", False)
+        ):
+            new_request = get_retry_request(
+                request,
+                spider=self.crawler.spider,
+                reason=reason,
+                stats_base_key="httpcompression/retry",
+            )
+            if new_request:
+                return new_request
+        msg = f"Ignored response {response} because of a {reason}: {exception}"
+        logger.warning(msg)
+        raise IgnoreRequest(msg) from exception
 
     def _handle_encoding(
         self, body: bytes, content_encoding: list[bytes], max_size: int

--- a/scrapy/settings/default_settings.py
+++ b/scrapy/settings/default_settings.py
@@ -516,8 +516,12 @@ RETRY_EXCEPTIONS = [
     "twisted.internet.error.ConnectionDone",
     "twisted.internet.error.ConnectError",
     "twisted.internet.error.ConnectionLost",
-    # OSError is raised by the HttpCompression middleware when trying to
-    # decompress an empty response
+    # OSError covers socket errors from download handlers. It used to be
+    # documented here as the exception that HttpCompressionMiddleware raises for
+    # a body it cannot decompress, but that never reached this setting:
+    # decompression happens in process_response(), and exceptions raised there
+    # are not passed to the process_exception() method of RetryMiddleware.
+    # HttpCompressionMiddleware requests those retries itself.
     OSError,
     "scrapy.core.downloader.handlers.http11.TunnelError",
 ]

--- a/scrapy/utils/_compression.py
+++ b/scrapy/utils/_compression.py
@@ -1,5 +1,7 @@
 import contextlib
+import struct
 import zlib
+from importlib.util import find_spec
 from io import BytesIO
 
 try:
@@ -12,6 +14,22 @@ with contextlib.suppress(ImportError):
 
 
 _CHUNK_SIZE = 65536  # 64 KiB
+
+#: Exceptions that the decompression functions below raise for a body that
+#: cannot be decompressed, e.g. one truncated by a lost connection. Each codec
+#: reports failure differently: gzip raises gzip.BadGzipFile (an OSError),
+#: EOFError or struct.error, deflate raises zlib.error, and the brotli and zstd
+#: bindings raise their own exception types.
+_DECOMPRESSION_ERRORS: tuple[type[Exception], ...] = (
+    EOFError,
+    OSError,  # includes gzip.BadGzipFile
+    struct.error,
+    zlib.error,
+    brotli.error,
+)
+
+if find_spec("zstandard") is not None:
+    _DECOMPRESSION_ERRORS += (zstandard.ZstdError,)
 
 
 class _DecompressionMaxSizeExceeded(ValueError):

--- a/tests/test_downloadermiddleware.py
+++ b/tests/test_downloadermiddleware.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import asyncio
 from contextlib import asynccontextmanager
-from gzip import BadGzipFile
 from typing import TYPE_CHECKING
 from unittest import mock
 
@@ -10,7 +9,7 @@ import pytest
 from twisted.internet.defer import Deferred, succeed
 
 from scrapy.core.downloader.middleware import DownloaderMiddlewareManager
-from scrapy.exceptions import ScrapyDeprecationWarning, _InvalidOutput
+from scrapy.exceptions import IgnoreRequest, ScrapyDeprecationWarning, _InvalidOutput
 from scrapy.http import Request, Response
 from scrapy.spiders import Spider
 from scrapy.utils.defer import maybe_deferred_to_future
@@ -102,12 +101,11 @@ class TestDefaults(TestManagerBase):
             "Not redirected to location header"
         )
 
-    @coroutine_test
-    async def test_200_and_invalid_gzipped_body_must_fail(self):
-        req = Request("http://example.com")
+    @staticmethod
+    def _invalid_gzipped_response(request: Request) -> Response:
         body = b"<p>You are being redirected</p>"
-        resp = Response(
-            req.url,
+        return Response(
+            request.url,
             status=200,
             body=body,
             headers={
@@ -117,9 +115,26 @@ class TestDefaults(TestManagerBase):
                 "Location": "http://example.com/login",
             },
         )
-        with pytest.raises(BadGzipFile):
+
+    @coroutine_test
+    async def test_200_and_invalid_gzipped_body_must_fail(self):
+        # HttpCompressionMiddleware retries a body it cannot decompress instead
+        # of letting the BadGzipFile out, so the response never reaches the
+        # spider either way.
+        req = Request("http://example.com")
+        async with self.get_mwman() as mwman:
+            result = await self._download(
+                mwman, req, self._invalid_gzipped_response(req)
+            )
+        assert isinstance(result, Request)
+        assert result.url == req.url
+
+    @coroutine_test
+    async def test_200_and_invalid_gzipped_body_must_fail_without_retries(self):
+        req = Request("http://example.com", meta={"max_retry_times": 0})
+        with pytest.raises(IgnoreRequest):
             async with self.get_mwman() as mwman:
-                await self._download(mwman, req, resp)
+                await self._download(mwman, req, self._invalid_gzipped_response(req))
 
 
 class TestResponseFromProcessRequest(TestManagerBase):

--- a/tests/test_downloadermiddleware_httpcompression.py
+++ b/tests/test_downloadermiddleware_httpcompression.py
@@ -207,6 +207,61 @@ class TestHttpCompression:
         assert newresponse is not response
         assert newresponse.headers.getlist("Content-Encoding") == [b"zstd"]
 
+    def _get_undecodable_response(self, content_encoding: str, body: bytes) -> Response:
+        """A response whose body cannot be decompressed, as if truncated."""
+        response = Response(
+            "http://scrapytest.org/",
+            body=body,
+            headers={"Content-Encoding": content_encoding},
+        )
+        response.request = Request("http://scrapytest.org/")
+        return response
+
+    @pytest.mark.parametrize(
+        ("content_encoding", "body"),
+        [
+            # gzip raises EOFError for a stream that ends early
+            ("gzip", b"\x1f\x8b\x08" + b"truncated"),
+            # gzip raises gzip.BadGzipFile, an OSError, for a bad header
+            ("gzip", b"\x1f\x8b\xff" + b"bad-header"),
+            # deflate raises zlib.error
+            ("deflate", b"not-deflate-data"),
+        ],
+    )
+    def test_process_response_undecodable_body_retries(self, content_encoding, body):
+        self.crawler.spider = self.crawler._create_spider("scrapytest.org")
+        response = self._get_undecodable_response(content_encoding, body)
+        assert response.request
+        result = self.mw.process_response(response.request, response)
+        assert isinstance(result, Request), f"expected a retry request, got {result!r}"
+        assert result.url == response.request.url
+        self.assertStatsEqual("httpcompression/retry/count", 1)
+
+    def test_process_response_undecodable_body_dont_retry(
+        self, caplog: pytest.LogCaptureFixture
+    ):
+        self.crawler.spider = self.crawler._create_spider("scrapytest.org")
+        response = self._get_undecodable_response("gzip", b"\x1f\x8b\x08trunc")
+        assert response.request
+        response.request.meta["dont_retry"] = True
+        with (
+            caplog.at_level(
+                WARNING, logger="scrapy.downloadermiddlewares.httpcompression"
+            ),
+            pytest.raises(IgnoreRequest),
+        ):
+            self.mw.process_response(response.request, response)
+        assert "decompression error" in caplog.text
+        self.assertStatsEqual("httpcompression/retry/count", None)
+
+    def test_process_response_undecodable_body_retries_exhausted(self):
+        self.crawler.spider = self.crawler._create_spider("scrapytest.org")
+        response = self._get_undecodable_response("gzip", b"\x1f\x8b\x08trunc")
+        assert response.request
+        response.request.meta["max_retry_times"] = 0
+        with pytest.raises(IgnoreRequest):
+            self.mw.process_response(response.request, response)
+
     def test_process_response_rawdeflate(self):
         response = self._getresponse("rawdeflate")
         assert response.request


### PR DESCRIPTION
`RETRY_EXCEPTIONS` lists `OSError` with this comment:

```python
# OSError is raised by the HttpCompression middleware when trying to
# decompress an empty response
OSError,
```

That retry has never worked, for the reason @kmike gave on the issue: the
decompression happens in `process_response()`, and `process_exception()` only
gets errors from download handlers and `process_request()`. So the exception goes
straight out of the downloader instead — which isn't what `process_response()` is
documented to raise either (only `IgnoreRequest`).

Easy to see:

```python
>>> # a truncated gzip body, through the middleware manager with default middlewares
>>> await mwman.download_async(download_func, request)
EOFError: Compressed file ended before the end-of-stream marker was reached
>>> crawler.stats.get_stats()   # no retry keys
```

Closes #1900.

A body that won't decompress is usually a body that got truncated in transit, so
it's worth asking again. Since `RetryMiddleware` can't be the one to do it,
`HttpCompressionMiddleware` now asks for the retry itself via `get_retry_request()`,
respecting `dont_retry` and raising `IgnoreRequest` once retries run out. Retries
are counted under `httpcompression/retry` so they're distinguishable from
ordinary ones.

Each codec signals failure differently — `gzip.BadGzipFile` (an `OSError`),
`EOFError` or `struct.error` for gzip, `zlib.error` for deflate, and their own
exception types for brotli and zstd — so I collected them in
`_DECOMPRESSION_ERRORS` in `_compression.py`, next to the helpers that raise them.

I left `OSError` in `RETRY_EXCEPTIONS` since it still covers socket errors from
download handlers, and only corrected the comment. Removing it would be a
separate, backwards-incompatible call that's yours to make.

**The bit that needs your opinion:** this changes
`test_200_and_invalid_gzipped_body_must_fail`, which asserted that `BadGzipFile`
comes out of the manager. I didn't want to quietly rewrite an intentional test,
so: the request still fails, it just fails after retrying and then as
`IgnoreRequest`. I split it into the retry case and a `max_retry_times: 0` case
that keeps the original "must fail" shape. If you'd rather not add retry
behaviour here, the smaller version of this PR is to raise `IgnoreRequest`
immediately instead — same containment, no retries — and I'm happy to switch.

Tests: five parametrised cases in `test_downloadermiddleware_httpcompression.py`
covering the gzip (`EOFError`, `BadGzipFile`) and deflate (`zlib.error`) failure
families, plus `dont_retry` and exhausted retries. All five fail on master.

`ruff check`, `ruff format`, the rest of pre-commit, and `mypy` on the two
changed source files are clean. Full suite: 3831 passed, 8 failed — the 8 are
the `reactorless`/`no_reactor` subprocess tests and the bench command, and they
fail identically on a clean master checkout here, so they look like something
about my local env rather than this change.

No `docs/news.rst` entry again, same question as my other PR — say the word and
I'll add one.
