### PR TITLE
Treat every 2xx status as a successful media download

### DIFF
--- a/scrapy/pipelines/files.py
+++ b/scrapy/pipelines/files.py
@@ -636,7 +636,7 @@ class FilesPipeline(MediaPipeline):
     ) -> FileInfo:
         referer = referer_str(request)
 
-        if response.status != 200:
+        if not 200 <= response.status < 300:
             logger.warning(
                 "File (code: %(status)s): Error downloading file from "
                 "%(request)s referred in <%(referer)s>",

--- a/tests/test_pipeline_files.py
+++ b/tests/test_pipeline_files.py
@@ -283,6 +283,21 @@ class TestFilesPipeline:
         assert result["files"][0]["status"] == "downloaded"
 
     @coroutine_test
+    async def test_file_created_status(self) -> None:
+        """Any successful (2xx) status is treated as a download, e.g. 201."""
+        item_url = "http://example.com/created.pdf"
+        item = _create_item_with_files(item_url)
+        with (
+            mock.patch.object(
+                FilesPipeline,
+                "get_media_requests",
+                return_value=[_prepare_request_object(item_url, status=201)],
+            ),
+        ):
+            result = await self.pipeline.process_item(item)
+        assert result["files"][0]["status"] == "downloaded"
+
+    @coroutine_test
     async def test_file_empty_content(self, caplog: pytest.LogCaptureFixture) -> None:
         item_url = "http://example.com/empty.pdf"
         item = _create_item_with_files(item_url)
@@ -1192,12 +1207,13 @@ def _prepare_request_object(
     item_url: str,
     flags: list[str] | None = None,
     headers: dict[str, str] | None = None,
+    status: int = 200,
 ) -> Request:
     return Request(
         item_url,
         meta={
             "response": Response(
-                item_url, status=200, body=b"data", flags=flags, headers=headers
+                item_url, status=status, body=b"data", flags=flags, headers=headers
             )
         },
     )


### PR DESCRIPTION
The files pipeline only accepted responses with status exactly 200:

```python
if response.status != 200:
```

so a server answering **201 Created** — e.g. for images or files generated on the fly — was logged as a download error and the file was silently dropped. This has bitten several people over the years (#1615, where @redapple agreed it is a bug).

Any 2xx response is a success by HTTP semantics, so the check now accepts the whole range:

```python
if not 200 <= response.status < 300:
```

A test with a 201 response has been added alongside the existing download tests.