### PR TITLE
Skip disabled controls in FormRequest.from_response

### DIFF
--- a/scrapy/http/request/form.py
+++ b/scrapy/http/request/form.py
@@ -229,12 +229,12 @@ def _get_inputs(
     if not formdata:
         formdata = []
     inputs = form.xpath(
-        "descendant::textarea"
-        "|descendant::select"
-        "|descendant::input[not(@type) or @type["
+        "descendant::textarea[not(@disabled)]"
+        "|descendant::select[not(@disabled)]"
+        "|descendant::input[not(@disabled) and (not(@type) or @type["
         ' not(re:test(., "^(?:submit|image|reset)$", "i"))'
         " and (../@checked or"
-        '  not(re:test(., "^(?:checkbox|radio)$", "i")))]]',
+        '  not(re:test(., "^(?:checkbox|radio)$", "i")))])]',
         namespaces={"re": "http://exslt.org/regular-expressions"},
     )
     values: list[FormdataKVType] = [
@@ -285,8 +285,10 @@ def _get_clickable(
     """
     clickables = list(
         form.xpath(
-            'descendant::input[re:test(@type, "^(submit|image)$", "i")]'
-            '|descendant::button[not(@type) or re:test(@type, "^submit$", "i")]',
+            "descendant::input[not(@disabled) and"
+            ' re:test(@type, "^(submit|image)$", "i")]'
+            "|descendant::button[not(@disabled) and"
+            ' (not(@type) or re:test(@type, "^submit$", "i"))]',
             namespaces={"re": "http://exslt.org/regular-expressions"},
         )
     )

--- a/tests/test_http_request_form.py
+++ b/tests/test_http_request_form.py
@@ -801,6 +801,24 @@ class TestFormRequest(TestRequestBase):
         fs = _qs(req)
         assert fs == {b"i1": [b"i1v1"], b"i2": [b""], b"i4": [b"i4v1"]}
 
+    def test_from_response_disabled_controls(self):
+        res = _buildresponse(
+            """<form>
+            <input type="text" name="i1" value="i1v1" disabled>
+            <input type="hidden" name="i2" value="i2v1" disabled>
+            <textarea name="i3" disabled>i3v1</textarea>
+            <select name="i4" disabled>
+                <option value="i4v1" selected>option 1</option>
+            </select>
+            <input type="text" name="i5" value="i5v1">
+            <input type="submit" name="i6" value="i6v1" disabled>
+            <input type="submit" name="i7" value="i7v1">
+            </form>"""
+        )
+        req = self.request_class.from_response(res)
+        fs = _qs(req)
+        assert fs == {b"i5": [b"i5v1"], b"i7": [b"i7v1"]}
+
     def test_from_response_input_hidden(self):
         res = _buildresponse(
             """<form>


### PR DESCRIPTION
﻿### Problem
`FormRequest.from_response()` currently submits disabled HTML controls, including disabled text/hidden/textarea/select controls and disabled submit buttons. Disabled controls are not successful controls in browser form submission, so their values should be ignored.

### Reproducer
```python
from scrapy.http import FormRequest, HtmlResponse
from urllib.parse import parse_qs

response = HtmlResponse(
    url="http://example.com",
    body=b'<form><input name="disabled" value="1" disabled><input name="enabled" value="2"></form>',
    encoding="utf-8",
)
request = FormRequest.from_response(response)
print(parse_qs(request.url.split("?", 1)[1]))
# current: {'disabled': ['1'], 'enabled': ['2']}
# expected: {'enabled': ['2']}
```

### Fix
Filter out controls with a `disabled` attribute while collecting form values and when selecting the clickable submit control. This matches browser form-submission behavior and keeps the change limited to `FormRequest.from_response()` parsing.

### Testing
Added `tests/test_http_request_form.py::TestFormRequest::test_from_response_disabled_controls`.

Before the fix:
```text
FAILED tests/test_http_request_form.py::TestFormRequest::test_from_response_disabled_controls
1 failed in 1.96s
```

After the fix:
```text
1 passed in 0.98s
924 passed, 1 skipped in 16.05s
```
