### PR TITLE
Warn that XMLFeedSpider's html iterator can mangle void-like tags

### DIFF
--- a/docs/topics/spiders.rst
+++ b/docs/topics/spiders.rst
@@ -624,7 +624,11 @@ XMLFeedSpider
 
            - ``'html'`` - an iterator which uses :class:`~scrapy.Selector`.
              Keep in mind this uses DOM parsing and must load all DOM in memory
-             which could be a problem for big feeds
+             which could be a problem for big feeds. It also parses the feed
+             with an HTML parser, which can silently mangle tags that HTML
+             treats as void elements, such as ``<link>``, dropping their
+             content and closing tag. Use ``xml`` or ``iternodes`` instead
+             for feeds affected by this.
 
            - ``'xml'`` - an iterator which uses :class:`~scrapy.Selector`.
              Keep in mind this uses DOM parsing and must load all DOM in memory


### PR DESCRIPTION
Resolves https://github.com/scrapy/scrapy/issues/4675