### PR TITLE
Remove stale module-level docstring from RetryMiddleware

### DIFF
--- a/scrapy/downloadermiddlewares/retry.py
+++ b/scrapy/downloadermiddlewares/retry.py
@@ -1,12 +1,3 @@
-"""
-An extension to retry failed requests that are potentially caused by temporary
-problems such as a connection timeout or HTTP 500 error.
-
-You can change the behaviour of this middleware by modifying the scraping settings:
-RETRY_TIMES - how many times to retry a failed page
-RETRY_HTTP_CODES - which HTTP response codes to retry
-"""
-
 from __future__ import annotations
 
 from logging import Logger, getLevelName, getLogger


### PR DESCRIPTION
Part of #7699.

The module-level docstring in `scrapy/downloadermiddlewares/retry.py` lists only two settings (`RETRY_TIMES`, `RETRY_HTTP_CODES`) and has not been updated since the five additional settings were added (`RETRY_ENABLED`, `RETRY_EXCEPTIONS`, `RETRY_GIVE_UP_LOG_LEVEL`, `RETRY_PRIORITY_ADJUST`, and the per-request meta equivalents). The description duplicates the first sentence of the class and the reference documentation in `docs/topics/downloader-middleware.rst`, which is the authoritative source.

Removing the docstring leaves the module without any misleading or incomplete inline summary.