### PR TITLE
Remove stale module-level docstring from RefererMiddleware

### DIFF
--- a/scrapy/spidermiddlewares/referer.py
+++ b/scrapy/spidermiddlewares/referer.py
@@ -1,8 +1,3 @@
-"""
-RefererMiddleware: populates Request referer field, based on the Response which
-originated it.
-"""
-
 from __future__ import annotations
 
 import warnings


### PR DESCRIPTION
Part of #7699.

The module-level docstring in `scrapy/spidermiddlewares/referer.py` duplicates the reference documentation in `docs/topics/`. Remove it.