### PR TITLE
docs: warn that is_asyncio_available cannot be used in extension __init__

### DIFF
--- a/docs/topics/asyncio.rst
+++ b/docs/topics/asyncio.rst
@@ -136,6 +136,14 @@ example:
                     f"of Scrapy for more information."
                 )
 
+.. warning::
+
+    :func: cannot be reliably used
+    in the __init__ method of a :ref:, because
+    extensions are instantiated in :meth:, before the
+    asyncio event loop is set up. Call it from a method that runs later in the
+    component lifecycle (e.g. spider_opened) instead.
+
 .. autofunction:: scrapy.utils.asyncio.is_asyncio_available
 .. autofunction:: scrapy.utils.reactor.is_asyncio_reactor_installed
 


### PR DESCRIPTION
Fixes #7812

**Problem**: the asyncio docs suggest calling `is_asyncio_available()` in a component's `__init__` to enforce the asyncio requirement, but that check is unreliable in extension `__init__`, because extensions are instantiated in `Crawler._apply_settings()` before the asyncio event loop is set up.

**Fix**: document this limitation with a warning, pointing users to call it from a later lifecycle method (e.g. `spider_opened`).