### PR TITLE
docs: clarify asyncio checks during component initialization

### DIFF
--- a/docs/topics/asyncio.rst
+++ b/docs/topics/asyncio.rst
@@ -117,24 +117,38 @@ Enforcing asyncio as a requirement
 ==================================
 
 If you are writing a :ref:`component <topics-components>` that requires asyncio
-to work, use :func:`scrapy.utils.asyncio.is_asyncio_available` to
-:ref:`enforce it as a requirement <enforce-component-requirements>`. For
-example:
+to work, use :func:`scrapy.utils.asyncio.is_asyncio_available` from code that
+runs during the crawl to :ref:`enforce it as a requirement
+<enforce-component-requirements>`. This function checks runtime state, so it
+must not be called from a component constructor: in reactorless mode, Scrapy
+initializes components before it starts the asyncio event loop. During
+initialization, use the crawler settings instead. For example:
 
 .. code-block:: python
 
     from scrapy.utils.asyncio import is_asyncio_available
+    from scrapy.utils.reactor import is_asyncio_reactor_installed
 
 
     class MyComponent:
-        def __init__(self):
-            if not is_asyncio_available():
+        @classmethod
+        def from_crawler(cls, crawler):
+            if not crawler.settings.getbool("TWISTED_REACTOR_ENABLED"):
+                # Reactorless mode uses asyncio once the crawl starts, but the
+                # loop is not running yet during component initialization.
+                return cls()
+            if not is_asyncio_reactor_installed():
                 raise ValueError(
                     f"{MyComponent.__qualname__} requires the asyncio support. "
                     f"Make sure you have configured the asyncio reactor in the "
                     f"TWISTED_REACTOR setting. See the asyncio documentation "
                     f"of Scrapy for more information."
                 )
+            return cls()
+
+        async def spider_opened(self):
+            if not is_asyncio_available():
+                raise RuntimeError("asyncio support is not available")
 
 .. autofunction:: scrapy.utils.asyncio.is_asyncio_available
 .. autofunction:: scrapy.utils.reactor.is_asyncio_reactor_installed

--- a/scrapy/utils/asyncio.py
+++ b/scrapy/utils/asyncio.py
@@ -59,6 +59,12 @@ def is_asyncio_available() -> bool:
     but it's possible to await on :class:`~twisted.internet.defer.Deferred`
     objects.
 
+    This function checks runtime state and should not be called from a component
+    constructor. In reactorless mode, components are initialized before
+    Scrapy starts its asyncio event loop. During initialization, inspect
+    ``crawler.settings.getbool("TWISTED_REACTOR_ENABLED")`` instead, and call
+    this function later from code running as part of the crawl.
+
     .. note:: As this function uses :func:`asyncio.get_running_loop()`, it will
         only detect the event loop if called in the same thread and from the
         code that runs inside that loop (this shouldn't be a problem when
@@ -86,7 +92,9 @@ def is_asyncio_available() -> bool:
     if not is_reactor_installed():
         raise RuntimeError(
             "is_asyncio_available() called without an installed reactor"
-            " or running asyncio loop."
+            " or running asyncio loop. Components should check the"
+            " TWISTED_REACTOR_ENABLED setting during initialization and call"
+            " is_asyncio_available() from code running during the crawl."
         )
 
     return is_asyncio_reactor_installed()

--- a/tests/test_utils_asyncio.py
+++ b/tests/test_utils_asyncio.py
@@ -28,6 +28,21 @@ async def test_is_asyncio_available(reactor_pytest: str) -> None:
     assert is_asyncio_available() == (reactor_pytest != "default")
 
 
+def test_is_asyncio_available_explains_initialization_limit() -> None:
+    with (
+        mock.patch(
+            "scrapy.utils.asyncio.asyncio.get_running_loop",
+            side_effect=RuntimeError,
+        ),
+        mock.patch("scrapy.utils.asyncio.is_reactor_installed", return_value=False),
+        pytest.raises(
+            RuntimeError,
+            match=r"TWISTED_REACTOR_ENABLED.*during initialization",
+        ),
+    ):
+        is_asyncio_available()
+
+
 @coroutine_test
 async def test_sleep() -> None:
     events: list[str] = []


### PR DESCRIPTION
## Summary

`is_asyncio_available()` is currently documented as a component requirement check, but calling it from an extension constructor raises in reactorless mode because components initialize before Scrapy starts the asyncio loop.

This patch:

- documents the initialization-time limitation;
- shows the supported `crawler.settings` / reactor check during `from_crawler()`;
- keeps `is_asyncio_available()` for code running during the crawl;
- makes the early-call error actionable;
- adds a regression test for the error guidance.

Fixes #7812

## Validation

- Reproduced the reported `Crawler._apply_settings()` failure.
- Verified the corrected `from_crawler()` pattern initializes successfully.
- `pytest -q tests/test_utils_asyncio.py tests/test_crawler.py`: 60 passed.
- Ruff check and formatting: passed.
- `git diff --check`: passed.
- Full collection: 4,286 tests. The full run exceeded a five-minute local Windows limit without a failure summary; no full-suite pass is claimed.

No runtime behavior was changed beyond the actionable error message.