### PR TITLE
Drop auto-assigned download slots on redirects (#2141)

### DIFF
--- a/docs/topics/request-response.rst
+++ b/docs/topics/request-response.rst
@@ -913,6 +913,24 @@ started, i.e. HTTP message sent over the network. This meta key only becomes
 available when the response has been downloaded. While most other meta keys are
 used to control Scrapy behavior, this one is supposed to be read-only.
 
+.. reqmeta:: download_slot
+
+download_slot
+-------------
+
+The download slot of this request. Requests that share a slot share concurrency
+and delay limits (see :setting:`DOWNLOAD_SLOTS` and
+:setting:`CONCURRENT_REQUESTS_PER_DOMAIN`).
+
+By default the slot is the request hostname. Set this key to assign a request to
+a specific slot.
+
+.. versionchanged:: VERSION
+
+    When the downloader assigned the slot because this key was not set, a
+    redirect drops it so the redirected request is slotted by its own hostname.
+    A user-set value is kept across redirects.
+
 .. reqmeta:: download_fail_on_dataloss
 
 download_fail_on_dataloss

--- a/scrapy/core/downloader/__init__.py
+++ b/scrapy/core/downloader/__init__.py
@@ -120,6 +120,8 @@ class Downloader:
                     self.middleware.download_async(self._enqueue_request, request)
                 )
             )
+            if not isinstance(result, Request):
+                request.meta.pop("_auto_download_slot", None)
             return result
         finally:
             self.active.remove(request)
@@ -159,6 +161,8 @@ class Downloader:
 
     # passed as download_func into self.middleware.download() in self.fetch()
     async def _enqueue_request(self, request: Request) -> Response:
+        if request.meta.get(self.DOWNLOAD_SLOT) is None:
+            request.meta["_auto_download_slot"] = True
         key, slot = self._get_slot(request)
         request.meta[self.DOWNLOAD_SLOT] = key
         slot.active.add(request)

--- a/scrapy/downloadermiddlewares/redirect.py
+++ b/scrapy/downloadermiddlewares/redirect.py
@@ -129,6 +129,8 @@ class BaseRedirectMiddleware:
             cls=None,
             cookies=None,
         )
+        if redirect_request.meta.pop("_auto_download_slot", None):
+            redirect_request.meta.pop("download_slot", None)
         if "_scheme_proxy" in redirect_request.meta:
             source_request_scheme = urlparse_cached(source_request).scheme
             redirect_request_scheme = urlparse_cached(redirect_request).scheme

--- a/tests/test_downloaderslotssettings.py
+++ b/tests/test_downloaderslotssettings.py
@@ -6,11 +6,46 @@ import pytest
 from scrapy import Request
 from scrapy.core.downloader import Downloader, Slot
 from scrapy.exceptions import ScrapyDeprecationWarning
+from scrapy.http import Response
+from scrapy.spiders import Spider
 from scrapy.utils.spider import DefaultSpider
 from scrapy.utils.test import get_crawler
 from tests.mockserver.http import MockServer
 from tests.spiders import MetaSpider
 from tests.utils.decorators import coroutine_test, inline_callbacks_test
+
+
+class _RedirectSlotDownloadHandler:
+    lazy = False
+
+    async def download_request(self, request: Request) -> Response:
+        if request.url == "http://a.example/":
+            return Response(
+                request.url,
+                status=302,
+                headers={"Location": "http://b.example/"},
+                request=request,
+            )
+        return Response(request.url, request=request)
+
+
+class CrossDomainRedirectSpider(Spider):
+    name = "cross_domain_redirect"
+    custom_settings = {
+        "DOWNLOAD_HANDLERS": {"http": _RedirectSlotDownloadHandler},
+    }
+
+    def __init__(self, *args: Any, **kwargs: Any):
+        super().__init__(*args, **kwargs)
+        self.slots: list[str] = []
+        self.auto_flag: object = None
+
+    async def start(self):
+        yield Request("http://a.example/", callback=self.parse)
+
+    def parse(self, response: Response):
+        self.slots.append(response.meta["download_slot"])
+        self.auto_flag = response.meta.get("_auto_download_slot")
 
 
 class DownloaderSlotsSettingsTestSpider(MetaSpider):
@@ -67,6 +102,31 @@ class NoDelayDownloaderSlotsSpider(DownloaderSlotsSettingsTestSpider):
     }
 
 
+class FollowFromResponseMetaSpider(MetaSpider):
+    name = "follow_from_response_meta"
+
+    def __init__(self, *args: Any, **kwargs: Any):
+        super().__init__(*args, **kwargs)
+        self.slots: list[str] = []
+        self.auto_flags: list[bool] = []
+
+    async def start(self):
+        assert self.mockserver
+        yield Request(self.mockserver.url("/text"), callback=self.parse)
+
+    def parse(self, response: Response):
+        self.auto_flags.append("_auto_download_slot" in response.meta)
+        meta = dict(response.meta)
+        meta["download_slot"] = "custom"
+        yield Request(
+            response.url, callback=self.not_parse, meta=meta, dont_filter=True
+        )
+
+    def not_parse(self, response: Response):
+        self.slots.append(response.meta["download_slot"])
+        self.auto_flags.append("_auto_download_slot" in response.meta)
+
+
 @inline_callbacks_test
 def test_delay(mockserver: MockServer):
     crawler = get_crawler(DownloaderSlotsSettingsTestSpider)
@@ -82,6 +142,24 @@ def test_delay(mockserver: MockServer):
 
     for slot, (first, second) in times.items():
         assert abs((second - first) - slots[slot].delay) < tolerance
+
+
+@inline_callbacks_test
+def test_redirect_to_other_host_changes_slot():
+    crawler = get_crawler(CrossDomainRedirectSpider)
+    yield crawler.crawl()
+    assert isinstance(crawler.spider, CrossDomainRedirectSpider)
+    assert crawler.spider.slots == ["b.example"]
+    assert crawler.spider.auto_flag is None
+
+
+@inline_callbacks_test
+def test_user_slot_from_response_meta_is_kept(mockserver: MockServer):
+    crawler = get_crawler(FollowFromResponseMetaSpider)
+    yield crawler.crawl(mockserver=mockserver)
+    assert isinstance(crawler.spider, FollowFromResponseMetaSpider)
+    assert crawler.spider.auto_flags == [False, False]
+    assert crawler.spider.slots == ["custom"]
 
 
 @coroutine_test

--- a/tests/utils/bases/redirect.py
+++ b/tests/utils/bases/redirect.py
@@ -115,6 +115,25 @@ class TestRedirectBase(ABC):
         assert req2.meta["redirect_reasons"] == [self.reason]
         assert req3.meta["redirect_reasons"] == [self.reason, self.reason]
 
+    def test_downloader_assigned_slot_dropped(self):
+        req = Request("http://a.example/")
+        req.meta["download_slot"] = "a.example"
+        req.meta["_auto_download_slot"] = True
+        redirected = self.mw.process_response(
+            req, self.get_response(req, "http://b.example/")
+        )
+        assert isinstance(redirected, Request)
+        assert "download_slot" not in redirected.meta
+        assert "_auto_download_slot" not in redirected.meta
+
+    def test_user_assigned_slot_kept(self):
+        req = Request("http://a.example/", meta={"download_slot": "custom"})
+        redirected = self.mw.process_response(
+            req, self.get_response(req, "http://b.example/")
+        )
+        assert isinstance(redirected, Request)
+        assert redirected.meta["download_slot"] == "custom"
+
     def test_cross_origin_header_dropping(self):
         safe_headers = {"A": "B"}
         cookie_header = {"Cookie": "a=b"}


### PR DESCRIPTION
Resolves #2141.

## Problem

The downloader writes the slot it picked into `request.meta["download_slot"]` (`Downloader._enqueue_request`). `_build_redirect_request` copies that meta onto the redirected request, so `get_slot_key()` keeps using the original hostname after a redirect to another host.

`CONCURRENT_REQUESTS_PER_DOMAIN`, `DOWNLOAD_DELAY` and AutoThrottle then apply as if the whole chain belonged to the first domain.

A user-set `download_slot` must still be kept: that is an explicit assignment, not an inherited hostname.

## Approach

- When the downloader assigns a slot because `download_slot` was not set, it marks the request with `_auto_download_slot`.
- Redirect middleware drops both that marker and `download_slot` on the follow-up request, so the downloader slots the new URL by hostname. A user-set slot is left alone.
- After a hop finishes with a response, the marker is removed from the request. Copying `response.meta` onto a later request and then pinning `download_slot` cannot treat that user slot as auto-assigned.

## Tests

- Redirect middleware (HTTP and meta-refresh): auto-assigned slots are dropped; user-set slots are kept.
- Crawl with a fake HTTP handler: `http://a.example/` → `http://b.example/` lands on slot `b.example`.
- Follow-up request built from `response.meta` with an explicit `download_slot` keeps that slot.

```
.venv/Scripts/python.exe -m pytest tests/test_downloadermiddleware_redirect.py tests/test_downloadermiddleware_redirect_metarefresh.py tests/test_downloaderslotssettings.py -q
186 passed
```