### PR TITLE
fix flaky test_slow_pipeline by comparing items unordered

### DIFF
--- a/tests/test_spider_start.py
+++ b/tests/test_spider_start.py
@@ -22,12 +22,6 @@ ITEM_A = {"id": "a"}
 ITEM_B = {"id": "b"}
 
 
-def _sort_key(item: Any) -> Any:
-    # Items used in these tests are plain dicts; sort by contents so
-    # unordered comparisons are deterministic regardless of item shape.
-    return tuple(sorted(item.items())) if isinstance(item, dict) else item
-
-
 async def _test_spider(
     spider: type[Spider],
     expected_items: list[Any] | None = None,
@@ -46,8 +40,8 @@ async def _test_spider(
     await crawler.crawl_async()
     assert crawler.stats.get_value("finish_reason") == "finished"
     if not ordered:
-        actual_items = sorted(actual_items, key=_sort_key)
-        expected_items = sorted(expected_items, key=_sort_key)
+        actual_items = sorted(actual_items, key=repr)
+        expected_items = sorted(expected_items, key=repr)
 
     assert actual_items == expected_items
 

--- a/tests/test_spider_start.py
+++ b/tests/test_spider_start.py
@@ -32,22 +32,23 @@ async def _test_spider(
     spider: type[Spider],
     expected_items: list[Any] | None = None,
     settings: dict[str, Any] | None = None,
+    *,
     ordered: bool = True,
 ) -> None:
-    actual_items = []
+    actual_items: list[Any] = []
     expected_items = [] if expected_items is None else expected_items
 
-    def track_item(item, response, spider):
+    def track_item(item: Any, response: Any, spider: Spider) -> None:
         actual_items.append(item)
 
     crawler = get_crawler(spider, settings)
     crawler.signals.connect(track_item, signals.item_scraped)
     await crawler.crawl_async()
     assert crawler.stats.get_value("finish_reason") == "finished"
-    if ordered:
-        assert sorted(actual_items, key=_sort_key) == sorted(
-            expected_items, key=_sort_key
-        )
+    if not ordered:
+        actual_items = sorted(actual_items, key=_sort_key)
+        expected_items = sorted(expected_items, key=_sort_key)
+
     assert actual_items == expected_items
 
 

--- a/tests/test_spider_start.py
+++ b/tests/test_spider_start.py
@@ -22,10 +22,17 @@ ITEM_A = {"id": "a"}
 ITEM_B = {"id": "b"}
 
 
+def _sort_key(item: Any) -> Any:
+    # Items used in these tests are plain dicts; sort by contents so
+    # unordered comparisons are deterministic regardless of item shape.
+    return tuple(sorted(item.items())) if isinstance(item, dict) else item
+
+
 async def _test_spider(
     spider: type[Spider],
     expected_items: list[Any] | None = None,
     settings: dict[str, Any] | None = None,
+    ordered: bool = True,
 ) -> None:
     actual_items = []
     expected_items = [] if expected_items is None else expected_items
@@ -37,6 +44,10 @@ async def _test_spider(
     crawler.signals.connect(track_item, signals.item_scraped)
     await crawler.crawl_async()
     assert crawler.stats.get_value("finish_reason") == "finished"
+    if ordered:
+        assert sorted(actual_items, key=_sort_key) == sorted(
+            expected_items, key=_sort_key
+        )
     assert actual_items == expected_items
 
 
@@ -124,4 +135,5 @@ async def test_slow_pipeline() -> None:
         TestSpider,
         [ITEM_A, ITEM_B],
         {"ITEM_PIPELINES": {SlowPipeline: 0}},
+        ordered=False,
     )


### PR DESCRIPTION
Fixes #8006

`test_slow_pipeline` asserts a strict item order (A then B), but both
items get an identical artificial delay in `SlowPipeline.process_item`.
Their completion order depends on event-loop scheduling rather than
submission order, so the assertion is racy — reproduced on the Windows
"min" CI job where timer resolution is coarser:
https://github.com/scrapy/scrapy/actions/runs/32053018703/job/95456761821

Fix: added an `ordered` flag to `_test_spider` (default `True`, so every
other test is unaffected). `test_slow_pipeline` now compares items
unordered instead of asserting a strict sequence.

Verified locally with 20x reruns via pytest-repeat, all passing.