### PR TITLE
Fix LocalCache evicting a different key when updating an existing key

### DIFF
--- a/scrapy/utils/datatypes.py
+++ b/scrapy/utils/datatypes.py
@@ -94,8 +94,11 @@ class LocalCache(OrderedDict[_KT, _VT]):
         if self.limit is not None:
             if self.limit == 0:
                 return
-            while len(self) >= self.limit:
-                self.popitem(last=False)
+            # Only evict to make room when inserting a *new* key. Updating an
+            # existing key must not evict another entry or shrink the cache.
+            if key not in self:
+                while len(self) >= self.limit:
+                    self.popitem(last=False)
         super().__setitem__(key, value)
 
 

--- a/scrapy/utils/datatypes.py
+++ b/scrapy/utils/datatypes.py
@@ -94,8 +94,6 @@ class LocalCache(OrderedDict[_KT, _VT]):
         if self.limit is not None:
             if self.limit == 0:
                 return
-            # Only evict to make room when inserting a *new* key. Updating an
-            # existing key must not evict another entry or shrink the cache.
             if key not in self:
                 while len(self) >= self.limit:
                     self.popitem(last=False)

--- a/tests/test_utils_datatypes.py
+++ b/tests/test_utils_datatypes.py
@@ -325,6 +325,19 @@ class TestLocalCache:
         assert "c" not in cache
 
 
+    def test_cache_update_existing_key_does_not_evict(self):
+        # Updating an existing key must not evict another entry or drop the
+        # cache below its limit (regression: it used to evict the oldest key).
+        cache: LocalCache[str, int] = LocalCache(limit=2)
+        cache["a"] = 1
+        cache["b"] = 2
+        cache["b"] = 20
+        assert len(cache) == 2
+        assert "a" in cache
+        assert cache["a"] == 1
+        assert cache["b"] == 20
+
+
 class TestLocalWeakReferencedCache:
     def test_cache_with_limit(self):
         cache: LocalWeakReferencedCache[Request, int] = LocalWeakReferencedCache(

--- a/tests/test_utils_datatypes.py
+++ b/tests/test_utils_datatypes.py
@@ -324,7 +324,6 @@ class TestLocalCache:
         assert "b" not in cache
         assert "c" not in cache
 
-
     def test_cache_update_existing_key_does_not_evict(self):
         # Updating an existing key must not evict another entry or drop the
         # cache below its limit (regression: it used to evict the oldest key).


### PR DESCRIPTION
## What's wrong

`scrapy.utils.datatypes.LocalCache` evicts an entry on *every* `__setitem__`
once it is full, including when the key being set already exists. Updating an
existing key therefore drops a different (oldest) key and leaves the cache
below its configured limit.

```python
from scrapy.utils.datatypes import LocalCache

cache = LocalCache(limit=2)
cache["a"] = 1
cache["b"] = 2
cache["b"] = 20          # update an existing key

print(dict(cache))       # {'b': 20}      <- 'a' was wrongly evicted
print(len(cache))        # 1              <- cache silently shrank below limit
```

A bounded cache must not shrink or discard unrelated entries when an existing
key is merely updated.

## Root cause

`__setitem__` runs the eviction loop unconditionally when the cache is full,
even when `key` already exists, so it pops an innocent entry and the subsequent
assignment just updates in place, leaving the cache one item short.

## Fix

Only evict to make room when inserting a genuinely new key (`if key not in
self:`). Behavior for new keys and for `limit == 0` is unchanged, and updates no
longer reorder entries (matching `OrderedDict`'s default and the existing tests).

## Impact

`LocalCache` backs Scrapy's DNS cache (`scrapy/resolver.py`,
`dnscache = LocalCache(10000)`) and, via `LocalWeakReferencedCache`, the
generator-callbacks cache (`scrapy/utils/misc.py`). Any update of an
already-cached key while the cache is full needlessly discards another entry.

## Tests

Added `test_cache_update_existing_key_does_not_evict` in
`tests/test_utils_datatypes.py`; it fails on `master` (`len == 1`, `"a"`
evicted) and passes with this change. The full `tests/test_utils_datatypes.py`
suite passes; `ruff check` and `ruff format` are clean on both changed files.
