### PR TITLE
docs: resolve the start-request-order refs

### DIFF
--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -110,7 +110,7 @@ See :ref:`topics-request-response-ref-request-userlogin`.
 Does Scrapy crawl in breadth-first or depth-first order?
 --------------------------------------------------------
 
-:ref:`DFO by default, but other orders are possible <request-order>`.
+:ref:`DFO by default, but other orders are possible <faq-bfo-dfo>`.
 
 
 My Scrapy crawler has memory leaks. What can I do?

--- a/docs/topics/settings.rst
+++ b/docs/topics/settings.rst
@@ -2046,6 +2046,8 @@ For available choices, see :setting:`SCHEDULER_DISK_QUEUE`.
 Use ``None`` or ``""`` to disable these separate queues entirely, and instead
 have start requests share the same queues as other requests.
 
+.. _start-request-order:
+
 .. note::
 
     Disabling separate start request queues makes :ref:`start request order


### PR DESCRIPTION
Two sites referenced a `start-request-order` label that was defined nowhere:

- `docs/topics/spiders.rst` (`.. seealso::`) and `docs/topics/settings.rst` — the label is now **defined** on the ordering note in `settings.rst` that both intend to target
- `docs/faq.rst`: `:ref:`DFO by default… <request-order>`` repointed at `faq-bfo-dfo` — the label of the very section the sentence sits in

Docs-only.