### PR TITLE
Fix fragment inheritance for redirects with an empty fragment

### DIFF
--- a/scrapy/downloadermiddlewares/redirect.py
+++ b/scrapy/downloadermiddlewares/redirect.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import logging
 from typing import TYPE_CHECKING, Any, cast
-from urllib.parse import urljoin, urlparse
+from urllib.parse import urljoin
 
 from w3lib.url import safe_url_string
 
@@ -220,15 +220,17 @@ class RedirectMiddleware(BaseRedirectMiddleware):
         }:
             return response
 
-        assert response.headers["Location"] is not None
-        location = safe_url_string(response.headers["Location"])
-        if response.headers["Location"].startswith(b"//"):
+        location_header = response.headers["Location"]
+        assert location_header is not None
+        location = safe_url_string(location_header)
+        if location_header.startswith(b"//"):
             request_scheme = urlparse_cached(request).scheme
             location = request_scheme + "://" + location.lstrip("/")
 
         redirected_url = urljoin(request.url, location)
 
-        if not urlparse(redirected_url).fragment:
+        # A percent-encoded number sign is URI data, not a fragment delimiter.
+        if b"#" not in location_header:
             fragment = urlparse_cached(request).fragment
             if fragment:
                 redirected_url = urljoin(redirected_url, f"#{fragment}")

--- a/tests/test_downloadermiddleware_redirect.py
+++ b/tests/test_downloadermiddleware_redirect.py
@@ -273,6 +273,26 @@ class TestRedirectMiddleware(TestRedirectBase):
         assert isinstance(req2, Request)
         assert req2.url == "http://www.example.com/redirected#target"
 
+    def test_redirect_target_has_empty_fragment(self):
+        url = "http://www.example.com/302#original"
+        url2 = "http://www.example.com/redirected#"
+        req = Request(url)
+        rsp = Response(url, headers={"Location": url2}, status=302)
+
+        req2 = self.mw.process_response(req, rsp)
+        assert isinstance(req2, Request)
+        assert req2.url == "http://www.example.com/redirected"
+
+    def test_redirect_target_has_percent_encoded_number_sign(self):
+        url = "http://www.example.com/302#original"
+        url2 = "http://www.example.com/redirected%23"
+        req = Request(url)
+        rsp = Response(url, headers={"Location": url2}, status=302)
+
+        req2 = self.mw.process_response(req, rsp)
+        assert isinstance(req2, Request)
+        assert req2.url == "http://www.example.com/redirected%23#original"
+
     def test_redirect_302_head(self):
         url = "http://www.example.com/302"
         url2 = "http://www.example.com/redirected2"


### PR DESCRIPTION
## Summary

Fix `RedirectMiddleware` so that redirects with an explicit empty fragment component do not inherit the fragment from the original request.

RFC 9110 Section 10.2.2 specifies that the original fragment is inherited only when the `Location` value does not have a fragment component.

Both `safe_url_string()` and `urljoin()` normalize a trailing empty fragment delimiter away, making `/new` and `/new#` indistinguishable after URL normalization. Check the raw `Location` header for the fragment delimiter instead.

For example, redirecting from:

    https://example.com/old#secret

with:

    Location: /new#

now produces:

    https://example.com/new

instead of incorrectly producing:

    https://example.com/new#secret

Reference:
https://www.rfc-editor.org/rfc/rfc9110.html#section-10.2.2


Tested with:

   ` python -m pytest tests/test_downloadermiddleware_redirect.py -q`