### PR TITLE
Fix ModuleNotFoundError when disabling removed components in settings

### DIFF
--- a/scrapy/settings/__init__.py
+++ b/scrapy/settings/__init__.py
@@ -366,7 +366,7 @@ class BaseSettings(MutableMapping[str, Any]):
         def normalize_key(key: Any) -> Any:
             try:
                 loaded_key = load_object(key)
-            except (NameError, TypeError, ValueError):
+            except Exception:
                 loaded_key = key
             else:
                 import_path = global_object_name(loaded_key)


### PR DESCRIPTION
### Problem

Since Scrapy 2.17, `get_component_priority_dict_with_base()` calls `normalize_key()` on **every** key in `EXTENSIONS`, `SPIDER_MIDDLEWARES`, and `DOWNLOADER_MIDDLEWARES` — including keys whose value is `None` (meaning \"disable this component\"). `normalize_key()` calls `load_object()`, which calls `importlib.import_module()`. When the module no longer exists (e.g. a previously-default extension that was removed from Scrapy), this raises `ModuleNotFoundError` and crashes the crawl startup.

The old guard only caught `(NameError, TypeError, ValueError)`, so `ImportError`/`ModuleNotFoundError` propagated uncaught.

**Reproducer:**

```python\nfrom scrapy.settings import Settings\n\ns = Settings()\ns.set(\"EXTENSIONS\", {\"nonexistent.module.Extension\": None}, priority=\"cmdline\")\ns.get_component_priority_dict_with_base(\"EXTENSIONS\")\n# Scrapy <=2.14: OK\n# Scrapy 2.17:   ModuleNotFoundError: No module named 'nonexistent'\n```\n\nA common real-world case: projects that for years disabled `scrapy.webservice.WebService` (removed in Scrapy 2.0) now crash on 2.17.

### Fix

Widen the exception clause in `normalize_key` from `except (NameError, TypeError, ValueError):` to `except Exception:`. When the import fails, `loaded_key` stays as the raw string key; since the value is `None`, the `if v is not None` filter drops it, so disabling still works correctly.

Normalisation is still needed for `None`-valued keys to match default-BASE entries and actually disable them — skipping `None` keys would silently re-enable anything they were meant to turn off.

Fixes #7820