### PR TITLE
Add S3 feed append via native PutObject WriteOffsetBytes (#7822)

### DIFF
--- a/docs/news.rst
+++ b/docs/news.rst
@@ -3,6 +3,33 @@
 Release notes
 =============
 
+.. _release-2.20.0:
+
+Scrapy 2.20.0
+-------------
+
+Backward-incompatible changes
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+-   Setting the :ref:`overwrite feed option <feed-options>` to ``False`` for
+    S3 feeds now appends using the Amazon S3 Express One Zone /
+    directory-bucket native append API instead of logging that S3 does not
+    support appending and still replacing the object. General-purpose S3
+    buckets do not support that API, so store will fail there if
+    ``overwrite`` is ``False``. The S3 default for ``overwrite`` remains
+    ``True``.
+    (:gh:`7822`)
+
+New features
+~~~~~~~~~~~~
+
+-   :class:`~scrapy.extensions.feedexport.S3FeedStorage` now supports appending
+    when the :ref:`overwrite feed option <feed-options>` is ``False``, using
+    the Amazon S3 Express One Zone / directory-bucket native append API
+    (``PutObject`` with ``WriteOffsetBytes``). The S3 default for
+    ``overwrite`` remains ``True``.
+    (:gh:`7822`)
+
 .. _release-2.19.0:
 
 Scrapy 2.19.0 (2026-09-10)

--- a/docs/topics/feed-exports.rst
+++ b/docs/topics/feed-exports.rst
@@ -256,6 +256,13 @@ pool size for exported feeds using these settings:
 The default value for the ``overwrite`` key in the :setting:`FEEDS` for this
 storage backend is: ``True``.
 
+When ``overwrite`` is ``False``, Scrapy appends to the existing object using
+the native append API of `Amazon S3 Express One Zone`_ directory buckets
+(``PutObject`` with the ``x-amz-write-offset-bytes`` header, exposed by boto3
+as ``WriteOffsetBytes``). If the object does not exist, it is created at write
+offset ``0``. Native append is not supported on general-purpose S3 buckets;
+storing with ``overwrite`` set to ``False`` will fail there.
+
 .. caution:: The value ``True`` in ``overwrite`` will cause you to lose the
      previous version of your data.
 
@@ -534,7 +541,11 @@ as a fallback value if that key is not provided for a specific feed definition:
         .. note:: Some FTP servers may not support appending to files (the
                   ``APPE`` FTP command).
 
-    -   :ref:`topics-feed-storage-s3`: ``True`` (appending is not supported)
+    -   :ref:`topics-feed-storage-s3`: ``True``
+
+        Native append (``overwrite: False``) uses the Amazon S3 Express One
+        Zone / directory-bucket append API. It is not supported on
+        general-purpose S3 buckets.
 
     -   :ref:`topics-feed-storage-gcs`: ``True`` (appending is not supported)
 
@@ -820,5 +831,6 @@ source spider in the feed URI:
 
 .. _URIs: https://en.wikipedia.org/wiki/Uniform_Resource_Identifier
 .. _Amazon S3: https://aws.amazon.com/s3/
+.. _Amazon S3 Express One Zone: https://docs.aws.amazon.com/AmazonS3/latest/userguide/directory-buckets-objects-append.html
 .. _Canned ACL: https://docs.aws.amazon.com/AmazonS3/latest/userguide/acl-overview.html#canned-acl
 .. _Google Cloud Storage: https://cloud.google.com/storage/

--- a/scrapy/extensions/feedexport.py
+++ b/scrapy/extensions/feedexport.py
@@ -233,6 +233,7 @@ class S3FeedStorage(BlockingFeedStorage):
         self.endpoint_url: str | None = endpoint_url
         self.region_name: str | None = region_name
         self.max_pool_connections: int | None = max_pool_connections
+        self.overwrite: bool = not feed_options or feed_options.get("overwrite", True)
 
         boto3_session = boto3.session.Session()
         self.s3_client = boto3_session.client(
@@ -248,13 +249,6 @@ class S3FeedStorage(BlockingFeedStorage):
                 else None
             ),
         )
-
-        if feed_options and feed_options.get("overwrite", True) is False:
-            logger.warning(
-                "S3 does not support appending to files. To "
-                "suppress this warning, remove the overwrite "
-                "option from your FEEDS setting or set it to True."
-            )
 
     @classmethod
     def from_crawler(
@@ -276,10 +270,36 @@ class S3FeedStorage(BlockingFeedStorage):
             feed_options=feed_options,
         )
 
+    def _object_size(self) -> int:
+        from botocore.exceptions import ClientError  # noqa: PLC0415
+
+        try:
+            response = self.s3_client.head_object(
+                Bucket=self.bucketname, Key=self.keyname
+            )
+        except ClientError as exc:
+            error_code = str((exc.response.get("Error") or {}).get("Code") or "")
+            if error_code in {"404", "NoSuchKey", "NotFound"}:
+                return 0
+            http_status = (exc.response.get("ResponseMetadata") or {}).get(
+                "HTTPStatusCode"
+            )
+            if not error_code and http_status == 404:
+                return 0
+            raise
+        return int(response["ContentLength"])
+
     def _store_in_thread(self, file: IO[bytes]) -> None:
         file.seek(0)
         try:
-            if self.acl:
+            if not self.overwrite:
+                self.s3_client.put_object(
+                    Bucket=self.bucketname,
+                    Key=self.keyname,
+                    Body=file,
+                    WriteOffsetBytes=self._object_size(),
+                )
+            elif self.acl:
                 self.s3_client.upload_fileobj(
                     Bucket=self.bucketname,
                     Key=self.keyname,

--- a/tests/test_feedexport_storages.py
+++ b/tests/test_feedexport_storages.py
@@ -499,20 +499,167 @@ class TestS3FeedStorage:
         assert acl == "custom-acl"
 
     def test_overwrite_default(self, caplog: pytest.LogCaptureFixture) -> None:
-        S3FeedStorage(
+        storage = S3FeedStorage(
             "s3://mybucket/export.csv", "access_key", "secret_key", "custom-acl"
         )
+        assert storage.overwrite is True
         assert "S3 does not support appending to files" not in caplog.text
 
     def test_overwrite_false(self, caplog: pytest.LogCaptureFixture) -> None:
-        S3FeedStorage(
+        storage = S3FeedStorage(
             "s3://mybucket/export.csv",
             "access_key",
             "secret_key",
             "custom-acl",
             feed_options={"overwrite": False},
         )
-        assert "S3 does not support appending to files" in caplog.text
+        assert storage.overwrite is False
+        assert "S3 does not support appending to files" not in caplog.text
+
+    @coroutine_test
+    async def test_store_overwrite_true(self):
+        storage = S3FeedStorage(
+            "s3://mybucket/export.csv",
+            "access_key",
+            "secret_key",
+            feed_options={"overwrite": True},
+        )
+        storage.s3_client = mock.MagicMock()
+        body = BytesIO(b"feed-bytes")
+        await maybe_deferred_to_future(storage.store(body))
+        assert storage.s3_client.upload_fileobj.call_args == mock.call(
+            Bucket="mybucket", Key="export.csv", Fileobj=body
+        )
+        storage.s3_client.head_object.assert_not_called()
+        storage.s3_client.put_object.assert_not_called()
+
+    @staticmethod
+    def _capture_put_object(client: mock.MagicMock) -> dict[str, Any]:
+        recorded: dict[str, Any] = {}
+
+        def put_object(**kwargs: Any) -> None:
+            recorded.update(kwargs)
+            recorded["body_bytes"] = kwargs["Body"].read()
+
+        client.put_object.side_effect = put_object
+        return recorded
+
+    @coroutine_test
+    async def test_store_append_existing(self):
+        storage = S3FeedStorage(
+            "s3://mybucket/export.csv",
+            "access_key",
+            "secret_key",
+            "custom-acl",
+            feed_options={"overwrite": False},
+        )
+        storage.s3_client = mock.MagicMock()
+        storage.s3_client.head_object.return_value = {"ContentLength": 42}
+        recorded = self._capture_put_object(storage.s3_client)
+        await maybe_deferred_to_future(storage.store(BytesIO(b"feed-bytes")))
+        storage.s3_client.head_object.assert_called_once_with(
+            Bucket="mybucket", Key="export.csv"
+        )
+        assert recorded["Bucket"] == "mybucket"
+        assert recorded["Key"] == "export.csv"
+        assert recorded["WriteOffsetBytes"] == 42
+        assert recorded["body_bytes"] == b"feed-bytes"
+        assert "ACL" not in recorded
+        storage.s3_client.upload_fileobj.assert_not_called()
+
+    @pytest.mark.parametrize(
+        "error_response",
+        [
+            {
+                "Error": {"Code": "404", "Message": "Not Found"},
+                "ResponseMetadata": {"HTTPStatusCode": 404},
+            },
+            {
+                "Error": {"Code": "NoSuchKey", "Message": "The specified key does not exist."},
+                "ResponseMetadata": {"HTTPStatusCode": 404},
+            },
+            {
+                "Error": {"Code": "NotFound", "Message": "Not Found"},
+                "ResponseMetadata": {"HTTPStatusCode": 404},
+            },
+            {
+                "Error": {},
+                "ResponseMetadata": {"HTTPStatusCode": 404},
+            },
+        ],
+        ids=["404", "NoSuchKey", "NotFound", "http-404-no-code"],
+    )
+    @coroutine_test
+    async def test_store_append_missing(self, error_response: dict[str, Any]):
+        from botocore.exceptions import ClientError  # noqa: PLC0415
+
+        storage = S3FeedStorage(
+            "s3://mybucket/export.csv",
+            "access_key",
+            "secret_key",
+            feed_options={"overwrite": False},
+        )
+        storage.s3_client = mock.MagicMock()
+        storage.s3_client.head_object.side_effect = ClientError(
+            error_response,
+            "HeadObject",
+        )
+        recorded = self._capture_put_object(storage.s3_client)
+        await maybe_deferred_to_future(storage.store(BytesIO(b"feed-bytes")))
+        storage.s3_client.head_object.assert_called_once_with(
+            Bucket="mybucket", Key="export.csv"
+        )
+        assert recorded["Bucket"] == "mybucket"
+        assert recorded["Key"] == "export.csv"
+        assert recorded["WriteOffsetBytes"] == 0
+        assert recorded["body_bytes"] == b"feed-bytes"
+        storage.s3_client.upload_fileobj.assert_not_called()
+
+    @coroutine_test
+    async def test_store_append_head_error(self):
+        from botocore.exceptions import ClientError  # noqa: PLC0415
+
+        storage = S3FeedStorage(
+            "s3://mybucket/export.csv",
+            "access_key",
+            "secret_key",
+            feed_options={"overwrite": False},
+        )
+        storage.s3_client = mock.MagicMock()
+        storage.s3_client.head_object.side_effect = ClientError(
+            {
+                "Error": {"Code": "403", "Message": "Forbidden"},
+                "ResponseMetadata": {"HTTPStatusCode": 403},
+            },
+            "HeadObject",
+        )
+        with pytest.raises(ClientError):
+            await maybe_deferred_to_future(storage.store(BytesIO(b"feed-bytes")))
+        storage.s3_client.put_object.assert_not_called()
+        storage.s3_client.upload_fileobj.assert_not_called()
+
+    @coroutine_test
+    async def test_store_append_missing_bucket(self):
+        from botocore.exceptions import ClientError  # noqa: PLC0415
+
+        storage = S3FeedStorage(
+            "s3://mybucket/export.csv",
+            "access_key",
+            "secret_key",
+            feed_options={"overwrite": False},
+        )
+        storage.s3_client = mock.MagicMock()
+        storage.s3_client.head_object.side_effect = ClientError(
+            {
+                "Error": {"Code": "NoSuchBucket", "Message": "The specified bucket does not exist"},
+                "ResponseMetadata": {"HTTPStatusCode": 404},
+            },
+            "HeadObject",
+        )
+        with pytest.raises(ClientError):
+            await maybe_deferred_to_future(storage.store(BytesIO(b"feed-bytes")))
+        storage.s3_client.put_object.assert_not_called()
+        storage.s3_client.upload_fileobj.assert_not_called()
 
 
 class TestGCSFeedStorage:


### PR DESCRIPTION
## Summary

S3 feed storage now appends with Amazon S3’s native append API when `overwrite` is `False`, instead of logging that S3 does not support appending and still replacing the object.

Fixes #7822

## Changes

- `S3FeedStorage` honors `overwrite` like FTP: default/`True` still uses `upload_fileobj` to replace the object.
- `overwrite: False` looks up the current object size with `head_object` and calls `put_object` with `WriteOffsetBytes` (offset `0` if the object does not exist).
- Missing-object 404 / `NoSuchKey` / `NotFound` append at offset 0. Other errors (`403`, `NoSuchBucket`) are not treated as a missing object.
- Docs describe S3 Express One Zone / directory-bucket native append and that the S3 default remains `overwrite: True`. General-purpose buckets do not support this API and will fail at store time rather than silently overwrite.
- News notes for 2.20.0 cover both the feature and the compatibility break.

## Testing

`tests/test_feedexport_storages.py::TestS3FeedStorage` drives the real `store` path with a mocked S3 client:

- overwrite default/`True` still does a full-object upload
- append uses existing size as `WriteOffsetBytes` and the feed bytes as the body
- missing object appends at offset 0
- the old “S3 does not support appending to files” warning is gone

```
pytest tests/test_feedexport_storages.py::TestS3FeedStorage -v
```

30 passed locally.

## Notes

Native append is only supported on S3 Express One Zone directory buckets (`x-amz-write-offset-bytes` / boto `WriteOffsetBytes`). There is no download-then-reupload fallback for general-purpose buckets.