### PR TITLE
utils/curl: fix opaque errors in from_curl() for semicolon headers, missing -u password, and empty command

### DIFF
--- a/scrapy/utils/curl.py
+++ b/scrapy/utils/curl.py
@@ -59,15 +59,48 @@ for argument in safe_to_ignore_arguments:
     curl_parser.add_argument(*argument, action="store_true")
 
 
+def _parse_header(header: str) -> tuple[str, str] | None:
+    """Parse a single ``-H``/``--header`` value the same way real curl does.
+
+    curl's header syntax:
+
+    * ``Name: value``  — send the header with the given value.
+    * ``Name:``        — send the header with an **empty** value (colon, no
+                          value).
+    * ``Name;``        — also sends the header with an empty value; the
+                          semicolon is curl's way of specifying an empty value
+                          when the colon form would be ambiguous.
+    * ``Name``         — **remove** the header (tell curl not to send it);
+                          Scrapy skips these entirely.
+    * ``Name;extra``   — also removes/suppresses the header; Scrapy skips.
+    * ``;``            — bare semicolon; Scrapy skips.
+
+    Returns ``(name, value)`` or ``None`` if the header should be skipped.
+    """
+    if ":" in header:
+        name, val = header.split(":", 1)
+        return name.strip(), val.strip()
+
+    # Semicolon syntax: "Name;" sends the header with an empty value.
+    # Any other form (no ":" and no trailing ";", or text after the ";")
+    # tells curl to suppress the header — we skip those.
+    if header.endswith(";"):
+        name = header[:-1].strip()
+        if name:
+            return name, ""
+    return None
+
+
 def _parse_headers_and_cookies(
     parsed_args: argparse.Namespace,
 ) -> tuple[list[tuple[str, bytes]], dict[str, str]]:
     headers: list[tuple[str, bytes]] = []
     cookies: dict[str, str] = {}
     for header in parsed_args.headers or ():
-        name, val = header.split(":", 1)
-        name = name.strip()
-        val = val.strip()
+        parsed = _parse_header(header)
+        if parsed is None:
+            continue
+        name, val = parsed
         if name.title() == "Cookie":
             for name, morsel in SimpleCookie(val).items():
                 cookies[name] = morsel.value
@@ -83,6 +116,11 @@ def _parse_headers_and_cookies(
             cookies[name] = morsel.value
 
     if parsed_args.auth:
+        if ":" not in parsed_args.auth:
+            raise ValueError(
+                f"Invalid -u/--user value {parsed_args.auth!r}: "
+                "a password is required (use 'user:password' format)."
+            )
         user, password = parsed_args.auth.split(":", 1)
         headers.append(("Authorization", basic_auth_header(user, password)))
 
@@ -102,6 +140,9 @@ def curl_to_request_kwargs(
     """
 
     curl_args = split(curl_command)
+
+    if not curl_args:
+        raise ValueError('A curl command must start with "curl"')
 
     if curl_args[0] != "curl":
         raise ValueError('A curl command must start with "curl"')

--- a/tests/test_utils_curl.py
+++ b/tests/test_utils_curl.py
@@ -285,3 +285,49 @@ class TestCurlToRequestKwargs:
     def test_must_start_with_curl_error(self):
         with pytest.raises(ValueError, match="A curl command must start"):
             curl_to_request_kwargs("carl -X POST http://example.org")
+
+    # --- Tests for issue #8131 ---
+
+    def test_empty_command_raises_clear_error(self):
+        """An empty string used to raise IndexError; now raises a clear ValueError."""
+        with pytest.raises(ValueError, match='A curl command must start with "curl"'):
+            curl_to_request_kwargs("")
+
+    # -H header semicolon syntax (curl's way of sending a header with an empty value)
+
+    def test_header_semicolon_empty_value(self):
+        """``-H "X-Flag;"`` sends the header with an empty value, matching curl behaviour."""
+        result = curl_to_request_kwargs('curl "http://example.org/" -H "X-Flag;"')
+        assert result["headers"] == [("X-Flag", "")]
+
+    def test_header_no_colon_no_semicolon_is_skipped(self):
+        """``-H "X-Flag"`` tells curl to remove the header; Scrapy skips it silently."""
+        result = curl_to_request_kwargs('curl "http://example.org/" -H "X-Flag"')
+        assert "headers" not in result
+
+    def test_header_semicolon_with_text_after_is_skipped(self):
+        """``-H "X-Flag;extra"`` removes the header in curl; Scrapy skips it silently."""
+        result = curl_to_request_kwargs('curl "http://example.org/" -H "X-Flag;extra"')
+        assert "headers" not in result
+
+    def test_header_bare_semicolon_is_skipped(self):
+        """``-H ";"`` is a bare semicolon with no name; Scrapy skips it."""
+        result = curl_to_request_kwargs('curl "http://example.org/" -H ";"')
+        assert "headers" not in result
+
+    def test_header_colon_only_sends_empty_value(self):
+        """``-H "X-Flag:"`` (colon, no value) is already handled; value is empty string."""
+        result = curl_to_request_kwargs('curl "http://example.org/" -H "X-Flag:"')
+        assert result["headers"] == [("X-Flag", "")]
+
+    # -u / --user without a colon (no password supplied)
+
+    def test_user_without_password_raises_clear_error(self):
+        """-u "alice" (no colon) used to raise ValueError with an unhelpful message."""
+        with pytest.raises(ValueError, match=r"Invalid -u/--user value.*password is required"):
+            curl_to_request_kwargs('curl "http://example.org/" -u "alice"')
+
+    def test_user_with_empty_password_is_accepted(self):
+        """-u "alice:" (colon, empty password) is valid and should not raise."""
+        result = curl_to_request_kwargs('curl "http://example.org/" -u "alice:"')
+        assert result["headers"] == [("Authorization", basic_auth_header("alice", ""))]


### PR DESCRIPTION
## Summary

Fixes #8131 — `Request.from_curl()` raises opaque built-in errors on valid curl commands.

Three distinct inputs caused exceptions that gave no hint about which option triggered them:

### 1. Colon-less `-H` headers (`ValueError: not enough values to unpack`)

`header.split(":", 1)` crashed whenever a header string contained no `:`.

Real curl has a precise semicolon syntax for headers:

| header string | real curl behaviour | before this PR | after this PR |
|---|---|---|---|
| `X-Flag;` | send `X-Flag:` with empty value | `ValueError` | `("X-Flag", "")` |
| `X-Flag` | remove/suppress the header | `ValueError` | skipped silently |
| `X-Flag;extra` | remove/suppress the header | `ValueError` | skipped silently |
| `;` | remove/suppress | `ValueError` | skipped silently |

A new private helper `_parse_header()` encapsulates these rules, with a docstring referencing each case.

### 2. `-u user` without a password (`ValueError: not enough values to unpack`)

`parsed_args.auth.split(":", 1)` crashed when no `:` was present. Real curl prompts interactively for the password; `from_curl()` cannot do that, so we now raise a descriptive `ValueError`:

```
ValueError: Invalid -u/--user value 'alice': a password is required (use 'user:password' format).
```

### 3. `from_curl("")` — empty string (`IndexError: list index out of range`)

`shlex.split("")` returns `[]`, so `curl_args[0]` raised `IndexError`. A length check before the index access now raises the same clear `ValueError` as an unrecognised command.

---

## Changes

- `scrapy/utils/curl.py` — add `_parse_header()` helper; fix header loop, auth check, and empty-command guard.
- `tests/test_utils_curl.py` — 8 new regression tests covering every case from the issue report.

## Checklist

- [x] Tests added for all fixed cases (27/27 pass)
- [x] No existing tests broken
- [x] Signed-off-by included (DCO)
