### PR TITLE
Match allowed_domains case-insensitively

### DIFF
--- a/scrapy/downloadermiddlewares/offsite.py
+++ b/scrapy/downloadermiddlewares/offsite.py
@@ -134,4 +134,4 @@ class OffsiteMiddleware:
                 continue
             domains.append(re.escape(domain))
         regex = rf"^(.*\.)?({'|'.join(domains)})$"
-        return re.compile(regex)
+        return re.compile(regex, re.IGNORECASE)

--- a/tests/test_downloadermiddleware_offsite.py
+++ b/tests/test_downloadermiddleware_offsite.py
@@ -17,6 +17,8 @@ UNSET = object()
     ("allowed_domain", "url", "allowed"),
     [
         ("example.com", "http://example.com/1", True),
+        ("EXAMPLE.COM", "http://example.com/1", True),
+        ("EXAMPLE.COM", "http://sub.example.com/1", True),
         ("example.com", "http://example.org/1", False),
         ("example.com", "http://sub.example.com/1", True),
         ("sub.example.com", "http://sub.example.com/1", True),
@@ -136,6 +138,8 @@ def test_process_request_invalid_domains():
     ("allowed_domain", "url", "allowed"),
     [
         ("example.com", "http://example.com/1", True),
+        ("EXAMPLE.COM", "http://example.com/1", True),
+        ("EXAMPLE.COM", "http://sub.example.com/1", True),
         ("example.com", "http://example.org/1", False),
         ("example.com", "http://sub.example.com/1", True),
         ("sub.example.com", "http://sub.example.com/1", True),


### PR DESCRIPTION
### Problem
`OffsiteMiddleware` treats `allowed_domains` case-sensitively. Domain names are case-insensitive, so a spider with `allowed_domains = ["EXAMPLE.COM"]` should allow requests to `example.com` and its subdomains, but they are currently filtered as offsite.

### Reproducer
```python
from scrapy import Request, Spider
from scrapy.downloadermiddlewares.offsite import OffsiteMiddleware
from scrapy.utils.misc import build_from_crawler
from scrapy.utils.test import get_crawler

crawler = get_crawler(Spider)
crawler.spider = crawler._create_spider(name="a", allowed_domains=["EXAMPLE.COM"])
mw = build_from_crawler(OffsiteMiddleware, crawler)
mw.spider_opened(crawler.spider)
mw.process_request(Request("http://example.com/1"))
# current: raises IgnoreRequest
# expected: returns None
```

### Fix
Compile the generated allowed-domain regular expression with `re.IGNORECASE`, so matching follows DNS case-insensitivity while preserving the existing exact-domain and subdomain boundary rules.

### Testing
Added uppercase `allowed_domains` regression cases for both `process_request()` and `request_scheduled()`.

Before the fix:
```text
4 failed, 22 passed in 3.41s
```

After the fix:
```text
26 passed in 3.04s
55 passed in 1.37s
```
