### PR TITLE
fix: handle curl options accepted by curl

### DIFF
--- a/scrapy/utils/curl.py
+++ b/scrapy/utils/curl.py
@@ -65,9 +65,16 @@ def _parse_headers_and_cookies(
     headers: list[tuple[str, bytes]] = []
     cookies: dict[str, str] = {}
     for header in parsed_args.headers or ():
-        name, val = header.split(":", 1)
+        if ":" in header:
+            name, val = header.split(":", 1)
+        elif header.endswith(";"):
+            name, val = header[:-1], ""
+        else:
+            continue
         name = name.strip()
         val = val.strip()
+        if not name:
+            continue
         if name.title() == "Cookie":
             for name, morsel in SimpleCookie(val).items():
                 cookies[name] = morsel.value
@@ -83,7 +90,9 @@ def _parse_headers_and_cookies(
             cookies[name] = morsel.value
 
     if parsed_args.auth:
-        user, password = parsed_args.auth.split(":", 1)
+        user, separator, password = parsed_args.auth.partition(":")
+        if not separator:
+            password = ""
         headers.append(("Authorization", basic_auth_header(user, password)))
 
     return headers, cookies
@@ -103,7 +112,7 @@ def curl_to_request_kwargs(
 
     curl_args = split(curl_command)
 
-    if curl_args[0] != "curl":
+    if not curl_args or curl_args[0] != "curl":
         raise ValueError('A curl command must start with "curl"')
 
     parsed_args, argv = curl_parser.parse_known_args(curl_args[1:])

--- a/tests/test_utils_curl.py
+++ b/tests/test_utils_curl.py
@@ -41,6 +41,34 @@ class TestCurlToRequestKwargs:
         }
         self._test_command(curl_command, expected_result)
 
+    def test_get_basic_auth_without_password(self):
+        curl_command = 'curl "https://api.test.com/" -u "some_username"'
+        expected_result = {
+            "method": "GET",
+            "url": "https://api.test.com/",
+            "headers": [
+                ("Authorization", basic_auth_header("some_username", ""))
+            ],
+        }
+        self._test_command(curl_command, expected_result)
+
+    def test_get_header_with_empty_value(self):
+        curl_command = 'curl "http://example.org/" -H "X-Flag;"'
+        expected_result = {
+            "method": "GET",
+            "url": "http://example.org/",
+            "headers": [("X-Flag", "")],
+        }
+        self._test_command(curl_command, expected_result)
+
+    @pytest.mark.parametrize(
+        "header", ["X-Flag", "X-Flag;extra", "X-Flag ; ", ";"]
+    )
+    def test_get_header_without_value_is_skipped(self, header):
+        curl_command = f'curl "http://example.org/" -H "{header}"'
+        expected_result = {"method": "GET", "url": "http://example.org/"}
+        self._test_command(curl_command, expected_result)
+
     def test_get_cookie_option(self):
         curl_command = 'curl "http://example.org/" -b "a=1; b=2"'
         expected_result = {
@@ -285,3 +313,9 @@ class TestCurlToRequestKwargs:
     def test_must_start_with_curl_error(self):
         with pytest.raises(ValueError, match="A curl command must start"):
             curl_to_request_kwargs("carl -X POST http://example.org")
+
+        with pytest.raises(ValueError, match="A curl command must start"):
+            curl_to_request_kwargs("")
+
+        with pytest.raises(ValueError, match="A curl command must start"):
+            curl_to_request_kwargs("   ")


### PR DESCRIPTION
Closes #8131

This updates `Request.from_curl()` handling for valid curl inputs that previously surfaced built-in parsing errors:

- `-H "name;"` produces an empty header value.
- Header values without a colon or a final semicolon are skipped, including a bare `;`.
- `-u user` is treated like `-u user:` with an empty password.
- Empty or whitespace-only commands use the existing clear `A curl command must start with "curl"` error.

I kept the `-H "name:"` behavior unchanged because curl uses that form to remove an internal header, and its Scrapy equivalent needs a separate decision.

Tests:

- `python -m pytest tests/test_utils_curl.py tests/test_utils_request.py tests/test_http_request.py -q -k 'curl or not curl'` (112 passed)
- `git diff --check`

The empty-password choice follows the issue's proposed behavior. If prompting semantics should instead be rejected explicitly, that part can be adjusted without changing the other fixes. Let me know what you think.