### PR TITLE
Match curl for header and user options that from_curl() crashed on

### DIFF
--- a/scrapy/utils/curl.py
+++ b/scrapy/utils/curl.py
@@ -65,7 +65,17 @@ def _parse_headers_and_cookies(
     headers: list[tuple[str, bytes]] = []
     cookies: dict[str, str] = {}
     for header in parsed_args.headers or ():
-        name, val = header.split(":", 1)
+        if ":" in header:
+            name, val = header.split(":", 1)
+        elif header.endswith(";") and header[:-1].strip():
+            # curl sends a header with an empty value when the name is
+            # terminated with a semicolon: -H "X-Flag;" puts "X-Flag:" on the
+            # wire. The semicolon must be the last character.
+            name, val = header[:-1], ""
+        else:
+            # curl silently drops a -H value that is neither "name: value"
+            # nor "name;", so there is no header to build here.
+            continue
         name = name.strip()
         val = val.strip()
         if name.title() == "Cookie":
@@ -83,7 +93,10 @@ def _parse_headers_and_cookies(
             cookies[name] = morsel.value
 
     if parsed_args.auth:
-        user, password = parsed_args.auth.split(":", 1)
+        # curl prompts for the password when -u has no colon; without a
+        # terminal to prompt at, the empty password that -u "user:" already
+        # produces is the matching request.
+        user, _, password = parsed_args.auth.partition(":")
         headers.append(("Authorization", basic_auth_header(user, password)))
 
     return headers, cookies
@@ -103,7 +116,7 @@ def curl_to_request_kwargs(
 
     curl_args = split(curl_command)
 
-    if curl_args[0] != "curl":
+    if not curl_args or curl_args[0] != "curl":
         raise ValueError('A curl command must start with "curl"')
 
     parsed_args, argv = curl_parser.parse_known_args(curl_args[1:])

--- a/tests/test_utils_curl.py
+++ b/tests/test_utils_curl.py
@@ -285,3 +285,60 @@ class TestCurlToRequestKwargs:
     def test_must_start_with_curl_error(self):
         with pytest.raises(ValueError, match="A curl command must start"):
             curl_to_request_kwargs("carl -X POST http://example.org")
+
+    def test_header_with_empty_value(self):
+        # curl sends a header with an empty value when the name is terminated
+        # with a semicolon: `-H "X-Flag;"` puts `X-Flag:` on the wire.
+        curl_command = 'curl "http://example.org/" -H "X-Flag;"'
+        expected_result = {
+            "method": "GET",
+            "url": "http://example.org/",
+            "headers": [("X-Flag", "")],
+        }
+        self._test_command(curl_command, expected_result)
+
+    @pytest.mark.parametrize(
+        "header",
+        [
+            "X-Flag",  # neither a colon nor a trailing semicolon
+            "X-Flag;extra",  # the semicolon is not the last character
+            ";",  # no name
+        ],
+    )
+    def test_header_curl_would_not_send_is_dropped(self, header):
+        # curl puts none of these on the wire, so neither does Scrapy. Before,
+        # each raised "not enough values to unpack (expected 2, got 1)".
+        curl_command = f'curl "http://example.org/" -H "{header}"'
+        expected_result = {"method": "GET", "url": "http://example.org/"}
+        self._test_command(curl_command, expected_result)
+
+    def test_header_without_colon_does_not_hide_the_others(self):
+        curl_command = 'curl "http://example.org/" -H "X-Flag" -H "X-Other: 2"'
+        expected_result = {
+            "method": "GET",
+            "url": "http://example.org/",
+            "headers": [("X-Other", "2")],
+        }
+        self._test_command(curl_command, expected_result)
+
+    def test_get_basic_auth_without_password(self):
+        # curl prompts for the password when -u has no colon, so the option is
+        # valid input. The request it builds once an empty password is given is
+        # the one `-u "user:"` builds, and that is what Scrapy produces.
+        expected_result = {
+            "method": "GET",
+            "url": "https://api.test.com/",
+            "headers": [("Authorization", basic_auth_header("some_username", ""))],
+        }
+        self._test_command(
+            'curl "https://api.test.com/" -u "some_username"', expected_result
+        )
+        self._test_command(
+            'curl "https://api.test.com/" -u "some_username:"', expected_result
+        )
+
+    @pytest.mark.parametrize("curl_command", ["", "   "])
+    def test_empty_command_error(self, curl_command):
+        # Previously "IndexError: list index out of range".
+        with pytest.raises(ValueError, match="A curl command must start"):
+            curl_to_request_kwargs(curl_command)


### PR DESCRIPTION
Fixes #8131.

`Request.from_curl()` raised opaque built-in exceptions on curl commands that real curl accepts, naming neither the option responsible nor the reason:

```
-H "X-Flag;"   ValueError: not enough values to unpack (expected 2, got 1)
-u "alice"     ValueError: not enough values to unpack (expected 2, got 1)
""             IndexError: list index out of range
```

## Ground truth

I checked each case against `curl 8.11.0` pointed at a local socket, printing the request as received, rather than relying on the manual:

| command | on the wire |
| --- | --- |
| `-H "X-Flag;"` | `X-Flag:` |
| `-H "X-Flag"` | omitted entirely |
| `-H "X-Flag;extra"` | omitted entirely, the semicolon must be last |
| `-H ";"` | omitted entirely |
| `-H " X-Flag ; "` | omitted entirely, no trailing whitespace |
| `-H "X-Flag: v"` | `X-Flag: v` |
| `-u "alice:"` | `Authorization: Basic YWxpY2U6` |
| `-u "alice"` | curl prompts for the password |

The last row is worth spelling out: the probe blocked on a password prompt, which is the evidence that curl treats `-u alice` as valid input rather than rejecting it.

## The change

- A `-H` value is read as `name: value` when it contains a colon, as an empty valued header when a semicolon terminates a non-empty name, and is otherwise skipped the way curl skips it.
- `-u` uses `partition` instead of `split`, so a missing colon gives the empty password that `-u "user:"` already produces.
- `curl_to_request_kwargs` tests for an empty argument list before indexing, so an empty command reaches the `A curl command must start with "curl"` message the function already defines.

The colon path is untouched, so headers that parse today parse byte for byte as before.

## Verification

**No previously working input changes behaviour.** Rather than argue that from reading, I ran a 57 command corpus through the old and new implementations: **41 results identical, 16 changed, and every one of the 16 raised before. Zero regressions.**

**The tests fail for the right reason.** All eight new cases fail against unmodified `curl.py`, each with the defect's own exception, six unpacking errors and two index errors. None of them passes or fails incidentally.

342 passed and 2 skipped across the curl, request and url suites. `ruff format` is clean, and `ruff check` reports the same four pre-existing findings at identical lines before and after the change.

## Notes

`-H "X-Flag:"` is left alone. A colon with nothing after it is curl's syntax for removing an internal header and curl sends nothing, while Scrapy emits `("X-Flag", "")`. It does not crash, the right Scrapy side equivalent is not obvious to me, and folding it in would widen this past the crashes. I mention it so you know it was looked at rather than missed.

On `-u user` without a colon there is a judgement call. Reading it as an empty password keeps it consistent with `-u "user:"`, which is what I assumed here. Raising a clear error saying Scrapy cannot prompt would also be defensible, and I am happy to switch.

I did not add a `docs/news.rst` entry because 2.19.0 shipped yesterday and there is no unreleased section to add to. Glad to add one wherever you would like it.
