### PR TITLE
Refresh cached response headers on RFC2616 revalidation

### DIFF
--- a/scrapy/downloadermiddlewares/httpcache.py
+++ b/scrapy/downloadermiddlewares/httpcache.py
@@ -139,6 +139,7 @@ class HttpCacheMiddleware:
 
         if self.policy.is_cached_response_valid(cachedresponse, response, request):
             self.stats.inc_value("httpcache/revalidate")
+            self._cache_response(cachedresponse, request)
             return cachedresponse
 
         self.stats.inc_value("httpcache/invalidate")

--- a/scrapy/extensions/httpcache.py
+++ b/scrapy/extensions/httpcache.py
@@ -170,7 +170,20 @@ class RFC2616Policy:
                 return True
 
         # Use the cached response if the server says it hasn't changed.
-        return response.status == 304
+        if response.status == 304:
+            cachedresponse.headers.update(response.headers)
+            warnings = [
+                warning
+                for warning in cachedresponse.headers.getlist(b"Warning")
+                if not warning.lstrip().startswith(b"1")
+            ]
+            if warnings:
+                cachedresponse.headers.setlist(b"Warning", warnings)
+            elif b"Warning" in cachedresponse.headers:
+                del cachedresponse.headers[b"Warning"]
+            return True
+
+        return False
 
     def _set_conditional_validators(
         self, request: Request, cachedresponse: Response

--- a/tests/test_downloadermiddleware_httpcache.py
+++ b/tests/test_downloadermiddleware_httpcache.py
@@ -7,6 +7,7 @@ import tempfile
 import time
 from contextlib import contextmanager
 from pathlib import Path
+from types import SimpleNamespace
 from typing import TYPE_CHECKING, Any
 from unittest import mock
 
@@ -16,7 +17,9 @@ from scrapy.downloadermiddlewares.httpcache import HttpCacheMiddleware
 from scrapy.exceptions import IgnoreRequest
 from scrapy.extensions.httpcache import DummyPolicy
 from scrapy.http import HtmlResponse, Request, Response
+from scrapy.settings import Settings
 from scrapy.spiders import Spider
+from scrapy.statscollectors import MemoryStatsCollector
 from scrapy.utils.misc import build_from_crawler
 from scrapy.utils.test import get_crawler
 
@@ -32,6 +35,61 @@ class AlwaysStalePolicy(DummyPolicy):
 
     def is_cached_response_fresh(self, cachedresponse, request):
         return False
+
+
+def test_rfc2616_revalidation_refreshes_cached_response():
+    settings = Settings(
+        {
+            "HTTPCACHE_ENABLED": True,
+            "HTTPCACHE_POLICY": "scrapy.extensions.httpcache.RFC2616Policy",
+            "HTTPCACHE_STORAGE": "scrapy.extensions.httpcache.FilesystemCacheStorage",
+        }
+    )
+    crawler = SimpleNamespace(settings=settings, spider=object())
+    middleware = HttpCacheMiddleware(settings, MemoryStatsCollector(crawler))
+    storage = SimpleNamespace(response=None)
+
+    def retrieve_response(spider, request):
+        return storage.response.copy() if storage.response else None
+
+    def store_response(spider, request, response):
+        storage.response = response.copy()
+
+    middleware.storage = SimpleNamespace(
+        retrieve_response=retrieve_response,
+        store_response=store_response,
+    )
+    middleware.crawler = crawler
+
+    request = Request("http://example.com")
+    cached_response = Response(
+        request.url,
+        headers={
+            "Cache-Control": "max-age=60",
+            "Date": "Wed, 01 Jan 2020 00:00:00 GMT",
+            "ETag": '"v1"',
+        },
+        body=b"cached",
+    )
+    assert middleware.process_response(request, cached_response) is cached_response
+
+    revalidation_request = request.replace(headers={"Cache-Control": "max-age=0"})
+    assert middleware.process_request(revalidation_request) is None
+    revalidated_response = Response(
+        request.url,
+        status=304,
+        headers={
+            "Cache-Control": "max-age=3600",
+            "Date": email.utils.formatdate(),
+            "ETag": '"v1"',
+        },
+    )
+    response = middleware.process_response(revalidation_request, revalidated_response)
+    assert response.status == 200
+    assert response.body == b"cached"
+    assert response.headers["Cache-Control"] == b"max-age=3600"
+
+    assert middleware.process_request(request) is not None
 
 
 class TestBase:


### PR DESCRIPTION
Fixes #3778

`RFC2616Policy.is_cached_response_valid()` treated a 304 response as a boolean success and discarded the headers it carried. `HttpCacheMiddleware` then kept returning the stale cached response without ever re-storing it, so the cache lifetime (`Date`/`Cache-Control`/validators) never advanced past the original response, even after a successful revalidation.

This merges the 304 response's headers into the cached response (dropping obsolete 1xx `Warning` headers, per HTTP caching semantics), then writes the refreshed response back through the configured storage.

## Reproduction

Added a regression test (`test_rfc2616_revalidation_refreshes_cached_response`) that:
1. Stores a 200 response with a 1-minute `max-age` and an old `Date`.
2. Makes the cached entry stale.
3. Simulates a successful 304 revalidation with a new `Date` and a longer `max-age`.
4. Requests the same URL again and confirms it's served from cache instead of triggering another revalidation.

Before this change, step 4 failed — the stale `Date`/`max-age` from the original response meant the entry looked expired again immediately, forcing a needless revalidation on every subsequent request.

## Testing

- New test passes; ran the full `test_downloadermiddleware_httpcache` suite locally, all passing.