### PR TITLE
Split the subprocess coverage patch across job groups

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -173,6 +173,7 @@ deps =
     PyDispatcher==2.0.5
 setenv =
     {[min]setenv}
+    SCRAPY_COVERAGE_PATCH=_exit  # redundant with "py"'s subprocess coverage of scrapy/commands/*
 commands = {[min]commands}
 
 [testenv:extra-deps]
@@ -206,6 +207,7 @@ deps =
     uvloop==0.16.0; platform_system != "Windows" and implementation_name != "pypy"
 setenv =
     {[min]setenv}
+    SCRAPY_COVERAGE_PATCH=_exit  # redundant with "extra-deps"'s subprocess coverage of scrapy/commands/*
 commands = {[min]commands}
 
 [testenv:vcs-deps]
@@ -255,6 +257,8 @@ commands_pre =
 [testenv:default-reactor]
 commands =
     {[testenv]commands} --reactor=default
+setenv =
+    SCRAPY_COVERAGE_PATCH=_exit  # redundant with "py"'s subprocess coverage of scrapy/commands/*
 
 [testenv:min-default-reactor]
 basepython = {[min]basepython}
@@ -262,6 +266,7 @@ deps = {[testenv:min]deps}
 commands = {[min]commands} --reactor=default
 setenv =
     {[min]setenv}
+    SCRAPY_COVERAGE_PATCH=_exit  # redundant with "py"'s subprocess coverage of scrapy/commands/*
 
 [testenv:no-reactor]
 deps =
@@ -269,6 +274,8 @@ deps =
     pytest-asyncio
 commands =
     {[testenv]commands} -p no:twisted --reactor=none
+setenv =
+    SCRAPY_COVERAGE_PATCH=_exit  # redundant with "py"'s subprocess coverage of scrapy/commands/*
 
 [testenv:no-reactor-extra-deps]
 deps =
@@ -276,6 +283,8 @@ deps =
     pytest-asyncio
 commands =
     {[testenv]commands} -p no:twisted --reactor=none
+setenv =
+    SCRAPY_COVERAGE_PATCH=_exit  # redundant with "extra-deps"'s subprocess coverage of scrapy/commands/*
 
 [testenv:min-no-reactor]
 basepython = {[min]basepython}
@@ -285,6 +294,7 @@ deps =
 commands = {[min]commands} -p no:twisted --reactor=none
 setenv =
     {[min]setenv}
+    SCRAPY_COVERAGE_PATCH=_exit  # redundant with "py"'s subprocess coverage of scrapy/commands/*
 
 [testenv:pypy3]
 basepython = pypy3

--- a/tox.ini
+++ b/tox.ini
@@ -173,7 +173,6 @@ deps =
     PyDispatcher==2.0.5
 setenv =
     {[min]setenv}
-    SCRAPY_COVERAGE_PATCH=_exit  # redundant with "py"'s subprocess coverage of scrapy/commands/*
 commands = {[min]commands}
 
 [testenv:extra-deps]


### PR DESCRIPTION
Subprocess coverage is a significant slowdown. So, if we can enable it only for a few key jobs, and still get the same CodeCov data, that will save us some CI time that can be spent elsewhere.