### PR TITLE
docs: repoint dead <async>/<bfo> refs to defined labels

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -220,7 +220,7 @@ Solving specific problems
     Learn how to pause and resume crawls for large spiders.
 
 :doc:`topics/coroutines`
-    Use the :ref:`coroutine syntax <async>`.
+    Use the :ref:`coroutine syntax <coroutine-support>`.
 
 :doc:`topics/asyncio`
     Use :mod:`asyncio` and :mod:`asyncio`-powered libraries.

--- a/docs/topics/coroutines.rst
+++ b/docs/topics/coroutines.rst
@@ -4,7 +4,7 @@
 Coroutines
 ==========
 
-Scrapy :ref:`supports <coroutine-support>` the :ref:`coroutine syntax <async>`
+Scrapy :ref:`supports <coroutine-support>` the :ref:`coroutine syntax <coroutine-support>`
 (i.e. ``async def``).
 
 

--- a/docs/topics/optimize.rst
+++ b/docs/topics/optimize.rst
@@ -322,7 +322,7 @@ For broad crawls, consider these adjustments:
 
 -   .. _broad-crawls-bfo:
 
-    If memory is a bottleneck, see if :ref:`crawling in BFO order <bfo>` lowers
+    If memory is a bottleneck, see if :ref:`crawling in BFO order <broad-crawls-bfo>` lowers
     memory usage.
 
 -   Improve DNS resolution speed:


### PR DESCRIPTION
Three `:ref:` targets were undefined:

- `docs/index.rst` + `docs/topics/coroutines.rst`: `:ref:`coroutine syntax <async>`` — no `_async:` label exists; the live `:ref:`coroutine-support`` label is two lines away in one of the sites
- `docs/topics/optimize.rst`: `:ref:`crawling in BFO order <bfo>`` — the intended ``.. _broad-crawls-bfo:`` label is defined in the same bullet

Docs-only.