### PR TITLE
Warn against using keep_fragments for JS-rendered fragment content

### DIFF
--- a/scrapy/utils/request.py
+++ b/scrapy/utils/request.py
@@ -69,6 +69,10 @@ def fingerprint(
     so they are also ignored by default when calculating the fingerprint.
     If you want to include them, set the keep_fragments argument to True
     (for instance when handling requests with a headless browser).
+
+    keep_fragments is not a substitute for rendering JavaScript to reach
+    content loaded based on the URL fragment; see
+    :ref:`topics-dynamic-content` for that instead.
     """
     processed_include_headers: tuple[bytes, ...] | None = None
     if include_headers:


### PR DESCRIPTION
Resolves https://github.com/scrapy/scrapy/issues/4789