### PR TITLE
Avoid redundant link deduplication in LxmlLinkExtractor

### DIFF
--- a/scrapy/linkextractors/lxmlhtml.py
+++ b/scrapy/linkextractors/lxmlhtml.py
@@ -397,7 +397,8 @@ class LxmlLinkExtractor:
         if self.canonicalize:
             for link in links:
                 link.url = canonicalize_url(link.url)
-        return self.link_extractor._process_links(links)
+            return self.link_extractor._process_links(links)
+        return links
 
     def _extract_links(self, *args: Any, **kwargs: Any) -> list[Link]:
         return self.link_extractor._extract_links(*args, **kwargs)
@@ -423,6 +424,6 @@ class LxmlLinkExtractor:
         for doc in docs:
             links = self._extract_links(doc, response.url, response.encoding, base_url)
             all_links.extend(self._process_links(links))
-        if self.link_extractor.unique:
+        if self.link_extractor.unique and len(docs) > 1:
             return unique_list(all_links, key=self.link_extractor.link_key)
         return all_links


### PR DESCRIPTION
`LxmlLinkExtractor` currently performs multiple deduplication passes during link extraction.

For the default case (`unique=True`, `canonicalize=False`) links are already deduplicated by the underlying extractor, but they are deduplicated again during processing and once more after collecting links.

This change skips those additional passes when they cannot introduce any new duplicates.

Deduplication is still preserved where it is needed:

* when `canonicalize=True`, since canonicalization can make previously distinct URLs equal
* when multiple restricted documents are processed, since the same URL may appear in different documents
* `unique=False` behavior is unchanged

In a synthetic test with 25,000 links over 20 extraction runs, the number of `unique_list` calls decreased from 60 to 20, and time spent inside `unique_list` decreased from about 169 ms to 67 ms.

The overall link extraction improvement is small because parsing and URL processing dominate the workload, but this removes unnecessary work from the extraction path.

Tests:

* `tox`
* pre-commit
