### PR TITLE
Remove stale module-level docstring from CoreStats extension

### DIFF
--- a/scrapy/extensions/corestats.py
+++ b/scrapy/extensions/corestats.py
@@ -1,7 +1,3 @@
-"""
-Extension for collecting core stats like items scraped and start/finish times
-"""
-
 from __future__ import annotations
 
 from datetime import datetime, timezone


### PR DESCRIPTION
Part of #7699.

The module-level docstring in `scrapy/extensions/corestats.py` duplicates the reference documentation in `docs/topics/`. Remove it.