### PR TITLE
Handle ImportError when normalizing component priority dict keys (#7820)

### DIFF
--- a/scrapy/settings/__init__.py
+++ b/scrapy/settings/__init__.py
@@ -366,7 +366,7 @@ class BaseSettings(MutableMapping[str, Any]):
         def normalize_key(key: Any) -> Any:
             try:
                 loaded_key = load_object(key)
-            except (NameError, TypeError, ValueError):
+            except (ImportError, NameError, TypeError, ValueError):
                 loaded_key = key
             else:
                 import_path = global_object_name(loaded_key)

--- a/tests/test_settings/__init__.py
+++ b/tests/test_settings/__init__.py
@@ -446,6 +446,29 @@ class TestBaseSettings:
         assert isinstance(value, BaseSettings)
         assert dict(value) == {key: 1}
 
+    def test_get_component_priority_dict_with_base_handles_import_error_with_none_value(
+        self,
+    ):
+        # Test for issue #7820: ImportError should be caught when normalizing keys
+        # with None values (which represent disabled components)
+        nonexistent_module = "scrapy.nonexistent.module.that.does.not.exist"
+
+        with pytest.raises(ImportError):
+            load_object(nonexistent_module)
+
+        settings = BaseSettings(
+            {
+                "FOO_BASE": BaseSettings({}),
+                "FOO": BaseSettings({nonexistent_module: None}),
+            }
+        )
+        # This should not raise ImportError; the None value means the component is disabled
+        value = settings.get_component_priority_dict_with_base("FOO")
+
+        assert isinstance(value, BaseSettings)
+        # The None-valued key should be filtered out from the result
+        assert dict(value) == {}
+
     def test_get_component_priority_dict_with_base_override_none_by_type(self):
         settings = BaseSettings()
         setting_names = set()


### PR DESCRIPTION
## Summary

The `get_component_priority_dict_with_base()` method normalizes every key in a component-priority dictionary (e.g., EXTENSIONS) by calling `load_object()` on it, including keys whose value is `None` (meaning "disable this component"). If a nonexistent module is referenced by a None-valued key, `load_object()` raises `ModuleNotFoundError` (a subclass of `ImportError`), which was not caught by the existing exception handler. This caused settings resolution to crash.

Since entries where `v is None` are filtered out regardless of import resolution, and the method already silently tolerates `NameError`/`TypeError`/`ValueError`, adding `ImportError` to the exception tuple is both safe and consistent.

## Test Plan

- Added regression test `test_get_component_priority_dict_with_base_handles_import_error_with_none_value` that reproduces the crash with a nonexistent module path as a None-valued key
- Confirmed the test fails before the fix (reproduces the bug)
- Applied the minimal fix (add ImportError to exception tuple)
- Confirmed the test now passes
- Ran full settings test suite (115 tests) - all pass

Resolves #7820
