### PR TITLE
Suppress parso's DEBUG logging noise in the Scrapy shell

### DIFF
--- a/scrapy/utils/log.py
+++ b/scrapy/utils/log.py
@@ -81,6 +81,9 @@ DEFAULT_LOGGING = {
         "httpx": {
             "level": "WARNING",
         },
+        "parso": {
+            "level": "ERROR",
+        },
         "scrapy": {
             "level": "DEBUG",
         },


### PR DESCRIPTION
Resolves https://github.com/scrapy/scrapy/pull/4065.

No reordering as discussed, the order/doc recommendation inconsistency is already gone, and this should solve the logging-related issue rather nicely.