### PR TITLE
Add GCS append support (#7823)

### DIFF
--- a/docs/topics/feed-exports.rst
+++ b/docs/topics/feed-exports.rst
@@ -290,6 +290,29 @@ storage backend is: ``True``.
 .. caution:: The value ``True`` in ``overwrite`` will cause you to lose the
      previous version of your data.
 
+.. versionchanged:: VERSION
+   Setting ``overwrite`` to ``False`` appends to the target object. It was
+   previously ignored, with a warning.
+
+Since objects cannot be modified, appending uploads the new data as a separate,
+temporary object of the target bucket, composes it with the target object into
+a `composite object`_, and then deletes it. Mind that:
+
+-   Appending requires permission to read, create and delete objects, while
+    overwriting only requires permission to create them.
+
+-   Composite objects have no MD5 hash.
+
+-   Appending takes several API calls, so it is not atomic. If one of them
+    fails, the temporary object may be left behind.
+
+-   In buckets with `object versioning`_ or `soft delete`_ enabled, appending
+    creates additional object versions, which may increase storage costs.
+
+.. _composite object: https://docs.cloud.google.com/storage/docs/composite-objects
+.. _object versioning: https://docs.cloud.google.com/storage/docs/object-versioning
+.. _soft delete: https://docs.cloud.google.com/storage/docs/soft-delete
+
 This storage backend uses :ref:`delayed file delivery <delayed-file-delivery>`.
 
 
@@ -536,7 +559,7 @@ as a fallback value if that key is not provided for a specific feed definition:
 
     -   :ref:`topics-feed-storage-s3`: ``True`` (appending is not supported)
 
-    -   :ref:`topics-feed-storage-gcs`: ``True`` (appending is not supported)
+    -   :ref:`topics-feed-storage-gcs`: ``True``
 
     -   :ref:`topics-feed-storage-stdout`: ``False`` (overwriting is not supported)
 

--- a/scrapy/extensions/feedexport.py
+++ b/scrapy/extensions/feedexport.py
@@ -19,6 +19,7 @@ from pathlib import Path, PureWindowsPath
 from tempfile import NamedTemporaryFile
 from typing import IO, TYPE_CHECKING, Any, Protocol, TypeAlias, cast
 from urllib.parse import unquote, urlparse
+from uuid import uuid4
 
 from twisted.internet.defer import Deferred, DeferredList
 from w3lib.url import file_uri_to_path
@@ -37,6 +38,7 @@ from scrapy.utils.python import without_none_values
 
 if TYPE_CHECKING:
     from _typeshed import OpenBinaryMode
+    from google.cloud.storage import Blob, Bucket
 
     # typing.Self requires Python 3.11
     from typing_extensions import Self
@@ -311,13 +313,7 @@ class GCSFeedStorage(BlockingFeedStorage):
         assert u.hostname
         self.bucket_name: str = u.hostname
         self.blob_name: str = u.path[1:]  # remove first "/"
-
-        if feed_options and feed_options.get("overwrite", True) is False:
-            logger.warning(
-                "GCS does not support appending to files. To "
-                "suppress this warning, remove the overwrite "
-                "option from your FEEDS setting or set it to True."
-            )
+        self.overwrite: bool = not feed_options or feed_options.get("overwrite", True)
 
     @classmethod
     def from_crawler(
@@ -341,10 +337,44 @@ class GCSFeedStorage(BlockingFeedStorage):
 
             client = Client(project=self.project_id)
             bucket = client.bucket(self.bucket_name)
-            blob = bucket.blob(self.blob_name)
-            blob.upload_from_file(file, predefined_acl=self.acl)
+            old_blob = None if self.overwrite else bucket.get_blob(self.blob_name)
+            if old_blob is None:
+                blob = bucket.blob(self.blob_name)
+                blob.upload_from_file(file, predefined_acl=self.acl)
+            else:
+                self._append_in_thread(bucket, old_blob, file)
         finally:
             file.close()
+
+    def _append_in_thread(
+        self, bucket: Bucket, old_blob: Blob, file: IO[bytes]
+    ) -> None:
+        # Objects cannot be modified, so the new data is uploaded as a separate,
+        # temporary object, which is then concatenated with the existing object
+        # into a composite object:
+        # https://docs.cloud.google.com/storage/docs/composite-objects
+        new_blob = bucket.blob(f"{self.blob_name}.scrapy-append-{uuid4().hex}")
+        # Composition sources must share the storage class of the destination.
+        new_blob.storage_class = old_blob.storage_class
+        new_blob.upload_from_file(file)
+        try:
+            blob = bucket.blob(self.blob_name)
+            if old_blob.content_type:
+                blob.content_type = old_blob.content_type
+            blob.compose([old_blob, new_blob])
+            if self.acl:
+                # Composition does not support predefined ACLs.
+                blob.acl.save_predefined(self.acl)
+        finally:
+            try:
+                new_blob.delete()
+            except Exception:
+                logger.warning(
+                    "Could not delete the temporary object gs://%s/%s.",
+                    self.bucket_name,
+                    new_blob.name,
+                    exc_info=True,
+                )
 
 
 class FTPFeedStorage(BlockingFeedStorage):

--- a/tests/test_feedexport_storages.py
+++ b/tests/test_feedexport_storages.py
@@ -29,7 +29,11 @@ from scrapy.utils.defer import maybe_deferred_to_future
 from scrapy.utils.misc import build_from_crawler
 from scrapy.utils.test import get_crawler
 from tests.mockserver.ftp import MockFTPServer
-from tests.utils.cloud import mock_google_cloud_storage
+from tests.utils.cloud import (
+    mock_google_cloud_storage,
+    mock_google_cloud_storage_blob,
+    mock_google_cloud_storage_blobs,
+)
 from tests.utils.decorators import coroutine_test
 
 
@@ -516,6 +520,9 @@ class TestS3FeedStorage:
 
 
 class TestGCSFeedStorage:
+    APPEND_UUID_HEX = "1a2b3c"
+    TEMP_BLOB_NAME = f"export.csv.scrapy-append-{APPEND_UUID_HEX}"
+
     def test_parse_settings(self):
         pytest.importorskip("google.cloud.storage")
 
@@ -592,20 +599,129 @@ class TestGCSFeedStorage:
             blob_mock.upload_from_file.assert_called_once_with(f, predefined_acl=acl)
             f.close.assert_called_once_with()
 
-    def test_overwrite_default(self, caplog: pytest.LogCaptureFixture):
-        with caplog.at_level(logging.DEBUG):
-            GCSFeedStorage("gs://mybucket/export.csv", "myproject-123", "custom-acl")
-        assert "GCS does not support appending to files" not in caplog.text
+    @pytest.fixture
+    def append_mocks(self):
+        """Mock the google-cloud-storage classes and the object name suffix
+        used when appending.
 
-    def test_overwrite_false(self, caplog: pytest.LogCaptureFixture):
-        with caplog.at_level(logging.DEBUG):
-            GCSFeedStorage(
-                "gs://mybucket/export.csv",
-                "myproject-123",
-                "custom-acl",
-                feed_options={"overwrite": False},
-            )
-        assert "GCS does not support appending to files" in caplog.text
+        Yields the Bucket mock and a dict of Blob mocks by object name, which
+        may be pre-populated to configure the Blob mock of a given object.
+        """
+        pytest.importorskip("google.cloud.storage")
+
+        (client_mock, bucket_mock, blob_mocks) = mock_google_cloud_storage_blobs()
+        with (
+            mock.patch("google.cloud.storage.Client", return_value=client_mock),
+            mock.patch("scrapy.extensions.feedexport.uuid4") as uuid4_mock,
+        ):
+            uuid4_mock.return_value.hex = self.APPEND_UUID_HEX
+            yield bucket_mock, blob_mocks
+
+    @staticmethod
+    def _append(file: Any, acl: str | None = "publicRead") -> Any:
+        storage = GCSFeedStorage(
+            "gs://mybucket/export.csv",
+            "myproject-123",
+            acl,
+            feed_options={"overwrite": False},
+        )
+        return maybe_deferred_to_future(storage.store(file))
+
+    @coroutine_test
+    async def test_append_to_missing_object(self, append_mocks):
+        bucket_mock, blob_mocks = append_mocks
+        f = mock.Mock()
+
+        await self._append(f)
+
+        bucket_mock.get_blob.assert_called_once_with("export.csv")
+        assert set(blob_mocks) == {"export.csv"}
+        blob_mock = blob_mocks["export.csv"]
+        blob_mock.upload_from_file.assert_called_once_with(
+            f, predefined_acl="publicRead"
+        )
+        blob_mock.compose.assert_not_called()
+        f.seek.assert_called_once_with(0)
+        f.close.assert_called_once_with()
+
+    @coroutine_test
+    async def test_append_to_existing_object(self, append_mocks):
+        bucket_mock, blob_mocks = append_mocks
+        old_blob_mock = mock_google_cloud_storage_blob(
+            name="export.csv", content_type="text/csv", storage_class="NEARLINE"
+        )
+        bucket_mock.get_blob.return_value = old_blob_mock
+        f = mock.Mock()
+
+        await self._append(f)
+
+        # The new data is uploaded as a temporary object, which must have the
+        # storage class of the existing object to be composable with it.
+        new_blob_mock = blob_mocks[self.TEMP_BLOB_NAME]
+        new_blob_mock.upload_from_file.assert_called_once_with(f)
+        assert new_blob_mock.storage_class == "NEARLINE"
+        # Both objects are then composed into the target object, preserving its
+        # content type and applying the ACL, which composition does not support.
+        blob_mock = blob_mocks["export.csv"]
+        blob_mock.compose.assert_called_once_with([old_blob_mock, new_blob_mock])
+        assert blob_mock.content_type == "text/csv"
+        blob_mock.acl.save_predefined.assert_called_once_with("publicRead")
+        blob_mock.upload_from_file.assert_not_called()
+        # And the temporary object is removed.
+        new_blob_mock.delete.assert_called_once_with()
+        f.seek.assert_called_once_with(0)
+        f.close.assert_called_once_with()
+
+    @coroutine_test
+    async def test_append_without_acl(self, append_mocks):
+        bucket_mock, blob_mocks = append_mocks
+        bucket_mock.get_blob.return_value = mock_google_cloud_storage_blob(
+            name="export.csv", content_type="text/csv", storage_class="STANDARD"
+        )
+
+        await self._append(mock.Mock(), acl=None)
+
+        blob_mock = blob_mocks["export.csv"]
+        blob_mock.compose.assert_called_once()
+        blob_mock.acl.save_predefined.assert_not_called()
+
+    @coroutine_test
+    async def test_append_deletes_temporary_object_on_compose_error(self, append_mocks):
+        bucket_mock, blob_mocks = append_mocks
+        bucket_mock.get_blob.return_value = mock_google_cloud_storage_blob(
+            name="export.csv", content_type="text/csv", storage_class="STANDARD"
+        )
+        blob_mocks["export.csv"] = mock_google_cloud_storage_blob(name="export.csv")
+        blob_mocks["export.csv"].compose.side_effect = OSError("Compose failed")
+        f = mock.Mock()
+
+        with pytest.raises(OSError, match="Compose failed"):
+            await self._append(f)
+
+        blob_mocks[self.TEMP_BLOB_NAME].delete.assert_called_once_with()
+        f.close.assert_called_once_with()
+
+    @coroutine_test
+    async def test_append_logs_temporary_object_deletion_error(
+        self, append_mocks, caplog: pytest.LogCaptureFixture
+    ):
+        bucket_mock, blob_mocks = append_mocks
+        bucket_mock.get_blob.return_value = mock_google_cloud_storage_blob(
+            name="export.csv", content_type="text/csv", storage_class="STANDARD"
+        )
+        blob_mocks[self.TEMP_BLOB_NAME] = mock_google_cloud_storage_blob(
+            name=self.TEMP_BLOB_NAME
+        )
+        blob_mocks[self.TEMP_BLOB_NAME].delete.side_effect = OSError("Delete failed")
+
+        with caplog.at_level(logging.WARNING):
+            await self._append(mock.Mock())
+
+        blob_mocks["export.csv"].compose.assert_called_once()
+        assert (
+            f"Could not delete the temporary object gs://mybucket/{self.TEMP_BLOB_NAME}"
+            in caplog.text
+        )
 
 
 class TestStdoutFeedStorage:

--- a/tests/utils/cloud.py
+++ b/tests/utils/cloud.py
@@ -19,3 +19,42 @@ def mock_google_cloud_storage() -> tuple[Any, Any, Any]:
     bucket_mock.blob.return_value = blob_mock
 
     return (client_mock, bucket_mock, blob_mock)
+
+
+def mock_google_cloud_storage_blobs() -> tuple[Any, Any, dict[str, Any]]:
+    """Like :func:`mock_google_cloud_storage`, but ``Bucket.blob()`` returns a
+    separate Blob mock for each object name, and ``Bucket.get_blob()`` returns
+    ``None`` unless configured otherwise.
+
+    Blob mocks are returned in a dict indexed by object name.
+    """
+    from google.cloud.storage import Bucket, Client  # noqa: PLC0415
+
+    client_mock = mock.create_autospec(Client)
+
+    bucket_mock = mock.create_autospec(Bucket)
+    client_mock.bucket.return_value = bucket_mock
+
+    blob_mocks: dict[str, Any] = {}
+
+    def blob(blob_name: str, *args: Any, **kwargs: Any) -> Any:
+        if blob_name not in blob_mocks:
+            blob_mocks[blob_name] = mock_google_cloud_storage_blob(name=blob_name)
+        return blob_mocks[blob_name]
+
+    bucket_mock.blob.side_effect = blob
+    bucket_mock.get_blob.return_value = None
+
+    return (client_mock, bucket_mock, blob_mocks)
+
+
+def mock_google_cloud_storage_blob(**properties: Any) -> Any:
+    """Creates an autospec mock for the google-cloud-storage Blob class with
+    the given properties, e.g. ``name`` or ``content_type``.
+    """
+    from google.cloud.storage import Blob  # noqa: PLC0415
+
+    blob_mock = mock.create_autospec(Blob)
+    for name, value in properties.items():
+        setattr(blob_mock, name, value)
+    return blob_mock


### PR DESCRIPTION
Resolves #7823

`overwrite: False` was ignored for `gs://` feeds, with a warning. It now appends to the target object using [composite objects](https://docs.cloud.google.com/storage/docs/composite-objects): the new data is uploaded as a temporary object of the target bucket, which is composed with the target object and then deleted.

The default value of `overwrite` for this storage backend stays `True`.

Implementation notes:

-   The temporary object is given the storage class of the target object, since composition sources must share it.

-   The ACL is applied after composition, since composition does not support predefined ACLs, and the content type of the target object is preserved.

-   No composition preconditions are used, because their signature is incompatible across the supported range of `google-cloud-storage`: in 1.29.0 (the current minimum) `if_generation_match` is a list matching the sources item-to-item, while in 2.x+ it is a destination precondition, paired with `if_source_generation_match`. As a result appending is not atomic; I am happy to raise the minimum version and add preconditions if you prefer.

-   Tests follow the existing mock-based GCS tests, since there is no GCS emulator in CI. Let me know if you would rather have this covered by integration tests instead.

Docs cover the new behavior and its caveats (extra permissions, no MD5 hash on composite objects, non-atomicity, extra object versions in buckets with object versioning or soft delete).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
