### PR TITLE
Remove stale module-level docstring from HttpErrorMiddleware

### DIFF
--- a/scrapy/spidermiddlewares/httperror.py
+++ b/scrapy/spidermiddlewares/httperror.py
@@ -1,9 +1,3 @@
-"""
-HttpError Spider Middleware
-
-See documentation in docs/topics/spider-middleware.rst
-"""
-
 from __future__ import annotations
 
 import logging


### PR DESCRIPTION
Part of #7699.

The module-level docstring in `scrapy/spidermiddlewares/httperror.py` duplicates the reference documentation in `docs/topics/`. Remove it.