### PR TITLE
Preserve Content-Encoding header after full decompression

### DIFF
--- a/docs/topics/downloader-middleware.rst
+++ b/docs/topics/downloader-middleware.rst
@@ -704,6 +704,13 @@ HttpCompressionMiddleware
    This middleware allows compressed (gzip, deflate, `brotli`_, `zstd`_)
    traffic to be sent/received from web sites.
 
+   .. versionchanged:: VERSION
+      When all ``Content-Encoding`` transfer encodings are decoded, the
+      original ``Content-Encoding`` header value is now preserved on the
+      response instead of being removed. Responses where at least one
+      encoding is unsupported (and therefore left undecoded) still carry
+      only the remaining, undecoded encodings in the header.
+
 .. _brotli: https://www.ietf.org/rfc/rfc7932.txt
 .. _zstd: https://www.ietf.org/rfc/rfc8478.txt
 

--- a/scrapy/downloadermiddlewares/httpcompression.py
+++ b/scrapy/downloadermiddlewares/httpcompression.py
@@ -89,6 +89,7 @@ class HttpCompressionMiddleware:
             return response
         content_encoding = response.headers.getlist("Content-Encoding")
         if content_encoding:
+            original_encoding = content_encoding
             max_size = request.meta.get("download_maxsize", self._max_size)
             warn_size = request.meta.get("download_warnsize", self._warn_size)
             try:
@@ -129,7 +130,7 @@ class HttpCompressionMiddleware:
                 kwargs["encoding"] = None
             response = response.replace(cls=respcls, **kwargs)
             if not content_encoding:
-                del response.headers["Content-Encoding"]
+                response.headers["Content-Encoding"] = original_encoding
         return response
 
     def _handle_encoding(

--- a/tests/test_downloadermiddleware_httpcompression.py
+++ b/tests/test_downloadermiddleware_httpcompression.py
@@ -140,7 +140,7 @@ class TestHttpCompression:
         newresponse = self.mw.process_response(request, response)
         assert newresponse is not response
         assert newresponse.body.startswith(b"<!DOCTYPE")
-        assert "Content-Encoding" not in newresponse.headers
+        assert newresponse.headers.get("Content-Encoding") == b"gzip"
         self.assertStatsEqual("httpcompression/response_count", 1)
         self.assertStatsEqual("httpcompression/response_bytes", 74837)
 
@@ -152,7 +152,7 @@ class TestHttpCompression:
         newresponse = self.mw.process_response(request, response)
         assert newresponse is not response
         assert newresponse.body.startswith(b"<!DOCTYPE")
-        assert "Content-Encoding" not in newresponse.headers
+        assert newresponse.headers.get("Content-Encoding") == b"br"
         self.assertStatsEqual("httpcompression/response_count", 1)
         self.assertStatsEqual("httpcompression/response_bytes", 74837)
 
@@ -172,7 +172,7 @@ class TestHttpCompression:
                 assert raw_content == newresponse.body
             assert newresponse is not response
             assert newresponse.body.startswith(b"<!DOCTYPE")
-            assert "Content-Encoding" not in newresponse.headers
+            assert newresponse.headers.get("Content-Encoding") == b"zstd"
 
     def test_process_response_rawdeflate(self):
         response = self._getresponse("rawdeflate")
@@ -183,7 +183,7 @@ class TestHttpCompression:
         newresponse = self.mw.process_response(request, response)
         assert newresponse is not response
         assert newresponse.body.startswith(b"<!DOCTYPE")
-        assert "Content-Encoding" not in newresponse.headers
+        assert newresponse.headers.get("Content-Encoding") == b"deflate"
         self.assertStatsEqual("httpcompression/response_count", 1)
         self.assertStatsEqual("httpcompression/response_bytes", 74840)
 
@@ -196,7 +196,7 @@ class TestHttpCompression:
         newresponse = self.mw.process_response(request, response)
         assert newresponse is not response
         assert newresponse.body.startswith(b"<!DOCTYPE")
-        assert "Content-Encoding" not in newresponse.headers
+        assert newresponse.headers.get("Content-Encoding") == b"deflate"
         self.assertStatsEqual("httpcompression/response_count", 1)
         self.assertStatsEqual("httpcompression/response_bytes", 74840)
 
@@ -226,7 +226,7 @@ class TestHttpCompression:
         request = response.request
         newresponse = self.mw.process_response(request, response)
         assert newresponse is not response
-        assert "Content-Encoding" not in newresponse.headers
+        assert newresponse.headers.get("Content-Encoding") == b"gzip, deflate"
         assert newresponse.body.startswith(b"<!DOCTYPE")
 
     def test_multi_compression_single_header_invalid_compression(
@@ -261,7 +261,7 @@ class TestHttpCompression:
         request = response.request
         newresponse = self.mw.process_response(request, response)
         assert newresponse is not response
-        assert "Content-Encoding" not in newresponse.headers
+        assert newresponse.headers.getlist("Content-Encoding") == [b"gzip", b"deflate"]
         assert newresponse.body.startswith(b"<!DOCTYPE")
 
     def test_multi_compression_multiple_header_invalid_compression(self):
@@ -280,7 +280,10 @@ class TestHttpCompression:
         request = response.request
         newresponse = self.mw.process_response(request, response)
         assert newresponse is not response
-        assert "Content-Encoding" not in newresponse.headers
+        assert newresponse.headers.getlist("Content-Encoding") == [
+            b"gzip",
+            b"deflate, gzip",
+        ]
         assert newresponse.body.startswith(b"<!DOCTYPE")
 
     def test_multi_compression_single_and_multiple_header_invalid_compression(self):
@@ -373,7 +376,7 @@ class TestHttpCompression:
         newresponse = self.mw.process_response(request, response)
         assert newresponse is not response
         assert newresponse.body.startswith(b"<!DOCTYPE")
-        assert "Content-Encoding" not in newresponse.headers
+        assert newresponse.headers.get("Content-Encoding") == b"gzip"
         self.assertStatsEqual("httpcompression/response_count", 1)
         self.assertStatsEqual("httpcompression/response_bytes", 74837)
 
@@ -386,7 +389,7 @@ class TestHttpCompression:
         newresponse = self.mw.process_response(request, response)
         assert newresponse is not response
         assert newresponse.body.startswith(b"<!DOCTYPE")
-        assert "Content-Encoding" not in newresponse.headers
+        assert newresponse.headers.get("Content-Encoding") == b"gzip"
         self.assertStatsEqual("httpcompression/response_count", 1)
         self.assertStatsEqual("httpcompression/response_bytes", 74837)
 
@@ -399,7 +402,7 @@ class TestHttpCompression:
         newresponse = self.mw.process_response(request, response)
         assert newresponse is not response
         assert newresponse.body.startswith(b"<!DOCTYPE")
-        assert "Content-Encoding" not in newresponse.headers
+        assert newresponse.headers.get("Content-Encoding") == b"x-gzip"
         self.assertStatsEqual("httpcompression/response_count", 1)
         self.assertStatsEqual("httpcompression/response_bytes", 74837)
 


### PR DESCRIPTION
## Summary

Closes #1988.

`HttpCompressionMiddleware` currently deletes the `Content-Encoding`
header from a response once it has fully decoded the body. This means
spiders and other middleware cannot tell whether — or how — a response
was compressed during transfer.

This change saves the original `Content-Encoding` value before
`_handle_encoding` replaces it with the list of remaining unsupported
encodings, and restores that original value on the response when all
encodings were decoded (i.e. when `content_encoding` is empty after
`_handle_encoding` returns).

**Behaviour that does not change:**

* Responses with no `Content-Encoding` header are untouched.
* When one or more encodings are unsupported and therefore left
  undecoded, the header continues to reflect only those remaining
  encodings — exactly the same as before.
* HEAD responses are returned early without modification.

**Behaviour that changes:**

* When all encodings were successfully decoded, the response now carries
  the original `Content-Encoding` header (e.g. `gzip`) instead of
  having the header absent.



All 55 tests pass.